### PR TITLE
feat: add Baidu search provider with smart/web mode support

### DIFF
--- a/src/components/settings/sections/WebSearchSection.tsx
+++ b/src/components/settings/sections/WebSearchSection.tsx
@@ -6,7 +6,8 @@ import { Select } from '@/components/ui/select';
 import { open } from '@tauri-apps/plugin-shell';
 import type { WebSearchProviderType } from '@/core/search/providers';
 
-const SEARCH_PROVIDERS: { id: WebSearchProviderType; labelKey: 'webSearchProviderBing' | 'webSearchProviderBrave' | 'webSearchProviderTavily' | 'webSearchProviderSearXNG'; signupUrl?: string }[] = [
+const SEARCH_PROVIDERS: { id: WebSearchProviderType; labelKey: 'webSearchProviderBaidu' | 'webSearchProviderBing' | 'webSearchProviderBrave' | 'webSearchProviderTavily' | 'webSearchProviderSearXNG'; signupUrl?: string }[] = [
+  { id: 'baidu', labelKey: 'webSearchProviderBaidu', signupUrl: 'https://cloud.baidu.com/' },
   { id: 'tavily', labelKey: 'webSearchProviderTavily', signupUrl: 'https://tavily.com/' },
   { id: 'brave', labelKey: 'webSearchProviderBrave', signupUrl: 'https://brave.com/search/api/' },
   { id: 'searxng', labelKey: 'webSearchProviderSearXNG', signupUrl: 'https://docs.searxng.org/' },
@@ -19,14 +20,17 @@ export function WebSearchForm() {
     webSearchProvider,
     webSearchApiKey,
     webSearchBaseUrl,
+    baiduSearchMode,
     setWebSearchProvider,
     setWebSearchApiKey,
     setWebSearchBaseUrl,
+    setBaiduSearchMode,
   } = useSettingsStore();
   const { t } = useI18n();
   const [showKey, setShowKey] = useState(false);
 
   const isSearXNG = webSearchProvider === 'searxng';
+  const isBaidu = webSearchProvider === 'baidu';
   const currentProvider = SEARCH_PROVIDERS.find((p) => p.id === webSearchProvider);
 
   return (
@@ -76,6 +80,26 @@ export function WebSearchForm() {
             </button>
           </div>
           <p className="text-xs text-[#888579]">{t.settings.webSearchApiKeyDesc}</p>
+        </div>
+      )}
+
+      {/* Baidu Search Mode */}
+      {isBaidu && (
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-[#29261b]">搜索模式</label>
+          <Select
+            value={baiduSearchMode}
+            onChange={(value) => setBaiduSearchMode(value as 'smart' | 'web')}
+            options={[
+              { value: 'smart', label: '智能搜索（AI 总结）' },
+              { value: 'web', label: '网页搜索（仅返回结果）' },
+            ]}
+          />
+          <p className="text-xs text-[#888579]">
+            {baiduSearchMode === 'smart'
+              ? '智能搜索：AI 会总结搜索结果，回答更精准，但消耗更多配额'
+              : '网页搜索：直接返回搜索结果列表，更便宜'}
+          </p>
         </div>
       )}
 

--- a/src/core/search/providers.ts
+++ b/src/core/search/providers.ts
@@ -232,14 +232,107 @@ export function createSearXNGProvider(baseUrl: string): SearchProvider {
   };
 }
 
+// --- Baidu Search API (Smart + Web) ---
+
+export type BaiduSearchMode = 'smart' | 'web';
+
+export function createBaiduProvider(apiKey: string, mode: BaiduSearchMode = 'smart'): SearchProvider {
+  return {
+    async search(query: string, options: SearchOptions): Promise<WebSearchResponse> {
+      const fetchFn = await getTauriFetch();
+
+      let url: string;
+      let requestBody: Record<string, unknown>;
+
+      if (mode === 'web') {
+        // Web search: 直接返回搜索结果
+        url = 'https://qianfan.baidubce.com/v2/ai_search/web_search';
+        requestBody = {
+          messages: [
+            {
+              role: 'user',
+              content: query,
+            },
+          ],
+          search_source: 'baidu_search_v2',
+          resource_type_filter: [
+            { type: 'web', top_k: Math.min(options.count, 20) },
+          ],
+        };
+      } else {
+        // Smart search: AI 总结 + 搜索结果
+        url = 'https://qianfan.baidubce.com/v2/ai_search/chat/completions';
+        requestBody = {
+          messages: [
+            {
+              role: 'user',
+              content: query,
+            },
+          ],
+          model: 'ernie-4.5-turbo-32k',
+          search_source: 'baidu_search_v2',
+          resource_type_filter: [
+            { type: 'web', top_k: Math.min(options.count, 10) },
+          ],
+          stream: false,
+          enable_reasoning: true,
+          enable_deep_search: false,
+          enable_corner_markers: true,
+        };
+      }
+
+      const response = await fetchFn(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Baidu Search API error: ${response.status} ${errorText}`);
+      }
+
+      const data = await response.json() as {
+        choices?: Array<{
+          message?: {
+            content?: string;
+          };
+        }>;
+        references?: Array<{
+          title?: string;
+          url?: string;
+          content?: string;
+          source?: string;
+        }>;
+      };
+
+      const references = data.references || [];
+
+      const results: SearchResult[] = references.slice(0, options.count).map((item, idx) => ({
+        title: item.title || `Result ${idx + 1}`,
+        url: item.url || '',
+        snippet: item.content?.substring(0, 300) || '',
+        source: item.source || extractDomain(item.url || ''),
+      }));
+
+      return { query, results };
+    },
+  };
+}
+
 // --- Provider factory ---
 
-export type WebSearchProviderType = 'bing' | 'brave' | 'tavily' | 'searxng';
+export type WebSearchProviderType = 'bing' | 'brave' | 'tavily' | 'searxng' | 'baidu';
 
 export function createSearchProvider(
   providerType: WebSearchProviderType,
   apiKey: string,
+  _secretKey?: string,
   baseUrl?: string,
+  baiduSearchMode?: BaiduSearchMode,
 ): SearchProvider {
   switch (providerType) {
     case 'bing':
@@ -250,5 +343,7 @@ export function createSearchProvider(
       return createTavilyProvider(apiKey);
     case 'searxng':
       return createSearXNGProvider(baseUrl || '');
+    case 'baidu':
+      return createBaiduProvider(apiKey, baiduSearchMode || 'smart');
   }
 }

--- a/src/core/tools/builtins.ts
+++ b/src/core/tools/builtins.ts
@@ -923,6 +923,7 @@ const webSearchTool: ToolDefinition = {
       const providerType = state.webSearchProvider || 'bing';
       const apiKey = state.webSearchApiKey;
       const baseUrl = state.webSearchBaseUrl;
+      const baiduSearchMode = state.baiduSearchMode;
 
       // SearXNG doesn't need API key
       if (providerType !== 'searxng' && !apiKey) {
@@ -933,7 +934,7 @@ const webSearchTool: ToolDefinition = {
       }
 
       const { createSearchProvider } = await import('../search/providers');
-      const provider = createSearchProvider(providerType, apiKey, baseUrl);
+      const provider = createSearchProvider(providerType, apiKey, baseUrl, undefined, baiduSearchMode);
       const response = await provider.search(query, { count, market, freshness });
 
       if (response.results.length === 0) {

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -278,6 +278,8 @@ const enUS: TranslationDict = {
     webSearchProviderBrave: 'Brave Search',
     webSearchProviderTavily: 'Tavily Search',
     webSearchProviderSearXNG: 'SearXNG (Self-hosted)',
+    webSearchProviderBaidu: 'Baidu Search',
+    webSearchSecretKey: 'Search Secret Key',
     // AI Services
     aiServices: 'AI Services',
     aiServicesDescription: 'Configure model, search, and image generation services',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -278,6 +278,8 @@ const zhCN: TranslationDict = {
     webSearchProviderBrave: 'Brave 搜索',
     webSearchProviderTavily: 'Tavily 搜索',
     webSearchProviderSearXNG: 'SearXNG（自建）',
+    webSearchProviderBaidu: '百度搜索',
+    webSearchSecretKey: '搜索 Secret Key',
     // AI Services
     aiServices: 'AI 服务',
     aiServicesDescription: '配置模型、搜索和图片生成服务',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -244,6 +244,8 @@ export interface TranslationDict {
     webSearchProviderBrave: string;
     webSearchProviderTavily: string;
     webSearchProviderSearXNG: string;
+    webSearchProviderBaidu: string;
+    webSearchSecretKey: string;
     // AI Services
     aiServices: string;
     aiServicesDescription: string;

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -223,6 +223,7 @@ interface SettingsState {
   webSearchProvider: WebSearchProviderType;
   webSearchApiKey: string;
   webSearchBaseUrl: string;
+  baiduSearchMode: 'smart' | 'web';
   // New: Language setting
   language: LanguageSetting;
   // System settings tab
@@ -288,6 +289,7 @@ interface SettingsActions {
   setUseBuiltinWebSearch: (enabled: boolean) => void;
   setWebSearchProvider: (provider: WebSearchProviderType) => void;
   setWebSearchApiKey: (key: string) => void;
+  setBaiduSearchMode: (mode: 'smart' | 'web') => void;
   setWebSearchBaseUrl: (url: string) => void;
   // Language action
   setLanguage: (lang: LanguageSetting) => void;
@@ -394,6 +396,7 @@ export const useSettingsStore = create<SettingsStore>()(
       webSearchProvider: 'brave' as WebSearchProviderType,
       webSearchApiKey: '',
       webSearchBaseUrl: '',
+      baiduSearchMode: 'smart',
       // Language default
       language: 'system' as LanguageSetting,
       // System settings defaults
@@ -446,8 +449,9 @@ export const useSettingsStore = create<SettingsStore>()(
       // Web search actions
       setUseBuiltinWebSearch: (useBuiltinWebSearch) => set({ useBuiltinWebSearch }),
       setWebSearchProvider: (webSearchProvider) => set({ webSearchProvider }),
-      setWebSearchApiKey: (webSearchApiKey) => set({ webSearchApiKey }),
-      setWebSearchBaseUrl: (webSearchBaseUrl) => set({ webSearchBaseUrl }),
+      setWebSearchApiKey: (webSearchApiKey: string) => set({ webSearchApiKey }),
+      setBaiduSearchMode: (mode: 'smart' | 'web') => set({ baiduSearchMode: mode }),
+      setWebSearchBaseUrl: (webSearchBaseUrl: string) => set({ webSearchBaseUrl }),
       // Language action - updates both store and i18n module
       setLanguage: (lang) => {
         setLanguage(lang);
@@ -520,10 +524,13 @@ export const useSettingsStore = create<SettingsStore>()(
     }),
     {
       name: 'abu-settings',
-      version: 6,
+      version: 8,
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
-        if (version < 6) {
+        if (version < 8) {
+          if (state.baiduSearchMode === undefined) state.baiduSearchMode = 'smart';
+        }
+        if (version < 7) {
           if (state.allowSkillCommands === undefined) state.allowSkillCommands = true;
         }
         if (version < 5) {
@@ -609,6 +616,7 @@ export const useSettingsStore = create<SettingsStore>()(
         webSearchProvider: state.webSearchProvider,
         webSearchApiKey: state.webSearchApiKey,
         webSearchBaseUrl: state.webSearchBaseUrl,
+        baiduSearchMode: state.baiduSearchMode,
         sidebarCollapsed: state.sidebarCollapsed,
         rightPanelCollapsed: state.rightPanelCollapsed,
         disabledSkills: state.disabledSkills,


### PR DESCRIPTION
- Add Baidu search engine option in web search settings
- Support two search modes:
  - Smart search (AI summary, uses more quota)
  - Web search (direct results, cheaper)
- Add search mode toggle UI in settings
- Use Baidu Intelligent Search API (qianfan.baidubce.com)
- Remove Secret Key requirement (only needs API Key)

BREAKING CHANGE: webSearchSecretKey is replaced with baiduSearchMode