### PR TITLE
feat: ask_user_question 交互式选择卡片（对标 Claude）

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -3,7 +3,8 @@ import { useChatStore, useActiveConversation } from '@/stores/chatStore';
 import type { Message, ImageAttachment } from '@/types';
 import { useAutoScroll } from '@/hooks/useAutoScroll';
 import { runAgentLoop } from '@/core/agent/agentLoop';
-import { getPendingCommandConfirmation, resolveCommandConfirmation, subscribeToCommandConfirmation, getPendingFilePermission, resolveFilePermission, subscribeToFilePermission, getPendingWorkspaceRequest, resolveWorkspaceRequest, subscribeToWorkspaceRequest } from '@/core/agent/permissionBridge';
+import { getPendingCommandConfirmation, resolveCommandConfirmation, subscribeToCommandConfirmation, getPendingFilePermission, resolveFilePermission, subscribeToFilePermission, getPendingWorkspaceRequest, resolveWorkspaceRequest, subscribeToWorkspaceRequest, getPendingUserQuestions, subscribeUserQuestion } from '@/core/agent/permissionBridge';
+import { TOOL_NAMES } from '@/core/tools/toolNames';
 import { useSettingsStore, getActiveApiKey, providerRequiresApiKey } from '@/stores/settingsStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import type { PermissionDuration } from '@/stores/permissionStore';
@@ -12,6 +13,7 @@ import { useI18n } from '@/i18n';
 import MessageGroup from './MessageGroup';
 import ChatInput from './ChatInput';
 import BackgroundAgents from './BackgroundAgents';
+import UserQuestionDock from './UserQuestionDock';
 import ScenarioGuide from './ScenarioGuide';
 import { agentRegistry } from '@/core/agent/registry';
 import PermissionDialog from '@/components/common/PermissionDialog';
@@ -107,6 +109,13 @@ export default function ChatView() {
   const workspaceRequest = useSyncExternalStore(
     subscribeToWorkspaceRequest,
     getPendingWorkspaceRequest
+  );
+
+  // Subscribe to pending ask_user_question entries — the docked card above
+  // the composer renders the first one belonging to the active conversation.
+  const pendingUserQuestions = useSyncExternalStore(
+    subscribeUserQuestion,
+    getPendingUserQuestions
   );
 
   const handleCommandConfirm = () => {
@@ -447,6 +456,26 @@ export default function ChatView() {
       <div className="shrink-0 px-6 md:px-10 pb-4 pt-1.5 bg-[var(--abu-bg-base)]">
         <div className="max-w-4xl mx-auto flex flex-col gap-1.5">
           <BackgroundAgents />
+          {/* Docked ask_user_question card — sits flush above the composer,
+              same width. Render the first pending question that belongs to the
+              active conversation and whose owning message can be located. */}
+          {(() => {
+            const pending = pendingUserQuestions.find((pq) => pq.conversationId === activeConvId);
+            if (!pending) return null;
+            const owningMsg = messages.find((m) =>
+              m.toolCalls?.some((tc) => tc.id === pending.id && tc.name === TOOL_NAMES.ASK_USER_QUESTION),
+            );
+            if (!owningMsg) return null;
+            return (
+              <UserQuestionDock
+                key={pending.id}
+                conversationId={pending.conversationId}
+                messageId={owningMsg.id}
+                toolCallId={pending.id}
+                payload={pending.payload}
+              />
+            );
+          })()}
           <ChatInput variant="chat" onSend={handleSend} />
           <div className="flex items-center justify-center gap-3 mt-1.5">
             <UsageChip conversationId={activeConv.id} />

--- a/src/components/chat/MessageGroup.tsx
+++ b/src/components/chat/MessageGroup.tsx
@@ -6,6 +6,7 @@ import type { ExecutionStep } from '@/types/execution';
 import type { WorkflowStep } from '@/utils/workflowExtractor';
 import MessageBubble from './MessageBubble';
 import SkillProposalCard from './SkillProposalCard';
+import UserQuestionCard from './UserQuestionCard';
 import TaskBlock from './TaskBlock';
 import MarkdownRenderer from './MarkdownRenderer';
 import FileAttachment, { ImagePreviewCard, ImageThumbnail, isImageFile } from './FileAttachment';
@@ -573,6 +574,19 @@ export default function MessageGroup({ messages, isLastGroup: isLastGroupProp = 
                   toolCallId={tc.id}
                   card={tc.noticeCard!}
                   settledAction={tc.noticeCardAction}
+                />
+              );
+            })}
+
+            {activeConv?.id && allToolCalls.filter((tc) => tc.name === TOOL_NAMES.ASK_USER_QUESTION).map((tc) => {
+              const owningMsg = assistantMsgs.find((m) => m.toolCalls?.some((x) => x.id === tc.id));
+              if (!owningMsg) return null;
+              return (
+                <UserQuestionCard
+                  key={`uq-${tc.id}`}
+                  conversationId={activeConv.id}
+                  messageId={owningMsg.id}
+                  toolCall={tc}
                 />
               );
             })}

--- a/src/components/chat/MessageGroup.tsx
+++ b/src/components/chat/MessageGroup.tsx
@@ -106,7 +106,7 @@ function stripMarkdownImages(text: string): string {
 
 type RenderSegment =
   | { kind: 'text'; text: string; message: Message; isLastTurn: boolean }
-  | { kind: 'steps'; executionSteps: ExecutionStep[]; legacySteps: WorkflowStep[]; isLastGroup: boolean };
+  | { kind: 'steps'; executionSteps: ExecutionStep[]; legacySteps: WorkflowStep[]; isLastGroup: boolean; stepsMsgs: Message[] };
 
 /**
  * Build render segments from assistant messages and their steps.
@@ -132,6 +132,7 @@ function buildRenderSegments(
   const segments: RenderSegment[] = [];
   let pendingExecSteps: ExecutionStep[] = [...thinkingExecSteps]; // thinking goes first
   let pendingLegacySteps: WorkflowStep[] = [...thinkingLegacySteps];
+  let pendingStepsMsgs: Message[] = [];
 
   let execOffset = 0;
   let legacyOffset = 0;
@@ -156,6 +157,7 @@ function buildRenderSegments(
           executionSteps: pendingExecSteps,
           legacySteps: pendingLegacySteps,
           isLastGroup: false, // not last yet, there's text after
+          stepsMsgs: pendingStepsMsgs,
         });
       }
 
@@ -165,10 +167,12 @@ function buildRenderSegments(
       // Start accumulating this turn's steps
       pendingExecSteps = [...turnExecSteps];
       pendingLegacySteps = [...turnLegacySteps];
+      pendingStepsMsgs = visibleToolCount > 0 ? [msg] : [];
     } else {
       // No text — accumulate steps
       pendingExecSteps.push(...turnExecSteps);
       pendingLegacySteps.push(...turnLegacySteps);
+      if (visibleToolCount > 0) pendingStepsMsgs.push(msg);
     }
   }
 
@@ -179,6 +183,7 @@ function buildRenderSegments(
       executionSteps: pendingExecSteps,
       legacySteps: pendingLegacySteps,
       isLastGroup: true,
+      stepsMsgs: pendingStepsMsgs,
     });
   }
 
@@ -527,14 +532,30 @@ export default function MessageGroup({ messages, isLastGroup: isLastGroupProp = 
               // finishing and the next LLM turn starting), we still want the
               // dots to keep pulsing so the user knows the loop is still going.
               const hasLaterSegment = segIdx < segments.length - 1;
+              // Exclude ask_user_question from "running" check — that step is
+              // waiting for user input, not processing, so we don't pulse while blocked.
               const execStepsRunning = seg.executionSteps.some(
-                (s) => s.status === 'running' || s.status === 'pending',
+                (s) => (s.status === 'running' || s.status === 'pending') && s.toolName !== TOOL_NAMES.ASK_USER_QUESTION,
               );
               const legacyStepsRunning = seg.legacySteps.some(
                 (s) => s.status === 'running' || s.status === 'pending',
               );
-              const execIsActive = hasLaterSegment ? (groupActive && execStepsRunning) : groupActive;
+              // For the trailing segment, only suppress pulsing if the sole running
+              // step is ask_user_question (otherwise keep pulsing to show loop is alive).
+              const onlyAskUserQuestionRunning =
+                seg.executionSteps.some((s) => s.status === 'running' && s.toolName === TOOL_NAMES.ASK_USER_QUESTION) &&
+                !execStepsRunning;
+              const execIsActive = hasLaterSegment
+                ? (groupActive && execStepsRunning)
+                : (groupActive && !onlyAskUserQuestionRunning);
               const legacyIsActive = hasLaterSegment ? (groupActive && legacyStepsRunning) : groupActive;
+
+              // Settled ask_user_question answers that belong to this steps segment
+              const segSettledUQCards = activeConv?.id
+                ? seg.stepsMsgs
+                    .flatMap((m) => m.toolCalls ?? [])
+                    .filter((tc) => tc.name === TOOL_NAMES.ASK_USER_QUESTION && tc.userQuestionAnswers)
+                : [];
 
               return (
                 <div key={`steps-${segIdx}`}>
@@ -551,6 +572,9 @@ export default function MessageGroup({ messages, isLastGroup: isLastGroupProp = 
                       onRetry={seg.isLastGroup && hasError && !isStreaming ? handleRetry : undefined}
                     />
                   )}
+                  {segSettledUQCards.map((tc) => (
+                    <UserQuestionCard key={`uq-${tc.id}`} toolCall={tc} />
+                  ))}
                 </div>
               );
             })}
@@ -574,19 +598,6 @@ export default function MessageGroup({ messages, isLastGroup: isLastGroupProp = 
                   toolCallId={tc.id}
                   card={tc.noticeCard!}
                   settledAction={tc.noticeCardAction}
-                />
-              );
-            })}
-
-            {activeConv?.id && allToolCalls.filter((tc) => tc.name === TOOL_NAMES.ASK_USER_QUESTION).map((tc) => {
-              const owningMsg = assistantMsgs.find((m) => m.toolCalls?.some((x) => x.id === tc.id));
-              if (!owningMsg) return null;
-              return (
-                <UserQuestionCard
-                  key={`uq-${tc.id}`}
-                  conversationId={activeConv.id}
-                  messageId={owningMsg.id}
-                  toolCall={tc}
                 />
               );
             })}

--- a/src/components/chat/TaskBlock.tsx
+++ b/src/components/chat/TaskBlock.tsx
@@ -19,6 +19,7 @@ import {
   Search,
   Plug,
   Users,
+  MessageSquare,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useI18n, format, type TranslationDict } from '@/i18n';
@@ -435,16 +436,18 @@ function TaskStepItem({ step, showConnector, locale, t }: {
   const isCompleted = step.status === 'completed';
   const isError = step.status === 'error';
   const isThinking = step.type === 'thinking';
+  const isWaitingForAnswer = isRunning && step.toolName === TOOL_NAMES.ASK_USER_QUESTION;
 
   const taskExecutionStore = useTaskExecutionStore();
 
-  // Generate step label - for thinking steps, show duration
+  // Generate step label - for thinking steps, show duration; for waiting ask_user_question, show waiting text
   const stepLabel = useMemo(() => {
+    if (isWaitingForAnswer) return t.userQuestion.waitingForAnswer;
     if (isThinking && isCompleted && step.duration) {
       return format(t.task.thoughtFor, { seconds: step.duration });
     }
     return step.label;
-  }, [step, isThinking, isCompleted, t]);
+  }, [step, isThinking, isCompleted, isWaitingForAnswer, t]);
 
   // Generate completion message if we have tool info
   const completionMsg = useMemo(() => {
@@ -585,7 +588,9 @@ function TaskStepItem({ step, showConnector, locale, t }: {
       {/* Icon column with vertical line */}
       <div className="flex flex-col items-center">
         <div className="w-3.5 h-3.5 mt-0.5 flex items-center justify-center shrink-0">
-          {isRunning ? (
+          {isWaitingForAnswer ? (
+            <MessageSquare className="h-3.5 w-3.5 text-[var(--abu-clay)]" />
+          ) : isRunning ? (
             <Loader2 className="h-3.5 w-3.5 text-[var(--abu-clay)] animate-spin" />
           ) : isError ? (
             <AlertCircle className="h-3.5 w-3.5 text-red-400" />

--- a/src/components/chat/ToolCallsGroup.tsx
+++ b/src/components/chat/ToolCallsGroup.tsx
@@ -1,10 +1,16 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
-import { Wrench, ChevronDown, ChevronRight, CheckCircle2, Loader2, Circle, Maximize2 } from 'lucide-react';
+import { Wrench, ChevronDown, ChevronRight, CheckCircle2, Loader2, Circle, Maximize2, MessageSquare } from 'lucide-react';
 import type { ToolCall, ToolResultContent, Message } from '@/types';
 import { TOOL_NAMES } from '@/core/tools/toolNames';
 import { useChatStore } from '@/stores/chatStore';
+import { useI18n } from '@/i18n';
 import { getBaseName } from '@/utils/pathUtils';
 import { cn } from '@/lib/utils';
+
+/** True when an ask_user_question tool call is parked waiting on the user. */
+function isAwaitingUser(tc: ToolCall): boolean {
+  return tc.name === TOOL_NAMES.ASK_USER_QUESTION && tc.result === undefined;
+}
 
 interface ToolCallsGroupProps {
   toolCalls: ToolCall[];
@@ -42,6 +48,10 @@ export default function ToolCallsGroup({ toolCalls }: ToolCallsGroupProps) {
   // Get current tool to display in collapsed state
   const currentTool = visibleToolCalls[currentDisplayIndex] || visibleToolCalls[0];
   const isAnyExecuting = executingIndex !== -1;
+  // When the in-flight tool is an ask_user_question awaiting the user, show a
+  // static "waiting" state rather than a spinner — the model isn't working.
+  const isAwaitingUserCurrent = !!currentTool && isAwaitingUser(currentTool);
+  const { t } = useI18n();
 
   if (visibleToolCalls.length === 0) return null;
 
@@ -75,7 +85,14 @@ export default function ToolCallsGroup({ toolCalls }: ToolCallsGroupProps) {
             ref={scrollRef}
             className="flex items-center gap-1.5 transition-transform duration-300"
           >
-            {isAnyExecuting ? (
+            {isAwaitingUserCurrent ? (
+              <>
+                <MessageSquare className="h-3 w-3 text-[var(--abu-clay)] shrink-0" />
+                <span className="text-[12px] text-[var(--abu-clay)] truncate">
+                  {t.userQuestion.waitingForAnswer}
+                </span>
+              </>
+            ) : isAnyExecuting ? (
               <>
                 <Loader2 className="h-3 w-3 animate-spin text-[var(--abu-clay)] shrink-0" />
                 <span className="font-mono text-[12px] text-[var(--abu-text-primary)] truncate">
@@ -100,7 +117,12 @@ export default function ToolCallsGroup({ toolCalls }: ToolCallsGroupProps) {
 
         {/* Status badge */}
         <div className="shrink-0">
-          {isAnyExecuting ? (
+          {isAwaitingUserCurrent ? (
+            <span className="flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-[var(--abu-clay-bg)] text-[var(--abu-clay)] font-medium">
+              <MessageSquare className="h-3 w-3" />
+              {t.userQuestion.waitingForAnswer}
+            </span>
+          ) : isAnyExecuting ? (
             <span className="text-[10px] px-1.5 py-0.5 rounded bg-[var(--abu-clay-bg)] text-[var(--abu-clay)] font-medium">
               {completedCount}/{totalCount}
             </span>
@@ -134,8 +156,10 @@ export default function ToolCallsGroup({ toolCalls }: ToolCallsGroupProps) {
  * Individual tool call item in expanded view
  */
 function ToolCallItem({ toolCall, isLast }: { toolCall: ToolCall; isLast: boolean }) {
+  const { t } = useI18n();
   const [showDetails, setShowDetails] = useState(false);
-  const isExecuting = toolCall.isExecuting;
+  const awaitingUser = isAwaitingUser(toolCall);
+  const isExecuting = toolCall.isExecuting && !awaitingUser;
   const isCompleted = toolCall.result !== undefined;
 
   return (
@@ -149,26 +173,32 @@ function ToolCallItem({ toolCall, isLast }: { toolCall: ToolCall; isLast: boolea
         <div className={cn(
           "w-4 h-4 rounded-full flex items-center justify-center shrink-0",
           isCompleted && "bg-emerald-500/15",
-          isExecuting && "bg-[var(--abu-clay-bg-15)]",
-          !isCompleted && !isExecuting && "bg-[var(--abu-bg-hover)]"
+          (isExecuting || awaitingUser) && "bg-[var(--abu-clay-bg-15)]",
+          !isCompleted && !isExecuting && !awaitingUser && "bg-[var(--abu-bg-hover)]"
         )}>
           {isCompleted && <CheckCircle2 className="h-2.5 w-2.5 text-emerald-600" />}
+          {awaitingUser && <MessageSquare className="h-2.5 w-2.5 text-[var(--abu-clay)]" />}
           {isExecuting && <Loader2 className="h-2.5 w-2.5 text-[var(--abu-clay)] animate-spin" />}
-          {!isCompleted && !isExecuting && <Circle className="h-1.5 w-1.5 text-[var(--abu-text-muted)] fill-current" />}
+          {!isCompleted && !isExecuting && !awaitingUser && <Circle className="h-1.5 w-1.5 text-[var(--abu-text-muted)] fill-current" />}
         </div>
 
         {/* Tool name */}
         <span className={cn(
           "font-mono text-[12px] truncate flex-1 text-left",
           isCompleted && "text-[var(--abu-text-primary)]",
-          isExecuting && "text-[var(--abu-clay)] font-medium",
-          !isCompleted && !isExecuting && "text-[var(--abu-text-muted)]"
+          (isExecuting || awaitingUser) && "text-[var(--abu-clay)] font-medium",
+          !isCompleted && !isExecuting && !awaitingUser && "text-[var(--abu-text-muted)]"
         )}>
           {toolCall.name}
+          {awaitingUser && (
+            <span className="ml-1.5 font-sans text-[11px] text-[var(--abu-clay)]">
+              · {t.userQuestion.waitingForAnswer}
+            </span>
+          )}
         </span>
 
         {/* Expand indicator for details */}
-        {(isCompleted || isExecuting) && (
+        {(isCompleted || isExecuting || awaitingUser) && (
           <ChevronRight className={cn(
             "h-3 w-3 text-[var(--abu-text-muted)] transition-transform",
             showDetails && "rotate-90"
@@ -177,7 +207,7 @@ function ToolCallItem({ toolCall, isLast }: { toolCall: ToolCall; isLast: boolea
       </button>
 
       {/* Details panel */}
-      {showDetails && (isCompleted || isExecuting) && (
+      {showDetails && (isCompleted || isExecuting || awaitingUser) && (
         <div className="bg-[#1c1c1e] px-3 py-2.5 space-y-2">
           {/* Input */}
           <div>

--- a/src/components/chat/UserQuestionCard.test.tsx
+++ b/src/components/chat/UserQuestionCard.test.tsx
@@ -1,0 +1,164 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserQuestionCard from './UserQuestionCard';
+import * as bridge from '@/core/agent/permissionBridge';
+import type { ToolCall, UserQuestionPayload } from '@/types';
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      userQuestion: {
+        cardTitle: '请选择',
+        singleSelectHint: '单选',
+        multiSelectHint: '可多选',
+        otherOptionLabel: '其他…',
+        otherInputPlaceholder: '请输入自定义内容',
+        submitButton: '提交',
+        answeredLabel: '已作答',
+        submitDisabledHint: '请为每道题选择或填写答案',
+        cancelledLabel: '已取消',
+      },
+    },
+  }),
+}));
+
+const mockSetAnswers = vi.fn();
+vi.mock('@/stores/chatStore', () => ({
+  useChatStore: (selector: (s: unknown) => unknown) =>
+    selector({ setToolCallUserQuestionAnswers: mockSetAnswers }),
+}));
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+const SINGLE_TC: ToolCall = {
+  id: 'tc-single',
+  name: 'ask_user_question',
+  input: {
+    questions: [
+      {
+        header: '格式',
+        question: '你希望输出什么格式？',
+        multiSelect: false,
+        options: [{ label: '详细', description: '带示例' }, { label: '简洁' }],
+      },
+    ],
+  },
+};
+
+const MULTI_TC: ToolCall = {
+  id: 'tc-multi',
+  name: 'ask_user_question',
+  input: {
+    questions: [
+      {
+        header: 'Sections',
+        question: '包含哪些部分？',
+        multiSelect: true,
+        options: [{ label: '引言' }, { label: '结论' }, { label: '示例' }],
+      },
+    ],
+  },
+};
+
+function makePending(tc: ToolCall) {
+  bridge.requestUserQuestion(tc.id, 'conv-a', tc.input as unknown as UserQuestionPayload);
+}
+
+describe('UserQuestionCard', () => {
+  beforeEach(() => {
+    bridge.drainUserQuestions();
+    mockSetAnswers.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    bridge.drainUserQuestions();
+  });
+
+  it('renders question header, text, options, and the Other option', () => {
+    makePending(SINGLE_TC);
+    render(<UserQuestionCard conversationId="conv-a" messageId="msg-1" toolCall={SINGLE_TC} />);
+
+    expect(screen.getByText('请选择')).toBeInTheDocument();
+    expect(screen.getByText('格式')).toBeInTheDocument();
+    expect(screen.getByText('你希望输出什么格式？')).toBeInTheDocument();
+    expect(screen.getByText('详细')).toBeInTheDocument();
+    expect(screen.getByText('简洁')).toBeInTheDocument();
+    expect(screen.getByText('其他…')).toBeInTheDocument();
+  });
+
+  it('disables submit until an option is chosen', () => {
+    makePending(SINGLE_TC);
+    render(<UserQuestionCard conversationId="conv-a" messageId="msg-1" toolCall={SINGLE_TC} />);
+    expect(screen.getByText('提交').closest('button')).toBeDisabled();
+  });
+
+  it('enables submit after a single-select choice', async () => {
+    const user = userEvent.setup();
+    makePending(SINGLE_TC);
+    render(<UserQuestionCard conversationId="conv-a" messageId="msg-1" toolCall={SINGLE_TC} />);
+
+    await user.click(screen.getByText('详细').closest('button')!);
+    expect(screen.getByText('提交').closest('button')).not.toBeDisabled();
+  });
+
+  it('keeps submit disabled when Other is checked but empty', async () => {
+    const user = userEvent.setup();
+    makePending(SINGLE_TC);
+    render(<UserQuestionCard conversationId="conv-a" messageId="msg-1" toolCall={SINGLE_TC} />);
+
+    await user.click(screen.getByText('其他…').closest('button')!);
+    expect(screen.getByText('提交').closest('button')).toBeDisabled();
+  });
+
+  it('submit calls setAnswers and resolveUserQuestion', async () => {
+    const user = userEvent.setup();
+    const resolveSpy = vi.spyOn(bridge, 'resolveUserQuestion');
+    makePending(SINGLE_TC);
+    render(<UserQuestionCard conversationId="conv-a" messageId="msg-1" toolCall={SINGLE_TC} />);
+
+    await user.click(screen.getByText('详细').closest('button')!);
+    await user.click(screen.getByText('提交').closest('button')!);
+
+    expect(mockSetAnswers).toHaveBeenCalledWith(
+      'conv-a',
+      'msg-1',
+      'tc-single',
+      expect.objectContaining({
+        answers: expect.arrayContaining([
+          expect.objectContaining({ header: '格式', selected: ['详细'] }),
+        ]),
+      }),
+    );
+    expect(resolveSpy).toHaveBeenCalledWith('tc-single', expect.any(Object));
+    resolveSpy.mockRestore();
+  });
+
+  it('renders read-only settled state when answered', () => {
+    const settledTc: ToolCall = {
+      ...SINGLE_TC,
+      userQuestionAnswers: {
+        answers: [{ header: '格式', question: '你希望输出什么格式？', selected: ['详细'] }],
+      },
+    };
+    render(<UserQuestionCard conversationId="conv-a" messageId="msg-1" toolCall={settledTc} />);
+
+    expect(screen.getByText('已作答')).toBeInTheDocument();
+    expect(screen.queryByText('提交')).not.toBeInTheDocument();
+  });
+
+  it('multi-select allows multiple choices', async () => {
+    const user = userEvent.setup();
+    makePending(MULTI_TC);
+    render(<UserQuestionCard conversationId="conv-a" messageId="msg-2" toolCall={MULTI_TC} />);
+
+    await user.click(screen.getByText('引言').closest('button')!);
+    await user.click(screen.getByText('结论').closest('button')!);
+
+    expect(screen.getByText('提交').closest('button')).not.toBeDisabled();
+  });
+});

--- a/src/components/chat/UserQuestionCard.test.tsx
+++ b/src/components/chat/UserQuestionCard.test.tsx
@@ -1,10 +1,8 @@
 /// <reference types="@testing-library/jest-dom" />
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import UserQuestionCard from './UserQuestionCard';
-import * as bridge from '@/core/agent/permissionBridge';
-import type { ToolCall, UserQuestionPayload } from '@/types';
+import type { ToolCall } from '@/types';
 
 // ── Mocks ───────────────────────────────────────────────────────────────
 
@@ -13,29 +11,19 @@ vi.mock('@/i18n', () => ({
     t: {
       userQuestion: {
         cardTitle: '请选择',
-        singleSelectHint: '单选',
-        multiSelectHint: '可多选',
-        otherOptionLabel: '其他…',
-        otherInputPlaceholder: '请输入自定义内容',
-        submitButton: '提交',
-        answeredLabel: '已作答',
-        submitDisabledHint: '请为每道题选择或填写答案',
         cancelledLabel: '已取消',
+        yourChoiceLabel: '你的选择',
       },
     },
+    format: (tpl: string, v: Record<string, string | number>) =>
+      tpl.replace(/\{(\w+)\}/g, (_, k) => String(v[k] ?? '')),
   }),
-}));
-
-const mockSetAnswers = vi.fn();
-vi.mock('@/stores/chatStore', () => ({
-  useChatStore: (selector: (s: unknown) => unknown) =>
-    selector({ setToolCallUserQuestionAnswers: mockSetAnswers }),
 }));
 
 // ── Fixtures ─────────────────────────────────────────────────────────────
 
-const SINGLE_TC: ToolCall = {
-  id: 'tc-single',
+const SETTLED_TC: ToolCall = {
+  id: 'tc-settled',
   name: 'ask_user_question',
   input: {
     questions: [
@@ -43,122 +31,45 @@ const SINGLE_TC: ToolCall = {
         header: '格式',
         question: '你希望输出什么格式？',
         multiSelect: false,
-        options: [{ label: '详细', description: '带示例' }, { label: '简洁' }],
+        options: [{ label: '详细' }, { label: '简洁' }],
       },
     ],
   },
-};
-
-const MULTI_TC: ToolCall = {
-  id: 'tc-multi',
-  name: 'ask_user_question',
-  input: {
-    questions: [
-      {
-        header: 'Sections',
-        question: '包含哪些部分？',
-        multiSelect: true,
-        options: [{ label: '引言' }, { label: '结论' }, { label: '示例' }],
-      },
-    ],
+  userQuestionAnswers: {
+    answers: [{ header: '格式', question: '你希望输出什么格式？', selected: ['详细'] }],
   },
 };
 
-function makePending(tc: ToolCall) {
-  bridge.requestUserQuestion(tc.id, 'conv-a', tc.input as unknown as UserQuestionPayload);
-}
+describe('UserQuestionCard (settled, read-only)', () => {
+  afterEach(() => cleanup());
 
-describe('UserQuestionCard', () => {
-  beforeEach(() => {
-    bridge.drainUserQuestions();
-    mockSetAnswers.mockClear();
-  });
+  it('renders a left-aligned "your choices" card with question and answer', () => {
+    render(<UserQuestionCard toolCall={SETTLED_TC} />);
 
-  afterEach(() => {
-    cleanup();
-    bridge.drainUserQuestions();
-  });
-
-  it('renders question header, text, options, and the Other option', () => {
-    makePending(SINGLE_TC);
-    render(<UserQuestionCard conversationId="conv-a" messageId="msg-1" toolCall={SINGLE_TC} />);
-
-    expect(screen.getByText('请选择')).toBeInTheDocument();
-    expect(screen.getByText('格式')).toBeInTheDocument();
+    // "Your choices" header present
+    expect(screen.getByText('你的选择')).toBeInTheDocument();
+    // Question + answer text present
     expect(screen.getByText('你希望输出什么格式？')).toBeInTheDocument();
     expect(screen.getByText('详细')).toBeInTheDocument();
-    expect(screen.getByText('简洁')).toBeInTheDocument();
-    expect(screen.getByText('其他…')).toBeInTheDocument();
-  });
-
-  it('disables submit until an option is chosen', () => {
-    makePending(SINGLE_TC);
-    render(<UserQuestionCard conversationId="conv-a" messageId="msg-1" toolCall={SINGLE_TC} />);
-    expect(screen.getByText('提交').closest('button')).toBeDisabled();
-  });
-
-  it('enables submit after a single-select choice', async () => {
-    const user = userEvent.setup();
-    makePending(SINGLE_TC);
-    render(<UserQuestionCard conversationId="conv-a" messageId="msg-1" toolCall={SINGLE_TC} />);
-
-    await user.click(screen.getByText('详细').closest('button')!);
-    expect(screen.getByText('提交').closest('button')).not.toBeDisabled();
-  });
-
-  it('keeps submit disabled when Other is checked but empty', async () => {
-    const user = userEvent.setup();
-    makePending(SINGLE_TC);
-    render(<UserQuestionCard conversationId="conv-a" messageId="msg-1" toolCall={SINGLE_TC} />);
-
-    await user.click(screen.getByText('其他…').closest('button')!);
-    expect(screen.getByText('提交').closest('button')).toBeDisabled();
-  });
-
-  it('submit calls setAnswers and resolveUserQuestion', async () => {
-    const user = userEvent.setup();
-    const resolveSpy = vi.spyOn(bridge, 'resolveUserQuestion');
-    makePending(SINGLE_TC);
-    render(<UserQuestionCard conversationId="conv-a" messageId="msg-1" toolCall={SINGLE_TC} />);
-
-    await user.click(screen.getByText('详细').closest('button')!);
-    await user.click(screen.getByText('提交').closest('button')!);
-
-    expect(mockSetAnswers).toHaveBeenCalledWith(
-      'conv-a',
-      'msg-1',
-      'tc-single',
-      expect.objectContaining({
-        answers: expect.arrayContaining([
-          expect.objectContaining({ header: '格式', selected: ['详细'] }),
-        ]),
-      }),
-    );
-    expect(resolveSpy).toHaveBeenCalledWith('tc-single', expect.any(Object));
-    resolveSpy.mockRestore();
-  });
-
-  it('renders read-only settled state when answered', () => {
-    const settledTc: ToolCall = {
-      ...SINGLE_TC,
-      userQuestionAnswers: {
-        answers: [{ header: '格式', question: '你希望输出什么格式？', selected: ['详细'] }],
-      },
-    };
-    render(<UserQuestionCard conversationId="conv-a" messageId="msg-1" toolCall={settledTc} />);
-
-    expect(screen.getByText('已作答')).toBeInTheDocument();
+    // No interactive submit control
     expect(screen.queryByText('提交')).not.toBeInTheDocument();
   });
 
-  it('multi-select allows multiple choices', async () => {
-    const user = userEvent.setup();
-    makePending(MULTI_TC);
-    render(<UserQuestionCard conversationId="conv-a" messageId="msg-2" toolCall={MULTI_TC} />);
+  it('joins multi-select answers with 、', () => {
+    const multiTc: ToolCall = {
+      ...SETTLED_TC,
+      id: 'tc-multi',
+      userQuestionAnswers: {
+        answers: [{ header: 'Sections', question: '包含哪些部分？', selected: ['引言', '结论'] }],
+      },
+    };
+    render(<UserQuestionCard toolCall={multiTc} />);
+    expect(screen.getByText('引言、结论')).toBeInTheDocument();
+  });
 
-    await user.click(screen.getByText('引言').closest('button')!);
-    await user.click(screen.getByText('结论').closest('button')!);
-
-    expect(screen.getByText('提交').closest('button')).not.toBeDisabled();
+  it('renders a cancelled marker when there are no answers', () => {
+    const cancelledTc: ToolCall = { ...SETTLED_TC, id: 'tc-cancel', userQuestionAnswers: undefined };
+    render(<UserQuestionCard toolCall={cancelledTc} />);
+    expect(screen.getByText(/已取消/)).toBeInTheDocument();
   });
 });

--- a/src/components/chat/UserQuestionCard.tsx
+++ b/src/components/chat/UserQuestionCard.tsx
@@ -1,102 +1,30 @@
 /**
- * UserQuestionCard — interactive choice card rendering an ask_user_question call.
+ * UserQuestionCard — read-only rendering of a *settled* ask_user_question call.
  *
- * Two modes:
- * - pending: there's a matching entry in the pending queue → interactive
- *   (select + submit)
- * - settled: tc.userQuestionAnswers is set, or the pending entry was
- *   drained/timed-out → read-only
+ * The interactive / paginated surface now lives in UserQuestionDock (docked
+ * above the composer). This component only renders once the user has answered:
+ * a right-aligned "user message" style bubble where each question is shown as
+ * two lines — `Q: <question>` / `A: <selected>` — with a blank line between
+ * questions. Multi-select answers join with "、"; "Other" shows the custom text.
  *
- * Each question gets an auto-appended "Other…" free-text escape hatch;
- * the submit button stays disabled until every question has a valid answer.
+ * If a tool call reaches this component without `userQuestionAnswers` (e.g.
+ * drained / timed out after the dock unmounted), a minimal cancelled marker is
+ * shown instead.
  */
 
-import { useState, useRef, useEffect, useSyncExternalStore } from 'react';
-import { MessageSquare, Check } from 'lucide-react';
+import { MessageSquare } from 'lucide-react';
 import { useI18n } from '@/i18n';
-import { useChatStore } from '@/stores/chatStore';
-import { getPendingUserQuestions, resolveUserQuestion, subscribeUserQuestion } from '@/core/agent/permissionBridge';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { cn } from '@/lib/utils';
-import type { ToolCall, UserQuestionPayload, UserQuestionResult, UserQuestionAnswerItem } from '@/types';
+import type { ToolCall } from '@/types';
 
 interface Props {
-  conversationId: string;
-  messageId: string;
   toolCall: ToolCall;
 }
 
-/** Per-question local selection state */
-interface QuestionState {
-  selected: Set<string>;
-  otherChecked: boolean;
-  otherText: string;
-}
-
-function initQuestionStates(count: number): QuestionState[] {
-  return Array.from({ length: count }, () => ({
-    selected: new Set<string>(),
-    otherChecked: false,
-    otherText: '',
-  }));
-}
-
-export default function UserQuestionCard({ conversationId, messageId, toolCall }: Props) {
+export default function UserQuestionCard({ toolCall }: Props) {
   const { t } = useI18n();
-  const setAnswers = useChatStore((s) => s.setToolCallUserQuestionAnswers);
 
-  // Subscribe to the pending queue — re-render when it changes
-  const pendingQuestions = useSyncExternalStore(subscribeUserQuestion, getPendingUserQuestions);
-  const isPending = pendingQuestions.some((pq) => pq.id === toolCall.id);
-
-  // Question data comes from the tool input (available as soon as streaming ends)
-  const payload = toolCall.input as unknown as UserQuestionPayload;
-  const questions = payload?.questions ?? [];
-
-  // Per-question selection state (only meaningful while interactive)
-  const [questionStates, setQuestionStates] = useState<QuestionState[]>(() =>
-    initQuestionStates(questions.length),
-  );
-
-  // Scroll into view when the card first appears as interactive
-  const cardRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (isPending && cardRef.current) {
-      cardRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-    }
-  }, [isPending]);
-
-  // ── Settled state: already answered ────────────────────────────────────
-  if (toolCall.userQuestionAnswers) {
-    const { answers } = toolCall.userQuestionAnswers;
-    return (
-      <div className="my-2 rounded-xl border border-[var(--abu-border-subtle)] bg-[var(--abu-bg-muted)] overflow-hidden">
-        <div className="px-3 py-2 border-b border-[var(--abu-border-subtle)] flex items-center gap-2">
-          <MessageSquare className="h-3.5 w-3.5 text-[var(--abu-clay)]" />
-          <span className="text-xs font-semibold text-[var(--abu-text-primary)]">
-            {t.userQuestion.answeredLabel}
-          </span>
-        </div>
-        <div className="px-3 py-2.5 space-y-2">
-          {answers.map((ans, i) => (
-            <div key={i} className="text-xs">
-              <span className="inline-block px-1.5 py-0.5 rounded bg-[var(--abu-bg-base)] border border-[var(--abu-border-subtle)] text-[var(--abu-text-tertiary)] font-medium mr-1.5">
-                {ans.header}
-              </span>
-              <span className="text-[var(--abu-text-secondary)]">{ans.question}</span>
-              <div className="mt-1 ml-1 text-[var(--abu-text-primary)] font-medium">
-                → {ans.selected.join('、')}
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    );
-  }
-
-  // ── Not settled and not pending: cancelled / drained ───────────────────
-  if (!isPending) {
+  // ── Cancelled / drained (no answers) ───────────────────────────────────
+  if (!toolCall.userQuestionAnswers) {
     return (
       <div className="my-2 px-3 py-2 rounded-lg border border-[var(--abu-border-subtle)] bg-[var(--abu-bg-muted)] text-xs text-[var(--abu-text-tertiary)]">
         <MessageSquare className="inline h-3.5 w-3.5 mr-1.5" />
@@ -105,217 +33,26 @@ export default function UserQuestionCard({ conversationId, messageId, toolCall }
     );
   }
 
-  // ── Interactive state ──────────────────────────────────────────────────
-
-  const toggleOption = (qIdx: number, label: string, multiSelect: boolean) => {
-    setQuestionStates((prev) => {
-      const next = prev.map((s, i) =>
-        i === qIdx ? { ...s, selected: new Set(s.selected) } : s,
-      );
-      const state = next[qIdx];
-      if (multiSelect) {
-        if (state.selected.has(label)) {
-          state.selected.delete(label);
-        } else {
-          state.selected.add(label);
-        }
-      } else {
-        // Single select: replace selection, drop "other"
-        state.selected = new Set([label]);
-        state.otherChecked = false;
-      }
-      return next;
-    });
-  };
-
-  const toggleOther = (qIdx: number, multiSelect: boolean) => {
-    setQuestionStates((prev) => {
-      const next = prev.map((s, i) => (i === qIdx ? { ...s, selected: new Set(s.selected) } : s));
-      const state = next[qIdx];
-      if (multiSelect) {
-        state.otherChecked = !state.otherChecked;
-      } else {
-        // Single select: checking "other" clears the regular selection
-        state.otherChecked = !state.otherChecked;
-        if (state.otherChecked) state.selected = new Set();
-      }
-      return next;
-    });
-  };
-
-  const setOtherText = (qIdx: number, text: string) => {
-    setQuestionStates((prev) => {
-      const next = [...prev];
-      next[qIdx] = { ...prev[qIdx], otherText: text };
-      return next;
-    });
-  };
-
-  /** Whether a single question has a valid answer */
-  const isQuestionValid = (qIdx: number): boolean => {
-    const q = questions[qIdx];
-    const state = questionStates[qIdx];
-    if (!q || !state) return false;
-    const hasRegular = state.selected.size > 0;
-    const hasOther = state.otherChecked && state.otherText.trim().length > 0;
-    return hasRegular || hasOther;
-  };
-
-  const allValid = questions.length > 0 && questions.every((_, i) => isQuestionValid(i));
-
-  const handleSubmit = () => {
-    const answers: UserQuestionAnswerItem[] = questions.map((q, i) => {
-      const state = questionStates[i];
-      let selected: string[];
-      if (q.multiSelect) {
-        selected = [...state.selected];
-        if (state.otherChecked && state.otherText.trim()) {
-          selected.push(state.otherText.trim());
-        }
-      } else {
-        if (state.otherChecked && state.otherText.trim()) {
-          selected = [state.otherText.trim()];
-        } else {
-          selected = [...state.selected];
-        }
-      }
-      return { header: q.header, question: q.question, selected };
-    });
-
-    const result: UserQuestionResult = { answers };
-    setAnswers(conversationId, messageId, toolCall.id, result);
-    resolveUserQuestion(toolCall.id, result);
-  };
+  // ── Settled: left-aligned, integrated "your choices" card (agent side) ──
+  const { answers } = toolCall.userQuestionAnswers;
 
   return (
-    <div
-      ref={cardRef}
-      className="my-2 rounded-xl border border-[var(--abu-border)] bg-[var(--abu-bg-elevated)] overflow-hidden"
-    >
-      {/* Header */}
-      <div className="px-3 py-2 border-b border-[var(--abu-border-subtle)] flex items-center gap-2">
-        <MessageSquare className="h-3.5 w-3.5 text-[var(--abu-clay)]" />
-        <span className="text-xs font-semibold text-[var(--abu-text-primary)]">
-          {t.userQuestion.cardTitle}
-        </span>
-      </div>
-
-      {/* Questions */}
-      <div className="px-3 py-2.5 space-y-4">
-        {questions.map((q, qIdx) => {
-          const state = questionStates[qIdx];
-          const hint = q.multiSelect
-            ? t.userQuestion.multiSelectHint
-            : t.userQuestion.singleSelectHint;
-
-          return (
-            <div key={qIdx} className="space-y-1.5">
-              {/* Header chip + question text */}
-              <div className="flex items-start gap-2 flex-wrap">
-                <span className="inline-block px-1.5 py-0.5 rounded bg-[var(--abu-bg-base)] border border-[var(--abu-border-subtle)] text-[11px] text-[var(--abu-text-tertiary)] font-medium flex-shrink-0">
-                  {q.header}
-                </span>
-                <span className="text-xs text-[var(--abu-text-primary)] flex-1">
-                  {q.question}
-                </span>
-                <span className="text-[11px] text-[var(--abu-text-muted)] flex-shrink-0">{hint}</span>
-              </div>
-
-              {/* Options */}
-              <div className="pl-1 space-y-1">
-                {q.options.map((opt, oIdx) => {
-                  const isChecked = state.selected.has(opt.label);
-                  return (
-                    <button
-                      key={oIdx}
-                      type="button"
-                      onClick={() => toggleOption(qIdx, opt.label, q.multiSelect)}
-                      className={cn(
-                        'w-full text-left px-2.5 py-1.5 rounded-lg text-xs transition-colors flex items-start gap-2',
-                        isChecked
-                          ? 'bg-[var(--abu-clay-bg)] border border-[var(--abu-clay-ring)] text-[var(--abu-text-primary)]'
-                          : 'border border-[var(--abu-border-subtle)] text-[var(--abu-text-secondary)] hover:bg-[var(--abu-bg-muted)] hover:border-[var(--abu-border)]',
-                      )}
-                    >
-                      <span
-                        className={cn(
-                          'mt-0.5 h-3.5 w-3.5 flex-shrink-0 border flex items-center justify-center',
-                          q.multiSelect ? 'rounded-sm' : 'rounded-full',
-                          isChecked
-                            ? 'bg-[var(--abu-clay)] border-[var(--abu-clay)]'
-                            : 'border-[var(--abu-border)]',
-                        )}
-                      >
-                        {isChecked && <Check className="h-2.5 w-2.5 text-white" />}
-                      </span>
-                      <span className="flex-1 min-w-0">
-                        <span className="font-medium">{opt.label}</span>
-                        {opt.description && (
-                          <span className="block text-[11px] text-[var(--abu-text-muted)] mt-0.5">
-                            {opt.description}
-                          </span>
-                        )}
-                      </span>
-                    </button>
-                  );
-                })}
-
-                {/* "Other…" option */}
-                <div>
-                  <button
-                    type="button"
-                    onClick={() => toggleOther(qIdx, q.multiSelect)}
-                    className={cn(
-                      'w-full text-left px-2.5 py-1.5 rounded-lg text-xs transition-colors flex items-center gap-2',
-                      state.otherChecked
-                        ? 'bg-[var(--abu-clay-bg)] border border-[var(--abu-clay-ring)] text-[var(--abu-text-primary)]'
-                        : 'border border-[var(--abu-border-subtle)] text-[var(--abu-text-tertiary)] hover:bg-[var(--abu-bg-muted)] hover:border-[var(--abu-border)]',
-                    )}
-                  >
-                    <span
-                      className={cn(
-                        'h-3.5 w-3.5 flex-shrink-0 border flex items-center justify-center',
-                        q.multiSelect ? 'rounded-sm' : 'rounded-full',
-                        state.otherChecked
-                          ? 'bg-[var(--abu-clay)] border-[var(--abu-clay)]'
-                          : 'border-[var(--abu-border)]',
-                      )}
-                    >
-                      {state.otherChecked && <Check className="h-2.5 w-2.5 text-white" />}
-                    </span>
-                    <span className="italic">{t.userQuestion.otherOptionLabel}</span>
-                  </button>
-
-                  {state.otherChecked && (
-                    <div className="mt-1.5 pl-1">
-                      <Input
-                        type="text"
-                        value={state.otherText}
-                        onChange={(e) => setOtherText(qIdx, e.target.value)}
-                        placeholder={t.userQuestion.otherInputPlaceholder}
-                        className="h-7 text-xs"
-                        autoFocus
-                      />
-                    </div>
-                  )}
-                </div>
-              </div>
+    <div className="my-2 flex justify-start w-full">
+      <div className="max-w-[460px] rounded-xl border border-[var(--abu-border)] bg-white px-3.5 py-3">
+        <div className="flex items-center gap-1.5 mb-2 text-[11px] font-semibold text-[var(--abu-text-tertiary)]">
+          <MessageSquare className="h-3.5 w-3.5 text-[var(--abu-clay)]" />
+          {t.userQuestion.yourChoiceLabel}
+        </div>
+        <div className="divide-y divide-[var(--abu-border-subtle)]">
+          {answers.map((ans, i) => (
+            <div key={i} className="py-1.5 first:pt-0 last:pb-0">
+              <p className="text-[12px] text-[var(--abu-text-tertiary)] mb-0.5 break-words">{ans.question}</p>
+              <p className="text-[13.5px] font-semibold text-[var(--abu-text-primary)] break-words">
+                {ans.selected.join('、')}
+              </p>
             </div>
-          );
-        })}
-      </div>
-
-      {/* Footer */}
-      <div className="px-3 py-2 border-t border-[var(--abu-border-subtle)] bg-[var(--abu-bg-base)] flex items-center justify-end">
-        <Button
-          size="sm"
-          onClick={handleSubmit}
-          disabled={!allValid}
-          title={!allValid ? t.userQuestion.submitDisabledHint : undefined}
-          className="text-xs"
-        >
-          {t.userQuestion.submitButton}
-        </Button>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/components/chat/UserQuestionCard.tsx
+++ b/src/components/chat/UserQuestionCard.tsx
@@ -1,0 +1,322 @@
+/**
+ * UserQuestionCard — interactive choice card rendering an ask_user_question call.
+ *
+ * Two modes:
+ * - pending: there's a matching entry in the pending queue → interactive
+ *   (select + submit)
+ * - settled: tc.userQuestionAnswers is set, or the pending entry was
+ *   drained/timed-out → read-only
+ *
+ * Each question gets an auto-appended "Other…" free-text escape hatch;
+ * the submit button stays disabled until every question has a valid answer.
+ */
+
+import { useState, useRef, useEffect, useSyncExternalStore } from 'react';
+import { MessageSquare, Check } from 'lucide-react';
+import { useI18n } from '@/i18n';
+import { useChatStore } from '@/stores/chatStore';
+import { getPendingUserQuestions, resolveUserQuestion, subscribeUserQuestion } from '@/core/agent/permissionBridge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import type { ToolCall, UserQuestionPayload, UserQuestionResult, UserQuestionAnswerItem } from '@/types';
+
+interface Props {
+  conversationId: string;
+  messageId: string;
+  toolCall: ToolCall;
+}
+
+/** Per-question local selection state */
+interface QuestionState {
+  selected: Set<string>;
+  otherChecked: boolean;
+  otherText: string;
+}
+
+function initQuestionStates(count: number): QuestionState[] {
+  return Array.from({ length: count }, () => ({
+    selected: new Set<string>(),
+    otherChecked: false,
+    otherText: '',
+  }));
+}
+
+export default function UserQuestionCard({ conversationId, messageId, toolCall }: Props) {
+  const { t } = useI18n();
+  const setAnswers = useChatStore((s) => s.setToolCallUserQuestionAnswers);
+
+  // Subscribe to the pending queue — re-render when it changes
+  const pendingQuestions = useSyncExternalStore(subscribeUserQuestion, getPendingUserQuestions);
+  const isPending = pendingQuestions.some((pq) => pq.id === toolCall.id);
+
+  // Question data comes from the tool input (available as soon as streaming ends)
+  const payload = toolCall.input as unknown as UserQuestionPayload;
+  const questions = payload?.questions ?? [];
+
+  // Per-question selection state (only meaningful while interactive)
+  const [questionStates, setQuestionStates] = useState<QuestionState[]>(() =>
+    initQuestionStates(questions.length),
+  );
+
+  // Scroll into view when the card first appears as interactive
+  const cardRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (isPending && cardRef.current) {
+      cardRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }, [isPending]);
+
+  // ── Settled state: already answered ────────────────────────────────────
+  if (toolCall.userQuestionAnswers) {
+    const { answers } = toolCall.userQuestionAnswers;
+    return (
+      <div className="my-2 rounded-xl border border-[var(--abu-border-subtle)] bg-[var(--abu-bg-muted)] overflow-hidden">
+        <div className="px-3 py-2 border-b border-[var(--abu-border-subtle)] flex items-center gap-2">
+          <MessageSquare className="h-3.5 w-3.5 text-[var(--abu-clay)]" />
+          <span className="text-xs font-semibold text-[var(--abu-text-primary)]">
+            {t.userQuestion.answeredLabel}
+          </span>
+        </div>
+        <div className="px-3 py-2.5 space-y-2">
+          {answers.map((ans, i) => (
+            <div key={i} className="text-xs">
+              <span className="inline-block px-1.5 py-0.5 rounded bg-[var(--abu-bg-base)] border border-[var(--abu-border-subtle)] text-[var(--abu-text-tertiary)] font-medium mr-1.5">
+                {ans.header}
+              </span>
+              <span className="text-[var(--abu-text-secondary)]">{ans.question}</span>
+              <div className="mt-1 ml-1 text-[var(--abu-text-primary)] font-medium">
+                → {ans.selected.join('、')}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Not settled and not pending: cancelled / drained ───────────────────
+  if (!isPending) {
+    return (
+      <div className="my-2 px-3 py-2 rounded-lg border border-[var(--abu-border-subtle)] bg-[var(--abu-bg-muted)] text-xs text-[var(--abu-text-tertiary)]">
+        <MessageSquare className="inline h-3.5 w-3.5 mr-1.5" />
+        {t.userQuestion.cardTitle} — {t.userQuestion.cancelledLabel}
+      </div>
+    );
+  }
+
+  // ── Interactive state ──────────────────────────────────────────────────
+
+  const toggleOption = (qIdx: number, label: string, multiSelect: boolean) => {
+    setQuestionStates((prev) => {
+      const next = prev.map((s, i) =>
+        i === qIdx ? { ...s, selected: new Set(s.selected) } : s,
+      );
+      const state = next[qIdx];
+      if (multiSelect) {
+        if (state.selected.has(label)) {
+          state.selected.delete(label);
+        } else {
+          state.selected.add(label);
+        }
+      } else {
+        // Single select: replace selection, drop "other"
+        state.selected = new Set([label]);
+        state.otherChecked = false;
+      }
+      return next;
+    });
+  };
+
+  const toggleOther = (qIdx: number, multiSelect: boolean) => {
+    setQuestionStates((prev) => {
+      const next = prev.map((s, i) => (i === qIdx ? { ...s, selected: new Set(s.selected) } : s));
+      const state = next[qIdx];
+      if (multiSelect) {
+        state.otherChecked = !state.otherChecked;
+      } else {
+        // Single select: checking "other" clears the regular selection
+        state.otherChecked = !state.otherChecked;
+        if (state.otherChecked) state.selected = new Set();
+      }
+      return next;
+    });
+  };
+
+  const setOtherText = (qIdx: number, text: string) => {
+    setQuestionStates((prev) => {
+      const next = [...prev];
+      next[qIdx] = { ...prev[qIdx], otherText: text };
+      return next;
+    });
+  };
+
+  /** Whether a single question has a valid answer */
+  const isQuestionValid = (qIdx: number): boolean => {
+    const q = questions[qIdx];
+    const state = questionStates[qIdx];
+    if (!q || !state) return false;
+    const hasRegular = state.selected.size > 0;
+    const hasOther = state.otherChecked && state.otherText.trim().length > 0;
+    return hasRegular || hasOther;
+  };
+
+  const allValid = questions.length > 0 && questions.every((_, i) => isQuestionValid(i));
+
+  const handleSubmit = () => {
+    const answers: UserQuestionAnswerItem[] = questions.map((q, i) => {
+      const state = questionStates[i];
+      let selected: string[];
+      if (q.multiSelect) {
+        selected = [...state.selected];
+        if (state.otherChecked && state.otherText.trim()) {
+          selected.push(state.otherText.trim());
+        }
+      } else {
+        if (state.otherChecked && state.otherText.trim()) {
+          selected = [state.otherText.trim()];
+        } else {
+          selected = [...state.selected];
+        }
+      }
+      return { header: q.header, question: q.question, selected };
+    });
+
+    const result: UserQuestionResult = { answers };
+    setAnswers(conversationId, messageId, toolCall.id, result);
+    resolveUserQuestion(toolCall.id, result);
+  };
+
+  return (
+    <div
+      ref={cardRef}
+      className="my-2 rounded-xl border border-[var(--abu-border)] bg-[var(--abu-bg-elevated)] overflow-hidden"
+    >
+      {/* Header */}
+      <div className="px-3 py-2 border-b border-[var(--abu-border-subtle)] flex items-center gap-2">
+        <MessageSquare className="h-3.5 w-3.5 text-[var(--abu-clay)]" />
+        <span className="text-xs font-semibold text-[var(--abu-text-primary)]">
+          {t.userQuestion.cardTitle}
+        </span>
+      </div>
+
+      {/* Questions */}
+      <div className="px-3 py-2.5 space-y-4">
+        {questions.map((q, qIdx) => {
+          const state = questionStates[qIdx];
+          const hint = q.multiSelect
+            ? t.userQuestion.multiSelectHint
+            : t.userQuestion.singleSelectHint;
+
+          return (
+            <div key={qIdx} className="space-y-1.5">
+              {/* Header chip + question text */}
+              <div className="flex items-start gap-2 flex-wrap">
+                <span className="inline-block px-1.5 py-0.5 rounded bg-[var(--abu-bg-base)] border border-[var(--abu-border-subtle)] text-[11px] text-[var(--abu-text-tertiary)] font-medium flex-shrink-0">
+                  {q.header}
+                </span>
+                <span className="text-xs text-[var(--abu-text-primary)] flex-1">
+                  {q.question}
+                </span>
+                <span className="text-[11px] text-[var(--abu-text-muted)] flex-shrink-0">{hint}</span>
+              </div>
+
+              {/* Options */}
+              <div className="pl-1 space-y-1">
+                {q.options.map((opt, oIdx) => {
+                  const isChecked = state.selected.has(opt.label);
+                  return (
+                    <button
+                      key={oIdx}
+                      type="button"
+                      onClick={() => toggleOption(qIdx, opt.label, q.multiSelect)}
+                      className={cn(
+                        'w-full text-left px-2.5 py-1.5 rounded-lg text-xs transition-colors flex items-start gap-2',
+                        isChecked
+                          ? 'bg-[var(--abu-clay-bg)] border border-[var(--abu-clay-ring)] text-[var(--abu-text-primary)]'
+                          : 'border border-[var(--abu-border-subtle)] text-[var(--abu-text-secondary)] hover:bg-[var(--abu-bg-muted)] hover:border-[var(--abu-border)]',
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          'mt-0.5 h-3.5 w-3.5 flex-shrink-0 border flex items-center justify-center',
+                          q.multiSelect ? 'rounded-sm' : 'rounded-full',
+                          isChecked
+                            ? 'bg-[var(--abu-clay)] border-[var(--abu-clay)]'
+                            : 'border-[var(--abu-border)]',
+                        )}
+                      >
+                        {isChecked && <Check className="h-2.5 w-2.5 text-white" />}
+                      </span>
+                      <span className="flex-1 min-w-0">
+                        <span className="font-medium">{opt.label}</span>
+                        {opt.description && (
+                          <span className="block text-[11px] text-[var(--abu-text-muted)] mt-0.5">
+                            {opt.description}
+                          </span>
+                        )}
+                      </span>
+                    </button>
+                  );
+                })}
+
+                {/* "Other…" option */}
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => toggleOther(qIdx, q.multiSelect)}
+                    className={cn(
+                      'w-full text-left px-2.5 py-1.5 rounded-lg text-xs transition-colors flex items-center gap-2',
+                      state.otherChecked
+                        ? 'bg-[var(--abu-clay-bg)] border border-[var(--abu-clay-ring)] text-[var(--abu-text-primary)]'
+                        : 'border border-[var(--abu-border-subtle)] text-[var(--abu-text-tertiary)] hover:bg-[var(--abu-bg-muted)] hover:border-[var(--abu-border)]',
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        'h-3.5 w-3.5 flex-shrink-0 border flex items-center justify-center',
+                        q.multiSelect ? 'rounded-sm' : 'rounded-full',
+                        state.otherChecked
+                          ? 'bg-[var(--abu-clay)] border-[var(--abu-clay)]'
+                          : 'border-[var(--abu-border)]',
+                      )}
+                    >
+                      {state.otherChecked && <Check className="h-2.5 w-2.5 text-white" />}
+                    </span>
+                    <span className="italic">{t.userQuestion.otherOptionLabel}</span>
+                  </button>
+
+                  {state.otherChecked && (
+                    <div className="mt-1.5 pl-1">
+                      <Input
+                        type="text"
+                        value={state.otherText}
+                        onChange={(e) => setOtherText(qIdx, e.target.value)}
+                        placeholder={t.userQuestion.otherInputPlaceholder}
+                        className="h-7 text-xs"
+                        autoFocus
+                      />
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Footer */}
+      <div className="px-3 py-2 border-t border-[var(--abu-border-subtle)] bg-[var(--abu-bg-base)] flex items-center justify-end">
+        <Button
+          size="sm"
+          onClick={handleSubmit}
+          disabled={!allValid}
+          title={!allValid ? t.userQuestion.submitDisabledHint : undefined}
+          className="text-xs"
+        >
+          {t.userQuestion.submitButton}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/UserQuestionDock.test.tsx
+++ b/src/components/chat/UserQuestionDock.test.tsx
@@ -1,0 +1,181 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserQuestionDock from './UserQuestionDock';
+import * as bridge from '@/core/agent/permissionBridge';
+import type { UserQuestionPayload } from '@/types';
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      userQuestion: {
+        singleSelectHint: '单选',
+        multiSelectHint: '可多选',
+        otherOptionLabel: '其他…',
+        otherInputPlaceholder: '请输入自定义内容',
+        submitButton: '提交',
+        submitDisabledHint: '请为每道题选择或填写答案',
+        pager: '{current} / {total}',
+        skip: '跳过',
+        skippedMarker: '（已跳过）',
+        navHint: '导航提示',
+        prevQuestion: '上一题',
+        nextQuestion: '下一题',
+        close: '关闭',
+      },
+    },
+    format: (tpl: string, v: Record<string, string | number>) =>
+      tpl.replace(/\{(\w+)\}/g, (_, k) => String(v[k] ?? '')),
+  }),
+}));
+
+const mockSetAnswers = vi.fn();
+vi.mock('@/stores/chatStore', () => ({
+  useChatStore: (selector: (s: unknown) => unknown) =>
+    selector({ setToolCallUserQuestionAnswers: mockSetAnswers }),
+}));
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+const SINGLE_PAYLOAD: UserQuestionPayload = {
+  questions: [
+    {
+      header: '格式',
+      question: '你希望输出什么格式？',
+      multiSelect: false,
+      options: [{ label: '详细', description: '带示例' }, { label: '简洁' }],
+    },
+  ],
+};
+
+const MULTI_PAYLOAD: UserQuestionPayload = {
+  questions: [
+    {
+      header: 'Sections',
+      question: '包含哪些部分？',
+      multiSelect: true,
+      options: [{ label: '引言' }, { label: '结论' }, { label: '示例' }],
+    },
+  ],
+};
+
+const TWO_Q_PAYLOAD: UserQuestionPayload = {
+  questions: [
+    { header: 'Q1', question: '第一题？', multiSelect: false, options: [{ label: 'A' }, { label: 'B' }] },
+    { header: 'Q2', question: '第二题？', multiSelect: false, options: [{ label: 'C' }, { label: 'D' }] },
+  ],
+};
+
+function renderDock(payload: UserQuestionPayload, toolCallId = 'tc-1') {
+  return render(
+    <UserQuestionDock
+      conversationId="conv-a"
+      messageId="msg-1"
+      toolCallId={toolCallId}
+      payload={payload}
+    />,
+  );
+}
+
+describe('UserQuestionDock', () => {
+  beforeEach(() => {
+    mockSetAnswers.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    bridge.drainUserQuestions();
+  });
+
+  it('renders header, question text, numbered options, Other and Skip', () => {
+    renderDock(SINGLE_PAYLOAD);
+    expect(screen.getByText('格式')).toBeInTheDocument();
+    expect(screen.getByText('你希望输出什么格式？')).toBeInTheDocument();
+    expect(screen.getByText('详细')).toBeInTheDocument();
+    expect(screen.getByText('简洁')).toBeInTheDocument();
+    expect(screen.getByText('其他…')).toBeInTheDocument();
+    expect(screen.getByText('跳过')).toBeInTheDocument();
+  });
+
+  it('shows the pager counter', () => {
+    renderDock(TWO_Q_PAYLOAD);
+    expect(screen.getByText('1 / 2')).toBeInTheDocument();
+  });
+
+  it('single-select on the last/only question submits via setAnswers + resolveUserQuestion', async () => {
+    const user = userEvent.setup();
+    const resolveSpy = vi.spyOn(bridge, 'resolveUserQuestion');
+    renderDock(SINGLE_PAYLOAD, 'tc-single');
+
+    // Clicking a single-select option on the last question auto-submits.
+    await user.click(screen.getByText('详细').closest('button')!);
+
+    expect(mockSetAnswers).toHaveBeenCalledWith(
+      'conv-a',
+      'msg-1',
+      'tc-single',
+      expect.objectContaining({
+        answers: expect.arrayContaining([
+          expect.objectContaining({ header: '格式', selected: ['详细'] }),
+        ]),
+      }),
+    );
+    expect(resolveSpy).toHaveBeenCalledWith('tc-single', expect.any(Object));
+    resolveSpy.mockRestore();
+  });
+
+  it('multi-select keeps the dock open and Submit becomes enabled after a choice', async () => {
+    const user = userEvent.setup();
+    renderDock(MULTI_PAYLOAD, 'tc-multi');
+
+    expect(screen.getByText('提交').closest('button')).toBeDisabled();
+    await user.click(screen.getByText('引言').closest('button')!);
+    await user.click(screen.getByText('结论').closest('button')!);
+    expect(screen.getByText('提交').closest('button')).not.toBeDisabled();
+  });
+
+  it('keeps Submit disabled when Other is checked but empty', async () => {
+    const user = userEvent.setup();
+    renderDock(MULTI_PAYLOAD, 'tc-multi-other');
+
+    await user.click(screen.getByText('其他…').closest('button')!);
+    expect(screen.getByText('提交').closest('button')).toBeDisabled();
+  });
+
+  it('advances pages and submits with one skipped question', async () => {
+    const user = userEvent.setup();
+    const resolveSpy = vi.spyOn(bridge, 'resolveUserQuestion');
+    renderDock(TWO_Q_PAYLOAD, 'tc-two');
+
+    // Skip question 1 → advances to question 2.
+    await user.click(screen.getByText('跳过').closest('button')!);
+    expect(screen.getByText('2 / 2')).toBeInTheDocument();
+
+    // Answer question 2 (single-select, last page → auto submit).
+    await user.click(screen.getByText('C').closest('button')!);
+
+    expect(resolveSpy).toHaveBeenCalledWith(
+      'tc-two',
+      expect.objectContaining({
+        answers: expect.arrayContaining([
+          expect.objectContaining({ header: 'Q1', selected: ['（已跳过）'] }),
+          expect.objectContaining({ header: 'Q2', selected: ['C'] }),
+        ]),
+      }),
+    );
+    resolveSpy.mockRestore();
+  });
+
+  it('close button cancels with null', async () => {
+    const user = userEvent.setup();
+    const resolveSpy = vi.spyOn(bridge, 'resolveUserQuestion');
+    renderDock(SINGLE_PAYLOAD, 'tc-cancel');
+
+    await user.click(screen.getByLabelText('关闭'));
+    expect(resolveSpy).toHaveBeenCalledWith('tc-cancel', null);
+    resolveSpy.mockRestore();
+  });
+});

--- a/src/components/chat/UserQuestionDock.tsx
+++ b/src/components/chat/UserQuestionDock.tsx
@@ -1,0 +1,460 @@
+/**
+ * UserQuestionDock — the interactive, paginated surface for a pending
+ * ask_user_question call. Docks above the composer (rendered from ChatView),
+ * shows ONE question at a time with a pager, and resolves the pending bridge
+ * entry on submit / cancel.
+ *
+ * Behaviour (mirrors Claude desktop):
+ * - One question per page, `current / total` counter + ‹ › arrows + ×.
+ * - Numbered options (1..n) + a trailing "Other…" free-text escape hatch,
+ *   plus an optional "Skip" per question.
+ * - Single-select: click / Enter selects and auto-advances; multi-select:
+ *   toggle multiple, then advance manually. Last page shows Submit.
+ * - Keyboard: ↑/↓ move highlight, Enter selects/advances/submits, ←/→ page.
+ *
+ * Settled (read-only) rendering lives in UserQuestionCard — not here.
+ */
+
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import { MessageSquare, Check, Pencil, ChevronLeft, ChevronRight, X } from 'lucide-react';
+import { useI18n } from '@/i18n';
+import { useChatStore } from '@/stores/chatStore';
+import { resolveUserQuestion } from '@/core/agent/permissionBridge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import type { UserQuestionPayload, UserQuestionResult, UserQuestionAnswerItem } from '@/types';
+
+interface Props {
+  conversationId: string;
+  messageId: string;
+  toolCallId: string;
+  payload: UserQuestionPayload;
+}
+
+/** Per-question local selection state */
+interface QuestionState {
+  selected: Set<string>;
+  otherChecked: boolean;
+  otherText: string;
+  skipped: boolean;
+}
+
+function initQuestionStates(count: number): QuestionState[] {
+  return Array.from({ length: count }, () => ({
+    selected: new Set<string>(),
+    otherChecked: false,
+    otherText: '',
+    skipped: false,
+  }));
+}
+
+export default function UserQuestionDock({ conversationId, messageId, toolCallId, payload }: Props) {
+  const { t, format } = useI18n();
+  const setAnswers = useChatStore((s) => s.setToolCallUserQuestionAnswers);
+
+  const questions = useMemo(() => payload?.questions ?? [], [payload]);
+  const total = questions.length;
+
+  const [page, setPage] = useState(0);
+  const [questionStates, setQuestionStates] = useState<QuestionState[]>(() =>
+    initQuestionStates(total),
+  );
+  // Index of the keyboard-highlighted row: 0..options-1 = options,
+  // options = "Other…", options+1 = "Skip".
+  const [highlight, setHighlight] = useState(0);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const q = questions[page];
+  const state = questionStates[page];
+  const isLast = page === total - 1;
+
+  // Focus the dock so keyboard nav works as soon as it appears / pages.
+  useEffect(() => {
+    containerRef.current?.focus();
+    setHighlight(0);
+  }, [page]);
+
+  // ── Selection mutators ──────────────────────────────────────────────────
+
+  const toggleOption = useCallback((label: string, multiSelect: boolean) => {
+    setQuestionStates((prev) => {
+      const next = prev.map((s, i) => (i === page ? { ...s, selected: new Set(s.selected) } : s));
+      const st = next[page];
+      st.skipped = false;
+      if (multiSelect) {
+        if (st.selected.has(label)) st.selected.delete(label);
+        else st.selected.add(label);
+      } else {
+        st.selected = new Set([label]);
+        st.otherChecked = false;
+      }
+      return next;
+    });
+  }, [page]);
+
+  const toggleOther = useCallback((multiSelect: boolean) => {
+    setQuestionStates((prev) => {
+      const next = prev.map((s, i) => (i === page ? { ...s, selected: new Set(s.selected) } : s));
+      const st = next[page];
+      st.skipped = false;
+      if (multiSelect) {
+        st.otherChecked = !st.otherChecked;
+      } else {
+        st.otherChecked = !st.otherChecked;
+        if (st.otherChecked) st.selected = new Set();
+      }
+      return next;
+    });
+  }, [page]);
+
+  const setOtherText = useCallback((text: string) => {
+    setQuestionStates((prev) => {
+      const next = [...prev];
+      next[page] = { ...prev[page], otherText: text };
+      return next;
+    });
+  }, [page]);
+
+  // ── Validity ────────────────────────────────────────────────────────────
+
+  const isAnswered = useCallback((idx: number): boolean => {
+    const st = questionStates[idx];
+    if (!st) return false;
+    if (st.skipped) return true;
+    const hasRegular = st.selected.size > 0;
+    const hasOther = st.otherChecked && st.otherText.trim().length > 0;
+    return hasRegular || hasOther;
+  }, [questionStates]);
+
+  const currentAnswered = isAnswered(page);
+  // Submit allowed unless every question is empty (all-skip is also blocked).
+  const anyRealAnswer = questions.some((_, i) => {
+    const st = questionStates[i];
+    return !st.skipped && (st.selected.size > 0 || (st.otherChecked && st.otherText.trim().length > 0));
+  });
+  const allResolved = questions.every((_, i) => isAnswered(i));
+  const canSubmit = total > 0 && allResolved && anyRealAnswer;
+
+  // ── Navigation / submit ─────────────────────────────────────────────────
+
+  const goPrev = useCallback(() => setPage((p) => Math.max(0, p - 1)), []);
+  const goNext = useCallback(() => setPage((p) => Math.min(total - 1, p + 1)), [total]);
+
+  // Build the answer payload from a given snapshot of states. Pure so callers
+  // can submit with a freshly-derived snapshot without waiting on a re-render.
+  const buildAnswers = useCallback((states: QuestionState[]): UserQuestionAnswerItem[] =>
+    questions.map((question, i) => {
+      const st = states[i];
+      if (st.skipped) {
+        return { header: question.header, question: question.question, selected: [t.userQuestion.skippedMarker] };
+      }
+      let selected: string[];
+      if (question.multiSelect) {
+        selected = [...st.selected];
+        if (st.otherChecked && st.otherText.trim()) selected.push(st.otherText.trim());
+      } else {
+        selected = st.otherChecked && st.otherText.trim() ? [st.otherText.trim()] : [...st.selected];
+      }
+      return { header: question.header, question: question.question, selected };
+    }), [questions, t.userQuestion.skippedMarker]);
+
+  const submitWith = useCallback((states: QuestionState[]) => {
+    const result: UserQuestionResult = { answers: buildAnswers(states) };
+    setAnswers(conversationId, messageId, toolCallId, result);
+    resolveUserQuestion(toolCallId, result);
+  }, [buildAnswers, conversationId, messageId, toolCallId, setAnswers]);
+
+  const handleSubmit = useCallback(() => {
+    submitWith(questionStates);
+  }, [submitWith, questionStates]);
+
+  const handleCancel = useCallback(() => {
+    resolveUserQuestion(toolCallId, null);
+  }, [toolCallId]);
+
+  // Single-select: apply the choice, then advance — or submit if it's the
+  // last page. On the last page we submit with a freshly-derived snapshot so
+  // the just-applied selection is included without waiting on a re-render.
+  const selectAndAdvance = useCallback((label: string) => {
+    const next = questionStates.map((s, i) =>
+      i === page ? { ...s, selected: new Set([label]), otherChecked: false, skipped: false } : s,
+    );
+    setQuestionStates(next);
+    if (isLast) submitWith(next);
+    else goNext();
+  }, [questionStates, page, isLast, submitWith, goNext]);
+
+  // Skip marks the current question skipped and advances. On the last page it
+  // submits, provided at least one other question carries a real answer.
+  const skipAndAdvance = useCallback(() => {
+    const next = questionStates.map((s, i) =>
+      i === page ? { ...s, skipped: true, selected: new Set<string>(), otherChecked: false } : s,
+    );
+    setQuestionStates(next);
+    if (isLast) {
+      const hasReal = next.some((st) => !st.skipped && (st.selected.size > 0 || (st.otherChecked && st.otherText.trim().length > 0)));
+      if (hasReal) submitWith(next);
+    } else {
+      goNext();
+    }
+  }, [questionStates, page, isLast, submitWith, goNext]);
+
+  // ── Keyboard ────────────────────────────────────────────────────────────
+
+  const rowCount = (q?.options.length ?? 0) + 2; // options + Other + Skip
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    // Don't hijack typing inside the "Other" text field.
+    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        containerRef.current?.focus();
+      }
+      return;
+    }
+    if (!q) return;
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setHighlight((h) => (h + 1) % rowCount);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setHighlight((h) => (h - 1 + rowCount) % rowCount);
+        break;
+      case 'ArrowLeft':
+        e.preventDefault();
+        goPrev();
+        break;
+      case 'ArrowRight':
+        e.preventDefault();
+        if (!isLast) goNext();
+        break;
+      case 'Enter': {
+        e.preventDefault();
+        const optionCount = q.options.length;
+        if (highlight < optionCount) {
+          const label = q.options[highlight].label;
+          if (q.multiSelect) toggleOption(label, true);
+          else selectAndAdvance(label);
+        } else if (highlight === optionCount) {
+          toggleOther(q.multiSelect);
+        } else {
+          // Skip row — mark skipped and advance / submit.
+          skipAndAdvance();
+        }
+        break;
+      }
+      case 'Escape':
+        e.preventDefault();
+        handleCancel();
+        break;
+    }
+  };
+
+  if (total === 0) return null;
+
+  const hint = q.multiSelect ? t.userQuestion.multiSelectHint : t.userQuestion.singleSelectHint;
+  const optionCount = q.options.length;
+
+  return (
+    <div
+      ref={containerRef}
+      tabIndex={-1}
+      onKeyDown={handleKeyDown}
+      className="rounded-xl border border-[var(--abu-border)] bg-white shadow-md overflow-hidden outline-none"
+    >
+      {/* Header: question + pager */}
+      <div className="px-3 py-2 border-b border-[var(--abu-border-subtle)] flex items-start gap-2">
+        <MessageSquare className="h-3.5 w-3.5 text-[var(--abu-clay)] shrink-0 mt-0.5" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <span className="inline-block px-1.5 py-0.5 rounded bg-[var(--abu-bg-base)] border border-[var(--abu-border-subtle)] text-[11px] text-[var(--abu-text-tertiary)] font-medium">
+              {q.header}
+            </span>
+            <span className="text-[11px] text-[var(--abu-text-muted)]">{hint}</span>
+          </div>
+          <p className="mt-1 text-[13px] text-[var(--abu-text-primary)] leading-snug">{q.question}</p>
+        </div>
+        {/* Pager controls */}
+        <div className="flex items-center gap-1 shrink-0">
+          <span className="text-[11px] text-[var(--abu-text-tertiary)] tabular-nums mr-0.5">
+            {format(t.userQuestion.pager, { current: page + 1, total })}
+          </span>
+          <button
+            type="button"
+            onClick={goPrev}
+            disabled={page === 0}
+            aria-label={t.userQuestion.prevQuestion}
+            className="btn-ghost p-1 rounded-md text-[var(--abu-text-tertiary)] hover:text-[var(--abu-text-primary)] hover:bg-[var(--abu-bg-muted)] disabled:opacity-30 disabled:pointer-events-none"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={goNext}
+            disabled={isLast}
+            aria-label={t.userQuestion.nextQuestion}
+            className="btn-ghost p-1 rounded-md text-[var(--abu-text-tertiary)] hover:text-[var(--abu-text-primary)] hover:bg-[var(--abu-bg-muted)] disabled:opacity-30 disabled:pointer-events-none"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={handleCancel}
+            aria-label={t.userQuestion.close}
+            className="btn-ghost p-1 rounded-md text-[var(--abu-text-tertiary)] hover:text-[var(--abu-text-primary)] hover:bg-[var(--abu-bg-muted)]"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Options for the current question */}
+      <div className="px-3 py-2 space-y-1">
+        {q.options.map((opt, oIdx) => {
+          const isChecked = !state.skipped && state.selected.has(opt.label);
+          const isHighlighted = highlight === oIdx;
+          return (
+            <button
+              key={oIdx}
+              type="button"
+              onClick={() => (q.multiSelect ? toggleOption(opt.label, true) : selectAndAdvance(opt.label))}
+              onMouseEnter={() => setHighlight(oIdx)}
+              className={cn(
+                'w-full text-left px-2 py-1.5 rounded-lg text-[13px] transition-colors flex items-start gap-2',
+                isChecked
+                  ? 'bg-[var(--abu-clay-bg)] border border-[var(--abu-clay-ring)] text-[var(--abu-text-primary)]'
+                  : cn(
+                      'border text-[var(--abu-text-secondary)]',
+                      isHighlighted
+                        ? 'bg-[var(--abu-bg-muted)] border-[var(--abu-border)]'
+                        : 'border-[var(--abu-border-subtle)]',
+                    ),
+              )}
+            >
+              <span className="mt-0.5 w-3.5 text-[11px] text-[var(--abu-text-muted)] tabular-nums shrink-0 text-center">
+                {oIdx + 1}
+              </span>
+              <span
+                className={cn(
+                  'mt-0.5 h-3.5 w-3.5 flex-shrink-0 border flex items-center justify-center',
+                  q.multiSelect ? 'rounded-sm' : 'rounded-full',
+                  isChecked ? 'bg-[var(--abu-clay)] border-[var(--abu-clay)]' : 'border-[var(--abu-border)]',
+                )}
+              >
+                {isChecked && <Check className="h-2.5 w-2.5 text-white" />}
+              </span>
+              <span className="flex-1 min-w-0">
+                <span className="font-medium">{opt.label}</span>
+                {opt.description && (
+                  <span className="block text-[11px] text-[var(--abu-text-muted)] mt-0.5">
+                    {opt.description}
+                  </span>
+                )}
+              </span>
+            </button>
+          );
+        })}
+
+        {/* "Other…" row */}
+        <div>
+          <button
+            type="button"
+            onClick={() => toggleOther(q.multiSelect)}
+            onMouseEnter={() => setHighlight(optionCount)}
+            className={cn(
+              'w-full text-left px-2 py-1.5 rounded-lg text-[13px] transition-colors flex items-center gap-2',
+              state.otherChecked
+                ? 'bg-[var(--abu-clay-bg)] border border-[var(--abu-clay-ring)] text-[var(--abu-text-primary)]'
+                : cn(
+                    'border text-[var(--abu-text-tertiary)]',
+                    highlight === optionCount
+                      ? 'bg-[var(--abu-bg-muted)] border-[var(--abu-border)]'
+                      : 'border-[var(--abu-border-subtle)]',
+                  ),
+            )}
+          >
+            <span className="w-3.5 shrink-0 flex items-center justify-center">
+              <Pencil className="h-3 w-3" />
+            </span>
+            <span
+              className={cn(
+                'h-3.5 w-3.5 flex-shrink-0 border flex items-center justify-center',
+                q.multiSelect ? 'rounded-sm' : 'rounded-full',
+                state.otherChecked ? 'bg-[var(--abu-clay)] border-[var(--abu-clay)]' : 'border-[var(--abu-border)]',
+              )}
+            >
+              {state.otherChecked && <Check className="h-2.5 w-2.5 text-white" />}
+            </span>
+            <span className="italic">{t.userQuestion.otherOptionLabel}</span>
+          </button>
+
+          {state.otherChecked && (
+            <div className="mt-1.5 pl-1">
+              <Input
+                type="text"
+                value={state.otherText}
+                onChange={(e) => setOtherText(e.target.value)}
+                placeholder={t.userQuestion.otherInputPlaceholder}
+                className="h-8 text-[13px]"
+                autoFocus
+              />
+            </div>
+          )}
+        </div>
+
+        {/* "Skip" row */}
+        <button
+          type="button"
+          onClick={skipAndAdvance}
+          onMouseEnter={() => setHighlight(optionCount + 1)}
+          className={cn(
+            'w-full text-left px-2 py-1 rounded-lg text-[12px] transition-colors flex items-center gap-2',
+            state.skipped
+              ? 'text-[var(--abu-text-secondary)] bg-[var(--abu-bg-muted)] border border-[var(--abu-border)]'
+              : cn(
+                  'border border-transparent text-[var(--abu-text-muted)]',
+                  highlight === optionCount + 1 && 'bg-[var(--abu-bg-muted)]',
+                ),
+          )}
+        >
+          <span className="w-3.5 shrink-0" />
+          <span className={cn('h-3.5 w-3.5 flex-shrink-0 flex items-center justify-center')}>
+            {state.skipped && <Check className="h-3 w-3 text-[var(--abu-text-secondary)]" />}
+          </span>
+          <span>{t.userQuestion.skip}</span>
+        </button>
+      </div>
+
+      {/* Footer: hint + next/submit */}
+      <div className="px-3 py-1.5 border-t border-[var(--abu-border-subtle)] bg-[var(--abu-bg-base)] flex items-center justify-between gap-2">
+        <p className="text-[11px] text-[var(--abu-text-muted)] truncate">{t.userQuestion.navHint}</p>
+        {isLast ? (
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            title={!canSubmit ? t.userQuestion.submitDisabledHint : undefined}
+            className="text-xs shrink-0"
+          >
+            {t.userQuestion.submitButton}
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={goNext}
+            disabled={!currentAnswered}
+            className="text-xs shrink-0"
+          >
+            {t.userQuestion.nextQuestion}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -148,6 +148,7 @@ import {
   drainConfirmationQueue,
   drainFilePermissionQueue,
   drainWorkspaceRequest,
+  drainUserQuestions,
 } from './permissionBridge';
 
 /** Persist execution steps onto the last assistant message for the given loop, then evict from memory */
@@ -1789,6 +1790,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         drainConfirmationQueue();
         drainFilePermissionQueue();
         drainWorkspaceRequest();
+        drainUserQuestions();
 
         chatStore.cancelStreaming(conversationId);
         chatStore.clearAbortController(conversationId);

--- a/src/core/agent/orchestrator.ts
+++ b/src/core/agent/orchestrator.ts
@@ -58,6 +58,9 @@ const PLANNING_INSTRUCTION = `
 - computer use 只在必须看屏幕画面或操作 GUI 界面时才用
 
 多步任务的最后一步应该是验证（如 list_directory 确认文件操作结果），不要仅依赖执行时的输出。
+
+### 交互式询问（ask_user_question）
+需求不明、或存在多条等效路径时，优先用 ask_user_question 弹卡片让用户在选项中选择，而不是擅自假设。有合理默认值就直接用默认；危险操作仍走权限确认机制，不用本工具。
 `;
 
 /** Examples appended to PLANNING_INSTRUCTION on first turn only — saves ~400 tokens per subsequent turn */

--- a/src/core/agent/permissionBridge.test.ts
+++ b/src/core/agent/permissionBridge.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for the UserQuestion queue in permissionBridge.ts
+ *
+ * Covers only the new requestUserQuestion / resolveUserQuestion /
+ * drainUserQuestions / drainUserQuestionsForConversation /
+ * subscribeUserQuestion / getPendingUserQuestions APIs.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  requestUserQuestion,
+  resolveUserQuestion,
+  drainUserQuestions,
+  drainUserQuestionsForConversation,
+  getPendingUserQuestions,
+  subscribeUserQuestion,
+} from './permissionBridge';
+import type { UserQuestionPayload, UserQuestionResult } from '../../types';
+
+const MINIMAL_PAYLOAD: UserQuestionPayload = {
+  questions: [
+    {
+      header: '格式',
+      question: '你希望输出什么格式？',
+      multiSelect: false,
+      options: [{ label: '详细' }, { label: '简洁' }],
+    },
+  ],
+};
+
+const MINIMAL_RESULT: UserQuestionResult = {
+  answers: [{ header: '格式', question: '你希望输出什么格式？', selected: ['详细'] }],
+};
+
+describe('permissionBridge — UserQuestion queue', () => {
+  beforeEach(() => {
+    drainUserQuestions();
+  });
+
+  afterEach(() => {
+    drainUserQuestions();
+  });
+
+  describe('requestUserQuestion + resolveUserQuestion', () => {
+    it('suspends a promise that resolveUserQuestion fulfills', async () => {
+      const promise = requestUserQuestion('tc-1', 'conv-a', MINIMAL_PAYLOAD);
+      expect(getPendingUserQuestions()).toHaveLength(1);
+      expect(getPendingUserQuestions()[0].id).toBe('tc-1');
+
+      resolveUserQuestion('tc-1', MINIMAL_RESULT);
+
+      const result = await promise;
+      expect(result).toEqual(MINIMAL_RESULT);
+      expect(getPendingUserQuestions()).toHaveLength(0);
+    });
+
+    it('does not throw when resolving a nonexistent id', () => {
+      expect(() => resolveUserQuestion('nonexistent', null)).not.toThrow();
+    });
+
+    it('resolves to null when resolved with null', async () => {
+      const promise = requestUserQuestion('tc-2', 'conv-b', MINIMAL_PAYLOAD);
+      resolveUserQuestion('tc-2', null);
+      const result = await promise;
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('drainUserQuestions', () => {
+    it('resolves all pending to null and clears the queue', async () => {
+      const p1 = requestUserQuestion('tc-3', 'conv-c', MINIMAL_PAYLOAD);
+      const p2 = requestUserQuestion('tc-4', 'conv-c', MINIMAL_PAYLOAD);
+      drainUserQuestions();
+      expect(getPendingUserQuestions()).toHaveLength(0);
+      expect(await p1).toBeNull();
+      expect(await p2).toBeNull();
+    });
+  });
+
+  describe('drainUserQuestionsForConversation', () => {
+    it('only drains pending for the given conversationId', async () => {
+      const pA = requestUserQuestion('tc-5', 'conv-target', MINIMAL_PAYLOAD);
+      const pB = requestUserQuestion('tc-6', 'conv-other', MINIMAL_PAYLOAD);
+
+      drainUserQuestionsForConversation('conv-target');
+
+      expect(await pA).toBeNull();
+      // pB should still be pending
+      expect(getPendingUserQuestions()).toHaveLength(1);
+      expect(getPendingUserQuestions()[0].id).toBe('tc-6');
+
+      // cleanup
+      resolveUserQuestion('tc-6', null);
+      await pB;
+    });
+  });
+
+  describe('subscribeUserQuestion', () => {
+    it('fires on both enqueue and dequeue, stops after unsubscribe', () => {
+      const listener = vi.fn();
+      const unsub = subscribeUserQuestion(listener);
+
+      requestUserQuestion('tc-7', 'conv-d', MINIMAL_PAYLOAD);
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      resolveUserQuestion('tc-7', null);
+      expect(listener).toHaveBeenCalledTimes(2);
+
+      unsub();
+      requestUserQuestion('tc-8', 'conv-d', MINIMAL_PAYLOAD);
+      expect(listener).toHaveBeenCalledTimes(2);
+      drainUserQuestions();
+    });
+  });
+
+  describe('timeout', () => {
+    it('auto-resolves to null after USER_QUESTION_TIMEOUT_MS', async () => {
+      vi.useFakeTimers();
+      const promise = requestUserQuestion('tc-timeout', 'conv-e', MINIMAL_PAYLOAD);
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 100);
+      const result = await promise;
+      expect(result).toBeNull();
+      vi.useRealTimers();
+    });
+  });
+});

--- a/src/core/agent/permissionBridge.ts
+++ b/src/core/agent/permissionBridge.ts
@@ -5,6 +5,7 @@
  * Loop context is stored per-loopId in a Map to support concurrent agents.
  */
 import type { ConfirmationInfo, FilePermissionCallback } from '../tools/registry';
+import type { UserQuestionPayload, UserQuestionResult } from '../../types';
 import { usePermissionStore } from '../../stores/permissionStore';
 import type { PermissionDuration } from '../../stores/permissionStore';
 import { authorizeWorkspace } from '../tools/pathSafety';
@@ -383,5 +384,113 @@ export async function requestWorkspace(reason: string, conversationId?: string, 
 
     pendingWorkspaceRequest = { reason, conversationId: convId, suggestedPath, resolve: wrappedResolve };
     notifyWorkspaceRequestListeners();
+  });
+}
+
+// ── User Question Infrastructure ──
+
+export interface PendingUserQuestion {
+  id: string;              // = toolCallId
+  conversationId: string;
+  payload: UserQuestionPayload;
+  resolve: (r: UserQuestionResult | null) => void;
+}
+
+/** Queue — supports multiple conversations; isConcurrencySafe:false keeps it serial per conv */
+let userQuestionQueue: PendingUserQuestion[] = [];
+
+const userQuestionListeners = new Set<() => void>();
+
+/** 10 minutes — user may need time to read and decide before auto-cancel */
+const USER_QUESTION_TIMEOUT_MS = 10 * 60 * 1000;
+
+function notifyUserQuestionListeners() {
+  userQuestionListeners.forEach((l) => l());
+}
+
+/**
+ * Subscribe to user question state changes (for useSyncExternalStore)
+ */
+export function subscribeUserQuestion(callback: () => void): () => void {
+  userQuestionListeners.add(callback);
+  return () => userQuestionListeners.delete(callback);
+}
+
+/**
+ * Get the current pending user questions snapshot (for useSyncExternalStore).
+ * Returns a stable array reference until the queue mutates.
+ */
+export function getPendingUserQuestions(): PendingUserQuestion[] {
+  return userQuestionQueue;
+}
+
+/**
+ * Resolve a specific user question (from UserQuestionCard on submit, or timeout).
+ */
+export function resolveUserQuestion(id: string, r: UserQuestionResult | null): void {
+  const idx = userQuestionQueue.findIndex((q) => q.id === id);
+  if (idx === -1) return;
+  const item = userQuestionQueue[idx];
+  userQuestionQueue = userQuestionQueue.filter((_, i) => i !== idx);
+  item.resolve(r);
+  notifyUserQuestionListeners();
+}
+
+/**
+ * Drain all pending user questions — resolve(null) so blocked tools exit.
+ */
+export function drainUserQuestions(): void {
+  if (userQuestionQueue.length === 0) return;
+  const drained = userQuestionQueue;
+  userQuestionQueue = [];
+  for (const item of drained) {
+    item.resolve(null);
+  }
+  notifyUserQuestionListeners();
+}
+
+/**
+ * Drain user questions for a specific conversation (on conversation delete).
+ */
+export function drainUserQuestionsForConversation(conversationId: string): void {
+  const keep: PendingUserQuestion[] = [];
+  const drain: PendingUserQuestion[] = [];
+  for (const q of userQuestionQueue) {
+    if (q.conversationId === conversationId) {
+      drain.push(q);
+    } else {
+      keep.push(q);
+    }
+  }
+  if (drain.length === 0) return;
+  userQuestionQueue = keep;
+  for (const item of drain) {
+    item.resolve(null);
+  }
+  notifyUserQuestionListeners();
+}
+
+/**
+ * Request the user to answer a structured question set. Suspends until the
+ * user submits or it times out (10 min). Resolves to result, or null.
+ */
+export function requestUserQuestion(
+  id: string,
+  conversationId: string,
+  payload: UserQuestionPayload,
+): Promise<UserQuestionResult | null> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      console.warn('[permissionBridge] UserQuestion timed out, auto-cancelling', id);
+      resolveUserQuestion(id, null);
+    }, USER_QUESTION_TIMEOUT_MS);
+
+    const wrappedResolve = (r: UserQuestionResult | null) => {
+      clearTimeout(timer);
+      resolve(r);
+    };
+
+    userQuestionQueue = [...userQuestionQueue, { id, conversationId, payload, resolve: wrappedResolve }];
+    notifyUserQuestionListeners();
   });
 }

--- a/src/core/agent/toolExecutor.ts
+++ b/src/core/agent/toolExecutor.ts
@@ -184,7 +184,7 @@ export async function executeToolBatch(params: ToolBatchParams): Promise<ToolBat
           }
         };
         abortController.signal.addEventListener('abort', onAbort, { once: true });
-        executeAnyTool(tc.name, effectiveInput, confirmCb, filePermCb, toolContext, contextUsagePercent)
+        executeAnyTool(tc.name, effectiveInput, confirmCb, filePermCb, { ...toolContext, toolCallId: tc.id }, contextUsagePercent)
           .then((result) => {
             if (!settled) {
               settled = true;

--- a/src/core/tools/builtins.ts
+++ b/src/core/tools/builtins.ts
@@ -39,6 +39,7 @@ import { skillManageTool } from './definitions/skillManageTool';
 import { toolSearchTool } from './definitions/toolSearchTool';
 
 // --- Computer tools ---
+import { askUserQuestionTool } from './definitions/askUserQuestionTool';
 import { computerTool } from './definitions/computerTools';
 export { setComputerUseBatchMode, setSkipAutoScreenshot } from './definitions/computerTools';
 
@@ -75,6 +76,7 @@ export function registerBuiltinTools(): void {
   toolRegistry.register(systemNotifyTool);
   toolRegistry.register(computerTool);
   toolRegistry.register(requestWorkspaceTool);
+  toolRegistry.register(askUserQuestionTool);
   toolRegistry.register(testSkillTriggerTool);
   toolRegistry.register(improveSkillDescriptionTool);
   toolRegistry.register(skillViewTool);

--- a/src/core/tools/definitions/askUserQuestion.integration.test.ts
+++ b/src/core/tools/definitions/askUserQuestion.integration.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Live end-to-end demonstration of ask_user_question, going through the SAME
+ * dispatch path the agent loop uses (executeAnyTool → registry → tool.execute),
+ * with the REAL permissionBridge (no mocks).
+ *
+ * Flow proven here:
+ *   1. agent calls the tool → execute() suspends on requestUserQuestion
+ *   2. the UI reads getPendingUserQuestions() to render the card  (← printed)
+ *   3. user submits → resolveUserQuestion() with a rich answer set
+ *   4. tool resumes and returns the tool_result string fed back to the model  (← printed)
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { executeAnyTool } from '../registry';
+import { registerBuiltinTools } from '../builtins';
+import {
+  getPendingUserQuestions,
+  resolveUserQuestion,
+  drainUserQuestions,
+} from '../../agent/permissionBridge';
+import type { UserQuestionResult } from '../../../types';
+
+// 3 questions: single-select, multi-select, and single-select answered via "Other…"
+const INPUT = {
+  questions: [
+    {
+      header: '格式',
+      question: '你希望输出什么格式？',
+      multiSelect: false,
+      options: [
+        { label: '详细', description: '带示例的完整说明' },
+        { label: '简洁', description: '只给要点' },
+      ],
+    },
+    {
+      header: '章节',
+      question: '报告包含哪些部分？',
+      multiSelect: true,
+      options: [{ label: '引言' }, { label: '正文' }, { label: '结论' }],
+    },
+    {
+      header: '部署',
+      question: '部署到哪里？',
+      multiSelect: false,
+      options: [{ label: '本地' }, { label: '云端' }],
+    },
+  ],
+};
+
+describe('ask_user_question — live e2e through executeAnyTool', () => {
+  beforeEach(() => {
+    registerBuiltinTools();
+    drainUserQuestions();
+  });
+  afterEach(() => drainUserQuestions());
+
+  it('suspends, hands the card to the UI, resumes with the user answer', async () => {
+    const ctx = { conversationId: 'conv-demo', toolCallId: 'tc-demo' };
+
+    // 1) agent dispatches the tool exactly like agentLoop does — it suspends
+    const toolPromise = executeAnyTool('ask_user_question', INPUT, undefined, undefined, ctx);
+
+    // 2) what the UI sees while the model waits
+    await new Promise<void>((r) => setTimeout(r, 0));
+    const pending = getPendingUserQuestions();
+    expect(pending).toHaveLength(1);
+    expect(pending[0].id).toBe('tc-demo');
+    expect(pending[0].payload.questions).toHaveLength(3);
+
+    console.log('\n──────── UI 会渲染的待答卡片（来自 pending 队列）────────');
+    pending[0].payload.questions.forEach((q) => {
+      const tag = q.multiSelect ? '多选' : '单选';
+      console.log(`  [${q.header}] (${tag}) ${q.question}`);
+      q.options.forEach((o) => console.log(`     ○ ${o.label}${o.description ? '  — ' + o.description : ''}`));
+      console.log('     ○ 其他…（自由输入）');
+    });
+
+    // 3) user picks: 详细 / 引言+结论 / Other="我们内部的 K8s 集群"
+    const userAnswer: UserQuestionResult = {
+      answers: [
+        { header: '格式', question: '你希望输出什么格式？', selected: ['详细'] },
+        { header: '章节', question: '报告包含哪些部分？', selected: ['引言', '结论'] },
+        { header: '部署', question: '部署到哪里？', selected: ['我们内部的 K8s 集群'] },
+      ],
+    };
+    resolveUserQuestion('tc-demo', userAnswer);
+
+    // 4) the tool_result string the model receives
+    const result = (await toolPromise) as string;
+    console.log('\n──────── 回传给模型的 tool_result ────────');
+    console.log(result);
+    console.log('────────────────────────────────────────\n');
+
+    expect(result).toContain('用户已作答');
+    expect(result).toContain('[格式] 你希望输出什么格式？');
+    expect(result).toContain('→ 详细');
+    expect(result).toContain('→ 引言、结论'); // multi-select joined
+    expect(result).toContain('→ 我们内部的 K8s 集群'); // "Other" free text, not the word 其他
+    expect(result).not.toContain('其他…');
+    // queue is drained after resolve
+    expect(getPendingUserQuestions()).toHaveLength(0);
+  });
+
+  it('returns the graceful fallback when the user cancels (drain/abort)', async () => {
+    const ctx = { conversationId: 'conv-demo', toolCallId: 'tc-cancel' };
+    const toolPromise = executeAnyTool('ask_user_question', INPUT, undefined, undefined, ctx);
+    await new Promise<void>((r) => setTimeout(r, 0));
+
+    drainUserQuestions(); // simulate user hitting Stop / aborting the agent
+    const result = (await toolPromise) as string;
+    console.log('\n──────── 取消/abort 时回传给模型 ────────\n' + result + '\n');
+    expect(result).toContain('用户未作答');
+  });
+});

--- a/src/core/tools/definitions/askUserQuestionTool.test.ts
+++ b/src/core/tools/definitions/askUserQuestionTool.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for askUserQuestionTool execute()
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { askUserQuestionTool } from './askUserQuestionTool';
+import * as bridge from '../../agent/permissionBridge';
+import type { UserQuestionResult } from '../../../types';
+
+const VALID_INPUT = {
+  questions: [
+    {
+      header: '格式',
+      question: '你希望输出什么格式？',
+      multiSelect: false,
+      options: [{ label: '详细' }, { label: '简洁' }],
+    },
+  ],
+};
+
+const VALID_CONTEXT = { conversationId: 'conv-test', toolCallId: 'tc-test' };
+
+const MOCK_RESULT: UserQuestionResult = {
+  answers: [{ header: '格式', question: '你希望输出什么格式？', selected: ['详细'] }],
+};
+
+describe('askUserQuestionTool', () => {
+  beforeEach(() => {
+    bridge.drainUserQuestions();
+  });
+
+  afterEach(() => {
+    bridge.drainUserQuestions();
+  });
+
+  describe('input validation', () => {
+    it('throws on empty questions array', async () => {
+      await expect(
+        askUserQuestionTool.execute({ questions: [] }, VALID_CONTEXT),
+      ).rejects.toThrow(/questions 数组长度/);
+    });
+
+    it('throws on more than 4 questions', async () => {
+      const questions = Array.from({ length: 5 }, (_, i) => ({
+        header: `题${i + 1}`,
+        question: `问题${i + 1}`,
+        multiSelect: false,
+        options: [{ label: 'A' }, { label: 'B' }],
+      }));
+      await expect(
+        askUserQuestionTool.execute({ questions }, VALID_CONTEXT),
+      ).rejects.toThrow(/questions 数组长度/);
+    });
+
+    it('throws when header exceeds 12 chars', async () => {
+      const input = {
+        questions: [{
+          header: '这个标签超过了十二个字数限制',
+          question: '问题',
+          multiSelect: false,
+          options: [{ label: 'A' }, { label: 'B' }],
+        }],
+      };
+      await expect(
+        askUserQuestionTool.execute(input, VALID_CONTEXT),
+      ).rejects.toThrow(/header.*超过 12 字符/);
+    });
+
+    it('throws when header is empty', async () => {
+      const input = {
+        questions: [{
+          header: '',
+          question: '问题',
+          multiSelect: false,
+          options: [{ label: 'A' }, { label: 'B' }],
+        }],
+      };
+      await expect(
+        askUserQuestionTool.execute(input, VALID_CONTEXT),
+      ).rejects.toThrow(/header.*不能为空/);
+    });
+
+    it('throws when a question has fewer than 2 options', async () => {
+      const input = {
+        questions: [{
+          header: '格式',
+          question: '问题',
+          multiSelect: false,
+          options: [{ label: 'A' }],
+        }],
+      };
+      await expect(
+        askUserQuestionTool.execute(input, VALID_CONTEXT),
+      ).rejects.toThrow(/options 长度/);
+    });
+
+    it('throws when a question has more than 4 options', async () => {
+      const input = {
+        questions: [{
+          header: '格式',
+          question: '问题',
+          multiSelect: false,
+          options: [
+            { label: 'A' }, { label: 'B' }, { label: 'C' }, { label: 'D' }, { label: 'E' },
+          ],
+        }],
+      };
+      await expect(
+        askUserQuestionTool.execute(input, VALID_CONTEXT),
+      ).rejects.toThrow(/options 长度/);
+    });
+
+    it('throws when multiSelect is not a boolean', async () => {
+      const input = {
+        questions: [{
+          header: '格式',
+          question: '问题',
+          multiSelect: 'yes',
+          options: [{ label: 'A' }, { label: 'B' }],
+        }],
+      };
+      await expect(
+        askUserQuestionTool.execute(input, VALID_CONTEXT),
+      ).rejects.toThrow(/multiSelect 必须是 boolean/);
+    });
+
+    it('throws when toolCallId is not injected', async () => {
+      await expect(
+        askUserQuestionTool.execute(VALID_INPUT, { conversationId: 'conv-x' }),
+      ).rejects.toThrow(/toolCallId 未注入/);
+    });
+  });
+
+  describe('happy path', () => {
+    it('awaits requestUserQuestion and formats the resolved result', async () => {
+      const executePromise = askUserQuestionTool.execute(VALID_INPUT, VALID_CONTEXT);
+
+      // Flush microtasks so the tool registers the pending question
+      await new Promise<void>((r) => setTimeout(r, 0));
+      bridge.resolveUserQuestion('tc-test', MOCK_RESULT);
+
+      const result = await executePromise;
+      expect(typeof result).toBe('string');
+      expect(result).toContain('用户已作答');
+      expect(result).toContain('[格式]');
+      expect(result).toContain('详细');
+    });
+
+    it('returns a fallback message when result is null', async () => {
+      const executePromise = askUserQuestionTool.execute(VALID_INPUT, VALID_CONTEXT);
+
+      await new Promise<void>((r) => setTimeout(r, 0));
+      bridge.resolveUserQuestion('tc-test', null);
+
+      const result = await executePromise;
+      expect(typeof result).toBe('string');
+      expect(result).toContain('用户未作答');
+    });
+  });
+
+  it('is not concurrency safe', () => {
+    expect(askUserQuestionTool.isConcurrencySafe).toBe(false);
+  });
+});

--- a/src/core/tools/definitions/askUserQuestionTool.ts
+++ b/src/core/tools/definitions/askUserQuestionTool.ts
@@ -1,0 +1,148 @@
+/**
+ * ask_user_question — 在对话中弹出结构化选项卡片，阻塞 agent 等用户作答。
+ *
+ * 对标 Claude Code 的 AskUserQuestion 工具。
+ * - 阻塞式：await requestUserQuestion(...)，isConcurrencySafe: false
+ * - 每题自动追加「其他…」自由文本出口（UI 层追加，工具不需感知）
+ * - 非法 input throw Error → is_error → 模型自行重试
+ */
+import type { ToolDefinition, UserQuestionPayload } from '../../../types';
+import { TOOL_NAMES } from '../toolNames';
+import { requestUserQuestion } from '../../agent/permissionBridge';
+
+export const askUserQuestionTool: ToolDefinition = {
+  name: TOOL_NAMES.ASK_USER_QUESTION,
+  description:
+    '向用户弹出结构化选择卡片，等用户作答后继续。' +
+    '\n\n**何时使用**：' +
+    '\n- 存在多条等效路径，需要用户偏好才能决定' +
+    '\n- 无法从上下文推断的关键决策（如输出格式、部署目标）' +
+    '\n- 需要暴露隐含假设让用户确认' +
+    '\n\n**何时不用**：' +
+    '\n- 有合理默认值可用时（直接选默认，不打扰用户）' +
+    '\n- 是/否类简单确认（用 confirm 语气直接提问即可）' +
+    '\n- 危险操作（走权限确认机制，不用本工具）' +
+    '\n\n约束：1-4 题；每题 2-4 选项；header ≤12 字符。' +
+    '每个问题自动追加「其他…」自由文本出口，用户可填写不在选项中的答案。',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      questions: {
+        type: 'array',
+        description:
+          '问题列表（1-4 题）。每题包含 header（≤12 字符短标签）、question（完整问题文本）、' +
+          'multiSelect（true=多选 / false=单选）、options（2-4 个选项，每个有 label 和可选 description）。',
+        items: {
+          type: 'object',
+          properties: {
+            header: {
+              type: 'string',
+              description: '≤12 字符的短标签，用于标识题目，如 "格式"、"部署目标"',
+            },
+            question: {
+              type: 'string',
+              description: '完整的问题文本，清晰描述用户需要做的选择',
+            },
+            multiSelect: {
+              type: 'boolean',
+              description: 'true = 多选（可选多项）；false = 单选',
+            },
+            options: {
+              type: 'array',
+              description: '2-4 个选项',
+              items: {
+                type: 'object',
+                properties: {
+                  label: { type: 'string', description: '选项标签' },
+                  description: { type: 'string', description: '可选的补充说明' },
+                },
+                required: ['label'],
+              },
+            },
+          },
+          required: ['header', 'question', 'multiSelect', 'options'],
+        },
+      },
+    },
+    required: ['questions'],
+  },
+  execute: async (input, context) => {
+    const questions = input.questions as unknown[];
+
+    // ── Validate input ──────────────────────────────────────────────────
+    if (!Array.isArray(questions) || questions.length < 1 || questions.length > 4) {
+      throw new Error(
+        `参数错误：questions 数组长度必须在 1-4 之间，收到 ${Array.isArray(questions) ? questions.length : typeof questions}。`,
+      );
+    }
+
+    for (let i = 0; i < questions.length; i++) {
+      const q = questions[i] as Record<string, unknown>;
+      const idx = i + 1;
+
+      if (typeof q.header !== 'string' || q.header.trim() === '') {
+        throw new Error(`参数错误：第 ${idx} 题 header 不能为空字符串。`);
+      }
+      if (q.header.length > 12) {
+        throw new Error(
+          `参数错误：第 ${idx} 题 header "${q.header}" 超过 12 字符（当前 ${q.header.length} 字符）。`,
+        );
+      }
+      if (typeof q.question !== 'string' || q.question.trim() === '') {
+        throw new Error(`参数错误：第 ${idx} 题 question 不能为空字符串。`);
+      }
+      if (typeof q.multiSelect !== 'boolean') {
+        throw new Error(`参数错误：第 ${idx} 题 multiSelect 必须是 boolean，收到 ${typeof q.multiSelect}。`);
+      }
+      const opts = q.options as unknown[];
+      if (!Array.isArray(opts) || opts.length < 2 || opts.length > 4) {
+        throw new Error(
+          `参数错误：第 ${idx} 题 options 长度必须在 2-4 之间，收到 ${Array.isArray(opts) ? opts.length : typeof opts}。`,
+        );
+      }
+      for (let j = 0; j < opts.length; j++) {
+        const opt = opts[j] as Record<string, unknown>;
+        if (typeof opt.label !== 'string' || opt.label.trim() === '') {
+          throw new Error(`参数错误：第 ${idx} 题 options[${j}].label 不能为空。`);
+        }
+      }
+    }
+
+    // ── Suspend until user answers ───────────────────────────────────────
+    const toolCallId = context?.toolCallId;
+    const conversationId = context?.conversationId ?? '';
+
+    if (!toolCallId) {
+      // Defensive: toolExecutor always injects this. If absent, surface as
+      // an error so the model is told why, rather than hanging forever.
+      throw new Error('内部错误：toolCallId 未注入，无法挂起等待用户作答。');
+    }
+
+    const payload: UserQuestionPayload = {
+      questions: (questions as Array<Record<string, unknown>>).map((q) => ({
+        header: q.header as string,
+        question: q.question as string,
+        multiSelect: q.multiSelect as boolean,
+        options: (q.options as Array<Record<string, unknown>>).map((o) => ({
+          label: o.label as string,
+          description: typeof o.description === 'string' ? o.description : undefined,
+        })),
+      })),
+    };
+
+    const result = await requestUserQuestion(toolCallId, conversationId, payload);
+
+    // ── Format result ────────────────────────────────────────────────────
+    if (result === null) {
+      return '用户未作答（已取消或超时）。请基于已知信息继续，或用更明确的方式再次询问。';
+    }
+
+    const lines: string[] = ['用户已作答：'];
+    result.answers.forEach((ans, i) => {
+      lines.push(`${i + 1}. [${ans.header}] ${ans.question}`);
+      lines.push(`   → ${ans.selected.join('、')}`);
+    });
+    return lines.join('\n');
+  },
+  isConcurrencySafe: false,
+};

--- a/src/core/tools/toolNames.ts
+++ b/src/core/tools/toolNames.ts
@@ -64,6 +64,9 @@ export const TOOL_NAMES = {
   // Workspace
   REQUEST_WORKSPACE: 'request_workspace',
 
+  // Human-in-the-loop
+  ASK_USER_QUESTION: 'ask_user_question',
+
   // Tool discovery
   TOOL_SEARCH: 'tool_search',
 } as const;

--- a/src/core/tools/toolPrefetch.test.ts
+++ b/src/core/tools/toolPrefetch.test.ts
@@ -13,8 +13,8 @@ function makeCtx(overrides: Partial<PrefetchContext> = {}): PrefetchContext {
 
 describe('toolPrefetch', () => {
   describe('CORE_TOOL_NAMES', () => {
-    it('should contain 13 core tools', () => {
-      expect(CORE_TOOL_NAMES.size).toBe(13);
+    it('should contain 14 core tools', () => {
+      expect(CORE_TOOL_NAMES.size).toBe(14);
     });
 
     it('should include essential tools', () => {
@@ -22,6 +22,9 @@ describe('toolPrefetch', () => {
       expect(CORE_TOOL_NAMES.has('write_file')).toBe(true);
       expect(CORE_TOOL_NAMES.has('run_command')).toBe(true);
       expect(CORE_TOOL_NAMES.has('web_search')).toBe(true);
+      // ask_user_question is core (always loaded), matching Claude — so the
+      // model never has to tool_search before showing a choice card.
+      expect(CORE_TOOL_NAMES.has('ask_user_question')).toBe(true);
     });
 
     it('should not include conditional tools', () => {

--- a/src/core/tools/toolPrefetch.ts
+++ b/src/core/tools/toolPrefetch.ts
@@ -21,6 +21,10 @@ export const CORE_TOOL_NAMES: ReadonlySet<string> = new Set([
   TOOL_NAMES.WEB_SEARCH,
   TOOL_NAMES.HTTP_FETCH,
   TOOL_NAMES.REQUEST_WORKSPACE,
+  // ask_user_question 常驻 core —— 对齐 Claude（其 bundle 里 AskUserQuestion 与
+  // ToolSearch 并列常驻、不走延迟加载）。否则弱模型走不通 tool_search→调用 的链路，
+  // 会误判“工具不可用”并退化成纯文本提问。
+  TOOL_NAMES.ASK_USER_QUESTION,
   TOOL_NAMES.USE_SKILL,
   TOOL_NAMES.DELEGATE_TO_AGENT,
   TOOL_NAMES.TOOL_SEARCH,

--- a/src/eval/__snapshots__/toolSchemaSnapshot.test.ts.snap
+++ b/src/eval/__snapshots__/toolSchemaSnapshot.test.ts.snap
@@ -1,9 +1,18 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Tool count stability > total builtin tool count matches snapshot 1`] = `37`;
+exports[`Tool count stability > total builtin tool count matches snapshot 1`] = `38`;
 
 exports[`Tool schema snapshot > all tool schemas match snapshot 1`] = `
 [
+  {
+    "name": "ask_user_question",
+    "paramNames": [
+      "questions",
+    ],
+    "requiredParams": [
+      "questions",
+    ],
+  },
   {
     "name": "clipboard_read",
     "paramNames": [],

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -1596,6 +1596,17 @@ const enUS: TranslationDict = {
     answeredLabel: 'Answered',
     submitDisabledHint: 'Please answer all questions before submitting',
     cancelledLabel: 'Cancelled',
+    pager: '{current} / {total}',
+    waitingForAnswer: 'Waiting for answer',
+    skip: 'Skip',
+    skippedMarker: '(skipped)',
+    navHint: '↑↓ navigate · Enter select · ←→ page · or just type below',
+    qLabel: 'Q',
+    aLabel: 'A',
+    prevQuestion: 'Previous question',
+    nextQuestion: 'Next question',
+    close: 'Close',
+    yourChoiceLabel: 'Your choices',
   },
 
   project: {

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -1586,6 +1586,18 @@ const enUS: TranslationDict = {
     needsAuthorization: 'User authorization required to access',
   },
 
+  userQuestion: {
+    cardTitle: 'Please choose',
+    singleSelectHint: 'Single choice',
+    multiSelectHint: 'Multiple choices allowed',
+    otherOptionLabel: 'Other…',
+    otherInputPlaceholder: 'Enter custom answer',
+    submitButton: 'Submit',
+    answeredLabel: 'Answered',
+    submitDisabledHint: 'Please answer all questions before submitting',
+    cancelledLabel: 'Cancelled',
+  },
+
   project: {
     sectionTitle: 'Projects',
     newTask: 'New Task',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -1587,6 +1587,18 @@ const zhCN: TranslationDict = {
     needsAuthorization: '需要用户授权才能访问',
   },
 
+  userQuestion: {
+    cardTitle: '请选择',
+    singleSelectHint: '单选',
+    multiSelectHint: '可多选',
+    otherOptionLabel: '其他…',
+    otherInputPlaceholder: '请输入自定义内容',
+    submitButton: '提交',
+    answeredLabel: '已作答',
+    submitDisabledHint: '请为每道题选择或填写答案',
+    cancelledLabel: '已取消',
+  },
+
   project: {
     sectionTitle: '项目',
     newTask: '新任务',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -1597,6 +1597,17 @@ const zhCN: TranslationDict = {
     answeredLabel: '已作答',
     submitDisabledHint: '请为每道题选择或填写答案',
     cancelledLabel: '已取消',
+    pager: '{current} / {total}',
+    waitingForAnswer: '等待回答',
+    skip: '跳过',
+    skippedMarker: '（已跳过）',
+    navHint: '↑↓ 导航 · Enter 选择 · ←→ 翻页 · 也可直接在下方输入',
+    qLabel: '问',
+    aLabel: '答',
+    prevQuestion: '上一题',
+    nextQuestion: '下一题',
+    close: '关闭',
+    yourChoiceLabel: '你的选择',
   },
 
   project: {

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1612,6 +1612,19 @@ export interface TranslationDict {
     needsAuthorization: string;
   };
 
+  // ask_user_question — interactive choice card
+  userQuestion: {
+    cardTitle: string;
+    singleSelectHint: string;
+    multiSelectHint: string;
+    otherOptionLabel: string;
+    otherInputPlaceholder: string;
+    submitButton: string;
+    answeredLabel: string;
+    submitDisabledHint: string;
+    cancelledLabel: string;
+  };
+
   // Projects
   project: {
     sectionTitle: string;

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1623,6 +1623,28 @@ export interface TranslationDict {
     answeredLabel: string;
     submitDisabledHint: string;
     cancelledLabel: string;
+    /** Pager counter, e.g. "1 / 3" — params: {current} {total} */
+    pager: string;
+    /** Waiting-for-answer status in the tool-call group */
+    waitingForAnswer: string;
+    /** Skip this question */
+    skip: string;
+    /** Marker appended to a skipped question's answer in the result */
+    skippedMarker: string;
+    /** Keyboard / interaction hint shown at the bottom of the dock */
+    navHint: string;
+    /** Label prefix for the question line in the settled bubble */
+    qLabel: string;
+    /** Label prefix for the answer line in the settled bubble */
+    aLabel: string;
+    /** aria-label: go to previous question */
+    prevQuestion: string;
+    /** aria-label: go to next question */
+    nextQuestion: string;
+    /** aria-label: dismiss / cancel the question */
+    close: string;
+    /** Header of the settled answers card (agent side) */
+    yourChoiceLabel: string;
   };
 
   // Projects

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -921,4 +921,50 @@ describe('chatStore', () => {
       expect(useChatStore.getState().conversations.nope).toBeUndefined();
     });
   });
+
+  // ── setToolCallUserQuestionAnswers ──
+  describe('setToolCallUserQuestionAnswers', () => {
+    it('writes tc.userQuestionAnswers and reads it back', () => {
+      const convId = useChatStore.getState().createConversation();
+      const msgId = 'msg-1';
+      const tcId = 'tc-1';
+
+      useChatStore.setState((state) => {
+        const conv = state.conversations[convId];
+        if (conv) {
+          conv.messages.push({
+            id: msgId,
+            role: 'assistant',
+            content: '',
+            timestamp: Date.now(),
+            toolCalls: [{ id: tcId, name: 'ask_user_question', input: {} }],
+          });
+        }
+      });
+
+      const answers = {
+        answers: [{ header: '格式', question: '什么格式？', selected: ['详细'] }],
+      };
+
+      useChatStore.getState().setToolCallUserQuestionAnswers(convId, msgId, tcId, answers);
+
+      const tc = useChatStore
+        .getState()
+        .conversations[convId]?.messages.find((m) => m.id === msgId)
+        ?.toolCalls?.find((t) => t.id === tcId);
+
+      expect(tc?.userQuestionAnswers).toEqual(answers);
+    });
+
+    it('does not throw when the tool call does not exist', () => {
+      const convId = useChatStore.getState().createConversation();
+      expect(() => {
+        useChatStore.getState().setToolCallUserQuestionAnswers(
+          convId, 'nonexistent-msg', 'nonexistent-tc',
+          { answers: [{ header: 'x', question: 'q', selected: ['a'] }] },
+        );
+      }).not.toThrow();
+    });
+  });
+
 });

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
-import type { Message, Conversation, AgentStatus, TokenUsage, ConversationStatus, ToolCallForContext, ToolResultContent, ToolCall, NoticeCardAction } from '../types';
+import type { Message, Conversation, AgentStatus, TokenUsage, ConversationStatus, ToolCallForContext, ToolResultContent, ToolCall, NoticeCardAction, UserQuestionResult } from '../types';
 import type { ExecutionStepSnapshot } from '../types/execution';
 import { useWorkspaceStore } from './workspaceStore';
 import { useProjectStore } from './projectStore';
@@ -273,6 +273,7 @@ interface ChatActions {
    * through to disk via replaceMessageById so reload keeps the state.
    */
   setToolCallNoticeCardAction: (convId: string, messageId: string, toolCallId: string, action: NoticeCardAction) => void;
+  setToolCallUserQuestionAnswers: (convId: string, messageId: string, toolCallId: string, answers: UserQuestionResult) => void;
   /**
    * Stash a post-loop proposal signal on the conversation so the next
    * turn's orchestrator can surface a one-shot <consider_sinking> nudge.
@@ -528,6 +529,10 @@ export const useChatStore = create<ChatStore>()(
               imStore.removeSession(key);
             }
           }
+        }).catch(() => {});
+        // Drain pending ask_user_question for this conversation on delete.
+        import('../core/agent/permissionBridge').then(({ drainUserQuestionsForConversation }) => {
+          drainUserQuestionsForConversation(id);
         }).catch(() => {});
         const wasActive = get().activeConversationId === id;
         // Compute the successor BEFORE the deletion mutates state, so the
@@ -785,6 +790,22 @@ export const useChatStore = create<ChatStore>()(
         });
         // Persist so the settled state survives reload. Mirrors the pattern
         // used by updateToolCall above.
+        const updatedMsg = get().conversations[convId]?.messages.find((m) => m.id === messageId);
+        if (updatedMsg) {
+          import('../core/session/conversationStorage').then(({ replaceMessageById }) => {
+            replaceMessageById(convId, updatedMsg).catch(() => {});
+          });
+        }
+      },
+
+      setToolCallUserQuestionAnswers: (convId, messageId, toolCallId, answers) => {
+        set((state) => {
+          const msg = state.conversations[convId]?.messages.find((m) => m.id === messageId);
+          const tc: ToolCall | undefined = msg?.toolCalls?.find((t) => t.id === toolCallId);
+          if (tc) {
+            tc.userQuestionAnswers = answers;
+          }
+        });
         const updatedMsg = get().conversations[convId]?.messages.find((m) => m.id === messageId);
         if (updatedMsg) {
           import('../core/session/conversationStorage').then(({ replaceMessageById }) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -99,6 +99,35 @@ export interface InteractiveNoticeCard {
   skillDeleted?: SkillDeletedPayload;
 }
 
+// --- ask_user_question — interactive choice cards ---
+
+export interface UserQuestionOption {
+  label: string;
+  description?: string;
+}
+
+export interface UserQuestion {
+  question: string;
+  header: string;                // ≤12 chars short label
+  multiSelect: boolean;
+  options: UserQuestionOption[]; // 2-4 options
+}
+
+export interface UserQuestionPayload {
+  questions: UserQuestion[];     // 1-4 questions
+}
+
+/** Single-question answer: selected labels, or custom free text (Other…) */
+export interface UserQuestionAnswerItem {
+  header: string;
+  question: string;
+  selected: string[];            // single-select length=1; multi-select ≥1; other=custom text
+}
+
+export interface UserQuestionResult {
+  answers: UserQuestionAnswerItem[];
+}
+
 export interface ToolCall {
   id: string;
   name: string;
@@ -125,6 +154,12 @@ export interface ToolCall {
    * cards until the user clicks a button.
    */
   noticeCardAction?: NoticeCardAction;
+  /**
+   * User's answers to an ask_user_question tool call. Set once the user
+   * submits — drives settled read-only rendering. undefined = still
+   * interactive (waiting for the user to answer).
+   */
+  userQuestionAnswers?: UserQuestionResult;
 }
 
 // Multimodal content types for messages
@@ -314,6 +349,8 @@ export interface ToolExecutionContext {
   loopId?: string;
   /** Conversation ID — tools should prefer this over activeConversationId */
   conversationId?: string;
+  /** Tool call ID — injected by toolExecutor so the tool can locate itself */
+  toolCallId?: string;
 }
 
 export interface ToolDefinition {


### PR DESCRIPTION
## 功能：ask_user_question 交互式选择卡片（对标 Claude）

AI 在对话中弹出结构化选项卡片，用户选择后把答案回传给模型继续。对标 Claude 桌面端的 AskUserQuestion。

### 包含
- **后端**：`ask_user_question` 工具 + permissionBridge 阻塞式挂起/恢复（复刻 requestWorkspace 范式），答案双流向（回传模型 + 持久化）
- **UI**：待答卡片停靠输入框上方、一题一页分页 + 键盘导航（UserQuestionDock）；待答时静态「等待回答」不转圈（TaskBlock）；答案以左侧「你的选择」卡片融入对话流（UserQuestionCard）
- **可用性**：`ask_user_question` 进 `CORE_TOOL_NAMES` 常驻（对齐 Claude），免 tool_search，修复弱模型误判"工具不可用"
- i18n（zh-CN / en-US）+ 测试

### 关于这条分支
从 `feat/multi-agent-harness` 中**单独拆出卡片功能**（2 个提交），不含企业版/多-agent-harness/plan-mode，基于 `dev`。因此无 enterprise 构建依赖。

### 验证
- `npm run build` ✅ 绿（tsc + vite build，17s，无 error）
- 卡片相关 6 测试文件 / 69 测试全过
- lint 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)
