### PR TITLE
feat: plan-mode 计划模式门控 (B1)

### DIFF
--- a/src/core/agent/planMode.test.ts
+++ b/src/core/agent/planMode.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for planMode.ts — Plan Mode state management and gate decision logic.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getPlanMode,
+  setPlanMode,
+  clearPlanMode,
+  evaluatePlanGate,
+  READONLY_FALLBACK_TOOLS,
+} from './planMode';
+import { TOOL_NAMES } from '@/core/tools/toolNames';
+
+// ── State Map ──
+
+describe('planMode state map', () => {
+  beforeEach(() => {
+    // Reset any state from prior tests
+    clearPlanMode('conv-a');
+    clearPlanMode('conv-b');
+    clearPlanMode('conv-x');
+  });
+
+  it('returns "off" by default when no entry exists', () => {
+    expect(getPlanMode('conv-a')).toBe('off');
+  });
+
+  it('set then get returns the stored state', () => {
+    setPlanMode('conv-a', 'planning');
+    expect(getPlanMode('conv-a')).toBe('planning');
+  });
+
+  it('set then get works for "approved"', () => {
+    setPlanMode('conv-a', 'approved');
+    expect(getPlanMode('conv-a')).toBe('approved');
+  });
+
+  it('clearPlanMode resets to "off"', () => {
+    setPlanMode('conv-a', 'planning');
+    clearPlanMode('conv-a');
+    expect(getPlanMode('conv-a')).toBe('off');
+  });
+
+  it('clearPlanMode on an absent id is a no-op (still returns "off")', () => {
+    clearPlanMode('conv-x');
+    expect(getPlanMode('conv-x')).toBe('off');
+  });
+
+  it('state is independent per conversationId', () => {
+    setPlanMode('conv-a', 'planning');
+    setPlanMode('conv-b', 'approved');
+    expect(getPlanMode('conv-a')).toBe('planning');
+    expect(getPlanMode('conv-b')).toBe('approved');
+  });
+
+  it('overwriting state works', () => {
+    setPlanMode('conv-a', 'planning');
+    setPlanMode('conv-a', 'approved');
+    expect(getPlanMode('conv-a')).toBe('approved');
+  });
+});
+
+// ── evaluatePlanGate ──
+
+describe('evaluatePlanGate', () => {
+  describe('planMode "off"', () => {
+    it('allows any tool call, including write tools', () => {
+      const result = evaluatePlanGate({
+        toolName: TOOL_NAMES.WRITE_FILE,
+        toolReadOnly: undefined,
+        planMode: 'off',
+      });
+      expect(result.allow).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('allows even when toolReadOnly is false', () => {
+      const result = evaluatePlanGate({
+        toolName: TOOL_NAMES.RUN_COMMAND,
+        toolReadOnly: false,
+        planMode: 'off',
+      });
+      expect(result.allow).toBe(true);
+    });
+  });
+
+  describe('planMode "approved"', () => {
+    it('allows write tools after approval', () => {
+      const result = evaluatePlanGate({
+        toolName: TOOL_NAMES.WRITE_FILE,
+        toolReadOnly: false,
+        planMode: 'approved',
+      });
+      expect(result.allow).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('allows even tools not in fallback list', () => {
+      const result = evaluatePlanGate({
+        toolName: TOOL_NAMES.RUN_COMMAND,
+        toolReadOnly: undefined,
+        planMode: 'approved',
+      });
+      expect(result.allow).toBe(true);
+    });
+  });
+
+  describe('planMode "planning"', () => {
+    it('allows when toolReadOnly is explicitly true', () => {
+      const result = evaluatePlanGate({
+        toolName: 'some_unknown_tool',
+        toolReadOnly: true,
+        planMode: 'planning',
+      });
+      expect(result.allow).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('allows READ_FILE (fallback allowlist) even with toolReadOnly undefined', () => {
+      const result = evaluatePlanGate({
+        toolName: TOOL_NAMES.READ_FILE,
+        toolReadOnly: undefined,
+        planMode: 'planning',
+      });
+      expect(result.allow).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('allows REPORT_PLAN (fallback allowlist)', () => {
+      const result = evaluatePlanGate({
+        toolName: TOOL_NAMES.REPORT_PLAN,
+        toolReadOnly: undefined,
+        planMode: 'planning',
+      });
+      expect(result.allow).toBe(true);
+    });
+
+    it('allows WEB_SEARCH (fallback allowlist)', () => {
+      const result = evaluatePlanGate({
+        toolName: TOOL_NAMES.WEB_SEARCH,
+        toolReadOnly: undefined,
+        planMode: 'planning',
+      });
+      expect(result.allow).toBe(true);
+    });
+
+    it('blocks WRITE_FILE with toolReadOnly undefined', () => {
+      const result = evaluatePlanGate({
+        toolName: TOOL_NAMES.WRITE_FILE,
+        toolReadOnly: undefined,
+        planMode: 'planning',
+      });
+      expect(result.allow).toBe(false);
+      expect(result.reason).toBeDefined();
+      expect(result.reason).toMatch(/计划模式/);
+      expect(result.reason).toMatch(/report_plan/);
+    });
+
+    it('blocks RUN_COMMAND with toolReadOnly false', () => {
+      const result = evaluatePlanGate({
+        toolName: TOOL_NAMES.RUN_COMMAND,
+        toolReadOnly: false,
+        planMode: 'planning',
+      });
+      expect(result.allow).toBe(false);
+      expect(result.reason).toBeDefined();
+    });
+
+    it('blocks an arbitrary unknown write tool', () => {
+      const result = evaluatePlanGate({
+        toolName: 'delete_database',
+        toolReadOnly: undefined,
+        planMode: 'planning',
+      });
+      expect(result.allow).toBe(false);
+      expect(result.reason).toBeDefined();
+    });
+
+    it('reason is absent (undefined) when the tool is allowed', () => {
+      const result = evaluatePlanGate({
+        toolName: TOOL_NAMES.READ_FILE,
+        toolReadOnly: undefined,
+        planMode: 'planning',
+      });
+      expect(result).not.toHaveProperty('reason');
+    });
+
+    it('reason is present and non-empty when blocked', () => {
+      const result = evaluatePlanGate({
+        toolName: TOOL_NAMES.WRITE_FILE,
+        toolReadOnly: false,
+        planMode: 'planning',
+      });
+      expect(typeof result.reason).toBe('string');
+      expect((result.reason as string).length).toBeGreaterThan(0);
+    });
+  });
+});
+
+// ── READONLY_FALLBACK_TOOLS ──
+
+describe('READONLY_FALLBACK_TOOLS', () => {
+  it('contains all expected tools', () => {
+    const expected = [
+      TOOL_NAMES.REPORT_PLAN,
+      TOOL_NAMES.ASK_USER_QUESTION,
+      TOOL_NAMES.READ_FILE,
+      TOOL_NAMES.LIST_DIRECTORY,
+      TOOL_NAMES.SEARCH_FILES,
+      TOOL_NAMES.FIND_FILES,
+      TOOL_NAMES.WEB_SEARCH,
+      TOOL_NAMES.HTTP_FETCH,
+      TOOL_NAMES.READ_MEMORY,
+      TOOL_NAMES.RECALL,
+      TOOL_NAMES.READ_SKILL_FILE,
+      TOOL_NAMES.SKILL_VIEW,
+      TOOL_NAMES.TOOL_SEARCH,
+      TOOL_NAMES.GET_SYSTEM_INFO,
+      TOOL_NAMES.CLIPBOARD_READ,
+    ];
+    for (const name of expected) {
+      expect(READONLY_FALLBACK_TOOLS.has(name)).toBe(true);
+    }
+  });
+
+  it('does not contain write tools', () => {
+    expect(READONLY_FALLBACK_TOOLS.has(TOOL_NAMES.WRITE_FILE)).toBe(false);
+    expect(READONLY_FALLBACK_TOOLS.has(TOOL_NAMES.RUN_COMMAND)).toBe(false);
+    expect(READONLY_FALLBACK_TOOLS.has(TOOL_NAMES.EDIT_FILE)).toBe(false);
+  });
+});

--- a/src/core/agent/planMode.ts
+++ b/src/core/agent/planMode.ts
@@ -1,0 +1,108 @@
+/**
+ * Plan Mode — per-conversation state and gate decision logic.
+ *
+ * State is transient (in-memory Map), not persisted — plan mode resets on restart.
+ * The pattern mirrors permissionBridge.ts loopContexts and other module-level Maps
+ * used for non-reactive agent state.
+ *
+ * UI wiring and loop integration are intentionally absent here (later slices).
+ */
+import { TOOL_NAMES } from '@/core/tools/toolNames';
+
+// ── State Type ──
+
+export type PlanModeState = 'off' | 'planning' | 'approved';
+
+// ── Per-conversation transient state ──
+
+/** Module-level singleton — supports concurrent conversations. */
+const planModeMap = new Map<string, PlanModeState>();
+
+/**
+ * Get the plan mode state for a conversation.
+ * Returns `'off'` if no entry exists.
+ */
+export function getPlanMode(conversationId: string): PlanModeState {
+  return planModeMap.get(conversationId) ?? 'off';
+}
+
+/**
+ * Set the plan mode state for a conversation.
+ */
+export function setPlanMode(conversationId: string, state: PlanModeState): void {
+  planModeMap.set(conversationId, state);
+}
+
+/**
+ * Clear the plan mode entry for a conversation, resetting it to `'off'`.
+ * Called on conversation delete or explicit reset.
+ */
+export function clearPlanMode(conversationId: string): void {
+  planModeMap.delete(conversationId);
+}
+
+// ── Read-only fallback allowlist ──
+
+/**
+ * Tools that are considered read-only for plan gate purposes, even if their
+ * `ToolDefinition.readOnly` field is absent or undefined.
+ *
+ * These are tools that observe the world but don't mutate it, making them
+ * safe to run while the agent is still in the planning phase.
+ */
+export const READONLY_FALLBACK_TOOLS: ReadonlySet<string> = new Set([
+  TOOL_NAMES.REPORT_PLAN,
+  TOOL_NAMES.ASK_USER_QUESTION,
+  TOOL_NAMES.READ_FILE,
+  TOOL_NAMES.LIST_DIRECTORY,
+  TOOL_NAMES.SEARCH_FILES,
+  TOOL_NAMES.FIND_FILES,
+  TOOL_NAMES.WEB_SEARCH,
+  TOOL_NAMES.HTTP_FETCH,
+  TOOL_NAMES.READ_MEMORY,
+  TOOL_NAMES.RECALL,
+  TOOL_NAMES.READ_SKILL_FILE,
+  TOOL_NAMES.SKILL_VIEW,
+  TOOL_NAMES.TOOL_SEARCH,
+  TOOL_NAMES.GET_SYSTEM_INFO,
+  TOOL_NAMES.CLIPBOARD_READ,
+]);
+
+// ── Gate Decision ──
+
+export interface PlanGateParams {
+  toolName: string;
+  /** From ToolDefinition.readOnly — undefined if not declared on the tool. */
+  toolReadOnly: boolean | undefined;
+  planMode: PlanModeState;
+}
+
+export interface PlanGateResult {
+  allow: boolean;
+  reason?: string;
+}
+
+/**
+ * Pure gate decision: should this tool call be allowed given the current plan mode?
+ *
+ * - `'off'` or `'approved'` → always allow.
+ * - `'planning'` → allow only if the tool is read-only (via explicit flag or fallback set);
+ *   otherwise block with a user-facing reason.
+ */
+export function evaluatePlanGate(params: PlanGateParams): PlanGateResult {
+  const { toolName, toolReadOnly, planMode } = params;
+
+  if (planMode === 'off' || planMode === 'approved') {
+    return { allow: true };
+  }
+
+  // planMode === 'planning'
+  if (toolReadOnly === true || READONLY_FALLBACK_TOOLS.has(toolName)) {
+    return { allow: true };
+  }
+
+  return {
+    allow: false,
+    reason: '计划模式:批准前仅允许只读操作,请先用 report_plan 提交计划等待用户批准。',
+  };
+}

--- a/src/core/agent/toolExecutor.ts
+++ b/src/core/agent/toolExecutor.ts
@@ -12,6 +12,7 @@ import type { ToolCall, ToolResultContent, ToolExecutionContext, ToolResult } fr
 import type { ConfirmationInfo, FilePermissionCallback } from '../tools/registry';
 import { executeAnyTool, toolResultToString } from '../tools/registry';
 import { processToolResult } from '../session/sessionMemory';
+import { evaluatePlanGate, getPlanMode } from './planMode';
 import { emitHook } from './lifecycleHooks';
 import type { PreToolCallEvent } from './lifecycleHooks';
 import { setComputerUseBatchMode, setSkipAutoScreenshot } from '../tools/builtins';
@@ -156,6 +157,21 @@ export async function executeToolBatch(params: ToolBatchParams): Promise<ToolBat
         return { id: tc.id, result: preEvent.blockReason, resultContent: undefined, error: true, duration: 0 };
       }
       return { id: tc.id, result: '[被 hook 拦截]', resultContent: undefined, error: false, duration: 0 };
+    }
+
+    // Plan mode gate: while a plan is pending approval ('planning'), block
+    // mutating tools; read-only tools and report_plan/ask_user_question pass.
+    // Read-only classification comes from planMode's explicit, security-reviewed
+    // allowlist (READONLY_FALLBACK_TOOLS). We deliberately do NOT derive it from
+    // isConcurrencySafe (a parallelism hint, not a security boundary), and
+    // ToolDefinition has no readOnly field — so toolReadOnly stays undefined.
+    const planGate = evaluatePlanGate({
+      toolName: tc.name,
+      toolReadOnly: undefined,
+      planMode: getPlanMode(conversationId),
+    });
+    if (!planGate.allow) {
+      return { id: tc.id, result: planGate.reason ?? '计划模式:已拦截写操作', resultContent: undefined, error: true, duration: 0 };
     }
 
     const effectiveInput = preEvent.modifiedInput ?? tc.input;

--- a/src/core/tools/definitions/memoryTools.test.ts
+++ b/src/core/tools/definitions/memoryTools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { updateMemoryTool } from './memoryTools';
+import { updateMemoryTool, reportPlanTool, buildPlanApprovalPayload, interpretPlanApproval, PLAN_APPROVE_LABEL, PLAN_REJECT_LABEL } from './memoryTools';
 
 // ──────────────────────────────────────────────────────────────────────────
 // Mocks: lazy-imported in updateMemoryTool.execute, so vi.mock the real paths
@@ -39,8 +39,22 @@ vi.mock('../../../stores/workspaceStore', () => ({
   },
 }));
 
+const mockGetPlanMode = vi.fn();
+const mockSetPlanMode = vi.fn();
+const mockRequestUserQuestion = vi.fn();
+
+vi.mock('../../agent/planMode', () => ({
+  getPlanMode: (...a: unknown[]) => mockGetPlanMode(...a),
+  setPlanMode: (...a: unknown[]) => mockSetPlanMode(...a),
+}));
+
+vi.mock('../../agent/permissionBridge', () => ({
+  requestUserQuestion: (...a: unknown[]) => mockRequestUserQuestion(...a),
+}));
+
 beforeEach(() => {
   vi.clearAllMocks();
+  mockGetPlanMode.mockReturnValue('off');
   mockWriteMemory.mockResolvedValue('newfile.md');
   mockDeleteMemory.mockResolvedValue(undefined);
   mockClearAllMemories.mockResolvedValue(0);
@@ -226,5 +240,81 @@ describe('updateMemoryTool — clear', () => {
     expect(mockClearAllMemories).toHaveBeenCalledWith('/test/workspace');
     expect(result).toContain('已清空');
     expect(result).toContain('7');
+  });
+});
+
+describe('reportPlanTool — plan-mode approval (B1)', () => {
+  describe('buildPlanApprovalPayload', () => {
+    it('builds a single approve/reject question listing the steps', () => {
+      const payload = buildPlanApprovalPayload(['扫描文件', '移动发票']);
+      expect(payload.questions).toHaveLength(1);
+      const q = payload.questions[0];
+      expect(q.header).toBe('计划审批');
+      expect(q.multiSelect).toBe(false);
+      expect(q.options.map((o) => o.label)).toEqual([PLAN_APPROVE_LABEL, PLAN_REJECT_LABEL]);
+      expect(q.question).toContain('扫描文件');
+      expect(q.question).toContain('移动发票');
+      expect(q.question).toContain('是否批准');
+    });
+  });
+
+  describe('interpretPlanApproval', () => {
+    it('returns false for null (timeout/cancel)', () => {
+      expect(interpretPlanApproval(null)).toBe(false);
+    });
+    it('returns true when the approve option is selected', () => {
+      expect(interpretPlanApproval({ answers: [{ header: '计划审批', question: 'q', selected: [PLAN_APPROVE_LABEL] }] })).toBe(true);
+    });
+    it('returns false when the reject option is selected', () => {
+      expect(interpretPlanApproval({ answers: [{ header: '计划审批', question: 'q', selected: [PLAN_REJECT_LABEL] }] })).toBe(false);
+    });
+    it('returns false for empty answers', () => {
+      expect(interpretPlanApproval({ answers: [] })).toBe(false);
+    });
+  });
+
+  describe('execute gating', () => {
+    const ctx = { conversationId: 'c1', toolCallId: 't1' };
+    const input = { steps: ['步骤一', '步骤二'] };
+
+    it('does not request approval when plan mode is off', async () => {
+      mockGetPlanMode.mockReturnValue('off');
+      const result = await reportPlanTool.execute(input, ctx);
+      expect(mockRequestUserQuestion).not.toHaveBeenCalled();
+      expect(mockSetPlanMode).not.toHaveBeenCalled();
+      expect(result).toContain('已记录执行计划');
+    });
+
+    it('approves: sets mode to approved and reports approval', async () => {
+      mockGetPlanMode.mockReturnValue('planning');
+      mockRequestUserQuestion.mockResolvedValue({ answers: [{ header: '计划审批', question: 'q', selected: [PLAN_APPROVE_LABEL] }] });
+      const result = await reportPlanTool.execute(input, ctx);
+      expect(mockRequestUserQuestion).toHaveBeenCalledWith('t1', 'c1', expect.objectContaining({ questions: expect.any(Array) }));
+      expect(mockSetPlanMode).toHaveBeenCalledWith('c1', 'approved');
+      expect(result).toContain('已批准');
+    });
+
+    it('rejects: stays in planning, does not approve', async () => {
+      mockGetPlanMode.mockReturnValue('planning');
+      mockRequestUserQuestion.mockResolvedValue({ answers: [{ header: '计划审批', question: 'q', selected: [PLAN_REJECT_LABEL] }] });
+      const result = await reportPlanTool.execute(input, ctx);
+      expect(mockSetPlanMode).not.toHaveBeenCalled();
+      expect(result).toContain('未批准');
+    });
+
+    it('null result (timeout): stays read-only, does not approve', async () => {
+      mockGetPlanMode.mockReturnValue('planning');
+      mockRequestUserQuestion.mockResolvedValue(null);
+      const result = await reportPlanTool.execute(input, ctx);
+      expect(mockSetPlanMode).not.toHaveBeenCalled();
+      expect(result).toContain('超时');
+    });
+
+    it('skips approval when toolCallId is absent', async () => {
+      mockGetPlanMode.mockReturnValue('planning');
+      const result = await reportPlanTool.execute(input, { conversationId: 'c1' });
+      expect(mockRequestUserQuestion).not.toHaveBeenCalled();
+      expect(result).toContain('已记录执行计划');
+    });
   });
 });

--- a/src/core/tools/definitions/memoryTools.test.ts
+++ b/src/core/tools/definitions/memoryTools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { updateMemoryTool, reportPlanTool, buildPlanApprovalPayload, interpretPlanApproval, PLAN_APPROVE_LABEL, PLAN_REJECT_LABEL } from './memoryTools';
+import { updateMemoryTool, reportPlanTool, buildPlanApprovalPayload, interpretPlanApproval, planHasRiskySteps, PLAN_APPROVE_LABEL, PLAN_REJECT_LABEL } from './memoryTools';
 
 // ──────────────────────────────────────────────────────────────────────────
 // Mocks: lazy-imported in updateMemoryTool.execute, so vi.mock the real paths
@@ -273,16 +273,45 @@ describe('reportPlanTool — plan-mode approval (B1)', () => {
     });
   });
 
+  describe('planHasRiskySteps', () => {
+    it('flags destructive steps (zh)', () => {
+      expect(planHasRiskySteps(['扫描桌面文件', '删除重复文件'])).toBe(true);
+      expect(planHasRiskySteps(['移动发票到文件夹'])).toBe(true);
+    });
+    it('flags destructive/outbound steps (en, case-insensitive)', () => {
+      expect(planHasRiskySteps(['Scan files', 'DELETE duplicates'])).toBe(true);
+      expect(planHasRiskySteps(['upload report to server'])).toBe(true);
+    });
+    it('does not flag pure read-only plans', () => {
+      expect(planHasRiskySteps(['查看文件列表', '分析数据', '总结结果'])).toBe(false);
+      expect(planHasRiskySteps(['search the web', 'read the file'])).toBe(false);
+    });
+    it('returns false for empty/invalid input', () => {
+      expect(planHasRiskySteps([])).toBe(false);
+      expect(planHasRiskySteps(undefined as unknown as string[])).toBe(false);
+    });
+  });
+
   describe('execute gating', () => {
     const ctx = { conversationId: 'c1', toolCallId: 't1' };
     const input = { steps: ['步骤一', '步骤二'] };
 
-    it('does not request approval when plan mode is off', async () => {
+    it('does not request approval for a safe plan when mode is off', async () => {
       mockGetPlanMode.mockReturnValue('off');
       const result = await reportPlanTool.execute(input, ctx);
       expect(mockRequestUserQuestion).not.toHaveBeenCalled();
       expect(mockSetPlanMode).not.toHaveBeenCalled();
       expect(result).toContain('已记录执行计划');
+    });
+
+    it('auto-triggers approval for a RISKY plan even when mode is off', async () => {
+      mockGetPlanMode.mockReturnValue('off');
+      mockRequestUserQuestion.mockResolvedValue({ answers: [{ header: '计划审批', question: 'q', selected: [PLAN_APPROVE_LABEL] }] });
+      const result = await reportPlanTool.execute({ steps: ['扫描桌面文件', '删除重复文件'] }, ctx);
+      expect(mockSetPlanMode).toHaveBeenCalledWith('c1', 'planning');
+      expect(mockRequestUserQuestion).toHaveBeenCalledOnce();
+      expect(mockSetPlanMode).toHaveBeenCalledWith('c1', 'approved');
+      expect(result).toContain('已批准');
     });
 
     it('approves: sets mode to approved and reports approval', async () => {
@@ -298,7 +327,7 @@ describe('reportPlanTool — plan-mode approval (B1)', () => {
       mockGetPlanMode.mockReturnValue('planning');
       mockRequestUserQuestion.mockResolvedValue({ answers: [{ header: '计划审批', question: 'q', selected: [PLAN_REJECT_LABEL] }] });
       const result = await reportPlanTool.execute(input, ctx);
-      expect(mockSetPlanMode).not.toHaveBeenCalled();
+      expect(mockSetPlanMode).not.toHaveBeenCalledWith('c1', 'approved');
       expect(result).toContain('未批准');
     });
 
@@ -306,7 +335,7 @@ describe('reportPlanTool — plan-mode approval (B1)', () => {
       mockGetPlanMode.mockReturnValue('planning');
       mockRequestUserQuestion.mockResolvedValue(null);
       const result = await reportPlanTool.execute(input, ctx);
-      expect(mockSetPlanMode).not.toHaveBeenCalled();
+      expect(mockSetPlanMode).not.toHaveBeenCalledWith('c1', 'approved');
       expect(result).toContain('超时');
     });
 

--- a/src/core/tools/definitions/memoryTools.ts
+++ b/src/core/tools/definitions/memoryTools.ts
@@ -34,6 +34,34 @@ export function interpretPlanApproval(result: UserQuestionResult | null): boolea
   return result.answers[0]?.selected.includes(PLAN_APPROVE_LABEL) ?? false;
 }
 
+/**
+ * High-risk operation keywords (heuristic). report_plan steps are natural-language
+ * and user-facing (no tool names), so we match destructive / mutating / outbound
+ * verbs to decide whether a plan needs explicit approval before execution. Tunable;
+ * lean inclusive for safety — a borderline approval prompt is cheaper than an
+ * unreviewed destructive run. Read-only verbs (查看/搜索/分析/list/read…) are absent
+ * on purpose so pure-research plans never trigger.
+ */
+export const PLAN_RISK_KEYWORDS: readonly string[] = [
+  // zh — destructive / mutating
+  '删除', '删掉', '移动', '移到', '覆盖', '替换', '重命名', '改名', '清空', '清除',
+  '卸载', '格式化', '重置', '丢弃', '抹除',
+  // zh — outbound / execution
+  '发送', '上传', '推送', '安装', '执行命令', '运行命令',
+  // en (matched lowercase)
+  'delete', 'remove', 'move', 'overwrite', 'replace', 'rename', 'clear',
+  'uninstall', 'format', 'reset', 'discard', 'erase', 'send', 'upload', 'push', 'install',
+];
+
+/** True if any plan step mentions a high-risk operation (heuristic — see PLAN_RISK_KEYWORDS). */
+export function planHasRiskySteps(steps: string[]): boolean {
+  if (!Array.isArray(steps)) return false;
+  return steps.some((s) => {
+    const text = String(s).toLowerCase();
+    return PLAN_RISK_KEYWORDS.some((kw) => text.includes(kw.toLowerCase()));
+  });
+}
+
 export const reportPlanTool: ToolDefinition = {
   name: TOOL_NAMES.REPORT_PLAN,
   description: '上报任务执行计划。在开始执行任何任务前必须先调用此工具，告知用户你将要执行的步骤。步骤描述要用用户能理解的业务语言，不要提及工具名称。',
@@ -50,25 +78,32 @@ export const reportPlanTool: ToolDefinition = {
   },
   execute: async (input, context) => {
     const steps = input.steps as string[];
+    const hasSteps = Array.isArray(steps) && steps.length > 0;
 
-    // Plan-mode approval gate (B1): while the conversation is in 'planning',
-    // presenting a plan requires user approval before writes are unlocked.
-    // Reuses the user-question UI; approve → 'approved' (the tool gate then allows
-    // writes), reject → stay 'planning' so the agent revises and re-submits.
+    // Plan approval (B1, auto-trigger): when a plan contains high-risk steps
+    // (move/delete/overwrite/send/install…), require user approval BEFORE writes
+    // are unlocked — no manual toggle needed; safe/read-only plans pass straight
+    // through unchanged. Also honors an explicitly-set 'planning' mode (e.g. a
+    // future manual toggle). On the gate: setPlanMode('planning') makes the tool
+    // gate (toolExecutor) block writes until the user decides. Approve →
+    // 'approved' (writes unlocked); reject/timeout → stay 'planning' (read-only)
+    // so the agent revises and re-submits report_plan.
     const convId = context?.conversationId;
-    if (convId && context?.toolCallId && getPlanMode(convId) === 'planning' && Array.isArray(steps) && steps.length > 0) {
+    const needsApproval = hasSteps && (planHasRiskySteps(steps) || (convId ? getPlanMode(convId) === 'planning' : false));
+    if (convId && context?.toolCallId && needsApproval) {
+      setPlanMode(convId, 'planning');
       const result = await requestUserQuestion(context.toolCallId, convId, buildPlanApprovalPayload(steps));
       if (interpretPlanApproval(result)) {
         setPlanMode(convId, 'approved');
         return '用户已批准计划，现在可以开始执行。';
       }
       if (result === null) {
-        return '计划审批超时或已取消，仍处于计划模式（只读）。可重新提交计划。';
+        return '计划审批超时或已取消，处于计划模式（只读）。可修改后重新提交计划。';
       }
-      return '用户未批准当前计划，请根据反馈修改后重新调用 report_plan。仍处于计划模式（只读）。';
+      return '用户未批准当前计划，请根据反馈修改后重新调用 report_plan。当前为计划模式（只读）。';
     }
 
-    if (!steps || steps.length === 0) {
+    if (!hasSteps) {
       return '已记录执行计划';
     }
     return `已记录执行计划：${steps.length}个步骤`;

--- a/src/core/tools/definitions/memoryTools.ts
+++ b/src/core/tools/definitions/memoryTools.ts
@@ -1,4 +1,6 @@
-import type { ToolDefinition } from '../../../types';
+import type { ToolDefinition, UserQuestionPayload, UserQuestionResult } from '../../../types';
+import { getPlanMode, setPlanMode } from '../../agent/planMode';
+import { requestUserQuestion } from '../../agent/permissionBridge';
 import { useChatStore } from '../../../stores/chatStore';
 import { useWorkspaceStore } from '../../../stores/workspaceStore';
 import { appendTaskLog, type TaskCategory } from '../../agent/taskLog';
@@ -6,6 +8,31 @@ import { getTodos, addTodo, updateTodo, setTodos, formatTodosForPrompt } from '.
 import type { TodoStatus } from '../../agent/todoManager';
 import { TOOL_NAMES } from '../toolNames';
 import type { MemoryType } from '../../memdir/types';
+
+// ── Plan-mode approval (B1) ─────────────────────────────────────────────────
+export const PLAN_APPROVE_LABEL = '批准执行';
+export const PLAN_REJECT_LABEL = '拒绝，重新规划';
+
+/** Build a single approve/reject question presenting the plan steps for approval. */
+export function buildPlanApprovalPayload(steps: string[]): UserQuestionPayload {
+  const stepList = steps.map((s, i) => `${i + 1}. ${s}`).join('\n');
+  return {
+    questions: [
+      {
+        header: '计划审批',
+        question: `${stepList}\n\n是否批准执行此计划？`,
+        multiSelect: false,
+        options: [{ label: PLAN_APPROVE_LABEL }, { label: PLAN_REJECT_LABEL }],
+      },
+    ],
+  };
+}
+
+/** True only if the user explicitly selected the approve option. */
+export function interpretPlanApproval(result: UserQuestionResult | null): boolean {
+  if (!result) return false;
+  return result.answers[0]?.selected.includes(PLAN_APPROVE_LABEL) ?? false;
+}
 
 export const reportPlanTool: ToolDefinition = {
   name: TOOL_NAMES.REPORT_PLAN,
@@ -21,8 +48,26 @@ export const reportPlanTool: ToolDefinition = {
     },
     required: ['steps'],
   },
-  execute: async (input) => {
+  execute: async (input, context) => {
     const steps = input.steps as string[];
+
+    // Plan-mode approval gate (B1): while the conversation is in 'planning',
+    // presenting a plan requires user approval before writes are unlocked.
+    // Reuses the user-question UI; approve → 'approved' (the tool gate then allows
+    // writes), reject → stay 'planning' so the agent revises and re-submits.
+    const convId = context?.conversationId;
+    if (convId && context?.toolCallId && getPlanMode(convId) === 'planning' && Array.isArray(steps) && steps.length > 0) {
+      const result = await requestUserQuestion(context.toolCallId, convId, buildPlanApprovalPayload(steps));
+      if (interpretPlanApproval(result)) {
+        setPlanMode(convId, 'approved');
+        return '用户已批准计划，现在可以开始执行。';
+      }
+      if (result === null) {
+        return '计划审批超时或已取消，仍处于计划模式（只读）。可重新提交计划。';
+      }
+      return '用户未批准当前计划，请根据反馈修改后重新调用 report_plan。仍处于计划模式（只读）。';
+    }
+
     if (!steps || steps.length === 0) {
       return '已记录执行计划';
     }


### PR DESCRIPTION
## Plan-mode（计划模式门控，B1）

只读决策逻辑 + 在 tool executor 强制计划门控；report_plan 的计划审批；高风险计划自动触发审批。

### 关于这条分支
从 `feat/multi-agent-harness` 中**单独拆出 plan-mode**（4 提交），基于 `dev`，不含 enterprise / harness / todos-inbox / 卡片。cherry-pick 零冲突。

### 验证
- `tsc -b` ✅ 零错误 · planMode / memoryTools 测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
