### PR TITLE
feat: 多 Agent Harness (sub-agents + run_agent_batch + 观测)

### DIFF
--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -726,6 +726,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         filePermissionCallback: filePermCb,
         onProgress,
         imContext: options?.imContext,
+        parentConversationId: conversationId,
       });
 
       // Complete the delegate step

--- a/src/core/agent/structuredOutput.test.ts
+++ b/src/core/agent/structuredOutput.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import { buildSchemaInstruction, extractJsonObject, validateStructured } from './structuredOutput';
+
+// ─── buildSchemaInstruction ───────────────────────────────────────────────
+
+describe('buildSchemaInstruction', () => {
+  it('contains the 【输出要求】 marker', () => {
+    const schema = { type: 'object', properties: { vendor: { type: 'string' } } };
+    const result = buildSchemaInstruction(schema);
+    expect(result).toContain('【输出要求】');
+  });
+
+  it('contains the serialised schema JSON', () => {
+    const schema = { type: 'object', required: ['vendor', 'amount'] };
+    const result = buildSchemaInstruction(schema);
+    expect(result).toContain(JSON.stringify(schema));
+  });
+
+  it('instructs not to use markdown fences', () => {
+    const result = buildSchemaInstruction({});
+    expect(result).toContain('markdown 代码块');
+  });
+
+  it('instructs not to output explanatory text', () => {
+    const result = buildSchemaInstruction({});
+    expect(result).toContain('解释性文字');
+  });
+
+  it('starts with a blank line separator', () => {
+    const result = buildSchemaInstruction({});
+    expect(result.startsWith('\n\n')).toBe(true);
+  });
+
+  it('works with an empty schema', () => {
+    const result = buildSchemaInstruction({});
+    expect(result).toContain('{}');
+  });
+});
+
+// ─── extractJsonObject ────────────────────────────────────────────────────
+
+describe('extractJsonObject', () => {
+  it('extracts a plain JSON object', () => {
+    const result = extractJsonObject('{"vendor":"Acme","amount":100}');
+    expect(result).toEqual({ vendor: 'Acme', amount: 100 });
+  });
+
+  it('extracts a JSON object wrapped in ```json fence', () => {
+    const text = '```json\n{"vendor":"Acme","amount":100}\n```';
+    expect(extractJsonObject(text)).toEqual({ vendor: 'Acme', amount: 100 });
+  });
+
+  it('extracts a JSON object wrapped in plain ``` fence', () => {
+    const text = '```\n{"key":"value"}\n```';
+    expect(extractJsonObject(text)).toEqual({ key: 'value' });
+  });
+
+  it('extracts a JSON object embedded in surrounding prose', () => {
+    const text = 'Here is my answer: {"vendor":"Beta","date":"2024-01-01"} Done.';
+    expect(extractJsonObject(text)).toEqual({ vendor: 'Beta', date: '2024-01-01' });
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(extractJsonObject('not json at all')).toBeNull();
+  });
+
+  it('returns null for a JSON array (not an object)', () => {
+    expect(extractJsonObject('[1, 2, 3]')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(extractJsonObject('')).toBeNull();
+  });
+
+  it('returns null for a JSON null literal', () => {
+    // JSON.parse("null") === null — should return null, not an object
+    expect(extractJsonObject('null')).toBeNull();
+  });
+
+  it('returns null for a bare number string', () => {
+    expect(extractJsonObject('42')).toBeNull();
+  });
+
+  it('handles nested objects correctly', () => {
+    const text = '{"a":{"b":1},"c":[1,2]}';
+    expect(extractJsonObject(text)).toEqual({ a: { b: 1 }, c: [1, 2] });
+  });
+
+  it('picks the outermost object when text has outer braces and inner prose', () => {
+    // first { last } approach — outer braces span the full JSON
+    const text = '{"x":1}';
+    expect(extractJsonObject(text)).toEqual({ x: 1 });
+  });
+});
+
+// ─── validateStructured ───────────────────────────────────────────────────
+
+describe('validateStructured', () => {
+  it('returns ok:true when all required keys are present', () => {
+    const result = validateStructured(
+      { vendor: 'Acme', amount: 100, date: '2024-01-01' },
+      { required: ['vendor', 'amount', 'date'] },
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('returns ok:false with missing keys when some are absent', () => {
+    const result = validateStructured(
+      { vendor: 'Acme' },
+      { required: ['vendor', 'amount', 'date'] },
+    );
+    expect(result).toEqual({ ok: false, missing: ['amount', 'date'] });
+  });
+
+  it('returns ok:true when schema has no required array', () => {
+    const result = validateStructured({ anything: 1 }, { type: 'object' });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('returns ok:true when required array is empty', () => {
+    const result = validateStructured({}, { required: [] });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('returns ok:true when data is empty but no required keys specified', () => {
+    const result = validateStructured({}, {});
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('returns ok:false listing all missing keys', () => {
+    const result = validateStructured(
+      {},
+      { required: ['a', 'b', 'c'] },
+    );
+    if (result.ok === false) {
+      expect(result.missing).toEqual(['a', 'b', 'c']);
+    } else {
+      throw new Error('Expected ok:false');
+    }
+  });
+
+  it('treats only own-property keys as present (does not check prototype chain)', () => {
+    const data = Object.create({ inherited: 'yes' }) as Record<string, unknown>;
+    data['own'] = 'value';
+    const result = validateStructured(data, { required: ['own', 'inherited'] });
+    // 'inherited' is on the prototype, not an own property — should be missing
+    expect(result).toEqual({ ok: false, missing: ['inherited'] });
+  });
+});

--- a/src/core/agent/structuredOutput.ts
+++ b/src/core/agent/structuredOutput.ts
@@ -1,0 +1,82 @@
+/**
+ * structuredOutput — pure helpers for structured (JSON) sub-agent results.
+ *
+ * These utilities are provider-portable: they work by instructing the sub-agent
+ * via a natural-language suffix appended to the task prompt, then extracting
+ * and lightly validating the JSON object from the sub-agent's text response.
+ * No forced-tool or model-specific features required.
+ */
+
+/**
+ * Build a Chinese instruction suffix to append to a task prompt.
+ * Tells the sub-agent to emit exactly one JSON object matching the given schema,
+ * without markdown fences or explanatory prose.
+ */
+export function buildSchemaInstruction(schema: Record<string, unknown>): string {
+  return (
+    '\n\n【输出要求】完成后，只输出一个 JSON 对象，严格匹配以下 JSON Schema，' +
+    '不要输出任何解释性文字、不要用 markdown 代码块包裹：\n' +
+    JSON.stringify(schema)
+  );
+}
+
+/**
+ * Robustly extract a single JSON object from model output text.
+ *
+ * Strategy:
+ * 1. Strip a leading/trailing ```json…``` or ```…``` fence if present.
+ * 2. Find the first `{` and the last `}` in the (possibly stripped) text.
+ * 3. JSON.parse that substring.
+ * 4. Return the parsed value only if it is a non-null plain object.
+ *    Arrays, primitives, and parse errors all return null (never throws).
+ */
+export function extractJsonObject(text: string): Record<string, unknown> | null {
+  let source = text.trim();
+
+  // Strip markdown code fence (```json … ``` or ``` … ```)
+  const fenceMatch = /^```(?:json)?\s*\n?([\s\S]*?)\n?```$/m.exec(source);
+  if (fenceMatch) {
+    source = fenceMatch[1].trim();
+  }
+
+  const start = source.indexOf('{');
+  const end = source.lastIndexOf('}');
+  if (start === -1 || end === -1 || end < start) return null;
+
+  const candidate = source.slice(start, end + 1);
+  try {
+    const parsed: unknown = JSON.parse(candidate);
+    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Light validation: check that every key listed in `schema.required` exists
+ * as an own property in `data`. No deep type checking is performed.
+ *
+ * Returns `{ ok: true }` when all required keys are present (or when there is
+ * no `required` array in the schema). Returns `{ ok: false, missing: [...] }`
+ * when one or more keys are absent.
+ */
+export function validateStructured(
+  data: Record<string, unknown>,
+  schema: Record<string, unknown>,
+): { ok: true } | { ok: false; missing: string[] } {
+  const required = schema.required;
+  if (!Array.isArray(required)) return { ok: true };
+
+  const missing: string[] = [];
+  for (const key of required) {
+    if (typeof key === 'string' && !Object.prototype.hasOwnProperty.call(data, key)) {
+      missing.push(key);
+    }
+  }
+
+  if (missing.length === 0) return { ok: true };
+  return { ok: false, missing };
+}

--- a/src/core/agent/subagentLoop.test.ts
+++ b/src/core/agent/subagentLoop.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from 'vitest';
-import { isNoProgressTurn } from './subagentLoop';
+import { describe, it, expect, afterEach } from 'vitest';
+import { isNoProgressTurn, buildSubagentStartEvent, buildSubagentEndEvent } from './subagentLoop';
+import { registerHook, clearAllHooks, getHookCount } from './lifecycleHooks';
+import type { SubagentStartEvent, SubagentEndEvent } from './lifecycleHooks';
 
 describe('isNoProgressTurn', () => {
   it('flags a turn where every tool call is unparseable', () => {
@@ -65,5 +67,96 @@ describe('isNoProgressTurn', () => {
       turnText: '',
       stopReason: 'end_turn',
     })).toBe(false);
+  });
+});
+
+// ─── Lifecycle hook event shape tests ────────────────────────────────────────
+
+describe('subagent lifecycle event builders', () => {
+  afterEach(() => {
+    clearAllHooks();
+  });
+
+  describe('buildSubagentStartEvent', () => {
+    it('returns a subagentStart event with correct shape', () => {
+      const before = Date.now();
+      const event = buildSubagentStartEvent('my-agent', 'write a report');
+      const after = Date.now();
+
+      expect(event.type).toBe('subagentStart');
+      expect(event.agentName).toBe('my-agent');
+      expect(event.task).toBe('write a report');
+      expect(event.timestamp).toBeGreaterThanOrEqual(before);
+      expect(event.timestamp).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe('buildSubagentEndEvent', () => {
+    it('returns a subagentEnd event with correct shape (success)', () => {
+      const event = buildSubagentEndEvent('my-agent', 'done', false);
+      expect(event.type).toBe('subagentEnd');
+      expect(event.agentName).toBe('my-agent');
+      expect(event.result).toBe('done');
+      expect(event.error).toBe(false);
+    });
+
+    it('returns a subagentEnd event with correct shape (error)', () => {
+      const event = buildSubagentEndEvent('my-agent', 'Error: something failed', true);
+      expect(event.type).toBe('subagentEnd');
+      expect(event.error).toBe(true);
+      expect(event.result).toBe('Error: something failed');
+    });
+  });
+
+  describe('hook registration and invocation', () => {
+    it('subagentStart hook is invoked when event is emitted via emitHook', async () => {
+      // Import emitHook directly so we can drive it without the full loop
+      const { emitHook } = await import('./lifecycleHooks');
+
+      const received: SubagentStartEvent[] = [];
+      registerHook<SubagentStartEvent>('subagentStart', (e) => { received.push(e); });
+      expect(getHookCount('subagentStart')).toBe(1);
+
+      const event = buildSubagentStartEvent('test-agent', 'test task');
+      await emitHook(event);
+
+      expect(received).toHaveLength(1);
+      expect(received[0].agentName).toBe('test-agent');
+      expect(received[0].task).toBe('test task');
+    });
+
+    it('subagentEnd hook is invoked when event is emitted via emitHook', async () => {
+      const { emitHook } = await import('./lifecycleHooks');
+
+      const received: SubagentEndEvent[] = [];
+      registerHook<SubagentEndEvent>('subagentEnd', (e) => { received.push(e); });
+
+      const event = buildSubagentEndEvent('test-agent', 'result text', false);
+      await emitHook(event);
+
+      expect(received).toHaveLength(1);
+      expect(received[0].result).toBe('result text');
+      expect(received[0].error).toBe(false);
+    });
+
+    it('clearAllHooks removes all registered hooks', () => {
+      registerHook<SubagentStartEvent>('subagentStart', () => {});
+      registerHook<SubagentEndEvent>('subagentEnd', () => {});
+      expect(getHookCount()).toBe(2);
+      clearAllHooks();
+      expect(getHookCount()).toBe(0);
+    });
+
+    it('emitHook is behavior-preserving when no hooks are registered (synchronous fast path)', async () => {
+      const { emitHook } = await import('./lifecycleHooks');
+      // clearAllHooks already called in afterEach, verify count is 0
+      expect(getHookCount('subagentStart')).toBe(0);
+
+      const event = buildSubagentStartEvent('no-hooks', 'task');
+      // When no hooks registered, emitHook returns synchronously (not a Promise)
+      // but awaiting it is always safe
+      const result = await emitHook(event);
+      expect(result).toBe(event); // same reference returned
+    });
   });
 });

--- a/src/core/agent/subagentLoop.ts
+++ b/src/core/agent/subagentLoop.ts
@@ -21,6 +21,21 @@ import { prepareContextMessages } from '../context/contextManager';
 import { compressContextIfNeeded } from '../context/contextCompressor';
 import { getMessageText } from '../context/contextUtils';
 import { withRetry } from './retry';
+import { emitHook } from './lifecycleHooks';
+import type { SubagentStartEvent, SubagentEndEvent, PreToolCallEvent } from './lifecycleHooks';
+import { startSubagentSpan } from '../observability/langfuse';
+
+// ─── Pure event-builder helpers (exported for unit-testing event shapes) ───
+
+/** Build a subagentStart lifecycle event (no side-effects). */
+export function buildSubagentStartEvent(agentName: string, task: string): SubagentStartEvent {
+  return { type: 'subagentStart', timestamp: Date.now(), agentName, task };
+}
+
+/** Build a subagentEnd lifecycle event (no side-effects). */
+export function buildSubagentEndEvent(agentName: string, result: string, error: boolean): SubagentEndEvent {
+  return { type: 'subagentEnd', timestamp: Date.now(), agentName, result, error };
+}
 
 /**
  * Extract a brief summary of parent conversation for subagent context.
@@ -127,6 +142,8 @@ export interface SubagentLoopOptions {
   onProgress?: (event: SubagentProgressEvent) => void;
   /** IM context — provides correct workspace path in headless mode */
   imContext?: IMContext;
+  /** Parent conversation ID for Langfuse parent-child span linking */
+  parentConversationId?: string;
 }
 
 export async function runSubagentLoop(options: SubagentLoopOptions): Promise<SubagentResult> {
@@ -139,6 +156,12 @@ export async function runSubagentLoop(options: SubagentLoopOptions): Promise<Sub
   // Guard: if signal is already aborted at entry, ignore it to avoid stale abort state from previous runs.
   // A genuinely cancelled request will re-abort the fresh controller created by the caller.
   const signal = options.signal?.aborted ? undefined : options.signal;
+
+  // Lifecycle: subagentStart
+  await emitHook({ type: 'subagentStart', timestamp: Date.now(), agentName: agent.name, task });
+
+  // Observability: open a Langfuse span (no-op when Langfuse not configured)
+  const subagentSpan = startSubagentSpan(options.parentConversationId ?? null, { agentName: agent.name, task });
 
   try {
     const settings = useSettingsStore.getState();
@@ -248,13 +271,16 @@ export async function runSubagentLoop(options: SubagentLoopOptions): Promise<Sub
 
     for (let turn = 0; turn < maxTurns; turn++) {
       if (signal?.aborted) {
-        return new SubagentResult({
+        const abortResult = new SubagentResult({
           text: resultBuffer || 'Error: 任务被取消',
           toolCallCount: totalToolCalls,
           turnCount: turn,
           tokenUsage: { input: totalInputTokens, output: totalOutputTokens },
           duration: (Date.now() - startTime) / 1000,
         });
+        await emitHook({ type: 'subagentEnd', timestamp: Date.now(), agentName: agent.name, result: abortResult.text, error: false });
+        subagentSpan.end({ output: abortResult.text, tokenUsage: abortResult.tokenUsage, toolCallCount: abortResult.toolCallCount, turnCount: abortResult.turnCount, duration: abortResult.duration });
+        return abortResult;
       }
 
       const collectedToolCalls: Array<{
@@ -420,25 +446,64 @@ export async function runSubagentLoop(options: SubagentLoopOptions): Promise<Sub
       };
       messages.push(assistantMsg);
 
-      // Execute tools in parallel
+      // Execute tools in parallel (routed through preToolCall/postToolCall hooks)
       const toolResults = await Promise.allSettled(
         collectedToolCalls.map(async (tc) => {
           if (signal?.aborted) {
             return { id: tc.id, result: '[已取消]' };
           }
+
+          // Emit preToolCall — may block or modify input
+          const preEvent = await emitHook({
+            type: 'preToolCall' as const,
+            timestamp: Date.now(),
+            toolName: tc.name,
+            toolInput: tc.input,
+          } as PreToolCallEvent);
+          if (preEvent.blocked) {
+            if (preEvent.blockReason) {
+              return { id: tc.id, result: `Error: ${preEvent.blockReason}` };
+            }
+            return { id: tc.id, result: '[被 hook 拦截]' };
+          }
+          const effectiveInput = preEvent.modifiedInput ?? tc.input;
+
+          const toolStart = Date.now();
           try {
             const subagentToolContext: ToolExecutionContext = { workspacePath };
             const rawResult = await executeAnyTool(
               tc.name,
-              tc.input,
+              effectiveInput,
               commandConfirmCallback,
               filePermissionCallback,
               subagentToolContext,
             );
-            return { id: tc.id, result: toolResultToString(rawResult) };
+            const result = toolResultToString(rawResult);
+            const durationMs = Date.now() - toolStart;
+            await emitHook({
+              type: 'postToolCall' as const,
+              timestamp: Date.now(),
+              toolName: tc.name,
+              toolInput: effectiveInput,
+              result,
+              error: false,
+              durationMs,
+            });
+            return { id: tc.id, result };
           } catch (err) {
             const errMsg = err instanceof Error ? err.message : String(err);
-            return { id: tc.id, result: `Error: ${errMsg}` };
+            const result = `Error: ${errMsg}`;
+            const durationMs = Date.now() - toolStart;
+            await emitHook({
+              type: 'postToolCall' as const,
+              timestamp: Date.now(),
+              toolName: tc.name,
+              toolInput: effectiveInput,
+              result,
+              error: true,
+              durationMs,
+            });
+            return { id: tc.id, result };
           }
         })
       );
@@ -470,21 +535,27 @@ export async function runSubagentLoop(options: SubagentLoopOptions): Promise<Sub
       );
     }
 
-    return new SubagentResult({
+    const finalResult = new SubagentResult({
       text: resultBuffer || 'Error: 子代理未产出内容（可能模型推理占满了输出预算）。建议换用能力更强或非推理的模型重试。',
       toolCallCount: totalToolCalls,
       turnCount: maxTurns,
       tokenUsage: { input: totalInputTokens, output: totalOutputTokens },
       duration: (Date.now() - startTime) / 1000,
     });
+    await emitHook({ type: 'subagentEnd', timestamp: Date.now(), agentName: agent.name, result: finalResult.text, error: false });
+    subagentSpan.end({ output: finalResult.text, tokenUsage: finalResult.tokenUsage, toolCallCount: finalResult.toolCallCount, turnCount: finalResult.turnCount, duration: finalResult.duration });
+    return finalResult;
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
-    return new SubagentResult({
+    const errorResult = new SubagentResult({
       text: `Error: ${errMsg}`,
       toolCallCount: totalToolCalls,
       turnCount: 0,
       tokenUsage: { input: totalInputTokens, output: totalOutputTokens },
       duration: (Date.now() - startTime) / 1000,
     });
+    await emitHook({ type: 'subagentEnd', timestamp: Date.now(), agentName: agent.name, result: errorResult.text, error: true });
+    subagentSpan.end({ output: errorResult.text, tokenUsage: errorResult.tokenUsage, toolCallCount: errorResult.toolCallCount, turnCount: errorResult.turnCount, duration: errorResult.duration, error: errMsg });
+    return errorResult;
   }
 }

--- a/src/core/llm/openai-compatible.test.ts
+++ b/src/core/llm/openai-compatible.test.ts
@@ -31,7 +31,8 @@ vi.mock('./tauriFetch', () => ({
 }));
 
 // Import after mock is registered.
-import { OpenAICompatibleAdapter } from './openai-compatible';
+import { OpenAICompatibleAdapter, toOpenAIToolChoice } from './openai-compatible';
+import type { ToolChoice } from './adapter';
 
 /** Build an SSE Response from a list of JSON-serializable chunks (plus [DONE]). */
 function makeSSEResponse(chunks: unknown[]): Response {
@@ -430,5 +431,56 @@ describe('OpenAICompatibleAdapter hang timeouts (abort on no progress)', () => {
 
     await vi.advanceTimersByTimeAsync(2_000);
     await expect(chatPromise).rejects.toMatchObject({ code: 'network_error', retryable: true });
+  });
+});
+
+describe('toOpenAIToolChoice (pure helper)', () => {
+  it('returns undefined when called with undefined', () => {
+    expect(toOpenAIToolChoice(undefined)).toBeUndefined();
+  });
+
+  it("maps { type: 'auto' } → 'auto'", () => {
+    const tc: ToolChoice = { type: 'auto' };
+    expect(toOpenAIToolChoice(tc)).toBe('auto');
+  });
+
+  it("maps { type: 'any' } → 'required'", () => {
+    const tc: ToolChoice = { type: 'any' };
+    expect(toOpenAIToolChoice(tc)).toBe('required');
+  });
+
+  it("maps { type: 'tool', name: 'X' } → { type: 'function', function: { name: 'X' } }", () => {
+    const tc: ToolChoice = { type: 'tool', name: 'X' };
+    expect(toOpenAIToolChoice(tc)).toEqual({ type: 'function', function: { name: 'X' } });
+  });
+});
+
+describe('OpenAICompatibleAdapter body wiring: tool_choice', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('sets body.tool_choice when toolChoice is provided and tools are present', async () => {
+    mockFetch.mockResolvedValueOnce(makeSSEResponse([
+      { choices: [{ delta: { content: 'ok' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]));
+    const adapter = new OpenAICompatibleAdapter();
+    await adapter.chat([userMessage], makeOptions({ toolChoice: { type: 'any' } }), () => {});
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string) as Record<string, unknown>;
+    expect(body.tool_choice).toBe('required');
+  });
+
+  it('omits body.tool_choice when toolChoice is not provided', async () => {
+    mockFetch.mockResolvedValueOnce(makeSSEResponse([
+      { choices: [{ delta: { content: 'ok' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]));
+    const adapter = new OpenAICompatibleAdapter();
+    await adapter.chat([userMessage], makeOptions(), () => {});
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string) as Record<string, unknown>;
+    expect(body.tool_choice).toBeUndefined();
   });
 });

--- a/src/core/llm/openai-compatible.ts
+++ b/src/core/llm/openai-compatible.ts
@@ -1,4 +1,4 @@
-import type { LLMAdapter, ChatOptions } from './adapter';
+import type { LLMAdapter, ChatOptions, ToolChoice } from './adapter';
 import { LLMError, classifyError } from './adapter';
 import type { Message, StreamEvent, ToolDefinition } from '../../types';
 import { getTauriFetch } from './tauriFetch';
@@ -250,6 +250,24 @@ function convertMessages(messages: Message[], systemPrompt?: string, supportsVis
   return serializeForOpenAI(turns, systemPrompt);
 }
 
+/**
+ * Convert Abu's ToolChoice into an OpenAI-compatible tool_choice value.
+ *
+ * Mapping:
+ *   undefined              → undefined  (omit field — preserves current default behaviour)
+ *   { type: 'auto' }      → 'auto'
+ *   { type: 'any' }       → 'required'
+ *   { type: 'tool', name} → { type: 'function', function: { name } }
+ */
+export function toOpenAIToolChoice(
+  tc: ToolChoice | undefined,
+): 'auto' | 'required' | { type: 'function'; function: { name: string } } | undefined {
+  if (tc === undefined) return undefined;
+  if (tc.type === 'auto') return 'auto';
+  if (tc.type === 'any') return 'required';
+  return { type: 'function', function: { name: tc.name } };
+}
+
 export class OpenAICompatibleAdapter implements LLMAdapter {
   async chat(
     messages: Message[],
@@ -288,6 +306,8 @@ export class OpenAICompatibleAdapter implements LLMAdapter {
 
     if (hasTools) {
       body.tools = convertTools(options.tools!);
+      const tc = toOpenAIToolChoice(options.toolChoice);
+      if (tc !== undefined) body.tool_choice = tc;
     }
 
     // Inject built-in web search if configured

--- a/src/core/observability/langfuse.test.ts
+++ b/src/core/observability/langfuse.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for Langfuse observability module — specifically the subagent span.
+ *
+ * The test environment may or may not have VITE_LANGFUSE_* keys (developer
+ * machines with .env.local have them, CI does not). Tests must hold in BOTH
+ * states: they verify the API contracts — non-throwing, correct return shape —
+ * not the enabled/disabled state itself.
+ */
+import { describe, it, expect } from 'vitest';
+import { startSubagentSpan } from './langfuse';
+
+describe('startSubagentSpan', () => {
+  it('always returns a handle (never null/undefined), regardless of observability state', () => {
+    const handle = startSubagentSpan(null, { agentName: 'test-agent', task: 'do something' });
+    expect(handle).toBeDefined();
+    expect(typeof handle.end).toBe('function');
+  });
+
+  it('.end() does not throw when called with no arguments (null parentId)', () => {
+    const handle = startSubagentSpan(null, { agentName: 'test-agent', task: 'do something' });
+    expect(() => handle.end()).not.toThrow();
+  });
+
+  it('.end() does not throw with a full payload (null parentId)', () => {
+    const handle = startSubagentSpan(null, { agentName: 'test-agent', task: 'do something' });
+    expect(() =>
+      handle.end({
+        output: 'result text',
+        tokenUsage: { input: 1000, output: 500 },
+        toolCallCount: 3,
+        turnCount: 2,
+        duration: 4.5,
+      })
+    ).not.toThrow();
+  });
+
+  it('.end() does not throw when parentConversationId is a non-existent trace id', () => {
+    // A conversationId that has no entry in _traces — must fall back gracefully
+    const handle = startSubagentSpan('missing-conversation-id', {
+      agentName: 'test-agent',
+      task: 'another task',
+    });
+    expect(() =>
+      handle.end({
+        output: 'some output',
+        tokenUsage: { input: 200, output: 100 },
+        toolCallCount: 1,
+        turnCount: 1,
+        duration: 1.2,
+        error: 'something went wrong',
+      })
+    ).not.toThrow();
+  });
+
+  it('.end() does not throw when called multiple times on the same handle', () => {
+    const handle = startSubagentSpan(null, { agentName: 'multi-end', task: 'task' });
+    expect(() => handle.end()).not.toThrow();
+    expect(() => handle.end({ output: 'second call' })).not.toThrow();
+  });
+
+  it('.end() does not throw with error field set', () => {
+    const handle = startSubagentSpan(null, { agentName: 'error-agent', task: 'fail task' });
+    expect(() =>
+      handle.end({
+        output: 'Error: network timeout',
+        error: 'network timeout',
+        duration: 0.5,
+      })
+    ).not.toThrow();
+  });
+});

--- a/src/core/observability/langfuse.ts
+++ b/src/core/observability/langfuse.ts
@@ -183,6 +183,71 @@ export function startToolSpan(
   };
 }
 
+/** Handle returned by startSubagentSpan */
+export interface EndableSubagentSpan {
+  end(data?: {
+    output?: unknown;
+    tokenUsage?: { input: number; output: number };
+    toolCallCount?: number;
+    turnCount?: number;
+    duration?: number;
+    error?: string;
+  }): void;
+}
+
+const NOOP_SUBAGENT_SPAN: EndableSubagentSpan = { end() {} };
+
+/**
+ * Start a subagent observability span. If the parent conversation trace exists,
+ * creates a child span on it; otherwise creates a standalone trace + span.
+ * Returns a no-op handle when observability is disabled. Never throws.
+ */
+export function startSubagentSpan(
+  parentConversationId: string | null,
+  data: { agentName: string; task: string },
+): EndableSubagentSpan {
+  const lf = getLangfuse();
+  if (!lf) return NOOP_SUBAGENT_SPAN;
+
+  try {
+    const spanName = `subagent:${data.agentName}`;
+    const spanInput = { task: data.task };
+
+    let span: ReturnType<LangfuseTraceClient['span']>;
+    let standaloneTrace: LangfuseTraceClient | null = null;
+
+    const parentTrace = parentConversationId ? _traces.get(parentConversationId) : undefined;
+    if (parentTrace) {
+      span = parentTrace.span({ name: spanName, input: spanInput });
+    } else {
+      standaloneTrace = lf.trace({ name: spanName, input: spanInput });
+      span = standaloneTrace.span({ name: spanName, input: spanInput });
+    }
+
+    return {
+      end(end) {
+        try {
+          span.end({
+            output: end?.output,
+            metadata: {
+              ...(end?.tokenUsage !== undefined ? { tokenUsage: end.tokenUsage } : {}),
+              ...(end?.toolCallCount !== undefined ? { toolCallCount: end.toolCallCount } : {}),
+              ...(end?.turnCount !== undefined ? { turnCount: end.turnCount } : {}),
+              ...(end?.duration !== undefined ? { duration: end.duration } : {}),
+            },
+            ...(end?.error ? { level: 'ERROR' as const, statusMessage: end.error } : {}),
+          });
+          if (standaloneTrace) {
+            void lf.flushAsync().catch(() => {});
+          }
+        } catch { /* best-effort */ }
+      },
+    };
+  } catch {
+    return NOOP_SUBAGENT_SPAN;
+  }
+}
+
 /**
  * Dev-only smoke test: emit one trace with a child generation + tool span and
  * flush synchronously. Verifies the Tauri→Langfuse transport (Phase A step 1).

--- a/src/core/tools/builtins.ts
+++ b/src/core/tools/builtins.ts
@@ -38,6 +38,8 @@ import { skillManageTool } from './definitions/skillManageTool';
 // --- Tool discovery ---
 import { toolSearchTool } from './definitions/toolSearchTool';
 
+// --- Orchestration tools ---
+import { runAgentBatchTool } from './definitions/orchestrationTools';
 // --- Computer tools ---
 import { computerTool } from './definitions/computerTools';
 export { setComputerUseBatchMode, setSkipAutoScreenshot } from './definitions/computerTools';
@@ -80,4 +82,5 @@ export function registerBuiltinTools(): void {
   toolRegistry.register(skillViewTool);
   toolRegistry.register(skillManageTool);
   toolRegistry.register(toolSearchTool);
+  toolRegistry.register(runAgentBatchTool);
 }

--- a/src/core/tools/definitions/orchestrationTools.test.ts
+++ b/src/core/tools/definitions/orchestrationTools.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for orchestrationTools.ts pure helpers.
+ *
+ * execute-level integration test note:
+ * The `execute` function calls `runSubagentLoop`, which in turn instantiates
+ * LLM adapters, Zustand stores, Tauri APIs, and Langfuse — all mocked globally
+ * in src/test/setup.ts but without a clean injection seam in the current
+ * runSubagentLoop signature. Wiring a `vi.mock('@/core/agent/subagentLoop')`
+ * module mock would require hoisting and re-exporting SubagentResult, which
+ * adds noise for little gain given the pure helpers already cover all the
+ * logic. Execute-level coverage is therefore deferred to E2E / manual tests
+ * and documented here as a deliberate trade-off (design note in design doc
+ * §切片1: "只 import `runSubagentLoop`").
+ */
+
+import { describe, it, expect } from 'vitest';
+import { clampConcurrency, runWithConcurrency, aggregateBatchResults } from './orchestrationTools';
+
+// ─── clampConcurrency ──────────────────────────────────────────────────────
+
+describe('clampConcurrency', () => {
+  it('returns 4 for undefined', () => {
+    expect(clampConcurrency(undefined)).toBe(4);
+  });
+
+  it('returns 4 for null', () => {
+    expect(clampConcurrency(null)).toBe(4);
+  });
+
+  it('returns 4 for a string', () => {
+    expect(clampConcurrency('high')).toBe(4);
+  });
+
+  it('returns 4 for NaN', () => {
+    expect(clampConcurrency(NaN)).toBe(4);
+  });
+
+  it('returns 4 for Infinity', () => {
+    expect(clampConcurrency(Infinity)).toBe(4);
+  });
+
+  it('returns default 4 for exact 4', () => {
+    expect(clampConcurrency(4)).toBe(4);
+  });
+
+  it('clamps below-minimum to 1', () => {
+    expect(clampConcurrency(0)).toBe(1);
+    expect(clampConcurrency(-5)).toBe(1);
+  });
+
+  it('clamps above-maximum to 8', () => {
+    expect(clampConcurrency(9)).toBe(8);
+    expect(clampConcurrency(100)).toBe(8);
+  });
+
+  it('accepts valid values within range', () => {
+    expect(clampConcurrency(1)).toBe(1);
+    expect(clampConcurrency(3)).toBe(3);
+    expect(clampConcurrency(8)).toBe(8);
+  });
+
+  it('floors floating-point values', () => {
+    expect(clampConcurrency(2.9)).toBe(2);
+    expect(clampConcurrency(7.1)).toBe(7);
+  });
+});
+
+// ─── runWithConcurrency ────────────────────────────────────────────────────
+
+describe('runWithConcurrency', () => {
+  it('runs all items and returns results', async () => {
+    const items = [1, 2, 3];
+    const results = await runWithConcurrency(items, 2, async (n) => n * 10);
+    expect(results).toHaveLength(3);
+    expect(results[0]).toEqual({ status: 'fulfilled', value: 10 });
+    expect(results[1]).toEqual({ status: 'fulfilled', value: 20 });
+    expect(results[2]).toEqual({ status: 'fulfilled', value: 30 });
+  });
+
+  it('preserves result order regardless of completion order', async () => {
+    // Item at index 1 resolves first (microtask-level), index 0 resolves second
+    const order: number[] = [];
+    const items = [50, 0, 30]; // "delay" in microtask iterations
+
+    const results = await runWithConcurrency(items, 3, async (delayTicks, index) => {
+      // Yield `delayTicks` microtasks to simulate ordering
+      for (let i = 0; i < delayTicks; i++) {
+        await Promise.resolve();
+      }
+      order.push(index);
+      return index;
+    });
+
+    // Results must be in index order regardless of completion order
+    expect(results.map((r) => (r.status === 'fulfilled' ? r.value : -1))).toEqual([0, 1, 2]);
+    // The zero-delay item (index 1) should have finished first
+    expect(order[0]).toBe(1);
+  });
+
+  it('never exceeds the concurrency limit', async () => {
+    let inFlight = 0;
+    let maxObservedInFlight = 0;
+    const items = Array.from({ length: 8 }, (_, i) => i);
+
+    await runWithConcurrency(items, 3, async () => {
+      inFlight++;
+      if (inFlight > maxObservedInFlight) maxObservedInFlight = inFlight;
+      // Yield to allow other workers to start before we decrement
+      await Promise.resolve();
+      inFlight--;
+    });
+
+    expect(maxObservedInFlight).toBeLessThanOrEqual(3);
+  });
+
+  it('produces rejected settled results when fn throws (does not propagate)', async () => {
+    const items = ['a', 'b', 'c'];
+    const results = await runWithConcurrency(items, 2, async (item) => {
+      if (item === 'b') throw new Error('boom');
+      return item.toUpperCase();
+    });
+
+    expect(results[0]).toEqual({ status: 'fulfilled', value: 'A' });
+    expect(results[1].status).toBe('rejected');
+    if (results[1].status === 'rejected') {
+      expect((results[1].reason as Error).message).toBe('boom');
+    }
+    expect(results[2]).toEqual({ status: 'fulfilled', value: 'C' });
+  });
+
+  it('handles empty items array', async () => {
+    const results = await runWithConcurrency([], 4, async (n: number) => n);
+    expect(results).toHaveLength(0);
+  });
+
+  it('handles limit larger than items count without error', async () => {
+    const items = [1, 2];
+    const results = await runWithConcurrency(items, 10, async (n) => n + 1);
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual({ status: 'fulfilled', value: 2 });
+    expect(results[1]).toEqual({ status: 'fulfilled', value: 3 });
+  });
+
+  it('passes correct index to fn', async () => {
+    const items = ['x', 'y', 'z'];
+    const captured: Array<[string, number]> = [];
+    await runWithConcurrency(items, 2, async (item, index) => {
+      captured.push([item, index]);
+    });
+    expect(captured).toContainEqual(['x', 0]);
+    expect(captured).toContainEqual(['y', 1]);
+    expect(captured).toContainEqual(['z', 2]);
+  });
+});
+
+// ─── aggregateBatchResults ────────────────────────────────────────────────
+
+describe('aggregateBatchResults', () => {
+  it('handles empty array', () => {
+    const result = aggregateBatchResults([]);
+    expect(result).toBe('共 0 个子任务，成功 0，失败 0');
+  });
+
+  it('ok-only: header shows all success, sections have no [失败] prefix', () => {
+    const result = aggregateBatchResults([
+      { label: '调研主题A', status: 'ok', text: '结果A' },
+      { label: '调研主题B', status: 'ok', text: '结果B' },
+    ]);
+    expect(result).toContain('共 2 个子任务，成功 2，失败 0');
+    expect(result).toContain('### 子任务 1: 调研主题A');
+    expect(result).toContain('结果A');
+    expect(result).toContain('### 子任务 2: 调研主题B');
+    expect(result).toContain('结果B');
+    expect(result).not.toContain('[失败]');
+  });
+
+  it('error-only: header shows all failures, sections have [失败] prefix', () => {
+    const result = aggregateBatchResults([
+      { label: '任务X', status: 'error', text: 'timeout' },
+    ]);
+    expect(result).toContain('共 1 个子任务，成功 0，失败 1');
+    expect(result).toContain('### 子任务 1: 任务X');
+    expect(result).toContain('[失败] timeout');
+  });
+
+  it('mixed: correct success/failure counts in header', () => {
+    const result = aggregateBatchResults([
+      { label: 'ok-task', status: 'ok', text: 'done' },
+      { label: 'bad-task', status: 'error', text: 'crashed' },
+      { label: 'ok-task2', status: 'ok', text: 'also done' },
+    ]);
+    expect(result).toContain('共 3 个子任务，成功 2，失败 1');
+    expect(result).toContain('### 子任务 1: ok-task');
+    expect(result).toContain('done');
+    expect(result).toContain('### 子任务 2: bad-task');
+    expect(result).toContain('[失败] crashed');
+    expect(result).toContain('### 子任务 3: ok-task2');
+    expect(result).toContain('also done');
+  });
+
+  it('sections are separated by blank lines', () => {
+    const result = aggregateBatchResults([
+      { label: 'A', status: 'ok', text: 'alpha' },
+      { label: 'B', status: 'ok', text: 'beta' },
+    ]);
+    // The separator between header and first section, and between sections
+    expect(result).toContain('\n\n');
+  });
+
+  it('header is the first line of output', () => {
+    const result = aggregateBatchResults([{ label: 'X', status: 'ok', text: 'out' }]);
+    expect(result.startsWith('共 1 个子任务')).toBe(true);
+  });
+});

--- a/src/core/tools/definitions/orchestrationTools.test.ts
+++ b/src/core/tools/definitions/orchestrationTools.test.ts
@@ -14,7 +14,12 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { clampConcurrency, runWithConcurrency, aggregateBatchResults } from './orchestrationTools';
+import {
+  clampConcurrency,
+  runWithConcurrency,
+  aggregateBatchResults,
+  aggregateStructuredResults,
+} from './orchestrationTools';
 
 // ─── clampConcurrency ──────────────────────────────────────────────────────
 
@@ -210,5 +215,60 @@ describe('aggregateBatchResults', () => {
   it('header is the first line of output', () => {
     const result = aggregateBatchResults([{ label: 'X', status: 'ok', text: 'out' }]);
     expect(result.startsWith('共 1 个子任务')).toBe(true);
+  });
+});
+
+// ─── aggregateStructuredResults ───────────────────────────────────────────
+
+describe('aggregateStructuredResults', () => {
+  it('returns a valid JSON array string', () => {
+    const entries = [
+      { task: 'invoice 1', ok: true, data: { vendor: 'Acme', amount: 100 } },
+      { task: 'invoice 2', ok: false, error: '未能解析出匹配的 JSON' },
+    ];
+    const result = aggregateStructuredResults(entries);
+    const parsed: unknown = JSON.parse(result);
+    expect(Array.isArray(parsed)).toBe(true);
+  });
+
+  it('preserves all fields for ok:true entries', () => {
+    const entries = [{ task: 'task A', ok: true, data: { vendor: 'Beta', amount: 200 } }];
+    const result = aggregateStructuredResults(entries);
+    const parsed = JSON.parse(result) as Array<{ task: string; ok: boolean; data: { vendor: string; amount: number } }>;
+    expect(parsed[0].task).toBe('task A');
+    expect(parsed[0].ok).toBe(true);
+    expect(parsed[0].data).toEqual({ vendor: 'Beta', amount: 200 });
+  });
+
+  it('preserves all fields for ok:false entries', () => {
+    const entries = [{ task: 'task B', ok: false, error: '缺少必填字段: amount' }];
+    const result = aggregateStructuredResults(entries);
+    const parsed = JSON.parse(result) as Array<{ task: string; ok: boolean; error: string }>;
+    expect(parsed[0].task).toBe('task B');
+    expect(parsed[0].ok).toBe(false);
+    expect(parsed[0].error).toBe('缺少必填字段: amount');
+  });
+
+  it('returns a pretty-printed (indented) JSON string', () => {
+    const result = aggregateStructuredResults([{ task: 't', ok: true, data: {} }]);
+    // Pretty-print means at least one newline and indentation
+    expect(result).toContain('\n');
+    expect(result).toContain('  ');
+  });
+
+  it('handles an empty entries array', () => {
+    const result = aggregateStructuredResults([]);
+    expect(JSON.parse(result)).toEqual([]);
+  });
+
+  it('preserves order of entries', () => {
+    const entries = [
+      { task: 'first', ok: true, data: { n: 1 } },
+      { task: 'second', ok: false, error: 'oops' },
+      { task: 'third', ok: true, data: { n: 3 } },
+    ];
+    const result = aggregateStructuredResults(entries);
+    const parsed = JSON.parse(result) as Array<{ task: string }>;
+    expect(parsed.map((e) => e.task)).toEqual(['first', 'second', 'third']);
   });
 });

--- a/src/core/tools/definitions/orchestrationTools.ts
+++ b/src/core/tools/definitions/orchestrationTools.ts
@@ -1,0 +1,295 @@
+/**
+ * Orchestration tools — deterministic fan-out + join for multi-agent workflows.
+ *
+ * `run_agent_batch`: runs N sub-agent tasks in parallel via Promise.allSettled
+ * over runSubagentLoop, then joins and returns ONE aggregated text result.
+ *
+ * This is the synchronous alternative to the lossy fire-and-forget
+ * `delegate_to_agent async:true` path — it blocks until all sub-agents finish.
+ */
+
+import type { ToolDefinition, ToolExecutionContext, SubagentDefinition } from '../../../types';
+import { TOOL_NAMES } from '../toolNames';
+import { agentRegistry } from '../../agent/registry';
+import { runSubagentLoop } from '../../agent/subagentLoop';
+import { useSettingsStore } from '../../../stores/settingsStore';
+import { getCurrentLoopContext, getLoopContext } from '../../agent/permissionBridge';
+import { extractParentConversationSummary } from '../../agent/subagentLoop';
+import { useChatStore } from '../../../stores/chatStore';
+
+// ─── Preset agents (mirrored from agentTools.ts) ──────────────────────────
+// Kept local so orchestrationTools has no runtime dependency on agentTools.ts.
+
+const PRESET_AGENTS: Record<string, { description: string; systemPrompt: string; tools: string[] }> = {
+  research: {
+    description: '信息搜索和调研',
+    systemPrompt: '你是一个专业的调研助手。专注于搜索、阅读和分析信息，输出结构化的调研结果。',
+    tools: [TOOL_NAMES.READ_FILE, TOOL_NAMES.LIST_DIRECTORY, TOOL_NAMES.FIND_FILES, TOOL_NAMES.SEARCH_FILES, TOOL_NAMES.WEB_SEARCH, TOOL_NAMES.HTTP_FETCH],
+  },
+  writer: {
+    description: '内容创作和文档撰写',
+    systemPrompt: '你是一个专业的写作助手。擅长撰写文档、报告、邮件等各类文字内容。',
+    tools: [TOOL_NAMES.READ_FILE, TOOL_NAMES.WRITE_FILE, TOOL_NAMES.EDIT_FILE, TOOL_NAMES.LIST_DIRECTORY, TOOL_NAMES.FIND_FILES, TOOL_NAMES.SEARCH_FILES, TOOL_NAMES.WEB_SEARCH],
+  },
+  executor: {
+    description: '执行复杂操作任务',
+    systemPrompt: '你是一个高效的执行助手。能够使用各种工具完成文件操作、命令执行等任务。',
+    tools: [],
+  },
+};
+
+function buildPresetAgent(type: string): SubagentDefinition {
+  const preset = PRESET_AGENTS[type];
+  return {
+    name: `preset-${type}`,
+    description: preset.description,
+    systemPrompt: preset.systemPrompt,
+    filePath: '__preset__',
+    tools: preset.tools.length > 0 ? preset.tools : undefined,
+    maxTurns: type === 'research' ? 15 : 20,
+  };
+}
+
+// ─── Pure exported helpers ─────────────────────────────────────────────────
+
+/**
+ * Clamp a concurrency value to [1, 8]. Non-numbers or out-of-range values
+ * fall back to 4 (the safe default for sub-agent batches).
+ */
+export function clampConcurrency(n: unknown): number {
+  if (typeof n !== 'number' || !isFinite(n)) return 4;
+  if (n < 1) return 1;
+  if (n > 8) return 8;
+  return Math.floor(n);
+}
+
+/**
+ * Run `items` through `fn` with at most `limit` concurrent in-flight calls.
+ * Result order matches input order. Errors from `fn` produce `rejected`
+ * settled results rather than propagating (same contract as Promise.allSettled).
+ */
+export async function runWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  const results: PromiseSettledResult<R>[] = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const i = nextIndex++;
+      try {
+        results[i] = { status: 'fulfilled', value: await fn(items[i], i) };
+      } catch (err) {
+        results[i] = { status: 'rejected', reason: err };
+      }
+    }
+  }
+
+  const workers: Promise<void>[] = [];
+  const actualLimit = Math.min(limit, items.length);
+  for (let w = 0; w < actualLimit; w++) {
+    workers.push(worker());
+  }
+  await Promise.all(workers);
+
+  return results;
+}
+
+/**
+ * Format batch results into a human-readable, sectioned report.
+ *
+ * Header line: `共 N 个子任务，成功 X，失败 Y`
+ * Each section: `### 子任务 N: <label>\n<text>` (ok)
+ *               `### 子任务 N: <label>\n[失败] <text>` (error)
+ */
+export function aggregateBatchResults(
+  entries: Array<{ label: string; status: 'ok' | 'error'; text: string }>,
+): string {
+  const total = entries.length;
+  const successCount = entries.filter((e) => e.status === 'ok').length;
+  const failCount = total - successCount;
+
+  const header = `共 ${total} 个子任务，成功 ${successCount}，失败 ${failCount}`;
+
+  if (total === 0) return header;
+
+  const sections = entries.map((entry, i) => {
+    const title = `### 子任务 ${i + 1}: ${entry.label}`;
+    const body = entry.status === 'ok' ? entry.text : `[失败] ${entry.text}`;
+    return `${title}\n${body}`;
+  });
+
+  return [header, ...sections].join('\n\n');
+}
+
+// ─── Task item type ────────────────────────────────────────────────────────
+
+interface BatchTaskItem {
+  type?: string;
+  agent_name?: string;
+  task: string;
+  context?: string;
+}
+
+// ─── Tool definition ───────────────────────────────────────────────────────
+
+export const runAgentBatchTool: ToolDefinition = {
+  name: TOOL_NAMES.RUN_AGENT_BATCH,
+  description:
+    '并行运行多个子代理任务，所有任务完成后一次性返回聚合报告。' +
+    '每个任务可指定 type（系统内置角色：research/writer/executor）或 agent_name（用户自定义代理）；' +
+    '两者均未指定时默认使用 research 调研角色。' +
+    '适用于需要同时调研多个独立话题、并行处理多个文件、或将大任务拆分为独立子任务并行执行的场景。' +
+    '注意：所有子任务均完成后结果才会一起回传，期间会阻塞当前对话。',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      tasks: {
+        type: 'array',
+        description: '子任务列表，1-16 个，每个任务独立并行执行',
+        minItems: 1,
+        maxItems: 16,
+        items: {
+          type: 'object',
+          properties: {
+            type: {
+              type: 'string',
+              description: '系统内置角色：research（只读调研）、writer（读写创作）、executor（全能执行）。与 agent_name 二选一；两者均不填时默认 research',
+              enum: ['research', 'writer', 'executor'],
+            },
+            agent_name: {
+              type: 'string',
+              description: '用户自定义代理名称。与 type 二选一',
+            },
+            task: {
+              type: 'string',
+              description: '该子任务的任务描述（必填）',
+            },
+            context: {
+              type: 'string',
+              description: '附加上下文（可选）',
+            },
+          },
+          required: ['task'],
+        },
+      },
+      concurrency: {
+        type: 'number',
+        description: '最大并发子代理数，默认 4，范围 1-8',
+      },
+    },
+    required: ['tasks'],
+  },
+
+  execute: async (input: Record<string, unknown>, toolExecContext?: ToolExecutionContext): Promise<string> => {
+    // ── 1. Parse + validate ────────────────────────────────────────────────
+    const rawTasks = input.tasks as BatchTaskItem[] | undefined;
+    if (!Array.isArray(rawTasks) || rawTasks.length === 0) {
+      return 'Error: tasks 必须是非空数组';
+    }
+    if (rawTasks.length > 16) {
+      return 'Error: tasks 最多支持 16 个子任务';
+    }
+
+    for (let i = 0; i < rawTasks.length; i++) {
+      const t = rawTasks[i];
+      if (!t.task || typeof t.task !== 'string' || t.task.trim() === '') {
+        return `Error: tasks[${i}].task 不能为空`;
+      }
+    }
+
+    const concurrency = clampConcurrency(input.concurrency as unknown);
+
+    // ── 2. Resolve parent loop context for callbacks ───────────────────────
+    const loopCtx = toolExecContext?.loopId
+      ? getLoopContext(toolExecContext.loopId)
+      : getCurrentLoopContext();
+
+    // ── 3. Extract parent conversation summary ─────────────────────────────
+    let parentConversationSummary: string | undefined;
+    try {
+      const chatState = useChatStore.getState();
+      const activeConvId = chatState.activeConversationId;
+      if (activeConvId) {
+        const messages = chatState.conversations[activeConvId]?.messages ?? [];
+        parentConversationSummary = extractParentConversationSummary(messages);
+      }
+    } catch {
+      // Non-critical
+    }
+
+    // ── 4. Resolve each task's agent ──────────────────────────────────────
+    type ResolvedTask = { agent: SubagentDefinition; task: string; context?: string; label: string };
+
+    const resolvedTasks: ResolvedTask[] = [];
+    for (let i = 0; i < rawTasks.length; i++) {
+      const item = rawTasks[i];
+      let agent: SubagentDefinition | undefined;
+      const agentType = item.type;
+      const agentName = item.agent_name;
+
+      if (agentType && PRESET_AGENTS[agentType]) {
+        agent = buildPresetAgent(agentType);
+      } else if (agentName) {
+        agent = agentRegistry.getAgent(agentName);
+        if (!agent) {
+          const available = agentRegistry
+            .getAvailableAgents()
+            .filter((a) => a.name !== 'abu')
+            .map((a) => `${a.name}`)
+            .join(', ');
+          const presetList = Object.keys(PRESET_AGENTS).join(', ');
+          return `Error: tasks[${i}] 代理 "${agentName}" 未找到。可用代理: ${available || '无'}。系统角色 type: ${presetList}`;
+        }
+        const { disabledAgents } = useSettingsStore.getState();
+        if (disabledAgents.includes(agentName)) {
+          return `Error: tasks[${i}] 代理 "${agentName}" 已被停用`;
+        }
+      } else {
+        // Default to research when neither type nor agent_name provided
+        agent = buildPresetAgent('research');
+      }
+
+      resolvedTasks.push({
+        agent,
+        task: item.task,
+        context: item.context,
+        label: item.task.slice(0, 60) + (item.task.length > 60 ? '…' : ''),
+      });
+    }
+
+    // ── 5. Run all sub-agents with concurrency pool ────────────────────────
+    const settled = await runWithConcurrency(
+      resolvedTasks,
+      concurrency,
+      async (resolved) => {
+        return runSubagentLoop({
+          agent: resolved.agent,
+          task: resolved.task,
+          context: resolved.context,
+          parentConversationSummary,
+          signal: loopCtx?.signal,
+          commandConfirmCallback: loopCtx?.commandConfirmCallback,
+          filePermissionCallback: loopCtx?.filePermissionCallback,
+        });
+      },
+    );
+
+    // ── 6. Aggregate results ───────────────────────────────────────────────
+    const entries = settled.map((result, i) => {
+      const label = resolvedTasks[i].label;
+      if (result.status === 'fulfilled') {
+        return { label, status: 'ok' as const, text: result.value.text };
+      }
+      const errMsg = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      return { label, status: 'error' as const, text: errMsg };
+    });
+
+    return aggregateBatchResults(entries);
+  },
+
+  // Already parallelizes internally — parent must not double-parallelize this tool.
+  isConcurrencySafe: () => false,
+};

--- a/src/core/tools/definitions/orchestrationTools.ts
+++ b/src/core/tools/definitions/orchestrationTools.ts
@@ -16,6 +16,7 @@ import { useSettingsStore } from '../../../stores/settingsStore';
 import { getCurrentLoopContext, getLoopContext } from '../../agent/permissionBridge';
 import { extractParentConversationSummary } from '../../agent/subagentLoop';
 import { useChatStore } from '../../../stores/chatStore';
+import { buildSchemaInstruction, extractJsonObject, validateStructured } from '../../agent/structuredOutput';
 
 // ─── Preset agents (mirrored from agentTools.ts) ──────────────────────────
 // Kept local so orchestrationTools has no runtime dependency on agentTools.ts.
@@ -124,6 +125,23 @@ export function aggregateBatchResults(
   return [header, ...sections].join('\n\n');
 }
 
+/**
+ * Aggregate structured sub-agent results into a JSON array string.
+ *
+ * Each entry carries:
+ *   - `task`: the label (first 60 chars of the task description)
+ *   - `ok`: whether extraction + validation succeeded
+ *   - `data`: the parsed JSON object (present when ok is true)
+ *   - `error`: human-readable reason (present when ok is false)
+ *
+ * Returns `JSON.stringify(entries, null, 2)` — a pretty-printed JSON array.
+ */
+export function aggregateStructuredResults(
+  entries: Array<{ task: string; ok: boolean; data?: Record<string, unknown>; error?: string }>,
+): string {
+  return JSON.stringify(entries, null, 2);
+}
+
 // ─── Task item type ────────────────────────────────────────────────────────
 
 interface BatchTaskItem {
@@ -179,6 +197,11 @@ export const runAgentBatchTool: ToolDefinition = {
         type: 'number',
         description: '最大并发子代理数，默认 4，范围 1-8',
       },
+      schema: {
+        type: 'object',
+        description:
+          '可选。提供 JSON Schema 时，每个子任务返回匹配该结构的 JSON 对象，聚合成 JSON 数组返回（适合批量提取结构化数据）。',
+      },
     },
     required: ['tasks'],
   },
@@ -201,6 +224,11 @@ export const runAgentBatchTool: ToolDefinition = {
     }
 
     const concurrency = clampConcurrency(input.concurrency as unknown);
+    const rawSchema = input.schema;
+    const schema: Record<string, unknown> | undefined =
+      rawSchema !== null && typeof rawSchema === 'object' && !Array.isArray(rawSchema)
+        ? (rawSchema as Record<string, unknown>)
+        : undefined;
 
     // ── 2. Resolve parent loop context for callbacks ───────────────────────
     const loopCtx = toolExecContext?.loopId
@@ -265,9 +293,13 @@ export const runAgentBatchTool: ToolDefinition = {
       resolvedTasks,
       concurrency,
       async (resolved) => {
+        const effectiveTask =
+          schema !== undefined
+            ? resolved.task + buildSchemaInstruction(schema)
+            : resolved.task;
         return runSubagentLoop({
           agent: resolved.agent,
-          task: resolved.task,
+          task: effectiveTask,
           context: resolved.context,
           parentConversationSummary,
           signal: loopCtx?.signal,
@@ -278,6 +310,33 @@ export const runAgentBatchTool: ToolDefinition = {
     );
 
     // ── 6. Aggregate results ───────────────────────────────────────────────
+    if (schema !== undefined) {
+      // Structured path: extract + validate JSON from each sub-agent's output
+      const structuredEntries = settled.map((result, i) => {
+        const task = resolvedTasks[i].label;
+        if (result.status === 'rejected') {
+          const errMsg =
+            result.reason instanceof Error ? result.reason.message : String(result.reason);
+          return { task, ok: false, error: errMsg };
+        }
+        const extracted = extractJsonObject(result.value.text);
+        if (extracted === null) {
+          return { task, ok: false, error: '未能解析出匹配的 JSON' };
+        }
+        const validation = validateStructured(extracted, schema);
+        if (!validation.ok) {
+          return {
+            task,
+            ok: false,
+            error: `缺少必填字段: ${validation.missing.join(', ')}`,
+          };
+        }
+        return { task, ok: true, data: extracted };
+      });
+      return aggregateStructuredResults(structuredEntries);
+    }
+
+    // Text aggregation path (behavior-preserving, schema absent)
     const entries = settled.map((result, i) => {
       const label = resolvedTasks[i].label;
       if (result.status === 'fulfilled') {

--- a/src/core/tools/toolNames.ts
+++ b/src/core/tools/toolNames.ts
@@ -66,6 +66,9 @@ export const TOOL_NAMES = {
 
   // Tool discovery
   TOOL_SEARCH: 'tool_search',
+
+  // Orchestration
+  RUN_AGENT_BATCH: 'run_agent_batch',
 } as const;
 
 export type ToolName = typeof TOOL_NAMES[keyof typeof TOOL_NAMES];

--- a/src/eval/__snapshots__/toolSchemaSnapshot.test.ts.snap
+++ b/src/eval/__snapshots__/toolSchemaSnapshot.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Tool count stability > total builtin tool count matches snapshot 1`] = `37`;
+exports[`Tool count stability > total builtin tool count matches snapshot 1`] = `38`;
 
 exports[`Tool schema snapshot > all tool schemas match snapshot 1`] = `
 [
@@ -308,6 +308,17 @@ exports[`Tool schema snapshot > all tool schemas match snapshot 1`] = `
     ],
     "requiredParams": [
       "reason",
+    ],
+  },
+  {
+    "name": "run_agent_batch",
+    "paramNames": [
+      "concurrency",
+      "schema",
+      "tasks",
+    ],
+    "requiredParams": [
+      "tasks",
     ],
   },
   {


### PR DESCRIPTION
## 多 Agent Harness

子 agent 一等公民化（lifecycle hooks + tool pipeline + Langfuse 观测）、`run_agent_batch`（确定性并行子 agent fan-out）、OpenAI-compatible adapter 支持 toolChoice、run_agent_batch 的结构化 JSON 输出。

### 关于这条分支
从 `feat/multi-agent-harness` 中**单独拆出多-agent-harness**（4 提交），基于 `dev`，不含 enterprise / todos-inbox / plan-mode / 卡片。

**注**：原始提交在 `subagentLoop.ts`/`builtins.ts`/`toolNames.ts` 与企业版、todos-inbox 共享文件，cherry-pick 时做了手工解冲突——**剔除了企业版的 `enterprise/llm-resolver` 引用和 todos 的 `create_todo` 注册**，只保留 harness 自身改动。子 agent LLM 走普通 adapter（OSS 行为）。

### 验证
- `tsc -b` ✅ 零错误 · orchestration / structuredOutput / langfuse / openai-compatible 测试 79 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
