### PR TITLE
feat(labs): 实验室（Labs）实验功能框架 + 待办/收件箱首住户

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,8 @@ import SystemSettingsView from '@/components/settings/SystemSettingsModal';
 import ToolboxView from '@/components/settings/ToolboxModal';
 import TodoView from '@/components/todos/TodoView';
 import InboxView from '@/components/inbox/InboxView';
+import { useLabsFlag } from '@/core/labs/resolve';
+import { LABS_TODOS_INBOX } from '@/core/labs/registry';
 import RightPanel from '@/components/panel/RightPanel';
 import ToastContainer from '@/components/common/ToastContainer';
 import { registerBuiltinTools } from '@/core/tools/builtins';
@@ -107,11 +109,22 @@ function App() {
   const rightPanelCollapsed = useSettingsStore((s) => s.rightPanelCollapsed);
   const toggleRightPanel = useSettingsStore((s) => s.toggleRightPanel);
   const viewMode = useSettingsStore((s) => s.viewMode);
+  const setViewMode = useSettingsStore((s) => s.setViewMode);
+  const showTodosInbox = useLabsFlag(LABS_TODOS_INBOX);
   const closeSystemSettings = useSettingsStore((s) => s.closeSystemSettings);
   const closeAutomation = useSettingsStore((s) => s.closeAutomation);
   const closeToolbox = useSettingsStore((s) => s.closeToolbox);
   const activeConv = useActiveConversation();
   const { t } = useI18n();
+
+  // If the Todos/Inbox Labs experiment is turned off while the user is parked
+  // on one of its views, fall back to chat — otherwise the sidebar nav out of
+  // that view disappears with it, stranding the user on an orphaned screen.
+  useEffect(() => {
+    if (!showTodosInbox && (viewMode === 'todos' || viewMode === 'inbox')) {
+      setViewMode('chat');
+    }
+  }, [showTodosInbox, viewMode, setViewMode]);
 
   const theme = useSettingsStore((s) => s.theme);
   useEffect(() => {

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -8,7 +8,7 @@ import { sendFeedback } from '@/utils/consoleFeedback';
 import { cn } from '@/lib/utils';
 import { usePreviewStore } from '@/stores/previewStore';
 import { useTodosStore } from '@/stores/todosStore';
-import { SHOW_TODOS_INBOX } from '@/config/featureGates';
+import { useLabsFlag } from '@/core/labs/resolve';
 import { runAgentLoop } from '@/core/agent/agentLoop';
 import { useI18n } from '@/i18n';
 import { getBaseName, loadLocalImage } from '@/utils/pathUtils';
@@ -232,6 +232,7 @@ function MessageTimestamp({ timestamp, className = '' }: { timestamp: number; cl
 
 function MessageActions({ message, onEdit, onDelete, onRegenerate, isUser, conversationId }: MessageActionsProps) {
   const { t } = useI18n();
+  const showTodosInbox = useLabsFlag('todos-inbox');
   const [copied, setCopied] = useState(false);
   const [addedToTodos, setAddedToTodos] = useState(false);
   const [feedbackRating, setFeedbackRating] = useState<'positive' | 'negative' | null>(null);
@@ -319,7 +320,7 @@ function MessageActions({ message, onEdit, onDelete, onRegenerate, isUser, conve
       )}
 
       {/* Add to Todos button - only for assistant messages */}
-      {SHOW_TODOS_INBOX && !isUser && (
+      {showTodosInbox && !isUser && (
         <button
           onClick={() => {
             const text = getTextContent(message.content).slice(0, 60).trim();

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/lib/utils';
 import { usePreviewStore } from '@/stores/previewStore';
 import { useTodosStore } from '@/stores/todosStore';
 import { useLabsFlag } from '@/core/labs/resolve';
+import { LABS_TODOS_INBOX } from '@/core/labs/registry';
 import { runAgentLoop } from '@/core/agent/agentLoop';
 import { useI18n } from '@/i18n';
 import { getBaseName, loadLocalImage } from '@/utils/pathUtils';
@@ -232,7 +233,7 @@ function MessageTimestamp({ timestamp, className = '' }: { timestamp: number; cl
 
 function MessageActions({ message, onEdit, onDelete, onRegenerate, isUser, conversationId }: MessageActionsProps) {
   const { t } = useI18n();
-  const showTodosInbox = useLabsFlag('todos-inbox');
+  const showTodosInbox = useLabsFlag(LABS_TODOS_INBOX);
   const [copied, setCopied] = useState(false);
   const [addedToTodos, setAddedToTodos] = useState(false);
   const [feedbackRating, setFeedbackRating] = useState<'positive' | 'negative' | null>(null);

--- a/src/components/settings/SystemSettingsModal.tsx
+++ b/src/components/settings/SystemSettingsModal.tsx
@@ -1,6 +1,6 @@
 import { useSettingsStore, type SystemSettingsTab } from '@/stores/settingsStore';
 import { useI18n } from '@/i18n';
-import { Settings2, Info, Shield, SlidersHorizontal, MessageCircle, Radio, Brain, Heart, Activity, BarChart3, Building2 } from 'lucide-react';
+import { Settings2, Info, Shield, SlidersHorizontal, MessageCircle, Radio, Brain, Heart, Activity, BarChart3, Building2, FlaskConical } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { AIServicesSection, AboutSection, SandboxSection, GeneralSection, IMChannelSection } from './sections';
 import FeedbackSection from './sections/FeedbackSection';
@@ -9,6 +9,7 @@ import SoulSection from './sections/SoulSection';
 import DiagnosticSection from './sections/DiagnosticSection';
 import UsageSection from './sections/UsageSection';
 import EnterpriseSection from './sections/EnterpriseSection';
+import LabsSection from './sections/LabsSection';
 import { IS_ENTERPRISE_BUILD } from '@/config/featureGates';
 
 export default function SystemSettingsView() {
@@ -26,6 +27,7 @@ export default function SystemSettingsView() {
     { id: 'soul', label: t.soul.title, icon: Heart },
     { id: 'sandbox', label: t.settings.sandbox, icon: Shield },
     { id: 'general', label: t.settings.general, icon: SlidersHorizontal },
+    { id: 'labs', label: t.settings.labs, icon: FlaskConical },
     { id: 'diagnostic', label: t.diagnostic.title, icon: Activity },
     { id: 'feedback', label: t.about.feedback, icon: MessageCircle },
     { id: 'about', label: t.common.version, icon: Info },
@@ -40,6 +42,8 @@ export default function SystemSettingsView() {
     switch (activeSystemTab) {
       case 'general':
         return <GeneralSection />;
+      case 'labs':
+        return <LabsSection />;
       case 'ai-services':
         return <AIServicesSection />;
       case 'sandbox':

--- a/src/components/settings/sections/LabsSection.tsx
+++ b/src/components/settings/sections/LabsSection.tsx
@@ -1,0 +1,56 @@
+import { useI18n } from '@/i18n';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { LABS_EXPERIMENTS } from '@/core/labs/registry';
+import { resolveLabsFlag } from '@/core/labs/resolve';
+import { Toggle } from '@/components/ui/toggle';
+
+export default function LabsSection() {
+  // Subscribe to the whole labs slice via useI18n's sibling store so the list
+  // re-renders on toggle; resolveLabsFlag reads the current stored map.
+  const { t } = useI18n();
+  const labs = useSettingsStore((s) => s.labs);
+  const setLabsFlag = useSettingsStore((s) => s.setLabsFlag);
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-[var(--abu-text-tertiary)]">
+        {t.settings.labsDescription}
+      </p>
+
+      {LABS_EXPERIMENTS.length === 0 ? (
+        <p className="text-xs text-[var(--abu-text-muted)] py-8 text-center">
+          {t.settings.labsEmpty}
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {LABS_EXPERIMENTS.map((exp) => {
+            const enabled = resolveLabsFlag(exp.id, labs);
+            return (
+              <div
+                key={exp.id}
+                className="flex items-center justify-between gap-4 p-4 rounded-xl border border-[var(--abu-border)] bg-[var(--abu-bg-muted)]"
+              >
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-[var(--abu-text-primary)]">
+                    {exp.title()}
+                  </p>
+                  <p className="text-xs text-[var(--abu-text-muted)] mt-0.5">
+                    {exp.description()}
+                  </p>
+                  <p className="text-[11px] text-[var(--abu-text-muted)] mt-1.5 opacity-70">
+                    {t.settings.labsChangeHint}
+                  </p>
+                </div>
+                <Toggle
+                  checked={enabled}
+                  onChange={() => setLabsFlag(exp.id, !enabled)}
+                  size="lg"
+                />
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -5,7 +5,7 @@ import { useProjectStore } from '@/stores/projectStore';
 import { useNoticeBadgeStore } from '@/stores/noticeBadgeStore';
 import { useInboxStore } from '@/stores/inboxStore';
 import { useI18n } from '@/i18n';
-import { SHOW_TODOS_INBOX } from '@/config/featureGates';
+import { useLabsFlag } from '@/core/labs/resolve';
 import { Plus, Workflow, Wrench, Trash2, Settings, Download, Upload, Pencil, Undo2, HelpCircle, FolderInput, FolderClosed, ChevronRight, Minus, Search, X, CheckSquare, Inbox } from 'lucide-react';
 import GuideModal from '@/components/common/GuideModal';
 import ProfileEditModal from '@/components/common/ProfileEditModal';
@@ -90,6 +90,7 @@ export default function Sidebar() {
   // remain unread — matches the "things you still owe a decision on" mental model.
   const pendingInboxCount = useInboxStore((s) => s.getPendingCount());
   const { t } = useI18n();
+  const showTodosInbox = useLabsFlag('todos-inbox');
 
   // Context menu state
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; convId: string } | null>(null);
@@ -272,7 +273,7 @@ export default function Sidebar() {
           <Plus className={cn('h-[18px] w-[18px]', activeConversationId === null && viewMode === 'chat' ? 'text-[var(--abu-clay)]' : 'text-[var(--abu-text-tertiary)]')} strokeWidth={2} />
           <span>{t.sidebar.newTask}</span>
         </button>
-        {SHOW_TODOS_INBOX && (
+        {showTodosInbox && (
           <>
             <button
               onClick={() => setViewMode('todos')}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -6,6 +6,7 @@ import { useNoticeBadgeStore } from '@/stores/noticeBadgeStore';
 import { useInboxStore } from '@/stores/inboxStore';
 import { useI18n } from '@/i18n';
 import { useLabsFlag } from '@/core/labs/resolve';
+import { LABS_TODOS_INBOX } from '@/core/labs/registry';
 import { Plus, Workflow, Wrench, Trash2, Settings, Download, Upload, Pencil, Undo2, HelpCircle, FolderInput, FolderClosed, ChevronRight, Minus, Search, X, CheckSquare, Inbox } from 'lucide-react';
 import GuideModal from '@/components/common/GuideModal';
 import ProfileEditModal from '@/components/common/ProfileEditModal';
@@ -90,7 +91,7 @@ export default function Sidebar() {
   // remain unread — matches the "things you still owe a decision on" mental model.
   const pendingInboxCount = useInboxStore((s) => s.getPendingCount());
   const { t } = useI18n();
-  const showTodosInbox = useLabsFlag('todos-inbox');
+  const showTodosInbox = useLabsFlag(LABS_TODOS_INBOX);
 
   // Context menu state
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; convId: string } | null>(null);

--- a/src/config/featureGates.ts
+++ b/src/config/featureGates.ts
@@ -1,23 +1,11 @@
 /**
- * Temporary, compile-time feature gates.
+ * Compile-time build gates.
  *
- * These hide not-yet-released features whose code already lives in the tree.
- * They are a stopgap until the Labs / experimental-features system exists — once
- * that lands, replace the constant reads with a Labs flag lookup (so users can
- * opt in) rather than deleting the gate.
- *
- * NOTE: this is deliberately NOT a persisted setting. Flipping the value (or
- * wiring it to Labs) is the only way to surface the feature — there is no
- * user-facing toggle yet by design.
+ * These are build-target constants, NOT user preferences — do not confuse them
+ * with the Labs (experimental features) system in `src/core/labs`, which is for
+ * user-facing opt-in toggles. Todos + Inbox moved to Labs ('todos-inbox'); the
+ * only remaining gate here is the enterprise-build flag below.
  */
-
-/**
- * Todos + Inbox (sidebar tabs, the "Add to Todos" chat action, and the
- * create_todo agent tool). Hidden for the v0.24 OSS release; the data stores
- * (`abu-todos` / `abu-inbox`) stay intact so nothing is lost when it ships.
- * Slated to become a Labs resident — see project-experimental-features-toggle.
- */
-export const SHOW_TODOS_INBOX = false;
 
 // Injected at build time by vite.config.ts / vitest.config.ts `define`.
 declare const __ENTERPRISE_BUILD__: boolean;

--- a/src/core/labs/registry.test.ts
+++ b/src/core/labs/registry.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { LABS_EXPERIMENTS, getLabsExperiment } from './registry';
+
+describe('labs registry', () => {
+  it('has unique ids (persisted keys must never collide)', () => {
+    const ids = LABS_EXPERIMENTS.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every experiment has a valid YYYY-MM-DD expiresAfter (lifecycle guard)', () => {
+    for (const exp of LABS_EXPERIMENTS) {
+      expect(exp.expiresAfter).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(Number.isNaN(Date.parse(exp.expiresAfter))).toBe(false);
+    }
+  });
+
+  it('every experiment resolves a non-empty i18n title and description', () => {
+    for (const exp of LABS_EXPERIMENTS) {
+      expect(exp.title().length).toBeGreaterThan(0);
+      expect(exp.description().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('ships the todos-inbox experiment, default off', () => {
+    const exp = getLabsExperiment('todos-inbox');
+    expect(exp).toBeDefined();
+    expect(exp?.defaultEnabled).toBe(false);
+  });
+
+  it('getLabsExperiment returns undefined for unknown ids', () => {
+    expect(getLabsExperiment('does-not-exist')).toBeUndefined();
+  });
+});

--- a/src/core/labs/registry.ts
+++ b/src/core/labs/registry.ts
@@ -1,0 +1,44 @@
+import { getI18n } from '@/i18n';
+
+/**
+ * A single Labs (experimental features) entry.
+ *
+ * Everything registered here is "实验中" — there is deliberately NO maturity
+ * state machine (Alpha/Beta/Stable). "Graduation" is a code action, not a
+ * stored tier: delete the entry here, drop its `if (labsFlag)` gate, and the
+ * feature becomes default behavior. Removing the entry also auto-drops any
+ * orphaned `settings.labs[id]` value, since the UI only renders registered ids.
+ *
+ * See docs/superpowers/specs/2026-07-04-labs-experimental-features-design.md.
+ */
+export interface LabsExperiment {
+  /** Stable key persisted in `settings.labs` — never rename or reuse. */
+  id: string;
+  /** i18n title, resolved lazily at render (not at module load). */
+  title: () => string;
+  /** i18n description, resolved lazily at render. */
+  description: () => string;
+  /** Effective value when the user has never toggled it. Almost always false. */
+  defaultEnabled: boolean;
+  /**
+   * `YYYY-MM-DD` review-by date. Forces a periodic lifecycle review so flags
+   * don't rot into Chrome-flags-style zombies — by this date the experiment
+   * should have graduated (removed) or been renewed.
+   */
+  expiresAfter: string;
+}
+
+export const LABS_EXPERIMENTS: readonly LabsExperiment[] = [
+  {
+    // Todos + Inbox are a linked cluster, surfaced as one experiment.
+    id: 'todos-inbox',
+    title: () => getI18n().settings.labsExpTodosInboxTitle,
+    description: () => getI18n().settings.labsExpTodosInboxDesc,
+    defaultEnabled: false,
+    expiresAfter: '2026-10-01',
+  },
+];
+
+export function getLabsExperiment(id: string): LabsExperiment | undefined {
+  return LABS_EXPERIMENTS.find((e) => e.id === id);
+}

--- a/src/core/labs/registry.ts
+++ b/src/core/labs/registry.ts
@@ -28,10 +28,18 @@ export interface LabsExperiment {
   expiresAfter: string;
 }
 
+/**
+ * Stable id for the Todos + Inbox experiment. Import this constant at every
+ * gate site instead of re-typing the raw string — a rename then becomes a
+ * compile error rather than a silent feature disable (resolveLabsFlag fails
+ * unknown ids safe to `false`).
+ */
+export const LABS_TODOS_INBOX = 'todos-inbox';
+
 export const LABS_EXPERIMENTS: readonly LabsExperiment[] = [
   {
     // Todos + Inbox are a linked cluster, surfaced as one experiment.
-    id: 'todos-inbox',
+    id: LABS_TODOS_INBOX,
     title: () => getI18n().settings.labsExpTodosInboxTitle,
     description: () => getI18n().settings.labsExpTodosInboxDesc,
     defaultEnabled: false,

--- a/src/core/labs/resolve.test.ts
+++ b/src/core/labs/resolve.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { resolveLabsFlag, isLabsFlagOn } from './resolve';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+describe('resolveLabsFlag', () => {
+  it('falls back to the registry default when the user never toggled it', () => {
+    // todos-inbox defaults to false
+    expect(resolveLabsFlag('todos-inbox', {})).toBe(false);
+  });
+
+  it('honors an explicit user opt-in', () => {
+    expect(resolveLabsFlag('todos-inbox', { 'todos-inbox': true })).toBe(true);
+  });
+
+  it('honors an explicit user opt-out even if it matches the default', () => {
+    expect(resolveLabsFlag('todos-inbox', { 'todos-inbox': false })).toBe(false);
+  });
+
+  it('resolves unknown/orphan ids to false (graduated experiment left a stale key)', () => {
+    expect(resolveLabsFlag('graduated-old-exp', { 'graduated-old-exp': true })).toBe(false);
+  });
+});
+
+describe('isLabsFlagOn', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ labs: {} });
+  });
+
+  it('reads the live store', () => {
+    expect(isLabsFlagOn('todos-inbox')).toBe(false);
+    useSettingsStore.getState().setLabsFlag('todos-inbox', true);
+    expect(isLabsFlagOn('todos-inbox')).toBe(true);
+  });
+});

--- a/src/core/labs/resolve.ts
+++ b/src/core/labs/resolve.ts
@@ -1,0 +1,34 @@
+import { useSettingsStore } from '@/stores/settingsStore';
+import { getLabsExperiment } from './registry';
+
+/**
+ * Effective value of a Labs flag: stored user override first, else the
+ * registry default, else `false`. An `id` with no registry entry (an orphan
+ * left behind by a graduated/removed experiment) resolves to `false`.
+ */
+export function resolveLabsFlag(id: string, stored: Record<string, boolean>): boolean {
+  const exp = getLabsExperiment(id);
+  // No registry entry → not a real (or no-longer-a) experiment. Fail safe to
+  // off, ignoring any stale stored value a graduated experiment left behind.
+  if (!exp) return false;
+  if (Object.prototype.hasOwnProperty.call(stored, id)) return stored[id];
+  return exp.defaultEnabled;
+}
+
+/**
+ * Imperative read for non-React callers (tool-list assembly, agent loop).
+ * Reads the live store, so callers that run per-request pick up toggles
+ * without a restart.
+ */
+export function isLabsFlagOn(id: string): boolean {
+  return resolveLabsFlag(id, useSettingsStore.getState().labs);
+}
+
+/**
+ * React selector hook. Subscribes to the `labs` slice so consumers re-render
+ * (and tabs/buttons appear/disappear) the instant a flag is toggled.
+ */
+export function useLabsFlag(id: string): boolean {
+  const stored = useSettingsStore((s) => s.labs);
+  return resolveLabsFlag(id, stored);
+}

--- a/src/core/labs/resolve.ts
+++ b/src/core/labs/resolve.ts
@@ -11,7 +11,9 @@ export function resolveLabsFlag(id: string, stored: Record<string, boolean>): bo
   // No registry entry → not a real (or no-longer-a) experiment. Fail safe to
   // off, ignoring any stale stored value a graduated experiment left behind.
   if (!exp) return false;
-  if (Object.prototype.hasOwnProperty.call(stored, id)) return stored[id];
+  // `=== true` enforces the boolean invariant the type claims: a corrupted or
+  // non-boolean persisted value resolves to off rather than truthy-on.
+  if (Object.prototype.hasOwnProperty.call(stored, id)) return stored[id] === true;
   return exp.defaultEnabled;
 }
 

--- a/src/core/tools/builtins.ts
+++ b/src/core/tools/builtins.ts
@@ -40,7 +40,6 @@ import { toolSearchTool } from './definitions/toolSearchTool';
 
 // --- Todo tools ---
 import { createTodoTool } from './definitions/todoTools';
-import { SHOW_TODOS_INBOX } from '@/config/featureGates';
 
 // --- Orchestration tools ---
 import { runAgentBatchTool } from './definitions/orchestrationTools';
@@ -89,8 +88,9 @@ export function registerBuiltinTools(): void {
   toolRegistry.register(skillViewTool);
   toolRegistry.register(skillManageTool);
   toolRegistry.register(toolSearchTool);
-  // create_todo feeds the Inbox, which is hidden until Labs ships — keep the
-  // agent tool out of the schema while the feature is gated off.
-  if (SHOW_TODOS_INBOX) toolRegistry.register(createTodoTool);
+  // create_todo feeds the Inbox. Registered unconditionally; getAllTools()
+  // filters it out of the per-request schema when the 'todos-inbox' Labs flag
+  // is off, so toggling the flag takes effect without an app restart.
+  toolRegistry.register(createTodoTool);
   toolRegistry.register(runAgentBatchTool);
 }

--- a/src/core/tools/registry.labsGating.test.ts
+++ b/src/core/tools/registry.labsGating.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { registerBuiltinTools } from './builtins';
+import { getAllTools, executeAnyTool } from './registry';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { LABS_TODOS_INBOX } from '../labs/registry';
+import { TOOL_NAMES } from './toolNames';
+
+// create_todo is registered unconditionally but gated on the 'todos-inbox'
+// Labs flag at BOTH advertisement (getAllTools) and execution (executeAnyTool).
+// These regressions lock in the fail-safe parity with the old compile-time gate.
+beforeAll(() => {
+  registerBuiltinTools();
+});
+
+describe('Labs-gated tool availability (create_todo / todos-inbox)', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ labs: {} });
+  });
+
+  it('withholds create_todo from the advertised schema when the flag is off', () => {
+    useSettingsStore.setState({ labs: { [LABS_TODOS_INBOX]: false } });
+    expect(getAllTools().some((t) => t.name === TOOL_NAMES.CREATE_TODO)).toBe(false);
+  });
+
+  it('advertises create_todo when the flag is on', () => {
+    useSettingsStore.setState({ labs: { [LABS_TODOS_INBOX]: true } });
+    expect(getAllTools().some((t) => t.name === TOOL_NAMES.CREATE_TODO)).toBe(true);
+  });
+
+  it('rejects create_todo execution as Unknown when the flag is off (fail-safe)', async () => {
+    useSettingsStore.setState({ labs: { [LABS_TODOS_INBOX]: false } });
+    const result = await executeAnyTool(TOOL_NAMES.CREATE_TODO, { title: 'x' });
+    expect(String(result)).toContain('Unknown tool');
+  });
+
+  it('does not reject create_todo as Unknown when the flag is on', async () => {
+    useSettingsStore.setState({ labs: { [LABS_TODOS_INBOX]: true } });
+    const result = await executeAnyTool(TOOL_NAMES.CREATE_TODO, { title: 'x' });
+    expect(String(result)).not.toContain('Unknown tool');
+  });
+});

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -13,6 +13,7 @@ import { reviewAction } from '../safety/reviewer';
 import { getLoopContext } from '../agent/permissionBridge';
 import { homeDir } from '@tauri-apps/api/path';
 import { TOOL_NAMES } from './toolNames';
+import { isLabsFlagOn } from '../labs/resolve';
 import { getCurrentPolicy } from '@/core/enterprise/policy/enforcer';
 import { checkTool } from '@/core/enterprise/policy/matcher';
 import { showPolicyConfirm } from '@/components/enterprise/policyConfirmQueue';
@@ -177,8 +178,14 @@ export function getAllTools(): ToolDefinition[] {
   // Computer use tools are always registered — the tool itself handles
   // auto-enabling and permission checks when first called.
 
+  // create_todo is registered unconditionally but only exposed to the agent
+  // when the 'todos-inbox' Labs experiment is enabled — mirrors the sidebar
+  // tabs' visibility so the flag governs the whole feature at once.
+  const todosInboxOn = isLabsFlagOn('todos-inbox');
+
   // Builtin tools first (higher priority)
   for (const tool of builtinTools) {
+    if (tool.name === TOOL_NAMES.CREATE_TODO && !todosInboxOn) continue;
     toolMap.set(tool.name, tool);
   }
   // MCP tools — only add if no name conflict

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -14,6 +14,23 @@ import { getLoopContext } from '../agent/permissionBridge';
 import { homeDir } from '@tauri-apps/api/path';
 import { TOOL_NAMES } from './toolNames';
 import { isLabsFlagOn } from '../labs/resolve';
+import { LABS_TODOS_INBOX } from '../labs/registry';
+
+/**
+ * Builtin tools whose availability is gated on a Labs experiment. A gated-off
+ * tool must be neither advertised (getAllTools) nor executable (executeAnyTool)
+ * — the two checks below keep parity so toggling the flag off fully retracts
+ * the tool, matching the old compile-time gate's fail-safe (the tool stays
+ * registered, so this map is the single source of truth for "is it live").
+ */
+const LABS_GATED_TOOLS: Record<string, string> = {
+  [TOOL_NAMES.CREATE_TODO]: LABS_TODOS_INBOX,
+};
+
+function isToolGatedOff(name: string): boolean {
+  const experimentId = LABS_GATED_TOOLS[name];
+  return experimentId !== undefined && !isLabsFlagOn(experimentId);
+}
 import { getCurrentPolicy } from '@/core/enterprise/policy/enforcer';
 import { checkTool } from '@/core/enterprise/policy/matcher';
 import { showPolicyConfirm } from '@/components/enterprise/policyConfirmQueue';
@@ -178,14 +195,10 @@ export function getAllTools(): ToolDefinition[] {
   // Computer use tools are always registered — the tool itself handles
   // auto-enabling and permission checks when first called.
 
-  // create_todo is registered unconditionally but only exposed to the agent
-  // when the 'todos-inbox' Labs experiment is enabled — mirrors the sidebar
-  // tabs' visibility so the flag governs the whole feature at once.
-  const todosInboxOn = isLabsFlagOn('todos-inbox');
-
-  // Builtin tools first (higher priority)
+  // Builtin tools first (higher priority). Labs-gated tools whose experiment
+  // is off are withheld from the advertised schema (see LABS_GATED_TOOLS).
   for (const tool of builtinTools) {
-    if (tool.name === TOOL_NAMES.CREATE_TODO && !todosInboxOn) continue;
+    if (isToolGatedOff(tool.name)) continue;
     toolMap.set(tool.name, tool);
   }
   // MCP tools — only add if no name conflict
@@ -389,8 +402,10 @@ export async function executeAnyTool(
     }
   }
 
-  // First check builtin tools
-  if (toolRegistry.has(name)) {
+  // First check builtin tools. A Labs-gated-off tool stays in the registry but
+  // is treated as absent here too, so a stale/hallucinated tool_use falls
+  // through to the "Unknown tool" fail-safe instead of silently executing.
+  if (toolRegistry.has(name) && !isToolGatedOff(name)) {
     const result = await toolRegistry.execute(name, input, toolContext);
     // Only truncate string results; rich content (images) passes through
     if (typeof result === 'string') {

--- a/src/eval/__snapshots__/toolSchemaSnapshot.test.ts.snap
+++ b/src/eval/__snapshots__/toolSchemaSnapshot.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Tool count stability > total builtin tool count matches snapshot 1`] = `39`;
+exports[`Tool count stability > total builtin tool count matches snapshot 1`] = `40`;
 
 exports[`Tool schema snapshot > all tool schemas match snapshot 1`] = `
 [
@@ -54,6 +54,16 @@ exports[`Tool schema snapshot > all tool schemas match snapshot 1`] = `
     ],
     "requiredParams": [
       "action",
+    ],
+  },
+  {
+    "name": "create_todo",
+    "paramNames": [
+      "reason",
+      "title",
+    ],
+    "requiredParams": [
+      "title",
     ],
   },
   {

--- a/src/eval/runOpenAI.ts
+++ b/src/eval/runOpenAI.ts
@@ -24,7 +24,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { ToolSelectionCase } from './types';
 import { registerBuiltinTools } from '@/core/tools/builtins';
-import { toolRegistry } from '@/core/tools/registry';
+import { getAllTools } from '@/core/tools/registry';
 import { buildSystemPromptSections, routeInput } from '@/core/agent/orchestrator';
 import { sectionsToString } from '@/core/llm/promptSections';
 import type { ToolDefinition } from '@/types';
@@ -171,7 +171,9 @@ async function main() {
   const sections = await buildSystemPromptSections(route, '', 'eval-session', evalImContext, 0);
   const systemPrompt = sectionsToString(sections);
 
-  const tools = toolRegistry.getAll();
+  // Real production toolset (Labs-gated tools respect their flag) so the
+  // benchmark matches what users actually see.
+  const tools = getAllTools();
   const openaiTools = convertToolsToOpenAI(tools);
 
   // Load cases

--- a/src/eval/toolSelectionRunner.ts
+++ b/src/eval/toolSelectionRunner.ts
@@ -13,7 +13,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import type { ToolSelectionCase, CaseResult, EvalTarget } from './types';
 import { registerBuiltinTools } from '@/core/tools/builtins';
-import { toolRegistry } from '@/core/tools/registry';
+import { getAllTools } from '@/core/tools/registry';
 import { buildSystemPromptSections, routeInput } from '@/core/agent/orchestrator';
 import { sectionsToString } from '@/core/llm/promptSections';
 import type { ToolDefinition } from '@/types';
@@ -89,8 +89,9 @@ export async function runToolSelectionEval(
   const sections = await buildSystemPromptSections(route, '', 'eval-session', evalImContext, 0);
   const systemPrompt = sectionsToString(sections);
 
-  // Get tool definitions for LLM
-  const tools = toolRegistry.getAll();
+  // Get tool definitions for LLM — the real production toolset (Labs-gated
+  // tools respect their flag), so the benchmark matches what users actually see.
+  const tools = getAllTools();
   const anthropicTools = convertTools(tools);
 
   // Create Anthropic client directly (bypasses tauriFetch)

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -418,6 +418,12 @@ const enUS: TranslationDict = {
 
   settings: {
     title: 'System Settings',
+    labs: 'Labs',
+    labsDescription: 'Features still being polished. Off by default — turn them on to try them early.',
+    labsChangeHint: 'Experimental features may change or be removed at any time',
+    labsEmpty: 'No experimental features in progress',
+    labsExpTodosInboxTitle: 'Todos & Inbox',
+    labsExpTodosInboxDesc: 'Enable the Todos and Inbox tabs in the sidebar so Abu can collect tasks and pending items in one place.',
     apiConfig: 'API Config',
     modelSelect: 'Model',
     advanced: 'Advanced',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -418,6 +418,12 @@ const zhCN: TranslationDict = {
 
   settings: {
     title: '系统设置',
+    labs: '实验室',
+    labsDescription: '这里是还在打磨中的新功能。默认关闭，你可以按需开启抢先体验。',
+    labsChangeHint: '实验功能可能随时调整或移除',
+    labsEmpty: '暂无进行中的实验功能',
+    labsExpTodosInboxTitle: '待办 & 收件箱',
+    labsExpTodosInboxDesc: '在侧边栏启用「待办」和「收件箱」，让阿布把任务和待确认项收拢到一处。',
     apiConfig: 'API 配置',
     modelSelect: '模型选择',
     advanced: '高级参数',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -529,6 +529,13 @@ export interface TranslationDict {
     networkWhitelist: string;
     networkPreset: string;
     networkCustom: string;
+    // Labs (experimental features)
+    labs: string;
+    labsDescription: string;
+    labsChangeHint: string;
+    labsEmpty: string;
+    labsExpTodosInboxTitle: string;
+    labsExpTodosInboxDesc: string;
     // General section
     general: string;
     generalDescription: string;

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -424,3 +424,46 @@ describe('settingsStore whitespace trim', () => {
     });
   });
 });
+
+describe('settingsStore labs flags', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ labs: {} });
+  });
+
+  it('setLabsFlag records an opt-in without clobbering other flags', () => {
+    useSettingsStore.getState().setLabsFlag('todos-inbox', true);
+    useSettingsStore.getState().setLabsFlag('other-exp', false);
+    expect(useSettingsStore.getState().labs).toEqual({
+      'todos-inbox': true,
+      'other-exp': false,
+    });
+  });
+
+  it('setLabsFlag can flip a flag back off', () => {
+    useSettingsStore.getState().setLabsFlag('todos-inbox', true);
+    useSettingsStore.getState().setLabsFlag('todos-inbox', false);
+    expect(useSettingsStore.getState().labs['todos-inbox']).toBe(false);
+  });
+
+  describe('v35 migration', () => {
+    const getMigrate = () =>
+      (useSettingsStore as unknown as {
+        persist: { getOptions: () => { migrate: (data: unknown, version: number) => Record<string, unknown> } };
+      }).persist.getOptions().migrate;
+
+    it('adds an empty labs map for pre-v35 state that lacks it', () => {
+      const migrated = getMigrate()({ theme: 'dark' }, 34);
+      expect(migrated.labs).toEqual({});
+    });
+
+    it('preserves an existing labs map', () => {
+      const migrated = getMigrate()({ labs: { 'todos-inbox': true } }, 34);
+      expect(migrated.labs).toEqual({ 'todos-inbox': true });
+    });
+
+    it('replaces a malformed labs value with an empty map', () => {
+      const migrated = getMigrate()({ labs: ['bad'] }, 34);
+      expect(migrated.labs).toEqual({});
+    });
+  });
+});

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -283,7 +283,7 @@ function createDefaultProviders(): ProviderInstance[] {
 
 export type ViewMode = 'chat' | 'automation' | 'toolbox' | 'settings' | 'todos' | 'inbox';
 export type AutomationTab = 'schedule' | 'trigger';
-export type SystemSettingsTab = 'general' | 'ai-services' | 'sandbox' | 'im-channels' | 'personal-memory' | 'soul' | 'diagnostic' | 'usage' | 'about' | 'feedback' | 'sponsor' | 'enterprise';
+export type SystemSettingsTab = 'general' | 'ai-services' | 'sandbox' | 'im-channels' | 'personal-memory' | 'soul' | 'diagnostic' | 'usage' | 'about' | 'feedback' | 'sponsor' | 'enterprise' | 'labs';
 export type ToolboxTab = 'skills' | 'agents' | 'mcp';
 
 // ============================================================
@@ -307,6 +307,9 @@ interface SettingsState {
   maxOutputTokens: number;
   contextWindowSize: number;
   language: LanguageSetting;
+  /** Labs (experimental features) opt-in map, keyed by LabsExperiment.id.
+   *  Absent id → registry default. See src/core/labs. */
+  labs: Record<string, boolean>;
   activeSystemTab: SystemSettingsTab;
   activeAutomationTab: AutomationTab;
   activeToolboxTab: ToolboxTab;
@@ -439,6 +442,8 @@ interface SettingsActions {
   openSystemSettings: (tab?: SystemSettingsTab) => void;
   closeSystemSettings: () => void;
   setActiveSystemTab: (tab: SystemSettingsTab) => void;
+  /** Toggle a Labs (experimental features) flag. Takes effect immediately. */
+  setLabsFlag: (id: string, enabled: boolean) => void;
   openAutomation: (tab?: AutomationTab) => void;
   closeAutomation: () => void;
   setActiveAutomationTab: (tab: AutomationTab) => void;
@@ -647,6 +652,7 @@ export const useSettingsStore = create<SettingsStore>()(
       maxOutputTokens: 32768,
       contextWindowSize: 200000,
       language: 'system' as LanguageSetting,
+      labs: {},
       activeSystemTab: 'usage' as SystemSettingsTab,
       activeAutomationTab: 'schedule' as AutomationTab,
       activeToolboxTab: 'skills' as ToolboxTab,
@@ -900,6 +906,8 @@ export const useSettingsStore = create<SettingsStore>()(
       closeSystemSettings: () =>
         set({ viewMode: 'chat' as ViewMode }),
       setActiveSystemTab: (tab) => set({ activeSystemTab: tab }),
+      setLabsFlag: (id, enabled) =>
+        set((s) => ({ labs: { ...s.labs, [id]: enabled } })),
       openAutomation: (tab) =>
         set({
           viewMode: 'automation' as ViewMode,
@@ -1003,9 +1011,18 @@ export const useSettingsStore = create<SettingsStore>()(
     }),
     {
       name: 'abu-settings',
-      version: 34,
+      version: 35,
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
+
+        // ════════════════════════════════════════════════
+        // V35: Add Labs (experimental features) opt-in map.
+        // ════════════════════════════════════════════════
+        if (version < 35) {
+          if (typeof state.labs !== 'object' || state.labs === null || Array.isArray(state.labs)) {
+            state.labs = {};
+          }
+        }
 
         // ════════════════════════════════════════════════
         // V34: Add 'system' option for theme; preserve existing value.
@@ -1623,6 +1640,7 @@ export const useSettingsStore = create<SettingsStore>()(
         // General settings
         theme: state.theme,
         language: state.language,
+        labs: state.labs,
         agentMaxTurns: state.agentMaxTurns,
         maxOutputTokens: state.maxOutputTokens,
         contextWindowSize: state.contextWindowSize,

--- a/src/stores/storeVersions.test.ts
+++ b/src/stores/storeVersions.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 // All persisted stores must be registered here.
 // When adding a new persist store, add it to this list — otherwise this test fails.
 const PERSISTED_STORES = [
-  { key: 'abu-settings', minVersion: 34 },
+  { key: 'abu-settings', minVersion: 35 },
   { key: 'abu-chat', minVersion: 6 },
   { key: 'abu-scratchpad-store', minVersion: 1 },
   { key: 'abu-permissions', minVersion: 1 },


### PR DESCRIPTION
## 概述

在系统设置里新增「实验室（Labs）」分区，作为重量级新功能的统一 **opt-in 通道 + 生命周期管理器**。V1 把此前用编译常量硬藏的 **待办 + 收件箱** 迁为首个真实住户，形成完整用户闭环。

## 设计（相对早期 brainstorm 砍掉两处过度设计）

业内交叉验证（Firefox Labs / VS Code / Chrome flags / Fowler feature-toggle）后：
- **三档成熟度状态机 → 单状态**：Labs 里只有「实验中」，"毕业" = 删注册表条目 + 去掉 `if` 分支（非存储档位）。
- **通用动态 tab 注册表 → 不建**：待办/收件箱 tab 已静态存在，只把 `SHOW_TODOS_INBOX` 编译常量换成 Labs flag 查询（YAGNI）。

## 实现（5 单元）

- `src/core/labs/registry.ts` — 实验注册表（`id` / i18n / `defaultEnabled` / `expiresAfter` 生命周期守卫）+ `LABS_TODOS_INBOX` 常量。
- `src/core/labs/resolve.ts` — `resolveLabsFlag`（stored `?? default ?? false`，未知 id fail-safe 到 off，`=== true` 强制 boolean）+ `isLabsFlagOn`（命令式）+ `useLabsFlag`（热切换 hook）。
- `settingsStore` — `labs: Record<string, boolean>` + `setLabsFlag`；persist **v34 → v35** 迁移。
- `LabsSection.tsx` + `SystemSettingsModal` 接线（FlaskConical 导航项）。
- 3 门控点替换（Sidebar / MessageBubble / `create_todo` 工具）。`create_todo` 改为**无条件注册 + `getAllTools()` 广告层过滤 + `executeAnyTool` 执行层门控**，flag 热切换免重启；`featureGates.ts` 只保留 `IS_ENTERPRISE_BUILD`（build gate ≠ 用户偏好）。

## 用户流程闭环

设置 → 实验室 → 「待办 & 收件箱（实验中）」开关（默认关）→ 开 → 侧栏 tab **立即出现**（React 热切换，免重启）+ create_todo 工具对 agent 可用 → 关 → 立即消失，`abu-todos`/`abu-inbox` 数据不丢。

## 验收

- ✅ `npm run build` / `npm run lint` clean；**2580 测试绿**（含 store migrate、resolver、工具门控回归）。
- ✅ `/code-review high`（25 agent）6 findings 逐条按 CLAUDE.md rule 15 亲验代码：
  - **F1**（真 bug）create_todo 执行层 fail-safe 缺失 → 修（advertisement + execution 双门控 + 回归测试）
  - **F3** eval 读 `getAll()` 绕过过滤 → 改 `getAllTools()`；**F6** magic-string → 常量；**F4** boolean 硬化
  - **F2**（切 off 滞留视图）**实测确认 UI 不可达**（`closeSystemSettings` 恒回 chat）→ 保留为不变量守卫，非活 bug
  - **F5**（每消息订阅）判定不值当，跳过
- ✅ **web e2e 15/15**：开 → 侧栏 tab 热现 → 关 → 消失 → 关设置回 chat。

## 后续

Labs 框架就位后，可依次接入 Design / 创作工作台 / 多 Agent 运行时面板 等重量级新功能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)