### PR TITLE
feat(pet): 桌宠改为两级 Labs 模型 — 实验解锁 + 系统设置菜单配置

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,8 +12,10 @@ import SystemSettingsView from '@/components/settings/SystemSettingsModal';
 import ToolboxView from '@/components/settings/ToolboxModal';
 import TodoView from '@/components/todos/TodoView';
 import InboxView from '@/components/inbox/InboxView';
-import { useLabsFlag } from '@/core/labs/resolve';
-import { LABS_TODOS_INBOX } from '@/core/labs/registry';
+import { useLabsFlag, resolveLabsFlag } from '@/core/labs/resolve';
+import { LABS_TODOS_INBOX, LABS_PET } from '@/core/labs/registry';
+import { resolvePetBootAction } from '@/core/pet/petBoot';
+import { setPetVisible, hidePet } from '@/core/pet/petVisibility';
 import RightPanel from '@/components/panel/RightPanel';
 import ToastContainer from '@/components/common/ToastContainer';
 import { registerBuiltinTools } from '@/core/tools/builtins';
@@ -300,13 +302,19 @@ function App() {
       });
     }
 
-    // Restore the desktop pet window if it was open when the app last quit
-    // (mirrors Codex's petOpenIntent behavior — the pet window itself doesn't
-    // persist, only the intent does).
-    if (useSettingsStore.getState().petOpen) {
-      invoke('pet_show').catch((err) => {
-        console.warn('[App] Failed to restore desktop pet:', err);
-      });
+    // Restore (or force-hide) the desktop pet on startup based on the pet Labs
+    // unlock flag + persisted petOpen intent. A pet that is no longer unlocked
+    // but left petOpen=true must never resurface.
+    {
+      const s = useSettingsStore.getState();
+      const petUnlocked = resolveLabsFlag(LABS_PET, s.labs);
+      const action = resolvePetBootAction(petUnlocked, s.petOpen);
+      if (action === 'show') {
+        void setPetVisible(true);
+      } else if (action === 'hide') {
+        void hidePet();
+        s.setPetOpen(false);
+      }
     }
 
     // Initialize notifications with logging

--- a/src/components/settings/SystemSettingsModal.tsx
+++ b/src/components/settings/SystemSettingsModal.tsx
@@ -1,6 +1,7 @@
+import { useEffect } from 'react';
 import { useSettingsStore, type SystemSettingsTab } from '@/stores/settingsStore';
 import { useI18n } from '@/i18n';
-import { Settings2, Info, Shield, SlidersHorizontal, MessageCircle, Radio, Brain, Heart, Activity, BarChart3, Building2, FlaskConical } from 'lucide-react';
+import { Settings2, Info, Shield, SlidersHorizontal, MessageCircle, Radio, Brain, Heart, Activity, BarChart3, Building2, FlaskConical, PawPrint } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { AIServicesSection, AboutSection, SandboxSection, GeneralSection, IMChannelSection } from './sections';
 import FeedbackSection from './sections/FeedbackSection';
@@ -10,7 +11,10 @@ import DiagnosticSection from './sections/DiagnosticSection';
 import UsageSection from './sections/UsageSection';
 import EnterpriseSection from './sections/EnterpriseSection';
 import LabsSection from './sections/LabsSection';
+import PetSection from './sections/PetSection';
 import { IS_ENTERPRISE_BUILD } from '@/config/featureGates';
+import { useLabsFlag } from '@/core/labs/resolve';
+import { LABS_PET } from '@/core/labs/registry';
 
 export default function SystemSettingsView() {
   const {
@@ -18,11 +22,23 @@ export default function SystemSettingsView() {
     setActiveSystemTab,
   } = useSettingsStore();
   const { t } = useI18n();
+  const petUnlocked = useLabsFlag(LABS_PET);
+
+  // If the user is on the 桌宠 tab when it gets locked (pet unlock turned off in
+  // Labs), fall back to a stable tab so the pane isn't blank.
+  useEffect(() => {
+    if (activeSystemTab === 'pet' && !petUnlocked) {
+      setActiveSystemTab('labs');
+    }
+  }, [activeSystemTab, petUnlocked, setActiveSystemTab]);
 
   const navItems: { id: SystemSettingsTab; label: string; icon: typeof Settings2 }[] = [
     { id: 'usage', label: t.usage.title, icon: BarChart3 },
     { id: 'ai-services', label: t.settings.aiServices, icon: Settings2 },
     { id: 'im-channels', label: t.imChannel.title, icon: Radio },
+    ...(petUnlocked
+      ? [{ id: 'pet' as SystemSettingsTab, label: t.settings.petEnable, icon: PawPrint }]
+      : []),
     { id: 'personal-memory', label: t.sidebar.personalMemory, icon: Brain },
     { id: 'soul', label: t.soul.title, icon: Heart },
     { id: 'sandbox', label: t.settings.sandbox, icon: Shield },
@@ -62,6 +78,10 @@ export default function SystemSettingsView() {
         return <AboutSection />;
       case 'feedback':
         return <FeedbackSection />;
+      case 'pet':
+        // Guard the one-frame window before the fallback effect fires: never
+        // render the pet pane (with its enable toggle) while locked.
+        return petUnlocked ? <PetSection /> : null;
       case 'enterprise':
         return IS_ENTERPRISE_BUILD ? <EnterpriseSection /> : <GeneralSection />;
       default:

--- a/src/components/settings/sections/LabsSection.test.tsx
+++ b/src/components/settings/sections/LabsSection.test.tsx
@@ -24,6 +24,7 @@ vi.mock('@/i18n', () => ({
     settings: {
       petEnable: 'Desktop Pet',
       petEnableDesc: 'Show a floating pet on your desktop',
+      labsExpPetDesc: 'Unlock the desktop pet — a floating Abu you can chat with anytime',
       labsExpPetWhere: 'Find it under System Settings → Desktop Pet',
     },
   }),
@@ -80,8 +81,8 @@ describe('LabsSection', () => {
       await user.click(toggle);
 
       expect(invoke).toHaveBeenCalledWith('pet_hide');
-      // labs.pet was set to false (the setLabsFlag call succeeds unconditionally)
-      expect(useSettingsStore.getState().labs['pet']).toBe(false);
+      // hide failed → the flag must NOT flip off (user can retry via the tab)
+      expect(useSettingsStore.getState().labs['pet']).toBe(true);
       // petOpen must remain true since the hide failed
       expect(useSettingsStore.getState().petOpen).toBe(true);
     });

--- a/src/components/settings/sections/LabsSection.test.tsx
+++ b/src/components/settings/sections/LabsSection.test.tsx
@@ -1,0 +1,89 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, within, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LabsSection from './LabsSection';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+// Local proxy so each test controls resolve/reject independently.
+const invoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      settings: {
+        labs: 'Labs',
+        labsDescription: 'Experimental features',
+        labsEmpty: 'No experiments',
+        labsEmptyHint: 'Check back later',
+      },
+    },
+  }),
+  getI18n: () => ({
+    settings: {
+      petEnable: 'Desktop Pet',
+      petEnableDesc: 'Show a floating pet on your desktop',
+      labsExpPetWhere: 'Find it under System Settings → Desktop Pet',
+    },
+  }),
+}));
+
+describe('LabsSection', () => {
+  beforeEach(() => {
+    invoke.mockReset();
+    invoke.mockResolvedValue(undefined);
+  });
+
+  afterEach(cleanup);
+
+  describe('unlock-only (turning pet ON): no pet_show', () => {
+    it('sets labs.pet=true and does NOT invoke pet_show', async () => {
+      useSettingsStore.setState({ labs: { pet: false }, petOpen: false });
+      const user = userEvent.setup();
+      render(<LabsSection />);
+
+      const card = screen.getByText('Desktop Pet').closest('div[class*="rounded-xl"]') as HTMLElement;
+      const toggle = within(card).getByRole('switch');
+      await user.click(toggle);
+
+      expect(useSettingsStore.getState().labs['pet']).toBe(true);
+      expect(invoke).not.toHaveBeenCalledWith('pet_show');
+    });
+  });
+
+  describe('teardown (turning pet OFF with pet running): pet_hide + petOpen cleared', () => {
+    it('calls pet_hide, clears petOpen, and sets labs.pet=false', async () => {
+      useSettingsStore.setState({ labs: { pet: true }, petOpen: true });
+      const user = userEvent.setup();
+      render(<LabsSection />);
+
+      const card = screen.getByText('Desktop Pet').closest('div[class*="rounded-xl"]') as HTMLElement;
+      const toggle = within(card).getByRole('switch');
+      await user.click(toggle);
+
+      expect(invoke).toHaveBeenCalledWith('pet_hide');
+      expect(useSettingsStore.getState().petOpen).toBe(false);
+      expect(useSettingsStore.getState().labs['pet']).toBe(false);
+    });
+  });
+
+  describe('reject path: pet_hide fails → petOpen stays true', () => {
+    it('does not clear petOpen when hide rejected', async () => {
+      useSettingsStore.setState({ labs: { pet: true }, petOpen: true });
+      invoke.mockRejectedValueOnce(new Error('window gone'));
+      const user = userEvent.setup();
+      render(<LabsSection />);
+
+      const card = screen.getByText('Desktop Pet').closest('div[class*="rounded-xl"]') as HTMLElement;
+      const toggle = within(card).getByRole('switch');
+      await user.click(toggle);
+
+      expect(invoke).toHaveBeenCalledWith('pet_hide');
+      // labs.pet was set to false (the setLabsFlag call succeeds unconditionally)
+      expect(useSettingsStore.getState().labs['pet']).toBe(false);
+      // petOpen must remain true since the hide failed
+      expect(useSettingsStore.getState().petOpen).toBe(true);
+    });
+  });
+});

--- a/src/components/settings/sections/LabsSection.tsx
+++ b/src/components/settings/sections/LabsSection.tsx
@@ -15,15 +15,23 @@ export default function LabsSection() {
   const setPetOpen = useSettingsStore((s) => s.setPetOpen);
 
   const handleToggle = async (id: string, next: boolean) => {
-    setLabsFlag(id, next);
-    // The pet unlock flag is a gate, not the pet switch. Turning it OFF must
-    // fully tear down a running pet; clear petOpen only if the hide succeeded so
-    // a failed hide is retried instead of desyncing from a still-visible window.
-    if (id === LABS_PET && !next && petOpen) {
-      if (await hidePet()) {
-        setPetOpen(false);
+    // The pet unlock's OFF transition is a teardown, not just a flag flip.
+    // Hide the running pet FIRST and only lock (flip the flag off) + clear
+    // petOpen once the hide succeeds — otherwise a failed pet_hide would strip
+    // the pet's settings tab while the pet is still visible, leaving no
+    // in-session control to dismiss it. On failure, leave the flag ON to retry.
+    if (id === LABS_PET && !next) {
+      if (petOpen) {
+        if (await hidePet()) {
+          setPetOpen(false);
+          setLabsFlag(id, false);
+        }
+        return;
       }
+      setLabsFlag(id, false);
+      return;
     }
+    setLabsFlag(id, next);
   };
 
   // Empty state: the section stays in the nav (stable, discoverable), but shows

--- a/src/components/settings/sections/LabsSection.tsx
+++ b/src/components/settings/sections/LabsSection.tsx
@@ -1,28 +1,29 @@
-import { invoke } from '@tauri-apps/api/core';
 import { useI18n } from '@/i18n';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { LABS_EXPERIMENTS, LABS_PET } from '@/core/labs/registry';
 import { resolveLabsFlag } from '@/core/labs/resolve';
+import { hidePet } from '@/core/pet/petVisibility';
 import { Toggle } from '@/components/ui/toggle';
 import SettingsSectionHeader from '@/components/settings/SettingsSectionHeader';
 import { FlaskConical } from 'lucide-react';
 
 export default function LabsSection() {
-  // Subscribe to the whole labs slice via useI18n's sibling store so the list
-  // re-renders on toggle; resolveLabsFlag reads the current stored map.
   const { t } = useI18n();
   const labs = useSettingsStore((s) => s.labs);
   const setLabsFlag = useSettingsStore((s) => s.setLabsFlag);
-  // Pet is a Labs experiment too, but its on/off drives a native Tauri window
-  // and lives in `petOpen` (not the generic labs map) — so LABS_PET is bound to
-  // petOpen + pet_show/pet_hide here rather than setLabsFlag.
   const petOpen = useSettingsStore((s) => s.petOpen);
   const setPetOpen = useSettingsStore((s) => s.setPetOpen);
-  const togglePet = async (next: boolean) => {
-    await invoke(next ? 'pet_show' : 'pet_hide').catch((err) => {
-      console.warn('[LabsSection] pet_show/pet_hide failed:', err);
-    });
-    setPetOpen(next);
+
+  const handleToggle = async (id: string, next: boolean) => {
+    setLabsFlag(id, next);
+    // The pet unlock flag is a gate, not the pet switch. Turning it OFF must
+    // fully tear down a running pet; clear petOpen only if the hide succeeded so
+    // a failed hide is retried instead of desyncing from a still-visible window.
+    if (id === LABS_PET && !next && petOpen) {
+      if (await hidePet()) {
+        setPetOpen(false);
+      }
+    }
   };
 
   // Empty state: the section stays in the nav (stable, discoverable), but shows
@@ -44,11 +45,7 @@ export default function LabsSection() {
 
       <div className="space-y-2">
         {LABS_EXPERIMENTS.map((exp) => {
-          const isPet = exp.id === LABS_PET;
-          const enabled = isPet ? petOpen : resolveLabsFlag(exp.id, labs);
-          const onToggle = isPet
-            ? () => togglePet(!petOpen)
-            : () => setLabsFlag(exp.id, !enabled);
+          const enabled = resolveLabsFlag(exp.id, labs);
           return (
               <div
                 key={exp.id}
@@ -67,7 +64,7 @@ export default function LabsSection() {
                 </div>
                 <Toggle
                   checked={enabled}
-                  onChange={onToggle}
+                  onChange={() => handleToggle(exp.id, !enabled)}
                   size="lg"
                 />
               </div>

--- a/src/components/settings/sections/PetSection.test.tsx
+++ b/src/components/settings/sections/PetSection.test.tsx
@@ -1,0 +1,73 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PetSection from './PetSection';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+// Local proxy so each test controls resolve/reject independently.
+const invoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      settings: {
+        petEnable: 'Desktop Pet',
+        petEnableDesc: 'Show a floating pet on your desktop',
+      },
+    },
+  }),
+}));
+
+describe('PetSection', () => {
+  beforeEach(() => {
+    invoke.mockReset();
+    invoke.mockResolvedValue(undefined);
+  });
+
+  afterEach(cleanup);
+
+  describe('toggling on (petOpen false → true)', () => {
+    it('calls pet_show and sets petOpen=true', async () => {
+      useSettingsStore.setState({ petOpen: false });
+      const user = userEvent.setup();
+      render(<PetSection />);
+
+      const toggle = screen.getByRole('switch');
+      await user.click(toggle);
+
+      expect(invoke).toHaveBeenCalledWith('pet_show');
+      expect(useSettingsStore.getState().petOpen).toBe(true);
+    });
+  });
+
+  describe('toggling off (petOpen true → false)', () => {
+    it('calls pet_hide and sets petOpen=false', async () => {
+      useSettingsStore.setState({ petOpen: true });
+      const user = userEvent.setup();
+      render(<PetSection />);
+
+      const toggle = screen.getByRole('switch');
+      await user.click(toggle);
+
+      expect(invoke).toHaveBeenCalledWith('pet_hide');
+      expect(useSettingsStore.getState().petOpen).toBe(false);
+    });
+  });
+
+  describe('reject path on turn-on', () => {
+    it('does not set petOpen=true when pet_show rejects', async () => {
+      useSettingsStore.setState({ petOpen: false });
+      invoke.mockRejectedValueOnce(new Error('tauri error'));
+      const user = userEvent.setup();
+      render(<PetSection />);
+
+      const toggle = screen.getByRole('switch');
+      await user.click(toggle);
+
+      expect(invoke).toHaveBeenCalledWith('pet_show');
+      expect(useSettingsStore.getState().petOpen).toBe(false);
+    });
+  });
+});

--- a/src/components/settings/sections/PetSection.tsx
+++ b/src/components/settings/sections/PetSection.tsx
@@ -1,0 +1,31 @@
+import { useSettingsStore } from '@/stores/settingsStore';
+import { useI18n } from '@/i18n';
+import { Toggle } from '@/components/ui/toggle';
+import { setPetVisible } from '@/core/pet/petVisibility';
+
+export default function PetSection() {
+  const petOpen = useSettingsStore((s) => s.petOpen);
+  const setPetOpen = useSettingsStore((s) => s.setPetOpen);
+  const { t } = useI18n();
+
+  const handleTogglePet = async () => {
+    const next = !petOpen;
+    // Persist the intent only if the window actually toggled, so a failed
+    // pet_show/pet_hide doesn't leave the switch out of sync with reality.
+    if (await setPetVisible(next)) {
+      setPetOpen(next);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-center justify-between p-4 rounded-xl border border-[var(--abu-border)] bg-[var(--abu-bg-muted)]">
+        <div className="flex-1 mr-4">
+          <p className="text-sm text-[var(--abu-text-primary)]">{t.settings.petEnable}</p>
+          <p className="text-xs text-[var(--abu-text-muted)] mt-0.5">{t.settings.petEnableDesc}</p>
+        </div>
+        <Toggle checked={petOpen} onChange={handleTogglePet} size="lg" />
+      </div>
+    </div>
+  );
+}

--- a/src/core/labs/registry.ts
+++ b/src/core/labs/registry.ts
@@ -53,7 +53,7 @@ export const LABS_EXPERIMENTS: readonly LabsExperiment[] = [
   {
     id: LABS_PET,
     title: () => getI18n().settings.petEnable,
-    description: () => getI18n().settings.petEnableDesc,
+    description: () => getI18n().settings.labsExpPetDesc,
     locationHint: () => getI18n().settings.labsExpPetWhere,
     defaultEnabled: false,
     expiresAfter: '2026-10-01',

--- a/src/core/labs/registry.ts
+++ b/src/core/labs/registry.ts
@@ -42,10 +42,10 @@ export interface LabsExperiment {
 export const LABS_TODOS_INBOX = 'todos-inbox';
 
 /**
- * Stable id for the Desktop Pet experiment. Unlike other experiments, the pet's
- * enabled state lives in `settings.petOpen` (it drives a native Tauri window via
- * pet_show/pet_hide), not the generic `settings.labs` map — LabsSection special-
- * cases this id. It's still listed here so it surfaces as a Labs card.
+ * Stable id for the Desktop Pet experiment. An *unlock* flag stored in
+ * settings.labs like any other experiment: turning it on reveals the 桌宠 entry
+ * in System Settings (where the pet is actually enabled/configured); it does NOT
+ * spawn the floating pet. Turning it off tears down a running pet (see LabsSection).
  */
 export const LABS_PET = 'pet';
 

--- a/src/core/pet/petBoot.test.ts
+++ b/src/core/pet/petBoot.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePetBootAction } from './petBoot';
+
+describe('resolvePetBootAction', () => {
+  it('unlocked + open → show', () => {
+    expect(resolvePetBootAction(true, true)).toBe('show');
+  });
+
+  it('unlocked + closed → none', () => {
+    expect(resolvePetBootAction(true, false)).toBe('none');
+  });
+
+  it('locked + open → hide (stale intent)', () => {
+    expect(resolvePetBootAction(false, true)).toBe('hide');
+  });
+
+  it('locked + closed → none', () => {
+    expect(resolvePetBootAction(false, false)).toBe('none');
+  });
+});

--- a/src/core/pet/petBoot.ts
+++ b/src/core/pet/petBoot.ts
@@ -1,0 +1,13 @@
+/**
+ * Decide what to do with the desktop pet window at app startup, given the pet
+ * Labs unlock flag and the persisted `petOpen` intent.
+ * - unlocked + open → 'show'; locked + open → 'hide' (stale intent); else 'none'.
+ * Pure so it is unit-testable without a Tauri runtime.
+ */
+export function resolvePetBootAction(
+  petUnlocked: boolean,
+  petOpen: boolean,
+): 'show' | 'hide' | 'none' {
+  if (petUnlocked) return petOpen ? 'show' : 'none';
+  return petOpen ? 'hide' : 'none';
+}

--- a/src/core/pet/petVisibility.test.ts
+++ b/src/core/pet/petVisibility.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setPetVisible, hidePet } from './petVisibility';
+
+// Local proxy lets each test control resolve/reject independently.
+const invoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
+
+describe('petVisibility', () => {
+  beforeEach(() => {
+    invoke.mockReset();
+  });
+
+  describe('setPetVisible(true)', () => {
+    it('invokes pet_show and returns true on resolve', async () => {
+      invoke.mockResolvedValue(undefined);
+      const result = await setPetVisible(true);
+      expect(invoke).toHaveBeenCalledWith('pet_show');
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('setPetVisible(false)', () => {
+    it('invokes pet_hide and returns true on resolve', async () => {
+      invoke.mockResolvedValue(undefined);
+      const result = await setPetVisible(false);
+      expect(invoke).toHaveBeenCalledWith('pet_hide');
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('setPetVisible when invoke rejects', () => {
+    it('returns false without throwing', async () => {
+      invoke.mockRejectedValue(new Error('window not found'));
+      const result = await setPetVisible(true);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('hidePet()', () => {
+    it('invokes pet_hide and returns true on resolve', async () => {
+      invoke.mockResolvedValue(undefined);
+      const result = await hidePet();
+      expect(invoke).toHaveBeenCalledWith('pet_hide');
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/src/core/pet/petVisibility.ts
+++ b/src/core/pet/petVisibility.ts
@@ -1,0 +1,23 @@
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * Show or hide the desktop pet window via its Tauri commands. Returns true if
+ * the command succeeded, false if it rejected (logged, not thrown). Callers that
+ * persist the "pet open" intent should update it only on a true result, so a
+ * failed hide/show is retried later instead of desyncing state from the actual
+ * window.
+ */
+export async function setPetVisible(open: boolean): Promise<boolean> {
+  try {
+    await invoke(open ? 'pet_show' : 'pet_hide');
+    return true;
+  } catch (err) {
+    console.warn(`[pet] pet_${open ? 'show' : 'hide'} failed:`, err);
+    return false;
+  }
+}
+
+/** Convenience: hide the pet. Returns true on success. */
+export function hidePet(): Promise<boolean> {
+  return setPetVisible(false);
+}

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -426,6 +426,7 @@ const enUS: TranslationDict = {
     labsExpTodosInboxDesc: 'Enable the Todos and Inbox tabs in the sidebar so Abu can collect tasks and pending items in one place.',
     labsExpTodosInboxWhere: 'Once on: a Todos and an Inbox entry appear in the left sidebar',
     labsExpPetWhere: 'Once on, enable and configure it in Settings → Desktop Pet',
+    labsExpPetDesc: 'Unlock the desktop pet — a floating Abu you can chat with anytime',
     apiConfig: 'API Config',
     modelSelect: 'Model',
     advanced: 'Advanced',

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -425,7 +425,7 @@ const enUS: TranslationDict = {
     labsExpTodosInboxTitle: 'Todos & Inbox',
     labsExpTodosInboxDesc: 'Enable the Todos and Inbox tabs in the sidebar so Abu can collect tasks and pending items in one place.',
     labsExpTodosInboxWhere: 'Once on: a Todos and an Inbox entry appear in the left sidebar',
-    labsExpPetWhere: 'Once on: a floating pet appears on your desktop — click to open a quick input, double-click for the main window, right-click for more',
+    labsExpPetWhere: 'Once on, enable and configure it in Settings → Desktop Pet',
     apiConfig: 'API Config',
     modelSelect: 'Model',
     advanced: 'Advanced',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -425,7 +425,7 @@ const zhCN: TranslationDict = {
     labsExpTodosInboxTitle: '待办 & 收件箱',
     labsExpTodosInboxDesc: '在侧边栏启用「待办」和「收件箱」，让阿布把任务和待确认项收拢到一处。',
     labsExpTodosInboxWhere: '开启后：左侧边栏出现「待办」和「收件箱」入口',
-    labsExpPetWhere: '开启后：桌面出现悬浮桌宠 —— 单击唤起输入，双击打开主窗，右键更多操作',
+    labsExpPetWhere: '开启后可在「系统设置 → 桌宠」中启用并配置',
     apiConfig: 'API 配置',
     modelSelect: '模型选择',
     advanced: '高级参数',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -426,6 +426,7 @@ const zhCN: TranslationDict = {
     labsExpTodosInboxDesc: '在侧边栏启用「待办」和「收件箱」，让阿布把任务和待确认项收拢到一处。',
     labsExpTodosInboxWhere: '开启后：左侧边栏出现「待办」和「收件箱」入口',
     labsExpPetWhere: '开启后可在「系统设置 → 桌宠」中启用并配置',
+    labsExpPetDesc: '解锁「桌宠」——一个可随时对话的桌面悬浮小阿布',
     apiConfig: 'API 配置',
     modelSelect: '模型选择',
     advanced: '高级参数',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -538,6 +538,7 @@ export interface TranslationDict {
     labsExpTodosInboxDesc: string;
     labsExpTodosInboxWhere: string;
     labsExpPetWhere: string;
+    labsExpPetDesc: string;
     // General section
     general: string;
     generalDescription: string;

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -485,4 +485,33 @@ describe('settingsStore labs flags', () => {
       expect(migrated.labs).toEqual({});
     });
   });
+
+  describe('v38 migration', () => {
+    const getMigrate = () =>
+      (useSettingsStore as unknown as {
+        persist: { getOptions: () => { migrate: (data: unknown, version: number) => Record<string, unknown> } };
+      }).persist.getOptions().migrate;
+
+    it('sets labs.pet=true when petOpen was true on upgrade from v37', () => {
+      const migrated = getMigrate()({ petOpen: true, labs: {} }, 37);
+      expect((migrated.labs as Record<string, boolean>)['pet']).toBe(true);
+    });
+
+    it('does NOT set labs.pet when petOpen was false on upgrade from v37', () => {
+      const migrated = getMigrate()({ petOpen: false, labs: {} }, 37);
+      expect((migrated.labs as Record<string, boolean>)['pet']).toBeUndefined();
+    });
+
+    it('creates labs map if absent and petOpen was true', () => {
+      const migrated = getMigrate()({ petOpen: true }, 37);
+      expect((migrated.labs as Record<string, boolean>)['pet']).toBe(true);
+    });
+
+    it('preserves existing labs flags while adding pet unlock', () => {
+      const migrated = getMigrate()({ petOpen: true, labs: { 'todos-inbox': true } }, 37);
+      const labs = migrated.labs as Record<string, boolean>;
+      expect(labs['pet']).toBe(true);
+      expect(labs['todos-inbox']).toBe(true);
+    });
+  });
 });

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -283,7 +283,7 @@ function createDefaultProviders(): ProviderInstance[] {
 
 export type ViewMode = 'chat' | 'automation' | 'toolbox' | 'settings' | 'todos' | 'inbox';
 export type AutomationTab = 'schedule' | 'trigger';
-export type SystemSettingsTab = 'general' | 'ai-services' | 'sandbox' | 'im-channels' | 'personal-memory' | 'soul' | 'diagnostic' | 'usage' | 'about' | 'feedback' | 'sponsor' | 'enterprise' | 'labs';
+export type SystemSettingsTab = 'general' | 'ai-services' | 'sandbox' | 'im-channels' | 'pet' | 'personal-memory' | 'soul' | 'diagnostic' | 'usage' | 'about' | 'feedback' | 'sponsor' | 'enterprise' | 'labs';
 export type ToolboxTab = 'skills' | 'agents' | 'mcp';
 
 // ============================================================
@@ -1034,9 +1034,24 @@ export const useSettingsStore = create<SettingsStore>()(
     }),
     {
       name: 'abu-settings',
-      version: 37,
+      version: 38,
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
+
+        // ════════════════════════════════════════════════
+        // V38: Desktop pet became a two-level Labs feature — the `pet` unlock
+        // flag now lives in `settings.labs` (was previously implicit in petOpen).
+        // Preserve continuity: anyone who already had the pet open stays
+        // "unlocked" so their pet isn't force-hidden on upgrade.
+        // ════════════════════════════════════════════════
+        if (version < 38) {
+          if (typeof state.labs !== 'object' || state.labs === null || Array.isArray(state.labs)) {
+            state.labs = {};
+          }
+          if (state.petOpen === true) {
+            (state.labs as Record<string, boolean>)['pet'] = true;
+          }
+        }
 
         // ════════════════════════════════════════════════
         // V37: Add petOpen — remembers whether the desktop pet was open

--- a/src/stores/storeVersions.test.ts
+++ b/src/stores/storeVersions.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 // All persisted stores must be registered here.
 // When adding a new persist store, add it to this list — otherwise this test fails.
 const PERSISTED_STORES = [
-  { key: 'abu-settings', minVersion: 37 },
+  { key: 'abu-settings', minVersion: 38 },
   { key: 'abu-chat', minVersion: 6 },
   { key: 'abu-scratchpad-store', minVersion: 1 },
   { key: 'abu-permissions', minVersion: 1 },


### PR DESCRIPTION
## 背景

用户反馈:实验(Labs)里点开「桌宠」不该**直接弹出**悬浮宠。桌宠是新功能,正确交互应是:实验开关**只解锁** → 系统设置侧边栏出现「桌宠」菜单,用户在那里**启用与配置**。

dev 目前的设计(`cf1a0f9`)恰恰是被反馈的那种:Labs 开关直接 `pet_show`/`pet_hide`,且删掉了独立的桌宠设置菜单。本 PR 把它改成两级模型。

## 改动

**核心层** (`4c063ea`)
- `src/core/pet/petVisibility.ts` — `setPetVisible(open)` / `hidePet()`,只在 invoke 成功时返回 true(调用方据此决定是否落 `petOpen`,失败不 desync)
- `src/core/pet/petBoot.ts` — 纯函数 `resolvePetBootAction(petUnlocked, petOpen)` → show/hide/none
- i18n `labsExpPetWhere` 改为指向「系统设置 → 桌宠」
- store **V38 迁移**:老用户 `petOpen=true` → 自动 `labs.pet=true`,升级后桌宠不被启动兜底强收

**UI 层** (`45e82f7`)
- `LabsSection`:桌宠改为普通解锁 flag(`setLabsFlag`),**不再直接弹宠**;关开关 = 收起悬浮宠(`hidePet`)
- **重新加回** `PetSection`(dev 删掉的),作为真正启用/配置的二级面板,门控在解锁 flag 上
- `SystemSettingsModal`:桌宠 nav 项条件渲染 `useLabsFlag(LABS_PET)` + 停在桌宠 tab 被锁时回退实验 tab + `case 'pet'` 守卫
- `App.tsx`:启动兜底走 `resolvePetBootAction`(未解锁却残留 → 强制不弹)

**Review 修复** (`2720bcb`)
- 关解锁的**收起时序**:先 `hidePet()` 成功才翻 flag + 清 `petOpen`(失败留 flag ON 可重试,避免"宠还在但配置菜单没了"无法关闭)
- Labs 卡片独立文案 `labsExpPetDesc`(不再复用 `petEnableDesc` 误导"开关即弹宠")

## 验证

- **2672 测试全绿** / typecheck / lint(`--max-warnings 0`)干净
- high `/code-review`(多 finder + 独立 verify)findings 已逐条处理
- store 迁移有单测(V37→V38 continuity)

## Test Plan(桌面真机 smoke,待人工)

- [ ] 默认(实验关):侧边栏无桌宠菜单、桌面无宠
- [ ] 实验开桌宠:侧边栏出现桌宠菜单,桌面**仍无**宠
- [ ] 进桌宠分区开启:悬浮宠出现
- [ ] 回实验关桌宠:悬浮宠消失 + 菜单消失(若停在桌宠 tab 自动回退实验)
- [ ] 重开实验:菜单回来、配置保留
- [ ] 老用户升级(petOpen=true):桌宠不丢(V38 迁移)

🤖 Generated with [Claude Code](https://claude.com/claude-code)