### PR TITLE
自定义模型接入体验优化（地址归一化 + 能力自声明 + 出参规则引擎）

### DIFF
--- a/src/components/settings/sections/ai-services/AddProviderModal.test.tsx
+++ b/src/components/settings/sections/ai-services/AddProviderModal.test.tsx
@@ -5,101 +5,77 @@
  * Full component render is impractical here: the modal depends on
  * useSettingsStore (persist + Tauri secret store), createPortal, and a dozen
  * LLM-core modules. Mocking all of them would produce a brittle test shell
- * that verifies the mock wiring rather than the logic. Instead, we extract and
- * test the two non-trivial pure-logic pieces directly:
+ * that verifies the mock wiring rather than the logic. Instead, we test the
+ * two non-trivial pure-logic pieces via their shared helper module, which the
+ * component itself imports — so these tests guard the real shipped code.
  *
  *   1. showAdvanced predicate — must be true for custom/ollama/lmstudio,
  *      false for builtin cloud providers.
  *   2. supportedEfforts toggle reducer — the Set-based add/delete logic.
  */
 import { describe, it, expect } from 'vitest';
-import type { DeclaredCapabilities } from '@/types/provider';
-
-// ── Logic extracted from AddProviderModal ──────────────────────────
-
-const CUSTOM_OPENAI_ID = '__custom_openai__';
-const CUSTOM_ANTHROPIC_ID = '__custom_anthropic__';
-
-function isCustomId(id: string): boolean {
-  return id === CUSTOM_OPENAI_ID || id === CUSTOM_ANTHROPIC_ID;
-}
-
-function computeShowAdvanced(selectedId: string, provider: string | undefined): boolean {
-  const isCustom = selectedId ? isCustomId(selectedId) : false;
-  const isOllama = provider === 'ollama';
-  const isLMStudio = provider === 'lmstudio';
-  return isCustom || isOllama || isLMStudio;
-}
-
-function toggleEffort(
-  declared: DeclaredCapabilities,
-  effort: 'low' | 'medium' | 'high',
-): DeclaredCapabilities {
-  const cur = new Set(declared.supportedEfforts ?? []);
-  if (cur.has(effort)) cur.delete(effort); else cur.add(effort);
-  return { ...declared, supportedEfforts: [...cur] as Array<'low' | 'medium' | 'high'> };
-}
+import { computeShowAdvanced, toggleEffort } from './providerCapabilities';
 
 // ── Tests ──────────────────────────────────────────────────────────
 
 describe('AddProviderModal — showAdvanced predicate', () => {
   it('shows advanced section for custom OpenAI provider', () => {
-    expect(computeShowAdvanced(CUSTOM_OPENAI_ID, 'custom')).toBe(true);
+    expect(computeShowAdvanced(true, 'custom')).toBe(true);
   });
 
   it('shows advanced section for custom Anthropic provider', () => {
-    expect(computeShowAdvanced(CUSTOM_ANTHROPIC_ID, 'custom')).toBe(true);
+    expect(computeShowAdvanced(true, 'custom')).toBe(true);
   });
 
   it('shows advanced section for ollama', () => {
-    expect(computeShowAdvanced('ollama', 'ollama')).toBe(true);
+    expect(computeShowAdvanced(false, 'ollama')).toBe(true);
   });
 
   it('shows advanced section for lmstudio', () => {
-    expect(computeShowAdvanced('lmstudio', 'lmstudio')).toBe(true);
+    expect(computeShowAdvanced(false, 'lmstudio')).toBe(true);
   });
 
   it('hides advanced section for builtin cloud provider (anthropic)', () => {
-    expect(computeShowAdvanced('anthropic', 'anthropic')).toBe(false);
+    expect(computeShowAdvanced(false, 'anthropic')).toBe(false);
   });
 
   it('hides advanced section for builtin cloud provider (openai)', () => {
-    expect(computeShowAdvanced('openai', 'openai')).toBe(false);
+    expect(computeShowAdvanced(false, 'openai')).toBe(false);
   });
 
   it('hides advanced section when no provider is selected', () => {
-    expect(computeShowAdvanced('', undefined)).toBe(false);
+    expect(computeShowAdvanced(false, undefined)).toBe(false);
   });
 });
 
 describe('AddProviderModal — supportedEfforts toggle reducer', () => {
   it('adds an effort level when not present', () => {
-    const result = toggleEffort({}, 'low');
-    expect(result.supportedEfforts).toContain('low');
+    const result = toggleEffort(undefined, 'low');
+    expect(result).toContain('low');
   });
 
   it('removes an effort level when already present', () => {
-    const result = toggleEffort({ supportedEfforts: ['low', 'medium'] }, 'low');
-    expect(result.supportedEfforts).not.toContain('low');
-    expect(result.supportedEfforts).toContain('medium');
+    const result = toggleEffort(['low', 'medium'], 'low');
+    expect(result).not.toContain('low');
+    expect(result).toContain('medium');
   });
 
-  it('preserves other declared fields when toggling', () => {
-    const result = toggleEffort({ supportsReasoning: true, supportedEfforts: [] }, 'high');
-    expect(result.supportsReasoning).toBe(true);
-    expect(result.supportedEfforts).toContain('high');
+  it('preserves other effort levels when toggling a new one', () => {
+    const result = toggleEffort(['medium'], 'high');
+    expect(result).toContain('medium');
+    expect(result).toContain('high');
   });
 
   it('handles toggle on empty supportedEfforts', () => {
-    const result = toggleEffort({ supportedEfforts: [] }, 'medium');
-    expect(result.supportedEfforts).toEqual(['medium']);
+    const result = toggleEffort([], 'medium');
+    expect(result).toEqual(['medium']);
   });
 
   it('can build all three effort levels independently', () => {
-    let d: DeclaredCapabilities = {};
+    let d: Array<'low' | 'medium' | 'high'> | undefined = undefined;
     d = toggleEffort(d, 'low');
     d = toggleEffort(d, 'medium');
     d = toggleEffort(d, 'high');
-    expect(new Set(d.supportedEfforts)).toEqual(new Set(['low', 'medium', 'high']));
+    expect(new Set(d)).toEqual(new Set(['low', 'medium', 'high']));
   });
 });

--- a/src/components/settings/sections/ai-services/AddProviderModal.test.tsx
+++ b/src/components/settings/sections/ai-services/AddProviderModal.test.tsx
@@ -1,0 +1,105 @@
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * Unit tests for the advanced-config section in AddProviderModal.
+ *
+ * Full component render is impractical here: the modal depends on
+ * useSettingsStore (persist + Tauri secret store), createPortal, and a dozen
+ * LLM-core modules. Mocking all of them would produce a brittle test shell
+ * that verifies the mock wiring rather than the logic. Instead, we extract and
+ * test the two non-trivial pure-logic pieces directly:
+ *
+ *   1. showAdvanced predicate — must be true for custom/ollama/lmstudio,
+ *      false for builtin cloud providers.
+ *   2. supportedEfforts toggle reducer — the Set-based add/delete logic.
+ */
+import { describe, it, expect } from 'vitest';
+import type { DeclaredCapabilities } from '@/types/provider';
+
+// ── Logic extracted from AddProviderModal ──────────────────────────
+
+const CUSTOM_OPENAI_ID = '__custom_openai__';
+const CUSTOM_ANTHROPIC_ID = '__custom_anthropic__';
+
+function isCustomId(id: string): boolean {
+  return id === CUSTOM_OPENAI_ID || id === CUSTOM_ANTHROPIC_ID;
+}
+
+function computeShowAdvanced(selectedId: string, provider: string | undefined): boolean {
+  const isCustom = selectedId ? isCustomId(selectedId) : false;
+  const isOllama = provider === 'ollama';
+  const isLMStudio = provider === 'lmstudio';
+  return isCustom || isOllama || isLMStudio;
+}
+
+function toggleEffort(
+  declared: DeclaredCapabilities,
+  effort: 'low' | 'medium' | 'high',
+): DeclaredCapabilities {
+  const cur = new Set(declared.supportedEfforts ?? []);
+  if (cur.has(effort)) cur.delete(effort); else cur.add(effort);
+  return { ...declared, supportedEfforts: [...cur] as Array<'low' | 'medium' | 'high'> };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+describe('AddProviderModal — showAdvanced predicate', () => {
+  it('shows advanced section for custom OpenAI provider', () => {
+    expect(computeShowAdvanced(CUSTOM_OPENAI_ID, 'custom')).toBe(true);
+  });
+
+  it('shows advanced section for custom Anthropic provider', () => {
+    expect(computeShowAdvanced(CUSTOM_ANTHROPIC_ID, 'custom')).toBe(true);
+  });
+
+  it('shows advanced section for ollama', () => {
+    expect(computeShowAdvanced('ollama', 'ollama')).toBe(true);
+  });
+
+  it('shows advanced section for lmstudio', () => {
+    expect(computeShowAdvanced('lmstudio', 'lmstudio')).toBe(true);
+  });
+
+  it('hides advanced section for builtin cloud provider (anthropic)', () => {
+    expect(computeShowAdvanced('anthropic', 'anthropic')).toBe(false);
+  });
+
+  it('hides advanced section for builtin cloud provider (openai)', () => {
+    expect(computeShowAdvanced('openai', 'openai')).toBe(false);
+  });
+
+  it('hides advanced section when no provider is selected', () => {
+    expect(computeShowAdvanced('', undefined)).toBe(false);
+  });
+});
+
+describe('AddProviderModal — supportedEfforts toggle reducer', () => {
+  it('adds an effort level when not present', () => {
+    const result = toggleEffort({}, 'low');
+    expect(result.supportedEfforts).toContain('low');
+  });
+
+  it('removes an effort level when already present', () => {
+    const result = toggleEffort({ supportedEfforts: ['low', 'medium'] }, 'low');
+    expect(result.supportedEfforts).not.toContain('low');
+    expect(result.supportedEfforts).toContain('medium');
+  });
+
+  it('preserves other declared fields when toggling', () => {
+    const result = toggleEffort({ supportsReasoning: true, supportedEfforts: [] }, 'high');
+    expect(result.supportsReasoning).toBe(true);
+    expect(result.supportedEfforts).toContain('high');
+  });
+
+  it('handles toggle on empty supportedEfforts', () => {
+    const result = toggleEffort({ supportedEfforts: [] }, 'medium');
+    expect(result.supportedEfforts).toEqual(['medium']);
+  });
+
+  it('can build all three effort levels independently', () => {
+    let d: DeclaredCapabilities = {};
+    d = toggleEffort(d, 'low');
+    d = toggleEffort(d, 'medium');
+    d = toggleEffort(d, 'high');
+    expect(new Set(d.supportedEfforts)).toEqual(new Set(['low', 'medium', 'high']));
+  });
+});

--- a/src/components/settings/sections/ai-services/AddProviderModal.test.tsx
+++ b/src/components/settings/sections/ai-services/AddProviderModal.test.tsx
@@ -19,32 +19,32 @@ import { computeShowAdvanced, toggleEffort } from './providerCapabilities';
 // ── Tests ──────────────────────────────────────────────────────────
 
 describe('AddProviderModal — showAdvanced predicate', () => {
-  it('shows advanced section for custom OpenAI provider', () => {
-    expect(computeShowAdvanced(true, 'custom')).toBe(true);
+  it('shows advanced section for custom OpenAI-compatible provider', () => {
+    expect(computeShowAdvanced(true, 'custom', 'openai-compatible')).toBe(true);
   });
 
-  it('shows advanced section for custom Anthropic provider', () => {
-    expect(computeShowAdvanced(true, 'custom')).toBe(true);
+  it('hides advanced section for custom Anthropic-format provider', () => {
+    expect(computeShowAdvanced(true, 'custom', 'anthropic')).toBe(false);
   });
 
   it('shows advanced section for ollama', () => {
-    expect(computeShowAdvanced(false, 'ollama')).toBe(true);
+    expect(computeShowAdvanced(false, 'ollama', undefined)).toBe(true);
   });
 
   it('shows advanced section for lmstudio', () => {
-    expect(computeShowAdvanced(false, 'lmstudio')).toBe(true);
+    expect(computeShowAdvanced(false, 'lmstudio', undefined)).toBe(true);
   });
 
   it('hides advanced section for builtin cloud provider (anthropic)', () => {
-    expect(computeShowAdvanced(false, 'anthropic')).toBe(false);
+    expect(computeShowAdvanced(false, 'anthropic', 'anthropic')).toBe(false);
   });
 
   it('hides advanced section for builtin cloud provider (openai)', () => {
-    expect(computeShowAdvanced(false, 'openai')).toBe(false);
+    expect(computeShowAdvanced(false, 'openai', 'openai-compatible')).toBe(false);
   });
 
   it('hides advanced section when no provider is selected', () => {
-    expect(computeShowAdvanced(false, undefined)).toBe(false);
+    expect(computeShowAdvanced(false, undefined, undefined)).toBe(false);
   });
 });
 

--- a/src/components/settings/sections/ai-services/AddProviderModal.tsx
+++ b/src/components/settings/sections/ai-services/AddProviderModal.tsx
@@ -9,7 +9,7 @@ import { useI18n } from '@/i18n';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Toggle } from '@/components/ui/toggle';
+import { Checkbox } from '@/components/ui/checkbox';
 import { checkProviderHealth } from '@/core/llm/healthCheck';
 import { buildFullChatUrl } from '@/core/llm/urlUtils';
 import { useSettingsStore, PROVIDER_CONFIGS } from '@/stores/settingsStore';
@@ -861,22 +861,22 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
               <div className="space-y-2">
                   <div className="grid grid-cols-2 gap-2">
                     <label className="flex items-center gap-2">
-                      <Toggle size="sm" checked={!!declared.supportsTools}
+                      <Checkbox checked={!!declared.supportsTools}
                         onChange={() => setDeclared(d => ({ ...d, supportsTools: !d.supportsTools }))} />
                       <span className="text-sm text-[var(--abu-text-primary)]">{t.settings.capTools}</span>
                     </label>
                     <label className="flex items-center gap-2">
-                      <Toggle size="sm" checked={!!declared.supportsImages}
+                      <Checkbox checked={!!declared.supportsImages}
                         onChange={() => setDeclared(d => ({ ...d, supportsImages: !d.supportsImages }))} />
                       <span className="text-sm text-[var(--abu-text-primary)]">{t.settings.capImages}</span>
                     </label>
                     <label className="flex items-center gap-2">
-                      <Toggle size="sm" checked={!!declared.supportsReasoning}
+                      <Checkbox checked={!!declared.supportsReasoning}
                         onChange={() => setDeclared(d => ({ ...d, supportsReasoning: !d.supportsReasoning }))} />
                       <span className="text-sm text-[var(--abu-text-primary)]">{t.settings.capReasoning}</span>
                     </label>
                     <label className="flex items-center gap-2" title={t.settings.capRawUrlHint}>
-                      <Toggle size="sm" checked={!!declared.useRawUrl}
+                      <Checkbox checked={!!declared.useRawUrl}
                         onChange={() => setDeclared(d => ({ ...d, useRawUrl: !d.useRawUrl }))} />
                       <span className="text-sm text-[var(--abu-text-primary)]">{t.settings.capRawUrl}</span>
                     </label>
@@ -887,7 +887,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
                         <span className="text-sm text-[var(--abu-text-secondary)]">{t.settings.capEffort}</span>
                         {(['low', 'medium', 'high'] as const).map(e => (
                           <label key={e} className="flex items-center gap-1">
-                            <Toggle size="sm" checked={!!declared.supportedEfforts?.includes(e)}
+                            <Checkbox checked={!!declared.supportedEfforts?.includes(e)}
                               onChange={() => setDeclared(d => ({ ...d, supportedEfforts: toggleEffort(d.supportedEfforts, e) }))} />
                             <span className="text-xs text-[var(--abu-text-secondary)]">
                               {{ low: t.settings.effortLow, medium: t.settings.effortMedium, high: t.settings.effortHigh }[e]}

--- a/src/components/settings/sections/ai-services/AddProviderModal.tsx
+++ b/src/components/settings/sections/ai-services/AddProviderModal.tsx
@@ -163,6 +163,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
 
   // ── Advanced capabilities (custom/local providers only) ──
   const [declared, setDeclared] = useState<DeclaredCapabilities>({});
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   // ── Validate state ──
   const [validating, setValidating] = useState(false);
@@ -235,6 +236,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
       const existingP = providers.find(p => p.id === option.provider);
       const willShowAdvanced = computeShowAdvanced(isCustomId(option.id), option.provider, option.format);
       setDeclared(existingP?.declaredCapabilities ?? (willShowAdvanced ? defaultDeclaredCapabilities() : {}));
+      setAdvancedOpen(!!existingP?.declaredCapabilities && Object.keys(existingP.declaredCapabilities).length > 0);
 
       // Reset Ollama state
       setOllamaStatus('idle');
@@ -463,6 +465,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
     setFetchedModels([]);
     setFetchModelsError('');
     setDeclared({});
+    setAdvancedOpen(false);
     onClose();
   }, [onClose]);
 
@@ -501,19 +504,20 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
         <div className="shrink-0 px-6 pt-5 pb-3 space-y-5">
           {/* 1. Service Name */}
           <div className="space-y-1.5">
-            <label className="text-sm font-medium text-[var(--abu-text-primary)]">
+            <label className="text-xs font-medium text-[var(--abu-text-primary)]">
               {t.settings.serviceName}
             </label>
             <Input
               value={serviceName}
               onChange={handleNameChange}
               placeholder={t.settings.serviceNameAuto}
+              className="h-8"
             />
           </div>
 
           {/* 2. Provider Dropdown */}
           <div className="space-y-1.5">
-            <label className="text-sm font-medium text-[var(--abu-text-primary)]">
+            <label className="text-xs font-medium text-[var(--abu-text-primary)]">
               {t.settings.selectProviderType}
             </label>
             <div className="relative" ref={dropdownRef}>
@@ -588,7 +592,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
         </div>
 
         {/* Scrollable content area: guide, API key, models, etc. */}
-        <div className="flex-1 overflow-y-auto px-6 pb-5 space-y-4">
+        <div className="flex-1 overflow-y-auto px-6 pb-5 space-y-3">
           {/* 3. Usage Guide Card */}
           {guide && (
             <p className="text-xs text-[var(--abu-text-muted)]">
@@ -608,7 +612,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
           {selectedId && !isOllama && !isLMStudio && (
             <div className="space-y-1.5">
               <div className="flex items-center gap-2">
-                <label className="text-sm font-medium text-[var(--abu-text-primary)]">
+                <label className="text-xs font-medium text-[var(--abu-text-primary)]">
                   {t.settings.apiKey}
                 </label>
                 <span className="text-xs text-[var(--abu-text-tertiary)]">
@@ -621,7 +625,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
                   value={apiKey}
                   onChange={(e) => setApiKey(e.target.value)}
                   placeholder="sk-..."
-                  className="pr-9"
+                  className="pr-9 h-8"
                 />
                 <button
                   type="button"
@@ -656,7 +660,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
           {/* 5. API Address */}
           {selectedId && (
             <div className="space-y-1.5">
-              <label className="text-sm font-medium text-[var(--abu-text-primary)]">
+              <label className="text-xs font-medium text-[var(--abu-text-primary)]">
                 {isOllama ? t.settings.ollamaUrlLabel : isLMStudio ? t.settings.lmstudioUrlLabel : t.settings.apiUrl}
               </label>
               <Input
@@ -664,6 +668,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
                 onChange={(e) => setBaseUrl(e.target.value)}
                 placeholder={isOllama ? 'http://127.0.0.1:11434' : isLMStudio ? 'http://127.0.0.1:1234/v1' : 'https://...'}
                 onBlur={isOllama ? handleCheckOllama : isLMStudio ? handleFetchModels : undefined}
+                className="h-8"
               />
               <p className="text-xs text-[var(--abu-text-tertiary)]">
                 {isOllama ? t.settings.ollamaUrlHint : isLMStudio ? t.settings.lmstudioUrlHint : t.settings.apiUrlNoChange}
@@ -711,7 +716,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
           {selectedId && (
             <div className="space-y-2">
               <div className="flex items-center justify-between">
-                <label className="text-sm font-medium text-[var(--abu-text-primary)]">
+                <label className="text-xs font-medium text-[var(--abu-text-primary)]">
                   {t.settings.models}
                 </label>
                 {/* Fetch/refresh models button — only when baseUrl is filled */}
@@ -849,7 +854,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
                     value={manualModelInput}
                     onChange={(e) => setManualModelInput(e.target.value)}
                     placeholder={t.settings.addModelPlaceholder}
-                    className="flex-1"
+                    className="flex-1 h-8"
                     onKeyDown={(e) => { if (e.key === 'Enter') handleAddManualModel(); }}
                   />
                   <Button
@@ -868,81 +873,97 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
           {/* 7. Advanced capabilities (custom/local providers only) */}
           {showAdvanced && (
             <div className="space-y-2">
-              <div className="text-sm font-medium text-[var(--abu-text-primary)]">
-                {t.settings.advancedConfig}
-              </div>
-              <div className="grid grid-cols-2 gap-2">
-                <label className="flex items-center gap-2">
-                  <Toggle size="sm" checked={!!declared.supportsTools}
-                    onChange={() => setDeclared(d => ({ ...d, supportsTools: !d.supportsTools }))} />
-                  <span className="text-sm text-[var(--abu-text-primary)]">{t.settings.capTools}</span>
-                </label>
-                <label className="flex items-center gap-2">
-                  <Toggle size="sm" checked={!!declared.supportsImages}
-                    onChange={() => setDeclared(d => ({ ...d, supportsImages: !d.supportsImages }))} />
-                  <span className="text-sm text-[var(--abu-text-primary)]">{t.settings.capImages}</span>
-                </label>
-                <label className="flex items-center gap-2">
-                  <Toggle size="sm" checked={!!declared.supportsReasoning}
-                    onChange={() => setDeclared(d => ({ ...d, supportsReasoning: !d.supportsReasoning }))} />
-                  <span className="text-sm text-[var(--abu-text-primary)]">{t.settings.capReasoning}</span>
-                </label>
-                <label className="flex items-center gap-2" title={t.settings.capRawUrlHint}>
-                  <Toggle size="sm" checked={!!declared.useRawUrl}
-                    onChange={() => setDeclared(d => ({ ...d, useRawUrl: !d.useRawUrl }))} />
-                  <span className="text-sm text-[var(--abu-text-primary)]">{t.settings.capRawUrl}</span>
-                </label>
-              </div>
-              {declared.supportsReasoning && (
-                <div className="pl-3 space-y-2 border-l border-black/10">
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm text-[var(--abu-text-secondary)]">{t.settings.capEffort}</span>
-                    {(['low', 'medium', 'high'] as const).map(e => (
-                      <label key={e} className="flex items-center gap-1">
-                        <Toggle size="sm" checked={!!declared.supportedEfforts?.includes(e)}
-                          onChange={() => setDeclared(d => ({ ...d, supportedEfforts: toggleEffort(d.supportedEfforts, e) }))} />
-                        <span className="text-xs text-[var(--abu-text-secondary)]">
-                          {{ low: t.settings.effortLow, medium: t.settings.effortMedium, high: t.settings.effortHigh }[e]}
-                        </span>
-                      </label>
-                    ))}
+              <button
+                type="button"
+                onClick={() => setAdvancedOpen(!advancedOpen)}
+                className="w-full flex items-center gap-1.5 text-left"
+              >
+                <ChevronDown className={cn(
+                  'h-3.5 w-3.5 text-[var(--abu-text-secondary)] transition-transform shrink-0',
+                  !advancedOpen && '-rotate-90',
+                )} />
+                <span className="text-xs font-medium text-[var(--abu-text-primary)]">
+                  {t.settings.advancedConfig}
+                </span>
+              </button>
+              {advancedOpen && (
+                <div className="space-y-2">
+                  <div className="grid grid-cols-2 gap-2">
+                    <label className="flex items-center gap-2">
+                      <Toggle size="sm" checked={!!declared.supportsTools}
+                        onChange={() => setDeclared(d => ({ ...d, supportsTools: !d.supportsTools }))} />
+                      <span className="text-sm text-[var(--abu-text-primary)]">{t.settings.capTools}</span>
+                    </label>
+                    <label className="flex items-center gap-2">
+                      <Toggle size="sm" checked={!!declared.supportsImages}
+                        onChange={() => setDeclared(d => ({ ...d, supportsImages: !d.supportsImages }))} />
+                      <span className="text-sm text-[var(--abu-text-primary)]">{t.settings.capImages}</span>
+                    </label>
+                    <label className="flex items-center gap-2">
+                      <Toggle size="sm" checked={!!declared.supportsReasoning}
+                        onChange={() => setDeclared(d => ({ ...d, supportsReasoning: !d.supportsReasoning }))} />
+                      <span className="text-sm text-[var(--abu-text-primary)]">{t.settings.capReasoning}</span>
+                    </label>
+                    <label className="flex items-center gap-2" title={t.settings.capRawUrlHint}>
+                      <Toggle size="sm" checked={!!declared.useRawUrl}
+                        onChange={() => setDeclared(d => ({ ...d, useRawUrl: !d.useRawUrl }))} />
+                      <span className="text-sm text-[var(--abu-text-primary)]">{t.settings.capRawUrl}</span>
+                    </label>
+                  </div>
+                  {declared.supportsReasoning && (
+                    <div className="pl-3 space-y-2 border-l border-black/10">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm text-[var(--abu-text-secondary)]">{t.settings.capEffort}</span>
+                        {(['low', 'medium', 'high'] as const).map(e => (
+                          <label key={e} className="flex items-center gap-1">
+                            <Toggle size="sm" checked={!!declared.supportedEfforts?.includes(e)}
+                              onChange={() => setDeclared(d => ({ ...d, supportedEfforts: toggleEffort(d.supportedEfforts, e) }))} />
+                            <span className="text-xs text-[var(--abu-text-secondary)]">
+                              {{ low: t.settings.effortLow, medium: t.settings.effortMedium, high: t.settings.effortHigh }[e]}
+                            </span>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  <div className="grid grid-cols-2 gap-2">
+                    <div className="space-y-1">
+                      <div className="text-sm text-[var(--abu-text-primary)]">{t.settings.capMaxInput}</div>
+                      <Input
+                        type="text"
+                        inputMode="numeric"
+                        placeholder={t.settings.capTokenDefault}
+                        value={declared.maxInputTokens ?? ''}
+                        className="h-8"
+                        onChange={e => { const raw = e.target.value.replace(/[^0-9]/g, ''); setDeclared(d => ({ ...d, maxInputTokens: raw === '' ? undefined : Number(raw) })); }}
+                      />
+                      <div className="flex gap-1 flex-wrap">
+                        {[32768, 65536, 131072, 262144].map(v => (
+                          <Button key={v} variant="ghost" size="xs" type="button"
+                            onClick={() => setDeclared(d => ({ ...d, maxInputTokens: v }))}>{v / 1024}K</Button>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="space-y-1">
+                      <div className="text-sm text-[var(--abu-text-primary)]">{t.settings.capMaxOutput}</div>
+                      <Input
+                        type="text"
+                        inputMode="numeric"
+                        placeholder={t.settings.capTokenDefault}
+                        value={declared.maxOutputTokens ?? ''}
+                        className="h-8"
+                        onChange={e => { const raw = e.target.value.replace(/[^0-9]/g, ''); setDeclared(d => ({ ...d, maxOutputTokens: raw === '' ? undefined : Number(raw) })); }}
+                      />
+                      <div className="flex gap-1 flex-wrap">
+                        {[8192, 16384, 32768, 65536].map(v => (
+                          <Button key={v} variant="ghost" size="xs" type="button"
+                            onClick={() => setDeclared(d => ({ ...d, maxOutputTokens: v }))}>{v / 1024}K</Button>
+                        ))}
+                      </div>
+                    </div>
                   </div>
                 </div>
               )}
-              <div className="grid grid-cols-2 gap-2">
-                <div className="space-y-1">
-                  <div className="text-sm text-[var(--abu-text-primary)]">{t.settings.capMaxInput}</div>
-                  <Input
-                    type="text"
-                    inputMode="numeric"
-                    placeholder={t.settings.capTokenDefault}
-                    value={declared.maxInputTokens ?? ''}
-                    onChange={e => { const raw = e.target.value.replace(/[^0-9]/g, ''); setDeclared(d => ({ ...d, maxInputTokens: raw === '' ? undefined : Number(raw) })); }}
-                  />
-                  <div className="flex gap-1 flex-wrap">
-                    {[32768, 65536, 131072, 262144].map(v => (
-                      <Button key={v} variant="ghost" size="xs" type="button"
-                        onClick={() => setDeclared(d => ({ ...d, maxInputTokens: v }))}>{v / 1024}K</Button>
-                    ))}
-                  </div>
-                </div>
-                <div className="space-y-1">
-                  <div className="text-sm text-[var(--abu-text-primary)]">{t.settings.capMaxOutput}</div>
-                  <Input
-                    type="text"
-                    inputMode="numeric"
-                    placeholder={t.settings.capTokenDefault}
-                    value={declared.maxOutputTokens ?? ''}
-                    onChange={e => { const raw = e.target.value.replace(/[^0-9]/g, ''); setDeclared(d => ({ ...d, maxOutputTokens: raw === '' ? undefined : Number(raw) })); }}
-                  />
-                  <div className="flex gap-1 flex-wrap">
-                    {[8192, 16384, 32768, 65536].map(v => (
-                      <Button key={v} variant="ghost" size="xs" type="button"
-                        onClick={() => setDeclared(d => ({ ...d, maxOutputTokens: v }))}>{v / 1024}K</Button>
-                    ))}
-                  </div>
-                </div>
-              </div>
             </div>
           )}
         </div>

--- a/src/components/settings/sections/ai-services/AddProviderModal.tsx
+++ b/src/components/settings/sections/ai-services/AddProviderModal.tsx
@@ -163,7 +163,6 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
 
   // ── Advanced capabilities (custom/local providers only) ──
   const [declared, setDeclared] = useState<DeclaredCapabilities>({});
-  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   // ── Validate state ──
   const [validating, setValidating] = useState(false);
@@ -236,7 +235,6 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
       const existingP = providers.find(p => p.id === option.provider);
       const willShowAdvanced = computeShowAdvanced(isCustomId(option.id), option.provider, option.format);
       setDeclared(existingP?.declaredCapabilities ?? (willShowAdvanced ? defaultDeclaredCapabilities() : {}));
-      setAdvancedOpen(!!existingP?.declaredCapabilities && Object.keys(existingP.declaredCapabilities).length > 0);
 
       // Reset Ollama state
       setOllamaStatus('idle');
@@ -465,7 +463,6 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
     setFetchedModels([]);
     setFetchModelsError('');
     setDeclared({});
-    setAdvancedOpen(false);
     onClose();
   }, [onClose]);
 
@@ -495,10 +492,34 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
           <h2 className="text-lg font-semibold text-[var(--abu-text-primary)]">
             {t.settings.addService}
           </h2>
-          <Button variant="ghost" size="icon-sm" onClick={handleClose}>
-            <X className="h-4 w-4" />
-          </Button>
+          <div className="flex items-center gap-1">
+            {selectedId && !isOllama && !isLMStudio && (
+              <button
+                type="button"
+                onClick={handleValidate}
+                disabled={validating || !apiKey.trim() || !baseUrl.trim()}
+                className="text-xs text-[var(--abu-clay)] hover:underline disabled:opacity-40 disabled:no-underline flex items-center gap-1 px-2 py-1"
+              >
+                {validating && <Loader2 className="h-3 w-3 animate-spin" />}
+                {validating ? t.settings.validating : t.settings.validateConnection}
+              </button>
+            )}
+            <Button variant="ghost" size="icon-sm" onClick={handleClose}>
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
         </div>
+        {/* Validate result — shown just below header when present */}
+        {validateResult && (
+          <div className="shrink-0 px-6 py-1.5 border-b border-[var(--abu-border)] flex items-center gap-1.5">
+            {validateResult.success
+              ? <CircleCheck className="h-3.5 w-3.5 text-green-600 shrink-0" />
+              : <CircleX className="h-3.5 w-3.5 text-red-500 shrink-0" />}
+            <span className={cn('text-xs', validateResult.success ? 'text-green-600' : 'text-red-500')}>
+              {validateResult.message}
+            </span>
+          </div>
+        )}
 
         {/* Fixed top area: name + provider selector (not scrollable, so dropdown won't clip) */}
         <div className="shrink-0 px-6 pt-5 pb-3 space-y-5">
@@ -636,23 +657,6 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
                     ? <EyeOff className="h-4 w-4" />
                     : <Eye className="h-4 w-4" />}
                 </button>
-              </div>
-              {/* Inline validate */}
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  onClick={handleValidate}
-                  disabled={validating || !apiKey.trim() || !baseUrl.trim()}
-                  className="text-xs text-[var(--abu-clay)] hover:underline disabled:opacity-40 disabled:no-underline flex items-center gap-1"
-                >
-                  {validating && <Loader2 className="h-3 w-3 animate-spin" />}
-                  {validating ? t.settings.validating : t.settings.validateConnection}
-                </button>
-                {validateResult && (
-                  <span className={cn('text-xs', validateResult.success ? 'text-green-600' : 'text-red-500')}>
-                    {validateResult.message}
-                  </span>
-                )}
               </div>
             </div>
           )}
@@ -873,21 +877,10 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
           {/* 7. Advanced capabilities (custom/local providers only) */}
           {showAdvanced && (
             <div className="space-y-2">
-              <button
-                type="button"
-                onClick={() => setAdvancedOpen(!advancedOpen)}
-                className="w-full flex items-center gap-1.5 text-left"
-              >
-                <ChevronDown className={cn(
-                  'h-3.5 w-3.5 text-[var(--abu-text-secondary)] transition-transform shrink-0',
-                  !advancedOpen && '-rotate-90',
-                )} />
-                <span className="text-xs font-medium text-[var(--abu-text-primary)]">
-                  {t.settings.advancedConfig}
-                </span>
-              </button>
-              {advancedOpen && (
-                <div className="space-y-2">
+              <div className="text-xs font-medium text-[var(--abu-text-primary)]">
+                {t.settings.advancedConfig}
+              </div>
+              <div className="space-y-2">
                   <div className="grid grid-cols-2 gap-2">
                     <label className="flex items-center gap-2">
                       <Toggle size="sm" checked={!!declared.supportsTools}
@@ -926,7 +919,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
                       </div>
                     </div>
                   )}
-                  <div className="grid grid-cols-2 gap-2">
+                  <div className="grid grid-cols-2 gap-2 mt-4">
                     <div className="space-y-1">
                       <div className="text-sm text-[var(--abu-text-primary)]">{t.settings.capMaxInput}</div>
                       <Input
@@ -963,7 +956,6 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
                     </div>
                   </div>
                 </div>
-              )}
             </div>
           )}
         </div>

--- a/src/components/settings/sections/ai-services/AddProviderModal.tsx
+++ b/src/components/settings/sections/ai-services/AddProviderModal.tsx
@@ -562,12 +562,10 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
                             <button
                               key={option.id}
                               type="button"
-                              disabled={added}
                               onClick={() => handleSelectProvider(option)}
                               className={cn(
                                 'w-full px-3 py-2 flex items-center justify-between text-sm',
                                 'hover:bg-[var(--abu-bg-hover)] transition-colors',
-                                added && 'opacity-50 cursor-not-allowed',
                                 selectedId === option.id && 'bg-[var(--abu-bg-hover)]',
                               )}
                             >
@@ -590,7 +588,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
         </div>
 
         {/* Scrollable content area: guide, API key, models, etc. */}
-        <div className="flex-1 overflow-y-auto px-6 pb-5 space-y-5">
+        <div className="flex-1 overflow-y-auto px-6 pb-5 space-y-4">
           {/* 3. Usage Guide Card */}
           {guide && (
             <p className="text-xs text-[var(--abu-text-muted)]">
@@ -869,7 +867,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
 
           {/* 7. Advanced capabilities (custom/local providers only) */}
           {showAdvanced && (
-            <div className="space-y-3">
+            <div className="space-y-2">
               <div className="text-sm font-medium text-[var(--abu-text-primary)]">
                 {t.settings.advancedConfig}
               </div>
@@ -911,15 +909,15 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
                   </div>
                 </div>
               )}
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid grid-cols-2 gap-2">
                 <div className="space-y-1">
                   <div className="text-sm text-[var(--abu-text-primary)]">{t.settings.capMaxInput}</div>
                   <Input
-                    type="number"
-                    min={0}
+                    type="text"
+                    inputMode="numeric"
                     placeholder={t.settings.capTokenDefault}
                     value={declared.maxInputTokens ?? ''}
-                    onChange={e => setDeclared(d => ({ ...d, maxInputTokens: e.target.value === '' ? undefined : Number(e.target.value) }))}
+                    onChange={e => { const raw = e.target.value.replace(/[^0-9]/g, ''); setDeclared(d => ({ ...d, maxInputTokens: raw === '' ? undefined : Number(raw) })); }}
                   />
                   <div className="flex gap-1 flex-wrap">
                     {[32768, 65536, 131072, 262144].map(v => (
@@ -931,11 +929,11 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
                 <div className="space-y-1">
                   <div className="text-sm text-[var(--abu-text-primary)]">{t.settings.capMaxOutput}</div>
                   <Input
-                    type="number"
-                    min={0}
+                    type="text"
+                    inputMode="numeric"
                     placeholder={t.settings.capTokenDefault}
                     value={declared.maxOutputTokens ?? ''}
-                    onChange={e => setDeclared(d => ({ ...d, maxOutputTokens: e.target.value === '' ? undefined : Number(e.target.value) }))}
+                    onChange={e => { const raw = e.target.value.replace(/[^0-9]/g, ''); setDeclared(d => ({ ...d, maxOutputTokens: raw === '' ? undefined : Number(raw) })); }}
                   />
                   <div className="flex gap-1 flex-wrap">
                     {[8192, 16384, 32768, 65536].map(v => (

--- a/src/components/settings/sections/ai-services/AddProviderModal.tsx
+++ b/src/components/settings/sections/ai-services/AddProviderModal.tsx
@@ -492,34 +492,10 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
           <h2 className="text-lg font-semibold text-[var(--abu-text-primary)]">
             {t.settings.addService}
           </h2>
-          <div className="flex items-center gap-1">
-            {selectedId && !isOllama && !isLMStudio && (
-              <button
-                type="button"
-                onClick={handleValidate}
-                disabled={validating || !apiKey.trim() || !baseUrl.trim()}
-                className="text-xs text-[var(--abu-clay)] hover:underline disabled:opacity-40 disabled:no-underline flex items-center gap-1 px-2 py-1"
-              >
-                {validating && <Loader2 className="h-3 w-3 animate-spin" />}
-                {validating ? t.settings.validating : t.settings.validateConnection}
-              </button>
-            )}
-            <Button variant="ghost" size="icon-sm" onClick={handleClose}>
-              <X className="h-4 w-4" />
-            </Button>
-          </div>
+          <Button variant="ghost" size="icon-sm" onClick={handleClose}>
+            <X className="h-4 w-4" />
+          </Button>
         </div>
-        {/* Validate result — shown just below header when present */}
-        {validateResult && (
-          <div className="shrink-0 px-6 py-1.5 border-b border-[var(--abu-border)] flex items-center gap-1.5">
-            {validateResult.success
-              ? <CircleCheck className="h-3.5 w-3.5 text-green-600 shrink-0" />
-              : <CircleX className="h-3.5 w-3.5 text-red-500 shrink-0" />}
-            <span className={cn('text-xs', validateResult.success ? 'text-green-600' : 'text-red-500')}>
-              {validateResult.message}
-            </span>
-          </div>
-        )}
 
         {/* Fixed top area: name + provider selector (not scrollable, so dropdown won't clip) */}
         <div className="shrink-0 px-6 pt-4 pb-2 space-y-5">
@@ -674,9 +650,11 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
                 onBlur={isOllama ? handleCheckOllama : isLMStudio ? handleFetchModels : undefined}
                 className="h-8"
               />
-              <p className="text-xs text-[var(--abu-text-tertiary)]">
-                {isOllama ? t.settings.ollamaUrlHint : isLMStudio ? t.settings.lmstudioUrlHint : t.settings.apiUrlNoChange}
-              </p>
+              {(isOllama || isLMStudio) && (
+                <p className="text-xs text-[var(--abu-text-tertiary)]">
+                  {isOllama ? t.settings.ollamaUrlHint : t.settings.lmstudioUrlHint}
+                </p>
+              )}
 
               {/* Final request URL preview — hidden for local providers which have their own status UI */}
               {!isOllama && !isLMStudio && baseUrl.trim() && selectedOption && (
@@ -961,16 +939,43 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
         </div>
 
         {/* Footer */}
-        <div className="shrink-0 px-6 py-4 border-t border-[var(--abu-border)] flex justify-end gap-3">
-          <Button variant="ghost" onClick={handleClose}>
-            {t.common.cancel}
-          </Button>
-          <Button
-            onClick={handleSave}
-            disabled={!canSave}
-          >
-            {t.settings.save}
-          </Button>
+        <div className="shrink-0 px-6 py-4 border-t border-[var(--abu-border)] flex items-center justify-between">
+          {/* Left: validate connection + inline result */}
+          <div className="flex items-center gap-2 min-w-0">
+            {selectedId && !isOllama && !isLMStudio && (
+              <button
+                type="button"
+                onClick={handleValidate}
+                disabled={validating || !apiKey.trim() || !baseUrl.trim()}
+                className="shrink-0 text-xs text-[var(--abu-clay)] hover:underline disabled:opacity-40 disabled:no-underline flex items-center gap-1"
+              >
+                {validating && <Loader2 className="h-3 w-3 animate-spin" />}
+                {validating ? t.settings.validating : t.settings.validateConnection}
+              </button>
+            )}
+            {validateResult && (
+              <div className="flex items-center gap-1 min-w-0">
+                {validateResult.success
+                  ? <CircleCheck className="h-3.5 w-3.5 text-green-600 shrink-0" />
+                  : <CircleX className="h-3.5 w-3.5 text-red-500 shrink-0" />}
+                <span className={cn('text-xs truncate max-w-[280px]', validateResult.success ? 'text-green-600' : 'text-red-500')}>
+                  {validateResult.message}
+                </span>
+              </div>
+            )}
+          </div>
+          {/* Right: cancel + save */}
+          <div className="flex items-center gap-3 shrink-0">
+            <Button variant="ghost" onClick={handleClose}>
+              {t.common.cancel}
+            </Button>
+            <Button
+              onClick={handleSave}
+              disabled={!canSave}
+            >
+              {t.settings.save}
+            </Button>
+          </div>
         </div>
       </div>
     </div>,

--- a/src/components/settings/sections/ai-services/AddProviderModal.tsx
+++ b/src/components/settings/sections/ai-services/AddProviderModal.tsx
@@ -9,12 +9,13 @@ import { useI18n } from '@/i18n';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Toggle } from '@/components/ui/toggle';
 import { checkProviderHealth } from '@/core/llm/healthCheck';
 import { buildFullChatUrl } from '@/core/llm/urlUtils';
 import { useSettingsStore, PROVIDER_CONFIGS } from '@/stores/settingsStore';
 import { PROVIDER_GUIDES } from './providerGuides';
 import type { LLMProvider, ApiFormat } from '@/types';
-import type { ModelInfo, ProviderSource } from '@/types/provider';
+import type { ModelInfo, ProviderSource, DeclaredCapabilities } from '@/types/provider';
 import {
   checkOllamaHealth,
   fetchOllamaModels,
@@ -159,6 +160,9 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
   const [fetchedModels, setFetchedModels] = useState<ModelInfo[]>([]);
   const [fetchModelsError, setFetchModelsError] = useState('');
 
+  // ── Advanced capabilities (custom/local providers only) ──
+  const [declared, setDeclared] = useState<DeclaredCapabilities>({});
+
   // ── Validate state ──
   const [validating, setValidating] = useState(false);
   const [validateResult, setValidateResult] = useState<{ success: boolean; message: string } | null>(null);
@@ -183,6 +187,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
   const isOllama = selectedOption?.provider === 'ollama';
   const isLMStudio = selectedOption?.provider === 'lmstudio';
   const isCustom = selectedId ? isCustomId(selectedId) : false;
+  const showAdvanced = isCustom || isOllama || isLMStudio;
   const guide = selectedOption && !isCustom ? PROVIDER_GUIDES[selectedOption.provider] : null;
 
   // knownModels removed — models are fetched from API or added manually
@@ -224,6 +229,10 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
         setSelectedModels(new Set());
       }
 
+      // Reset declared capabilities; load from existing store entry if already configured
+      const existingP = providers.find(p => p.id === option.provider);
+      setDeclared(existingP?.declaredCapabilities ?? {});
+
       // Reset Ollama state
       setOllamaStatus('idle');
       setOllamaError('');
@@ -239,7 +248,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
       // (fetch removed)
       setManualModelInput('');
     },
-    [nameManuallyEdited]
+    [nameManuallyEdited, providers]
   );
 
   const handleNameChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -384,6 +393,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
     const capabilities = selectedOption && !isCustom
       ? PROVIDER_CONFIGS[selectedOption.provider].capabilities
       : undefined;
+    const declaredCapabilities = showAdvanced ? declared : undefined;
 
     // For builtin providers: update the existing entry instead of creating a duplicate
     const existingBuiltin = !isCustom && selectedOption
@@ -400,6 +410,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
         models: modelInfos,
         capabilities,
         userAdded: true,
+        declaredCapabilities,
       });
       providerId = existingBuiltin.id;
     } else {
@@ -413,6 +424,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
         models: modelInfos,
         capabilities,
         userAdded: true,
+        declaredCapabilities,
       });
     }
 
@@ -425,8 +437,8 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
     onClose();
   }, [
     serviceName, selectedModels, ollamaModels, selectedOption,
-    isCustom, baseUrl, apiKey, providers, addProvider, updateProvider,
-    selectModel, onClose,
+    isCustom, showAdvanced, declared, baseUrl, apiKey, providers,
+    addProvider, updateProvider, selectModel, onClose,
   ]);
 
   // ── Reset on close ──
@@ -447,6 +459,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
     setFetchModelsStatus('idle');
     setFetchedModels([]);
     setFetchModelsError('');
+    setDeclared({});
     onClose();
   }, [onClose]);
 
@@ -846,6 +859,60 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
                   >
                     <Plus className="h-4 w-4" />
                   </Button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* 7. Advanced capabilities (custom/local providers only) */}
+          {showAdvanced && (
+            <div className="space-y-3">
+              <div className="text-sm font-medium text-[var(--abu-text-primary)]">
+                {t.settings.advancedConfig}
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <label className="flex items-center gap-2">
+                  <Toggle size="sm" checked={!!declared.supportsTools}
+                    onChange={() => setDeclared(d => ({ ...d, supportsTools: !d.supportsTools }))} />
+                  <span className="text-sm text-[var(--abu-text-primary)]">{t.settings.capTools}</span>
+                </label>
+                <label className="flex items-center gap-2">
+                  <Toggle size="sm" checked={!!declared.supportsImages}
+                    onChange={() => setDeclared(d => ({ ...d, supportsImages: !d.supportsImages }))} />
+                  <span className="text-sm text-[var(--abu-text-primary)]">{t.settings.capImages}</span>
+                </label>
+                <label className="flex items-center gap-2">
+                  <Toggle size="sm" checked={!!declared.supportsReasoning}
+                    onChange={() => setDeclared(d => ({ ...d, supportsReasoning: !d.supportsReasoning }))} />
+                  <span className="text-sm text-[var(--abu-text-primary)]">{t.settings.capReasoning}</span>
+                </label>
+                <label className="flex items-center gap-2" title={t.settings.capRawUrlHint}>
+                  <Toggle size="sm" checked={!!declared.useRawUrl}
+                    onChange={() => setDeclared(d => ({ ...d, useRawUrl: !d.useRawUrl }))} />
+                  <span className="text-sm text-[var(--abu-text-primary)]">{t.settings.capRawUrl}</span>
+                </label>
+              </div>
+              {declared.supportsReasoning && (
+                <div className="pl-3 space-y-2 border-l border-black/10">
+                  <label className="flex items-center gap-2">
+                    <Toggle size="sm" checked={!!declared.canDisableThinking}
+                      onChange={() => setDeclared(d => ({ ...d, canDisableThinking: !d.canDisableThinking }))} />
+                    <span className="text-sm text-[var(--abu-text-primary)]">{t.settings.capCanDisableThinking}</span>
+                  </label>
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm text-[var(--abu-text-secondary)]">{t.settings.capEffort}</span>
+                    {(['low', 'medium', 'high'] as const).map(e => (
+                      <label key={e} className="flex items-center gap-1">
+                        <Toggle size="sm" checked={!!declared.supportedEfforts?.includes(e)}
+                          onChange={() => setDeclared(d => {
+                            const cur = new Set(d.supportedEfforts ?? []);
+                            if (cur.has(e)) cur.delete(e); else cur.add(e);
+                            return { ...d, supportedEfforts: [...cur] as Array<'low' | 'medium' | 'high'> };
+                          })} />
+                        <span className="text-xs text-[var(--abu-text-secondary)]">{e}</span>
+                      </label>
+                    ))}
+                  </div>
                 </div>
               )}
             </div>

--- a/src/components/settings/sections/ai-services/AddProviderModal.tsx
+++ b/src/components/settings/sections/ai-services/AddProviderModal.tsx
@@ -14,6 +14,7 @@ import { checkProviderHealth } from '@/core/llm/healthCheck';
 import { buildFullChatUrl } from '@/core/llm/urlUtils';
 import { useSettingsStore, PROVIDER_CONFIGS } from '@/stores/settingsStore';
 import { PROVIDER_GUIDES } from './providerGuides';
+import { computeShowAdvanced, toggleEffort } from './providerCapabilities';
 import type { LLMProvider, ApiFormat } from '@/types';
 import type { ModelInfo, ProviderSource, DeclaredCapabilities } from '@/types/provider';
 import {
@@ -187,7 +188,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
   const isOllama = selectedOption?.provider === 'ollama';
   const isLMStudio = selectedOption?.provider === 'lmstudio';
   const isCustom = selectedId ? isCustomId(selectedId) : false;
-  const showAdvanced = isCustom || isOllama || isLMStudio;
+  const showAdvanced = computeShowAdvanced(isCustom, selectedOption?.provider);
   const guide = selectedOption && !isCustom ? PROVIDER_GUIDES[selectedOption.provider] : null;
 
   // knownModels removed — models are fetched from API or added manually
@@ -904,11 +905,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
                     {(['low', 'medium', 'high'] as const).map(e => (
                       <label key={e} className="flex items-center gap-1">
                         <Toggle size="sm" checked={!!declared.supportedEfforts?.includes(e)}
-                          onChange={() => setDeclared(d => {
-                            const cur = new Set(d.supportedEfforts ?? []);
-                            if (cur.has(e)) cur.delete(e); else cur.add(e);
-                            return { ...d, supportedEfforts: [...cur] as Array<'low' | 'medium' | 'high'> };
-                          })} />
+                          onChange={() => setDeclared(d => ({ ...d, supportedEfforts: toggleEffort(d.supportedEfforts, e) }))} />
                         <span className="text-xs text-[var(--abu-text-secondary)]">{e}</span>
                       </label>
                     ))}

--- a/src/components/settings/sections/ai-services/AddProviderModal.tsx
+++ b/src/components/settings/sections/ai-services/AddProviderModal.tsx
@@ -911,6 +911,40 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
                   </div>
                 </div>
               )}
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1">
+                  <div className="text-sm text-[var(--abu-text-primary)]">{t.settings.capMaxInput}</div>
+                  <Input
+                    type="number"
+                    min={0}
+                    placeholder={t.settings.capTokenDefault}
+                    value={declared.maxInputTokens ?? ''}
+                    onChange={e => setDeclared(d => ({ ...d, maxInputTokens: e.target.value === '' ? undefined : Number(e.target.value) }))}
+                  />
+                  <div className="flex gap-1 flex-wrap">
+                    {[32768, 65536, 131072, 262144].map(v => (
+                      <Button key={v} variant="ghost" size="xs" type="button"
+                        onClick={() => setDeclared(d => ({ ...d, maxInputTokens: v }))}>{v / 1024}K</Button>
+                    ))}
+                  </div>
+                </div>
+                <div className="space-y-1">
+                  <div className="text-sm text-[var(--abu-text-primary)]">{t.settings.capMaxOutput}</div>
+                  <Input
+                    type="number"
+                    min={0}
+                    placeholder={t.settings.capTokenDefault}
+                    value={declared.maxOutputTokens ?? ''}
+                    onChange={e => setDeclared(d => ({ ...d, maxOutputTokens: e.target.value === '' ? undefined : Number(e.target.value) }))}
+                  />
+                  <div className="flex gap-1 flex-wrap">
+                    {[8192, 16384, 32768, 65536].map(v => (
+                      <Button key={v} variant="ghost" size="xs" type="button"
+                        onClick={() => setDeclared(d => ({ ...d, maxOutputTokens: v }))}>{v / 1024}K</Button>
+                    ))}
+                  </div>
+                </div>
+              </div>
             </div>
           )}
         </div>

--- a/src/components/settings/sections/ai-services/AddProviderModal.tsx
+++ b/src/components/settings/sections/ai-services/AddProviderModal.tsx
@@ -14,7 +14,7 @@ import { checkProviderHealth } from '@/core/llm/healthCheck';
 import { buildFullChatUrl } from '@/core/llm/urlUtils';
 import { useSettingsStore, PROVIDER_CONFIGS } from '@/stores/settingsStore';
 import { PROVIDER_GUIDES } from './providerGuides';
-import { computeShowAdvanced, toggleEffort } from './providerCapabilities';
+import { computeShowAdvanced, defaultDeclaredCapabilities, toggleEffort } from './providerCapabilities';
 import type { LLMProvider, ApiFormat } from '@/types';
 import type { ModelInfo, ProviderSource, DeclaredCapabilities } from '@/types/provider';
 import {
@@ -188,7 +188,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
   const isOllama = selectedOption?.provider === 'ollama';
   const isLMStudio = selectedOption?.provider === 'lmstudio';
   const isCustom = selectedId ? isCustomId(selectedId) : false;
-  const showAdvanced = computeShowAdvanced(isCustom, selectedOption?.provider);
+  const showAdvanced = computeShowAdvanced(isCustom, selectedOption?.provider, selectedOption?.format);
   const guide = selectedOption && !isCustom ? PROVIDER_GUIDES[selectedOption.provider] : null;
 
   // knownModels removed — models are fetched from API or added manually
@@ -230,9 +230,11 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
         setSelectedModels(new Set());
       }
 
-      // Reset declared capabilities; load from existing store entry if already configured
+      // Reset declared capabilities; load from existing store entry if already configured.
+      // New custom/local providers get explicit defaults so toggles are not misleading tri-state.
       const existingP = providers.find(p => p.id === option.provider);
-      setDeclared(existingP?.declaredCapabilities ?? {});
+      const willShowAdvanced = computeShowAdvanced(isCustomId(option.id), option.provider, option.format);
+      setDeclared(existingP?.declaredCapabilities ?? (willShowAdvanced ? defaultDeclaredCapabilities() : {}));
 
       // Reset Ollama state
       setOllamaStatus('idle');
@@ -672,7 +674,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
               {/* Final request URL preview — hidden for local providers which have their own status UI */}
               {!isOllama && !isLMStudio && baseUrl.trim() && selectedOption && (
                 <p className="text-[11px] font-mono text-[var(--abu-text-muted)] break-all">
-                  ↳ {t.settings.apiUrlPreview}: POST {buildFullChatUrl(baseUrl, selectedOption.format)}
+                  ↳ {t.settings.apiUrlPreview}: POST {buildFullChatUrl(baseUrl, selectedOption.format, { useRawUrl: declared.useRawUrl })}
                 </p>
               )}
 
@@ -895,18 +897,15 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
               </div>
               {declared.supportsReasoning && (
                 <div className="pl-3 space-y-2 border-l border-black/10">
-                  <label className="flex items-center gap-2">
-                    <Toggle size="sm" checked={!!declared.canDisableThinking}
-                      onChange={() => setDeclared(d => ({ ...d, canDisableThinking: !d.canDisableThinking }))} />
-                    <span className="text-sm text-[var(--abu-text-primary)]">{t.settings.capCanDisableThinking}</span>
-                  </label>
                   <div className="flex items-center gap-2">
                     <span className="text-sm text-[var(--abu-text-secondary)]">{t.settings.capEffort}</span>
                     {(['low', 'medium', 'high'] as const).map(e => (
                       <label key={e} className="flex items-center gap-1">
                         <Toggle size="sm" checked={!!declared.supportedEfforts?.includes(e)}
                           onChange={() => setDeclared(d => ({ ...d, supportedEfforts: toggleEffort(d.supportedEfforts, e) }))} />
-                        <span className="text-xs text-[var(--abu-text-secondary)]">{e}</span>
+                        <span className="text-xs text-[var(--abu-text-secondary)]">
+                          {{ low: t.settings.effortLow, medium: t.settings.effortMedium, high: t.settings.effortHigh }[e]}
+                        </span>
                       </label>
                     ))}
                   </div>

--- a/src/components/settings/sections/ai-services/AddProviderModal.tsx
+++ b/src/components/settings/sections/ai-services/AddProviderModal.tsx
@@ -484,7 +484,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
       onMouseDown={(e) => { e.stopPropagation(); }}
     >
       <div
-        className="bg-[var(--abu-bg-base)] rounded-2xl shadow-xl w-full max-w-2xl max-h-[85vh] flex flex-col animate-in zoom-in-95 duration-150"
+        className="bg-[var(--abu-bg-base)] rounded-2xl shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col animate-in zoom-in-95 duration-150"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
@@ -522,9 +522,9 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
         )}
 
         {/* Fixed top area: name + provider selector (not scrollable, so dropdown won't clip) */}
-        <div className="shrink-0 px-6 pt-5 pb-3 space-y-5">
+        <div className="shrink-0 px-6 pt-4 pb-2 space-y-5">
           {/* 1. Service Name */}
-          <div className="space-y-1.5">
+          <div className="space-y-1">
             <label className="text-xs font-medium text-[var(--abu-text-primary)]">
               {t.settings.serviceName}
             </label>
@@ -537,7 +537,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
           </div>
 
           {/* 2. Provider Dropdown */}
-          <div className="space-y-1.5">
+          <div className="space-y-1">
             <label className="text-xs font-medium text-[var(--abu-text-primary)]">
               {t.settings.selectProviderType}
             </label>
@@ -613,7 +613,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
         </div>
 
         {/* Scrollable content area: guide, API key, models, etc. */}
-        <div className="flex-1 overflow-y-auto px-6 pb-5 space-y-3">
+        <div className="flex-1 overflow-y-auto px-6 pb-5 space-y-2.5">
           {/* 3. Usage Guide Card */}
           {guide && (
             <p className="text-xs text-[var(--abu-text-muted)]">
@@ -631,7 +631,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
 
           {/* 4. API Key (hidden for keyless local providers) */}
           {selectedId && !isOllama && !isLMStudio && (
-            <div className="space-y-1.5">
+            <div className="space-y-1">
               <div className="flex items-center gap-2">
                 <label className="text-xs font-medium text-[var(--abu-text-primary)]">
                   {t.settings.apiKey}
@@ -663,7 +663,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
 
           {/* 5. API Address */}
           {selectedId && (
-            <div className="space-y-1.5">
+            <div className="space-y-1">
               <label className="text-xs font-medium text-[var(--abu-text-primary)]">
                 {isOllama ? t.settings.ollamaUrlLabel : isLMStudio ? t.settings.lmstudioUrlLabel : t.settings.apiUrl}
               </label>
@@ -919,7 +919,7 @@ export default function AddProviderModal({ open: isOpen, onClose }: AddProviderM
                       </div>
                     </div>
                   )}
-                  <div className="grid grid-cols-2 gap-2 mt-4">
+                  <div className="grid grid-cols-2 gap-2 mt-3">
                     <div className="space-y-1">
                       <div className="text-sm text-[var(--abu-text-primary)]">{t.settings.capMaxInput}</div>
                       <Input

--- a/src/components/settings/sections/ai-services/ProviderCard.tsx
+++ b/src/components/settings/sections/ai-services/ProviderCard.tsx
@@ -242,7 +242,7 @@ export default function ProviderCard({ provider, isActive }: ProviderCardProps) 
           )}
           {!isOllama && formBaseUrl.trim() && (
             <p className="text-[11px] font-mono text-[var(--abu-text-muted)] break-all">
-              ↳ POST {buildFullChatUrl(formBaseUrl, provider.apiFormat)}
+              ↳ POST {buildFullChatUrl(formBaseUrl, provider.apiFormat, { useRawUrl: provider.declaredCapabilities?.useRawUrl })}
             </p>
           )}
         </div>

--- a/src/components/settings/sections/ai-services/providerCapabilities.ts
+++ b/src/components/settings/sections/ai-services/providerCapabilities.ts
@@ -1,0 +1,17 @@
+import type { LLMProvider } from '@/types';
+
+/** Whether the "advanced config" (declared capabilities) section should show:
+ *  custom providers, or local Ollama / LM Studio. Builtin cloud providers → false. */
+export function computeShowAdvanced(isCustom: boolean, provider: LLMProvider | undefined): boolean {
+  return isCustom || provider === 'ollama' || provider === 'lmstudio';
+}
+
+/** Toggle one effort level in the supportedEfforts array (order-preserving add/remove). */
+export function toggleEffort(
+  current: Array<'low' | 'medium' | 'high'> | undefined,
+  effort: 'low' | 'medium' | 'high',
+): Array<'low' | 'medium' | 'high'> {
+  const set = new Set(current ?? []);
+  if (set.has(effort)) set.delete(effort); else set.add(effort);
+  return [...set];
+}

--- a/src/components/settings/sections/ai-services/providerCapabilities.ts
+++ b/src/components/settings/sections/ai-services/providerCapabilities.ts
@@ -1,9 +1,22 @@
-import type { LLMProvider } from '@/types';
+import type { LLMProvider, ApiFormat } from '@/types';
+import type { DeclaredCapabilities } from '@/types/provider';
 
-/** Whether the "advanced config" (declared capabilities) section should show:
- *  custom providers, or local Ollama / LM Studio. Builtin cloud providers → false. */
-export function computeShowAdvanced(isCustom: boolean, provider: LLMProvider | undefined): boolean {
-  return isCustom || provider === 'ollama' || provider === 'lmstudio';
+/** Whether the "advanced config" (declared capabilities) section should show.
+ *  Only custom providers using openai-compatible format, or local Ollama / LM Studio.
+ *  Builtin cloud providers and anthropic-format custom providers → false. */
+export function computeShowAdvanced(
+  isCustom: boolean,
+  provider: LLMProvider | undefined,
+  apiFormat: ApiFormat | undefined,
+): boolean {
+  return (isCustom && apiFormat === 'openai-compatible')
+    || provider === 'ollama' || provider === 'lmstudio';
+}
+
+/** Defaults for a newly added custom/local provider so capability toggles are explicit
+ *  (not misleading undefined tri-state). Tools on, images/reasoning off — user adjusts. */
+export function defaultDeclaredCapabilities(): DeclaredCapabilities {
+  return { supportsTools: true, supportsImages: false, supportsReasoning: false };
 }
 
 /** Toggle one effort level in the supportedEfforts array (order-preserving add/remove). */

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,34 @@
+import { Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export function Checkbox({
+  checked,
+  onChange,
+  disabled,
+  className,
+}: {
+  checked: boolean;
+  onChange: () => void;
+  disabled?: boolean;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={onChange}
+      className={cn(
+        'inline-flex items-center justify-center h-4 w-4 rounded border transition-colors shrink-0',
+        checked
+          ? 'bg-[var(--abu-clay)] border-[var(--abu-clay)] text-white'
+          : 'bg-transparent border-[var(--abu-border)] hover:border-[var(--abu-clay)]',
+        disabled && 'opacity-50 cursor-not-allowed',
+        className,
+      )}
+    >
+      {checked && <Check className="h-3 w-3" strokeWidth={3} />}
+    </button>
+  );
+}

--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -42,6 +42,7 @@ import { formatTodosForPrompt } from './todoManager';
 import { isWindows } from '../../utils/platform';
 import { getBuiltinSearchConfig } from '../capabilities';
 import { resolveCapabilities, resolveEffectiveContextWindow, computeReasoningParams, type ModelCapabilities } from '../llm/modelCapabilities';
+import { applyDeclaredCapabilities } from '../llm/applyDeclaredCapabilities';
 import { TOOL_NAMES } from '../tools/toolNames';
 import { prefetchTools } from '../tools/toolPrefetch';
 import { classifyTools, buildDeferredToolsSummary } from '../tools/toolSearch';
@@ -736,7 +737,10 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
   // Tell tools whether this model can consume images. read_file uses it to
   // avoid emitting base64 image blocks to text-only models (which bloats
   // context and triggers a 400 on providers that only accept text content).
-  toolContext.supportsVision = resolveCapabilities(effectiveModelId).vision;
+  toolContext.supportsVision = applyDeclaredCapabilities(
+    resolveCapabilities(effectiveModelId),
+    getActiveProvider(settingsForModel)?.declaredCapabilities,
+  ).vision;
 
   // Pin the resolved model to the conversation on first run, so it survives
   // later global model switches (for display + future runs). Pins the
@@ -1148,7 +1152,10 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       // 400 response). Discovered values come from real API errors so they
       // override the registry — but they don't override the *user's* setting,
       // since the user may have a smaller budget on purpose.
-      const modelCaps = resolveCapabilities(effectiveModelId);
+      let modelCaps = resolveCapabilities(effectiveModelId);
+      // Override auto-detected caps with user-declared values (custom/local providers only).
+      // No-op when activeProvider has no declaredCapabilities (builtin providers).
+      modelCaps = applyDeclaredCapabilities(modelCaps, activeProvider?.declaredCapabilities);
       const discoveredCaps = activeProvider
         ? useDiscoveredCapsStore.getState().get(activeProvider.id, effectiveModelId)
         : undefined;
@@ -1368,6 +1375,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         thinkingBudget: reasoningParams.thinkingBudget,
         reasoningEffort: reasoningParams.reasoningEffort,
         supportsVision: modelCaps.vision,
+        declaredCapabilities: activeProvider?.declaredCapabilities,
         builtinWebSearch,
         // When the adapter's max_tokens auto-retry succeeds, persist the
         // discovered limit so the next request uses it pre-emptively.

--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -1121,6 +1121,11 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       const builtinWebSearch = activeProvider
         ? getBuiltinSearchConfig(activeProvider.id as LLMProvider, true)
         : undefined;
+      // When the provider explicitly declared supportsTools=false, suppress tool
+      // resolution entirely so the model never sees tool definitions in the system
+      // prompt and can't hallucinate tool calls. The adapter-level toolsGate rule
+      // also strips tools from the request body as belt-and-suspenders.
+      const noTools = activeProvider?.declaredCapabilities?.supportsTools === false;
       // Build prefetch context for conditional tool loading
       const conv = useChatStore.getState().conversations[conversationId];
       const activeSkillObjects = (conv?.activeSkills ?? [])
@@ -1132,7 +1137,9 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         activeSkills: activeSkillObjects,
         turnCount,
       };
-      const { tools, deferredTools, inputValidators } = resolveTools(route, !!builtinWebSearch, options?.blockedTools, prefetchCtx);
+      const { tools: rawTools, deferredTools: rawDeferredTools, inputValidators } = resolveTools(route, !!builtinWebSearch, options?.blockedTools, prefetchCtx);
+      const tools = noTools ? [] : rawTools;
+      const deferredTools = noTools ? [] : rawDeferredTools;
       const toolTokens = estimateToolSchemaTokens(tools);
       const dynamicCapabilities = buildDynamicCapabilities(tools);
       const deferredToolsSummary = buildDeferredToolsSummary(deferredTools);
@@ -1176,7 +1183,10 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         contextWindow: effectiveModelContext,
         // A model observed reasoning despite the registry saying otherwise → can't
         // bound it; treat as uncontrollable so it gets the full budget + reactive net.
+        // Exception: if the user explicitly declared supportsReasoning=false for this
+        // provider, respect that declaration and never flip thinking back on.
         ...(discoveredCaps?.isReasoningModel && modelCaps.thinking === false
+            && activeProvider?.declaredCapabilities?.supportsReasoning !== false
           ? { thinking: 'uncontrollable' as const }
           : {}),
       };
@@ -1774,7 +1784,8 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         // Handle MCP tool changes — inject notification into conversation
         if (batchResult.mcpChanged) {
           const toolNames = new Set(tools.map(t => t.name));
-          const { tools: freshTools } = resolveTools(route, !!builtinWebSearch, options?.blockedTools);
+          const { tools: freshRawTools } = resolveTools(route, !!builtinWebSearch, options?.blockedTools);
+          const freshTools = noTools ? [] : freshRawTools;
           const freshNames = new Set(freshTools.map(t => t.name));
           const added = freshTools.filter(t => !toolNames.has(t.name));
           const removed = tools.filter(t => !freshNames.has(t.name));
@@ -1801,7 +1812,10 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
 
       // L4: learn that a statically-non-reasoning model actually reasons, so future
       // turns bound it (treated as 'uncontrollable' → full budget + reserved content).
-      if (collectedThinking && modelCaps.thinking === false && activeProvider) {
+      // Skip if the user explicitly declared supportsReasoning=false — their declaration
+      // takes precedence over runtime observation.
+      if (collectedThinking && modelCaps.thinking === false && activeProvider
+          && activeProvider.declaredCapabilities?.supportsReasoning !== false) {
         useDiscoveredCapsStore.getState().recordReasoningObserved(activeProvider.id, effectiveModelId);
       }
 

--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -1192,7 +1192,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       };
       const reasoningParams = computeReasoningParams(
         effectiveCaps,
-        freshSettings.maxOutputTokens ?? effectiveModelMaxOutput,
+        activeProvider?.declaredCapabilities?.maxOutputTokens ?? freshSettings.maxOutputTokens ?? effectiveModelMaxOutput,
       );
       let maxOutputTokens = reasoningParams.maxTokens;
       // Effective context window = min(model published cap, user setting, runtime-discovered).
@@ -1201,7 +1201,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       // because the project default settingsStore.contextWindowSize is 200k.
       const contextWindowSize = resolveEffectiveContextWindow(
         effectiveModelId,
-        freshSettings.contextWindowSize,
+        activeProvider?.declaredCapabilities?.maxInputTokens ?? freshSettings.contextWindowSize,
         discoveredCaps?.contextWindow,
       );
 

--- a/src/core/llm/adapter.ts
+++ b/src/core/llm/adapter.ts
@@ -34,6 +34,8 @@ export interface ChatOptions {
   reasoningEffort?: 'low' | 'medium' | 'high'; // OpenAI o-series / gpt-5 reasoning depth
   // Whether the model supports vision (image inputs)
   supportsVision?: boolean;
+  /** 自定义端点用户声明的能力，供适配器 URL 归一化与出参规则引擎读取 */
+  declaredCapabilities?: import('@/types/provider').DeclaredCapabilities;
   // Built-in web search method to inject into the request
   builtinWebSearch?: BuiltinSearchMethod;
   // Abort controller for cancellation

--- a/src/core/llm/applyDeclaredCapabilities.test.ts
+++ b/src/core/llm/applyDeclaredCapabilities.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { applyDeclaredCapabilities } from './applyDeclaredCapabilities';
+import type { ModelCapabilities } from './modelCapabilities';
+
+const base: ModelCapabilities = {
+  vision: true, thinking: false, toolResultImages: 'none',
+  documentBlock: false, maxOutputTokens: 4096, contextWindow: 128000,
+};
+
+describe('applyDeclaredCapabilities', () => {
+  it('undefined declared → returns caps unchanged', () => {
+    expect(applyDeclaredCapabilities(base, undefined)).toEqual(base);
+  });
+  it('supportsImages=false → vision false', () => {
+    expect(applyDeclaredCapabilities(base, { supportsImages: false }).vision).toBe(false);
+  });
+  it('supportsReasoning=false → thinking false', () => {
+    expect(applyDeclaredCapabilities(base, { supportsReasoning: false }).thinking).toBe(false);
+  });
+  it('supportsReasoning=true on non-reasoning model → thinking openai-reasoning', () => {
+    expect(applyDeclaredCapabilities(base, { supportsReasoning: true }).thinking).toBe('openai-reasoning');
+  });
+  it('does not mutate input', () => {
+    const copy = { ...base };
+    applyDeclaredCapabilities(base, { supportsImages: false });
+    expect(base).toEqual(copy);
+  });
+});

--- a/src/core/llm/applyDeclaredCapabilities.ts
+++ b/src/core/llm/applyDeclaredCapabilities.ts
@@ -1,0 +1,21 @@
+import type { DeclaredCapabilities } from '@/types/provider';
+import type { ModelCapabilities } from './modelCapabilities';
+
+/**
+ * Override auto-detected capabilities with user-declared values (custom/local providers only).
+ * Returns a new object; never mutates input.
+ * - supportsImages → vision
+ * - supportsReasoning=false → thinking off; =true on a non-thinking model → 'openai-reasoning'
+ * tools/efforts/useRawUrl are NOT applied here — the adapter's rule engine + URL builder handle those.
+ */
+export function applyDeclaredCapabilities(
+  caps: ModelCapabilities,
+  declared: DeclaredCapabilities | undefined,
+): ModelCapabilities {
+  if (!declared) return caps;
+  const next = { ...caps };
+  if (declared.supportsImages !== undefined) next.vision = declared.supportsImages;
+  if (declared.supportsReasoning === false) next.thinking = false;
+  else if (declared.supportsReasoning === true && next.thinking === false) next.thinking = 'openai-reasoning';
+  return next;
+}

--- a/src/core/llm/modelRequestProcessors.test.ts
+++ b/src/core/llm/modelRequestProcessors.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { applyModelRequestProcessors } from './modelRequestProcessors';
+
+const run = (body: Record<string, unknown>, ctx: Parameters<typeof applyModelRequestProcessors>[1]) => {
+  applyModelRequestProcessors(body, ctx);
+  return body;
+};
+
+describe('modelRequestProcessors', () => {
+  it('responses-native-fallback: gpt-5.5 + tools on openai host drops reasoning_effort', () => {
+    const b = run({ model: 'gpt-5.5', reasoning_effort: 'medium', tools: [{}] },
+      { modelId: 'gpt-5.5', requestHost: 'api.openai.com', hasTools: true, caps: undefined });
+    expect(b.reasoning_effort).toBeUndefined();
+    expect(Array.isArray(b.tools)).toBe(true);
+  });
+  it('reasoning-support: declared supportsReasoning=false strips reasoning_effort', () => {
+    const b = run({ reasoning_effort: 'high' },
+      { modelId: 'x', requestHost: 'h', hasTools: false, caps: { supportsReasoning: false } });
+    expect(b.reasoning_effort).toBeUndefined();
+  });
+  it('tools-gate: declared supportsTools=false removes tools + tool_choice', () => {
+    const b = run({ tools: [{}], tool_choice: 'auto' },
+      { modelId: 'x', requestHost: 'h', hasTools: true, caps: { supportsTools: false } });
+    expect(b.tools).toBeUndefined();
+    expect(b.tool_choice).toBeUndefined();
+  });
+  it('effort-clamp: reasoning_effort outside supportedEfforts clamps to nearest', () => {
+    const b = run({ reasoning_effort: 'high' },
+      { modelId: 'x', requestHost: 'h', hasTools: false, caps: { supportedEfforts: ['low', 'medium'] } });
+    expect(b.reasoning_effort).toBe('medium');
+  });
+  it('no caps + non-openai host: leaves body untouched', () => {
+    const b = run({ reasoning_effort: 'medium', tools: [{}] },
+      { modelId: 'llama3', requestHost: 'localhost', hasTools: true, caps: undefined });
+    expect(b.reasoning_effort).toBe('medium');
+    expect(Array.isArray(b.tools)).toBe(true);
+  });
+});

--- a/src/core/llm/modelRequestProcessors.test.ts
+++ b/src/core/llm/modelRequestProcessors.test.ts
@@ -13,6 +13,14 @@ describe('modelRequestProcessors', () => {
     expect(b.reasoning_effort).toBeUndefined();
     expect(Array.isArray(b.tools)).toBe(true);
   });
+  it('responses-native-fallback: gpt-5.5 + tools on NON-openai host also drops reasoning_effort', () => {
+    // Regression: the original guard required isDirectOpenAIHost, so proxies/gateways
+    // would still send reasoning_effort and get a 400 from OpenAI's API.
+    const b = run({ model: 'gpt-5.5', reasoning_effort: 'high', tools: [{}] },
+      { modelId: 'gpt-5.5', requestHost: 'proxy.corp', hasTools: true, caps: undefined });
+    expect(b.reasoning_effort).toBeUndefined();
+    expect(Array.isArray(b.tools)).toBe(true);
+  });
   it('reasoning-support: declared supportsReasoning=false strips reasoning_effort', () => {
     const b = run({ reasoning_effort: 'high' },
       { modelId: 'x', requestHost: 'h', hasTools: false, caps: { supportsReasoning: false } });

--- a/src/core/llm/modelRequestProcessors.ts
+++ b/src/core/llm/modelRequestProcessors.ts
@@ -1,0 +1,74 @@
+import type { DeclaredCapabilities } from '@/types/provider';
+
+export interface RequestContext {
+  modelId: string;
+  requestHost: string;
+  hasTools: boolean;
+  caps?: DeclaredCapabilities;
+}
+
+export interface ModelRequestProcessor {
+  name: string;
+  priority?: number;
+  matches(body: Record<string, unknown>, ctx: RequestContext): boolean;
+  apply(body: Record<string, unknown>, ctx: RequestContext): void;
+}
+
+const EFFORT_ORDER = ['low', 'medium', 'high'] as const;
+
+function isGpt55(model: string): boolean {
+  return /gpt-?5\.5/i.test(model);
+}
+function isDirectOpenAIHost(host: string): boolean {
+  return /(^|\.)openai\.com$/i.test(host) || /(^|\.)azure\.com$/i.test(host);
+}
+
+const responsesNativeFallback: ModelRequestProcessor = {
+  name: 'responses-native-fallback',
+  priority: 10,
+  matches: (_b, ctx) => ctx.hasTools && isGpt55(ctx.modelId) && isDirectOpenAIHost(ctx.requestHost),
+  apply: (b) => { delete b.reasoning_effort; delete (b as { reasoning?: unknown }).reasoning; },
+};
+
+const reasoningSupport: ModelRequestProcessor = {
+  name: 'reasoning-support',
+  priority: 20,
+  matches: (_b, ctx) => ctx.caps?.supportsReasoning === false,
+  apply: (b) => { delete b.reasoning_effort; delete (b as { reasoning?: unknown }).reasoning; delete b.thinking_budget; },
+};
+
+const toolsGate: ModelRequestProcessor = {
+  name: 'tools-gate',
+  priority: 20,
+  matches: (_b, ctx) => ctx.caps?.supportsTools === false,
+  apply: (b) => { delete b.tools; delete b.tool_choice; },
+};
+
+const effortClamp: ModelRequestProcessor = {
+  name: 'effort-clamp',
+  priority: 30,
+  matches: (b, ctx) =>
+    typeof b.reasoning_effort === 'string' &&
+    Array.isArray(ctx.caps?.supportedEfforts) &&
+    ctx.caps!.supportedEfforts!.length > 0 &&
+    !ctx.caps!.supportedEfforts!.includes(b.reasoning_effort as 'low' | 'medium' | 'high'),
+  apply: (b, ctx) => {
+    const supported = ctx.caps!.supportedEfforts!;
+    const want = EFFORT_ORDER.indexOf(b.reasoning_effort as typeof EFFORT_ORDER[number]);
+    let best = supported[0];
+    let bestDist = Infinity;
+    for (const e of supported) {
+      const d = Math.abs(EFFORT_ORDER.indexOf(e) - want);
+      if (d < bestDist) { bestDist = d; best = e; }
+    }
+    b.reasoning_effort = best;
+  },
+};
+
+const PROCESSORS: ModelRequestProcessor[] = [responsesNativeFallback, reasoningSupport, toolsGate, effortClamp];
+
+export function applyModelRequestProcessors(body: Record<string, unknown>, ctx: RequestContext): void {
+  for (const p of [...PROCESSORS].sort((a, b) => (a.priority ?? 1000) - (b.priority ?? 1000))) {
+    if (p.matches(body, ctx)) p.apply(body, ctx);
+  }
+}

--- a/src/core/llm/modelRequestProcessors.ts
+++ b/src/core/llm/modelRequestProcessors.ts
@@ -19,14 +19,13 @@ const EFFORT_ORDER = ['low', 'medium', 'high'] as const;
 function isGpt55(model: string): boolean {
   return /gpt-?5\.5/i.test(model);
 }
-function isDirectOpenAIHost(host: string): boolean {
-  return /(^|\.)openai\.com$/i.test(host) || /(^|\.)azure\.com$/i.test(host);
-}
-
 const responsesNativeFallback: ModelRequestProcessor = {
   name: 'responses-native-fallback',
   priority: 10,
-  matches: (_b, ctx) => ctx.hasTools && isGpt55(ctx.modelId) && isDirectOpenAIHost(ctx.requestHost),
+  // Host-agnostic: gpt-5.5 rejects reasoning_effort when tools are present on ANY
+  // host (direct OpenAI, proxy, gateway). The original fix (#86) guarded only
+  // api.openai.com — this restores protection for routed/proxied deployments.
+  matches: (_b, ctx) => ctx.hasTools && isGpt55(ctx.modelId),
   apply: (b) => { delete b.reasoning_effort; delete (b as { reasoning?: unknown }).reasoning; },
 };
 

--- a/src/core/llm/openai-compatible.ts
+++ b/src/core/llm/openai-compatible.ts
@@ -7,6 +7,7 @@ import type { PreparedTurn, PreparedContentBlock } from './messageNormalizer';
 import { createHeartbeat, anySignal, DEFAULT_STREAM_HANG_TIMEOUT_MS as STREAM_HANG_TIMEOUT_MS } from './heartbeat';
 import { createLogger } from '../logging/logger';
 import { resolveOpenAIBaseUrl, buildFullChatUrl } from './urlUtils';
+import { applyModelRequestProcessors } from './modelRequestProcessors';
 
 const logger = createLogger('openai-compatible');
 
@@ -268,22 +269,6 @@ export function toOpenAIToolChoice(
   return { type: 'function', function: { name: tc.name } };
 }
 
-/**
- * gpt-5.5 rejects "function tools + reasoning_effort" together on
- * /v1/chat/completions ("...are not supported for gpt-5.5 in /v1/chat/completions.
- * Please use /v1/responses instead.", issue #86). The Responses API is the only
- * endpoint that accepts the combo, but it imposes a reasoning-item pairing rule
- * that breaks stateless multi-turn tool use, so we stay on chat/completions and
- * simply drop reasoning_effort for this exact combo. gpt-5.5 still reasons at the
- * model default; the rest of the gpt-5 / o-series family is unaffected.
- *
- * Matches the gpt-5.5 family only: `gpt-5.5`, `gpt-5.5-2026-..`, `gpt-5.5-chat-*`.
- * NOT `gpt-5`, `gpt-5.1`, or `o5` (those keep reasoning_effort with tools).
- */
-function isGpt55Model(model: string): boolean {
-  return /gpt-?5\.5/i.test(model);
-}
-
 export class OpenAICompatibleAdapter implements LLMAdapter {
   async chat(
     messages: Message[],
@@ -322,9 +307,7 @@ export class OpenAICompatibleAdapter implements LLMAdapter {
     if (options.thinkingBudget != null) {
       body.thinking_budget = options.thinkingBudget;
     }
-    // Skip reasoning_effort for gpt-5.5 when tools are present — OpenAI rejects
-    // that combo on /chat/completions (issue #86). See isGpt55Model above.
-    if (options.reasoningEffort && !(hasTools && isGpt55Model(options.model))) {
+    if (options.reasoningEffort) {
       body.reasoning_effort = options.reasoningEffort;
     }
 
@@ -343,6 +326,13 @@ export class OpenAICompatibleAdapter implements LLMAdapter {
         body[method.paramName] = method.paramValue;
       }
     }
+
+    applyModelRequestProcessors(body, {
+      modelId: options.model,
+      requestHost: (() => { try { return new URL(fullUrl).host; } catch { return ''; } })(),
+      hasTools,
+      caps: options.declaredCapabilities,
+    });
 
     const requestHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
     if (options.apiKey) {

--- a/src/core/llm/openai-compatible.ts
+++ b/src/core/llm/openai-compatible.ts
@@ -6,7 +6,7 @@ import { normalizeMessages } from './messageNormalizer';
 import type { PreparedTurn, PreparedContentBlock } from './messageNormalizer';
 import { createHeartbeat, anySignal, DEFAULT_STREAM_HANG_TIMEOUT_MS as STREAM_HANG_TIMEOUT_MS } from './heartbeat';
 import { createLogger } from '../logging/logger';
-import { resolveOpenAIBaseUrl } from './urlUtils';
+import { resolveOpenAIBaseUrl, buildFullChatUrl } from './urlUtils';
 
 const logger = createLogger('openai-compatible');
 
@@ -294,6 +294,12 @@ export class OpenAICompatibleAdapter implements LLMAdapter {
     // and defensively trims whitespace users paste in (e.g. trailing space
     // would otherwise bypass the regex and emit /%20/v1/... to the server).
     const baseUrl = resolveOpenAIBaseUrl(options.baseUrl);
+    // Full URL for POST — idempotent: a user-pasted URL that already ends in
+    // /chat/completions is not double-appended. useRawUrl bypasses all
+    // normalization for proxies with non-standard paths.
+    const fullUrl = buildFullChatUrl(options.baseUrl, 'openai-compatible', {
+      useRawUrl: options.declaredCapabilities?.useRawUrl,
+    });
 
     // Ollama: streaming + tool calling is broken in /v1/chat/completions.
     // When tools are present and endpoint looks like Ollama, use non-streaming.
@@ -367,7 +373,7 @@ export class OpenAICompatibleAdapter implements LLMAdapter {
     }, STREAM_HANG_TIMEOUT_MS);
     let response: Awaited<ReturnType<typeof fetchFn>>;
     try {
-      response = await fetchFn(`${baseUrl}/chat/completions`, {
+      response = await fetchFn(fullUrl, {
         method: 'POST',
         headers: requestHeaders,
         body: JSON.stringify(body),
@@ -396,7 +402,7 @@ export class OpenAICompatibleAdapter implements LLMAdapter {
           limit: retryLimit,
         });
         body.max_tokens = retryLimit;
-        response = await fetchFn(`${baseUrl}/chat/completions`, {
+        response = await fetchFn(fullUrl, {
           method: 'POST',
           headers: requestHeaders,
           body: JSON.stringify(body),

--- a/src/core/llm/openai-gpt55-tools.test.ts
+++ b/src/core/llm/openai-gpt55-tools.test.ts
@@ -39,6 +39,23 @@ async function capture(opts: Partial<ChatOptions>): Promise<{ url: string; body:
   return { url, body };
 }
 
+describe('URL normalization (Phase 3)', () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it('posts to full endpoint when baseUrl already has /chat/completions (idempotent)', async () => {
+    const { url } = await capture({ baseUrl: 'https://api.example.com/v1/chat/completions' });
+    expect(url).toBe('https://api.example.com/v1/chat/completions');
+  });
+
+  it('useRawUrl posts to exact baseUrl without normalization', async () => {
+    const { url } = await capture({
+      baseUrl: 'https://proxy.corp/gw',
+      declaredCapabilities: { useRawUrl: true },
+    });
+    expect(url).toBe('https://proxy.corp/gw');
+  });
+});
+
 describe('gpt-5.5 + tools reasoning_effort handling (issue #86)', () => {
   beforeEach(() => mockFetch.mockReset());
 

--- a/src/core/llm/urlUtils.test.ts
+++ b/src/core/llm/urlUtils.test.ts
@@ -66,6 +66,34 @@ describe('urlUtils', () => {
         .toBe('http://x.com/v1/chat/completions');
     });
 
+    // Phase 3: idempotent normalization + useRawUrl
+    describe('idempotent normalization', () => {
+      const f = (u: string, opts?: { useRawUrl?: boolean }) =>
+        buildFullChatUrl(u, 'openai-compatible', opts);
+
+      it('bare host → append /v1/chat/completions', () => {
+        expect(f('https://api.example.com')).toBe('https://api.example.com/v1/chat/completions');
+      });
+      it('base ending /v1 → append once', () => {
+        expect(f('https://api.example.com/v1')).toBe('https://api.example.com/v1/chat/completions');
+      });
+      it('full endpoint → returned as-is (no double append)', () => {
+        expect(f('https://api.example.com/v1/chat/completions')).toBe('https://api.example.com/v1/chat/completions');
+      });
+      it('trailing slash + full endpoint → normalized once', () => {
+        expect(f('https://api.example.com/v1/chat/completions/')).toBe('https://api.example.com/v1/chat/completions');
+      });
+      it('preserves query/fragment suffix', () => {
+        expect(f('https://api.example.com/v1/chat/completions?x=1')).toBe('https://api.example.com/v1/chat/completions?x=1');
+      });
+      it('useRawUrl → use exactly, skip normalization', () => {
+        expect(f('https://proxy.corp/llm/gateway', { useRawUrl: true })).toBe('https://proxy.corp/llm/gateway');
+      });
+      it('anthropic format unchanged by opts', () => {
+        expect(buildFullChatUrl('https://api.anthropic.com', 'anthropic')).toBe('https://api.anthropic.com/v1/messages');
+      });
+    });
+
     it('builds Anthropic messages URL', () => {
       expect(buildFullChatUrl('http://x.com', 'anthropic'))
         .toBe('http://x.com/v1/messages');

--- a/src/core/llm/urlUtils.ts
+++ b/src/core/llm/urlUtils.ts
@@ -21,16 +21,37 @@ export function resolveOpenAIBaseUrl(raw: string | undefined | null): string {
 }
 
 /**
+ * Idempotently ensure a URL ends in exactly one /chat/completions,
+ * stripping any repeats and preserving ?query / #fragment suffixes.
+ */
+export function normalizeChatCompletionsUrl(raw: string | undefined | null): string {
+  const s = (raw ?? '').trim();
+  const cut = s.search(/[?#]/);
+  const suffix = cut >= 0 ? s.slice(cut) : '';
+  let base = (cut >= 0 ? s.slice(0, cut) : s).replace(/\/+$/, '');
+  while (base.endsWith('/chat/completions')) base = base.slice(0, -'/chat/completions'.length);
+  base = resolveOpenAIBaseUrl(base);
+  return `${base}/chat/completions${suffix}`;
+}
+
+/**
  * Build the full chat endpoint URL the app will hit for a given provider config.
  * Used by the adapter (to POST) and by the settings UI (to preview for the user).
+ *
+ * For openai-compatible: idempotently normalizes to .../chat/completions so a
+ * user-pasted full URL (e.g. https://api.x/v1/chat/completions) is not
+ * double-appended. Pass opts.useRawUrl to skip normalization entirely and use
+ * the URL exactly as typed (for proxies with non-standard paths).
  */
 export function buildFullChatUrl(
   rawBaseUrl: string | undefined | null,
   format: ApiFormat,
+  opts?: { useRawUrl?: boolean },
 ): string {
   if (format === 'anthropic') {
     const base = normalizeBaseUrl(rawBaseUrl) || 'https://api.anthropic.com';
     return `${base}/v1/messages`;
   }
-  return `${resolveOpenAIBaseUrl(rawBaseUrl)}/chat/completions`;
+  if (opts?.useRawUrl) return normalizeBaseUrl(rawBaseUrl);
+  return normalizeChatCompletionsUrl(rawBaseUrl);
 }

--- a/src/core/llm/urlUtils.ts
+++ b/src/core/llm/urlUtils.ts
@@ -40,8 +40,10 @@ export function normalizeChatCompletionsUrl(raw: string | undefined | null): str
  *
  * For openai-compatible: idempotently normalizes to .../chat/completions so a
  * user-pasted full URL (e.g. https://api.x/v1/chat/completions) is not
- * double-appended. Pass opts.useRawUrl to skip normalization entirely and use
- * the URL exactly as typed (for proxies with non-standard paths).
+ * double-appended. Pass opts.useRawUrl to skip the /chat/completions path
+ * normalization — the URL is used as-is apart from trimming whitespace and
+ * trailing slashes (via normalizeBaseUrl). Intended for proxies with non-standard
+ * endpoint paths where auto-appending /v1/chat/completions is wrong.
  */
 export function buildFullChatUrl(
   rawBaseUrl: string | undefined | null,

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -622,7 +622,6 @@ const enUS: TranslationDict = {
     guideGoTo: 'Go to {name}',
     apiKeyRequired: 'Required',
     apiKeyOptional: 'Leave empty if no auth needed',
-    apiUrlNoChange: 'Usually no need to change; replace when using a proxy',
     apiUrlPreview: 'Will request',
     fetchModels: 'Fetch Models',
     fetchingModels: 'Fetching...',

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -671,6 +671,9 @@ const enUS: TranslationDict = {
     effortLow: 'Low',
     effortMedium: 'Medium',
     effortHigh: 'High',
+    capMaxInput: 'Max Input Tokens',
+    capMaxOutput: 'Max Output Tokens',
+    capTokenDefault: 'Use provider default',
   },
 
   sandbox: {

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -665,10 +665,12 @@ const enUS: TranslationDict = {
     capTools: 'Tool Calling',
     capImages: 'Image Input',
     capReasoning: 'Reasoning',
-    capCanDisableThinking: 'Allow disabling reasoning',
     capRawUrl: 'Custom Protocol',
     capRawUrlHint: 'Use the endpoint URL as-is; for proxies that handle protocol routing.',
     capEffort: 'Reasoning effort',
+    effortLow: 'Low',
+    effortMedium: 'Medium',
+    effortHigh: 'High',
   },
 
   sandbox: {

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -661,6 +661,14 @@ const enUS: TranslationDict = {
     models: 'Models',
     modelsCount: '{count} models',
     capabilitiesLabel: 'Capabilities',
+    advancedConfig: 'Advanced',
+    capTools: 'Tool Calling',
+    capImages: 'Image Input',
+    capReasoning: 'Reasoning',
+    capCanDisableThinking: 'Allow disabling reasoning',
+    capRawUrl: 'Custom Protocol',
+    capRawUrlHint: 'Use the endpoint URL as-is; for proxies that handle protocol routing.',
+    capEffort: 'Reasoning effort',
   },
 
   sandbox: {

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -661,6 +661,14 @@ const zhCN: TranslationDict = {
     models: '模型',
     modelsCount: '{count} 个模型',
     capabilitiesLabel: '能力',
+    advancedConfig: '高级配置',
+    capTools: '工具调用',
+    capImages: '图片输入',
+    capReasoning: '思考模式',
+    capCanDisableThinking: '允许关闭思考',
+    capRawUrl: '自定义协议',
+    capRawUrlHint: '接口地址原样使用，不自动补全 /chat/completions。适用于代理层已处理协议的场景。',
+    capEffort: '思考档位',
   },
 
   sandbox: {

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -665,10 +665,12 @@ const zhCN: TranslationDict = {
     capTools: '工具调用',
     capImages: '图片输入',
     capReasoning: '思考模式',
-    capCanDisableThinking: '允许关闭思考',
     capRawUrl: '自定义协议',
     capRawUrlHint: '接口地址原样使用，不自动补全 /chat/completions。适用于代理层已处理协议的场景。',
     capEffort: '思考档位',
+    effortLow: '低',
+    effortMedium: '中',
+    effortHigh: '高',
   },
 
   sandbox: {

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -671,6 +671,9 @@ const zhCN: TranslationDict = {
     effortLow: '低',
     effortMedium: '中',
     effortHigh: '高',
+    capMaxInput: '最大输入 Token',
+    capMaxOutput: '最大输出 Token',
+    capTokenDefault: '使用提供商默认值',
   },
 
   sandbox: {

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -622,7 +622,6 @@ const zhCN: TranslationDict = {
     guideGoTo: '前往 {name}',
     apiKeyRequired: '必填',
     apiKeyOptional: '如无需认证可留空',
-    apiUrlNoChange: '一般不需要修改，使用自建代理时可替换',
     apiUrlPreview: '将请求',
     fetchModels: '获取模型列表',
     fetchingModels: '获取中...',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -666,6 +666,15 @@ export interface TranslationDict {
     models: string;
     modelsCount: string;
     capabilitiesLabel: string;
+    // Advanced config (custom/local providers)
+    advancedConfig: string;
+    capTools: string;
+    capImages: string;
+    capReasoning: string;
+    capCanDisableThinking: string;
+    capRawUrl: string;
+    capRawUrlHint: string;
+    capEffort: string;
   };
 
   // Sandbox recovery

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -671,10 +671,12 @@ export interface TranslationDict {
     capTools: string;
     capImages: string;
     capReasoning: string;
-    capCanDisableThinking: string;
     capRawUrl: string;
     capRawUrlHint: string;
     capEffort: string;
+    effortLow: string;
+    effortMedium: string;
+    effortHigh: string;
   };
 
   // Sandbox recovery

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -677,6 +677,9 @@ export interface TranslationDict {
     effortLow: string;
     effortMedium: string;
     effortHigh: string;
+    capMaxInput: string;
+    capMaxOutput: string;
+    capTokenDefault: string;
   };
 
   // Sandbox recovery

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -627,7 +627,6 @@ export interface TranslationDict {
     guideGoTo: string;
     apiKeyRequired: string;
     apiKeyOptional: string;
-    apiUrlNoChange: string;
     apiUrlPreview: string;
     fetchModels: string;
     fetchingModels: string;

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -514,4 +514,36 @@ describe('settingsStore labs flags', () => {
       expect(labs['todos-inbox']).toBe(true);
     });
   });
+
+  describe('v39 migration', () => {
+    const getMigrate = () =>
+      (useSettingsStore as unknown as {
+        persist: { getOptions: () => { migrate: (data: unknown, version: number) => Record<string, unknown> } };
+      }).persist.getOptions().migrate;
+
+    it('explicitly adds declaredCapabilities key (as undefined) to providers lacking it', () => {
+      const provider = { id: 'openai', name: 'OpenAI', enabled: true };
+      const migrated = getMigrate()({ providers: [provider] }, 38);
+      const providers = migrated.providers as Array<Record<string, unknown>>;
+      expect(providers).toHaveLength(1);
+      expect(providers[0].id).toBe('openai');
+      // Migration must explicitly set the key to undefined so downstream code
+      // can use `'declaredCapabilities' in p` to distinguish "migrated" from "new"
+      expect('declaredCapabilities' in providers[0]).toBe(true);
+      expect(providers[0].declaredCapabilities).toBeUndefined();
+    });
+
+    it('does not overwrite an existing declaredCapabilities field', () => {
+      const caps = { streaming: true };
+      const provider = { id: 'openai', name: 'OpenAI', declaredCapabilities: caps };
+      const migrated = getMigrate()({ providers: [provider] }, 38);
+      const providers = migrated.providers as Array<Record<string, unknown>>;
+      expect(providers[0].declaredCapabilities).toEqual(caps);
+    });
+
+    it('handles missing providers array gracefully', () => {
+      const migrated = getMigrate()({ theme: 'dark' }, 38);
+      expect(migrated.providers).toBeUndefined();
+    });
+  });
 });

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1034,9 +1034,26 @@ export const useSettingsStore = create<SettingsStore>()(
     }),
     {
       name: 'abu-settings',
-      version: 38,
+      version: 39,
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
+
+        // ════════════════════════════════════════════════
+        // V39: ProviderInstance gains `declaredCapabilities` (optional).
+        // Existing providers get the key explicitly set to undefined so
+        // downstream code can rely on `'declaredCapabilities' in p` as a
+        // reliable "migrated" sentinel. undefined → fall back to auto-detect.
+        // Non-breaking: existing behaviour is unchanged.
+        // ════════════════════════════════════════════════
+        if (version < 39) {
+          if (Array.isArray(state.providers)) {
+            for (const p of state.providers as Array<Record<string, unknown>>) {
+              if (p && typeof p === 'object' && !('declaredCapabilities' in p)) {
+                p.declaredCapabilities = undefined;
+              }
+            }
+          }
+        }
 
         // ════════════════════════════════════════════════
         // V38: Desktop pet became a two-level Labs feature — the `pet` unlock

--- a/src/stores/storeVersions.test.ts
+++ b/src/stores/storeVersions.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 // All persisted stores must be registered here.
 // When adding a new persist store, add it to this list — otherwise this test fails.
 const PERSISTED_STORES = [
-  { key: 'abu-settings', minVersion: 38 },
+  { key: 'abu-settings', minVersion: 39 },
   { key: 'abu-chat', minVersion: 6 },
   { key: 'abu-scratchpad-store', minVersion: 1 },
   { key: 'abu-permissions', minVersion: 1 },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -428,7 +428,7 @@ export interface CustomService {
 }
 
 // Re-export V2 provider types
-export type { ProviderSource, ProviderStatus, ModelCapability, ModelInfo, ProviderInstance, ActiveModel, AuxiliaryServices, ProviderGuide } from './provider';
+export type { ProviderSource, ProviderStatus, ModelCapability, ModelInfo, ProviderInstance, ActiveModel, AuxiliaryServices, ProviderGuide, DeclaredCapabilities } from './provider';
 
 export interface LLMConfig {
   provider: LLMProvider;

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -31,7 +31,6 @@ export interface DeclaredCapabilities {
   supportsTools?: boolean;
   supportsImages?: boolean;
   supportsReasoning?: boolean;
-  canDisableThinking?: boolean;
   supportedEfforts?: Array<'low' | 'medium' | 'high'>;
   /** 自定义协议：接口地址原样使用，跳过 /chat/completions 归一化 */
   useRawUrl?: boolean;

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -23,6 +23,20 @@ export interface ModelInfo {
   isCustom?: boolean;
 }
 
+/**
+ * 用户对自定义/本地端点显式声明的能力。仅 source==='custom' 或本地(ollama/lmstudio)
+ * provider 上出现；builtin 为 undefined → 回退 modelCapabilities.ts 自动探测(非破坏)。
+ */
+export interface DeclaredCapabilities {
+  supportsTools?: boolean;
+  supportsImages?: boolean;
+  supportsReasoning?: boolean;
+  canDisableThinking?: boolean;
+  supportedEfforts?: Array<'low' | 'medium' | 'high'>;
+  /** 自定义协议：接口地址原样使用，跳过 /chat/completions 归一化 */
+  useRawUrl?: boolean;
+}
+
 /** Unified Provider instance (builtin and custom share the same structure) */
 export interface ProviderInstance {
   id: string;
@@ -49,6 +63,7 @@ export interface ProviderInstance {
    * explicitly clicks the trash-can delete action.
    */
   userAdded?: boolean;
+  declaredCapabilities?: DeclaredCapabilities;
 }
 
 /** Currently active model selection */

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -34,6 +34,10 @@ export interface DeclaredCapabilities {
   supportedEfforts?: Array<'low' | 'medium' | 'high'>;
   /** 自定义协议：接口地址原样使用，跳过 /chat/completions 归一化 */
   useRawUrl?: boolean;
+  /** Max input/context tokens for this endpoint; blank → provider default. */
+  maxInputTokens?: number;
+  /** Max output tokens (request max_tokens); blank → provider default. */
+  maxOutputTokens?: number;
 }
 
 /** Unified Provider instance (builtin and custom share the same structure) */


### PR DESCRIPTION
## 自定义模型接入体验优化

让自定义 / 本地（Ollama / LM Studio）端点的接入更友好：地址智能处理、能力用户可声明、按声明改写出参，并对齐业内成熟客户端的「添加模型」交互。

### 核心（三件套）
- **接口地址幂等归一化** (`urlUtils.ts`)：修复完整地址被拼成 `.../chat/completions/v1/chat/completions` 的 bug；裸域名/完整地址都自动对，普通用户零选择。`useRawUrl`（自定义协议）逃生口给非标准路径代理原样透传。
- **能力自声明**：自定义/Ollama/LM Studio 的「高级配置」用勾选框声明 工具调用 / 图片输入 / 思考模式（含 低/中/高 档位）/ 自定义协议，以及**每模型的最大输入/输出 Token**（带 32K–256K / 8K–64K 预设快填）。内置供应商保留自动探测（非破坏）。
- **出参规则引擎** (`modelRequestProcessors.ts`)：带优先级的请求处理器，按声明能力/host/模型改写出参；把原先写死的 gpt-5.5 `reasoning_effort` 守卫（#86）收口成一条 host-agnostic 规则。

### 支撑
- `DeclaredCapabilities` 类型 + `ProviderInstance` 字段；settings store `v38→v39` 迁移（老 provider 回退自动探测）。
- `applyDeclaredCapabilities` 在 agentLoop 单点覆盖能力链（vision/thinking），`supportsTools=false` 时在**源头**掐工具解析+提示词注入（Abu 自研循环会把工具注入系统提示词，与仅删 body.tools 不同）。
- 新增 `ui/Checkbox` 组件（能力声明是表单选项，语义上用勾选框而非开关）。
- Token 限制经 `resolveEffectiveContextWindow` / `computeReasoningParams` 现成入口注入（每模型 > 全局 > 自动探测）。

### 已知边界（设计内）
- 纯 Responses-only 中转（只吃 `input` items）不支持——自定义路径一律发 chat/completions body，列为已知限制。

### 验收
- build / lint / **2796 单测** / **Playwright E2E 11** 全绿。
- `/code-review high`（42 agent）9 发现全部核实修复（#86 host 门控回归、tri-state toggle 误导、anthropic 忽略声明、工具源头门控等）。
- 真机 `tauri:dev` smoke 通过（能力显示范围 / URL 预览幂等 / 高级配置交互 / token 预设）。
- ⚠️ 轻覆盖点：每模型 token 限制的 agentLoop 注入是平凡 `?? ` 链，靠真机 smoke + 既有单测兜底，未加独立集成测试（成本不成比例）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
