### PR TITLE
feat(chat): 长会话压缩持久化(Part A)+ 原生 O(1) 落盘(B1)

### DIFF
--- a/src-tauri/src/append_file.rs
+++ b/src-tauri/src/append_file.rs
@@ -1,0 +1,153 @@
+//! Native O(1) file append.
+//!
+//! `conversationStorage.ts`'s `appendToFile` used to be O(file size) per call:
+//! Tauri's `@tauri-apps/plugin-fs` has no native append, so every append had to
+//! read the whole file, concatenate in memory, and atomic-rewrite it (see
+//! `atomic_write.rs`). For long conversations that means each new message costs
+//! a full read + full rewrite of an ever-growing `messages.jsonl`.
+//!
+//! This module exposes a real append: `OpenOptions::new().append(true)` lets
+//! the OS seek to EOF and write just the new bytes — O(1) in the size of
+//! `data`, independent of how large the file already is.
+//!
+//! ### Atomicity trade-off (deliberately NOT the same guarantee as atomic_write)
+//!
+//! `atomic_write_text` (tempfile + fsync + rename) guarantees a reader never
+//! observes a half-written file — the rename is a single atomic syscall, so
+//! the target is always either fully-old or fully-new content.
+//!
+//! Native append does **not** have that guarantee: `write_all` can be
+//! interrupted by a crash/kill/power-loss *mid-write*, leaving a half-written
+//! last line appended to an otherwise-intact file. This is an accepted
+//! trade-off for B1: `loadMessages` (`conversationStorage.ts`) already tolerates
+//! corrupt JSONL lines by skipping them (per-line try/catch), so the worst case
+//! of a crash during append is losing the *one* message that was mid-flight —
+//! never the messages already durably on disk before this call started. That
+//! is a much smaller blast radius than the old read+rewrite path, which could
+//! (before the file-lock fix) corrupt/lose arbitrary lines under concurrent
+//! writers. Callers that need the older strict atomicity should keep using
+//! `atomic_write_text`; conversation message appends are fine with this
+//! weaker guarantee given the existing damage-reduction on read.
+//!
+//! All FS work runs on the blocking thread pool (`spawn_blocking`) to avoid
+//! blocking the Tokio reactor, matching the pattern in `atomic_write.rs`.
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+
+use tauri::async_runtime::spawn_blocking;
+
+/// Append `data` to the file at `path`, creating the file (and any missing
+/// parent directories) if needed. Does **not** read existing content — this
+/// is the whole point: cost is O(len(data)), not O(file size).
+fn append_sync(path: &Path, data: &str) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        // create_dir_all is idempotent — safe to call even if parent exists.
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("create_dir_all({}) failed: {}", parent.display(), e))?;
+    }
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| format!("open({}) for append failed: {}", path.display(), e))?;
+
+    file.write_all(data.as_bytes())
+        .map_err(|e| format!("write_all({}) failed: {}", path.display(), e))?;
+    file.flush()
+        .map_err(|e| format!("flush({}) failed: {}", path.display(), e))?;
+    Ok(())
+}
+
+/// Append `data` to the file at `path` (creating it and its parent
+/// directories if they don't exist yet). Native O(1) append — no read of
+/// existing content, unlike the atomic_write tempfile+rename path.
+#[tauri::command]
+pub async fn append_file_text(path: String, data: String) -> Result<(), String> {
+    spawn_blocking(move || append_sync(Path::new(&path), &data))
+        .await
+        .map_err(|e| format!("spawn_blocking failed: {}", e))?
+}
+
+// ── Tests ──
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::thread;
+    use tempfile::tempdir;
+
+    #[test]
+    fn two_appends_concatenate_in_order() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("messages.jsonl");
+
+        append_sync(&target, "line one\n").unwrap();
+        append_sync(&target, "line two\n").unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&target).unwrap(),
+            "line one\nline two\n"
+        );
+    }
+
+    #[test]
+    fn creates_missing_parent_directories() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("nested/deep/messages.jsonl");
+
+        assert!(!target.parent().unwrap().exists());
+        append_sync(&target, "first line\n").unwrap();
+
+        assert!(target.exists());
+        assert_eq!(fs::read_to_string(&target).unwrap(), "first line\n");
+    }
+
+    #[test]
+    fn concurrent_appends_do_not_lose_lines() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("concurrent.jsonl");
+        // File must exist before concurrent OpenOptions::append callers race on it.
+        fs::write(&target, "").unwrap();
+
+        const N: usize = 20;
+        let handles: Vec<_> = (0..N)
+            .map(|i| {
+                let target = target.clone();
+                thread::spawn(move || {
+                    append_sync(&target, &format!("line-{}\n", i)).unwrap();
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let content = fs::read_to_string(&target).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(
+            lines.len(),
+            N,
+            "expected {} lines, got {}: {:?}",
+            N,
+            lines.len(),
+            lines
+        );
+        // Every line-N marker must be present exactly once — append(true) opens
+        // seek to EOF atomically per the POSIX/Windows append-mode contract, so
+        // concurrent small writes shouldn't interleave or clobber each other.
+        for i in 0..N {
+            let marker = format!("line-{}", i);
+            assert_eq!(
+                lines.iter().filter(|l| **l == marker).count(),
+                1,
+                "marker {} missing or duplicated",
+                marker
+            );
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ mod overlay;
 mod pet;
 mod secrets;
 mod atomic_write;
+mod append_file;
 mod notice;
 mod notice_db;
 mod sleep_prevention;
@@ -1401,6 +1402,7 @@ pub fn run() {
             atomic_write::atomic_write_with_backup,
             atomic_write::restore_from_backup,
             atomic_write::cleanup_old_backups,
+            append_file::append_file_text,
             sleep_prevention::set_prevent_sleep,
             clipboard_files::read_clipboard_file_paths,
             preview_server::get_preview_server_info,

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -10,6 +10,10 @@ import type { PermissionDuration } from '@/stores/permissionStore';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { useI18n } from '@/i18n';
 import MessageGroup from './MessageGroup';
+import CompactDivider from './CompactDivider';
+import { isCompactBoundary } from '@/core/context/compactBoundary';
+import { compactConversationManually } from '@/core/context/compactionService';
+import { useToastStore } from '@/stores/toastStore';
 import ChatInput from './ChatInput';
 import UserQuestionDock from './UserQuestionDock';
 import AgentStatusStrip from './AgentStatusStrip';
@@ -197,6 +201,19 @@ export default function ChatView() {
     }
 
     let convId = activeConv?.id;
+
+    if (text.trim() === '/compact') {
+      const res = await compactConversationManually(convId ?? '');
+      useToastStore.getState().addToast(
+        res.compacted
+          ? { type: 'success', title: t.chat.compactCommand.done }
+          : res.reason === 'too-few'
+            ? { type: 'info', title: t.chat.compactCommand.tooFew }
+            : { type: 'error', title: t.chat.compactCommand.failed },
+      );
+      return;
+    }
+
     const isNewConversation = !convId;
     if (!convId) {
       convId = createConversation(workspacePath);
@@ -420,13 +437,17 @@ export default function ChatView() {
       <div className="relative flex-1 min-h-0 overflow-y-auto" ref={containerRef}>
         <div className="w-full max-w-4xl mx-auto px-6 md:px-10 pt-5 pb-16 overflow-hidden">
           <div className="space-y-5">
-            {messageGroups.map((group, idx) => (
-              <MessageGroup
-                key={group[0].id}
-                messages={group}
-                isLastGroup={idx === messageGroups.length - 1}
-              />
-            ))}
+            {messageGroups.map((group, idx) =>
+              group.length === 1 && isCompactBoundary(group[0]) ? (
+                <CompactDivider key={group[0].id} message={group[0]} />
+              ) : (
+                <MessageGroup
+                  key={group[0].id}
+                  messages={group}
+                  isLastGroup={idx === messageGroups.length - 1}
+                />
+              ),
+            )}
 
             {/* Typing indicator - brief flash before assistant message is created */}
             {activeConv?.status === 'running' && messages.every((m) => m.role === 'user') && (

--- a/src/components/chat/CompactDivider.test.tsx
+++ b/src/components/chat/CompactDivider.test.tsx
@@ -1,0 +1,49 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import CompactDivider from './CompactDivider';
+import type { Message } from '@/types';
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      chat: {
+        compactDivider: {
+          compacted: '上下文已压缩',
+          compactedManual: '上下文已压缩（手动）',
+        },
+      },
+    },
+  }),
+}));
+
+function makeMarker(source: 'auto' | 'manual'): Message {
+  return {
+    id: 'compact-boundary-test',
+    role: 'system',
+    content: '',
+    timestamp: 0,
+    compactBoundary: {
+      summaryText: 'summary',
+      summarizedFromId: 'm1',
+      summarizedToId: 'm2',
+      createdAt: 0,
+      source,
+    },
+  };
+}
+
+describe('CompactDivider', () => {
+  afterEach(() => cleanup());
+
+  it('renders "上下文已压缩" for an auto marker', () => {
+    render(<CompactDivider message={makeMarker('auto')} />);
+    expect(screen.getByText('上下文已压缩')).toBeInTheDocument();
+  });
+
+  it('renders "上下文已压缩（手动）" for a manual marker', () => {
+    render(<CompactDivider message={makeMarker('manual')} />);
+    expect(screen.getByText('上下文已压缩（手动）')).toBeInTheDocument();
+  });
+});

--- a/src/components/chat/CompactDivider.tsx
+++ b/src/components/chat/CompactDivider.tsx
@@ -1,0 +1,30 @@
+import { Minimize2 } from 'lucide-react';
+import { useI18n } from '@/i18n';
+import type { Message } from '@/types';
+
+/**
+ * Passive inline divider rendered for a compact-boundary marker message.
+ *
+ * A compact-boundary marker (role='system', isSystem NOT set) stays visible in
+ * the message list but is not a real conversational turn — it just marks where
+ * the older history was summarized away. Old messages stay above it unchanged
+ * (no fold, no hide, no expand button); this is purely a visual separator,
+ * mirroring WorkBuddy's compactDivider / Codex's synthetic divider.
+ */
+export default function CompactDivider({ message }: { message: Message }) {
+  const { t } = useI18n();
+  const source = message.compactBoundary?.source;
+  const label =
+    source === 'manual'
+      ? t.chat.compactDivider.compactedManual
+      : t.chat.compactDivider.compacted;
+
+  return (
+    <div className="flex items-center gap-2 my-3 px-2 text-[var(--abu-text-tertiary)]">
+      <div className="flex-1 h-px bg-[var(--abu-border)]" />
+      <Minimize2 className="h-3.5 w-3.5 flex-shrink-0" />
+      <span className="text-xs select-none">{label}</span>
+      <div className="flex-1 h-px bg-[var(--abu-border)]" />
+    </div>
+  );
+}

--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -21,7 +21,12 @@ import { joinPath } from '../../utils/pathUtils';
 import { matchesToolName, parseToolPatterns } from '../skill/toolFilter';
 import { notifyTaskCompleted, notifyTaskError } from '../../utils/notifications';
 import { prepareContextMessages, trimOldScreenshots } from '../context/contextManager';
-import { compressContextIfNeeded } from '../context/contextCompressor';
+import { compressContextIfNeeded, summarizeConversation } from '../context/contextCompressor';
+import {
+  buildContextFromBoundary,
+  computeCompactionPlan,
+  createCompactBoundaryMarker,
+} from '../context/compactBoundary';
 import { applyMicroCompaction } from '../context/microCompactor';
 import { AutoCompactTracker, getUsagePercent } from '../context/autoCompact';
 import { estimateToolSchemaTokens, estimateTokens, estimateMessageTokens, calibrateFromUsage, setActiveModel } from '../context/tokenEstimator';
@@ -56,6 +61,14 @@ import { createLogger } from '../logging/logger';
 import { reportError } from '@/utils/consoleError';
 
 const logger = createLogger('agentLoop');
+
+// Persistent compaction (long-conversation Part A): when the post-compression
+// payload is still this fraction of the input budget, land an append-only
+// compact-boundary marker so future turns read a compact context from the
+// marker (survives restart) instead of re-running the ephemeral 65% pass every
+// turn. Higher than the 65% send-only trigger — the ephemeral pass fires first;
+// only when it can't bring the payload down does a durable marker land.
+const PERSISTENT_COMPACTION_THRESHOLD = 0.85;
 
 /** MIME type to file extension mapping */
 const MIME_TO_EXT: Record<string, string> = {
@@ -1379,7 +1392,17 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       // Compression triggers when: enough turns AND (cached result available OR warning level triggers compaction)
       let messagesForContext = historyMessages;
       let compressionApplied = false;
-      if (turnCount >= 3) {
+      // Long-conversation Part A: honour a persistent compact-boundary marker if
+      // one exists. buildContextFromBoundary returns the compact view (firstRound
+      // + summary + recent, markers stripped) when the LAST marker is present,
+      // else the SAME array reference. A marker takes over → skip the ephemeral
+      // 65% cache path below; otherwise fall through to the existing send-only
+      // compression. The marker itself is NEVER sent to the LLM.
+      const boundaryView = buildContextFromBoundary(historyMessages);
+      if (boundaryView !== historyMessages) {
+        messagesForContext = boundaryView;
+        compressionApplied = true;
+      } else if (turnCount >= 3) {
         const convForCache = useChatStore.getState().conversations[conversationId];
         const cache = convForCache?.contextCache;
 
@@ -1492,6 +1515,65 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         tokensMax: contextWindowSize,
         overhead: systemAndToolsOverhead,
       });
+
+      // Step 2.1: Persistent compaction (long-conversation Part A). When the
+      // payload is still critically large after the send-only pass, land an
+      // append-only compact-boundary marker so future turns read a compact
+      // context from the marker (survives restart; no re-summarizing every turn).
+      // Gating: computeCompactionPlan gets the token estimator so it only returns
+      // a plan when there is enough NEW content the LAST marker doesn't already
+      // cover (delta guard) — prevents divider-spam / a blocking summarize call
+      // every turn while the conversation stays large. autoCompactTracker (shared
+      // with the 65% path) is the failure circuit breaker. No per-turn latch: the
+      // marker lands immediately so the next iteration already sees it.
+      if (
+        turnCount >= 3 &&
+        postCompressionTokens >= maxInputTokens * PERSISTENT_COMPACTION_THRESHOLD &&
+        !autoCompactTracker.isDisabled()
+      ) {
+        const plan = computeCompactionPlan(historyMessages, { estimateTokens: estimateMessageTokens });
+        if (plan) {
+          const compactionCreds = resolveEffectiveLlmCreds(
+            getActiveApiKey(settingsForModel),
+            getActiveProvider(settingsForModel)?.baseUrl || undefined,
+          );
+          let summaryText = '';
+          try {
+            summaryText = await summarizeConversation(plan.middleMessages, {
+              adapter,
+              model: effectiveModelId,
+              apiKey: compactionCreds.apiKey,
+              baseUrl: compactionCreds.baseUrl,
+              signal: abortController.signal,
+            });
+          } catch (err) {
+            autoCompactTracker.recordFailure();
+            logger.warn('[persistentCompaction] summarize failed — skipping this turn', { error: String(err) });
+          }
+          if (summaryText.trim()) {
+            // Append-only: create a marker and add it as the new last message. No
+            // existing message is mutated — the rewrite data-loss class cannot
+            // occur. buildContextFromBoundary picks it up next turn. (Known minor:
+            // when this fires mid tool-use loop the divider can visually split
+            // that loop's group — cosmetic.)
+            const marker = createCompactBoundaryMarker({
+              summaryText,
+              summarizedFromId: plan.summarizedFromId,
+              summarizedToId: plan.summarizedToId,
+              source: 'auto',
+              timestamp: Date.now(),
+            });
+            useChatStore.getState().addMessage(conversationId, marker);
+            autoCompactTracker.recordSuccess();
+            logger.info('[persistentCompaction] landed compact-boundary marker', {
+              from: plan.summarizedFromId,
+              to: plan.summarizedToId,
+              summarizedCount: plan.middleMessages.length,
+            });
+          }
+        }
+      }
+
       const trimmedMessages = trimOldScreenshots(messagesForContext, usagePercent);
 
       // Step 3: Hard truncation as safety net
@@ -1779,8 +1861,12 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
                 getActiveApiKey(settingsForModel),
                 getActiveProvider(settingsForModel)?.baseUrl || undefined,
               )
+              // Use boundaryView (marker-free compact view if a marker exists,
+              // else raw history) so recovery never re-feeds a marker to the LLM
+              // and reuses the existing summary instead of re-summarizing full raw
+              // history.
               const compressionResult = await compressContextIfNeeded(
-                historyMessages,
+                boundaryView,
                 effectiveSystemPrompt,
                 contextWindowSize,
                 maxOutputTokens,
@@ -1813,7 +1899,9 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
           // Stage 2: Hard truncation as fallback
           if (!recovered) {
             logger.info('Attempting hard truncation recovery');
-            const emergencyRounds = identifyRounds(historyMessages);
+            // boundaryView is marker-free (compact view if a marker exists) so
+            // the truncated emergency payload never contains a boundary marker.
+            const emergencyRounds = identifyRounds(boundaryView);
             if (emergencyRounds.length > 3) {
               const firstRound = emergencyRounds[0];
               const lastTwoRounds = emergencyRounds.slice(-2);

--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -1547,8 +1547,11 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
               signal: abortController.signal,
             });
           } catch (err) {
-            autoCompactTracker.recordFailure();
-            logger.warn('[persistentCompaction] summarize failed — skipping this turn', { error: String(err) });
+            // Defensive: summarizeConversation is contractually no-throw (it
+            // swallows timeout/error and returns ''), but keep this in case an
+            // unexpected error escapes. The empty-string path below is the real
+            // failure recorder.
+            logger.warn('[persistentCompaction] summarize threw unexpectedly', { error: String(err) });
           }
           if (summaryText.trim()) {
             // Append-only: create a marker and add it as the new last message. No
@@ -1564,12 +1567,25 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
               timestamp: Date.now(),
             });
             useChatStore.getState().addMessage(conversationId, marker);
+            // Clear the now-stale ephemeral 65% cache (a marker supersedes it),
+            // mirroring the manual /compact path so the two land paths stay
+            // symmetric.
+            useChatStore.getState().clearContextCache(conversationId);
             autoCompactTracker.recordSuccess();
             logger.info('[persistentCompaction] landed compact-boundary marker', {
               from: plan.summarizedFromId,
               to: plan.summarizedToId,
               summarizedCount: plan.middleMessages.length,
             });
+          } else {
+            // Empty return = timeout / error / empty summary. Record against the
+            // SHARED circuit breaker: when a marker is already active this Step
+            // 2.1 call is the ONLY compaction path (buildContextFromBoundary
+            // short-circuits the 65% path that otherwise records failures), so
+            // without this a provider that keeps timing out would re-issue a
+            // blocking summarize every turn with no breaker relief — the "死寂"
+            // stall class the breaker exists to prevent.
+            autoCompactTracker.recordFailure();
           }
         }
       }

--- a/src/core/context/compactBoundary.test.ts
+++ b/src/core/context/compactBoundary.test.ts
@@ -1,0 +1,624 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { Message } from '@/types';
+import {
+  COMPACT_BOUNDARY_ID_PREFIX,
+  isCompactBoundary,
+  findLastCompactBoundary,
+  createCompactBoundaryMarker,
+  computeCompactionPlan,
+  buildContextFromBoundary,
+} from './compactBoundary';
+import { RECENT_ROUNDS_TO_KEEP } from './contextUtils';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let _seq = 0;
+function msg(
+  role: 'user' | 'assistant' | 'system',
+  overrides: Partial<Message> = {},
+): Message {
+  _seq++;
+  return {
+    id: `msg-${_seq}`,
+    role,
+    content: `content-${_seq}`,
+    timestamp: 1000 * _seq,
+    ...overrides,
+  };
+}
+
+function resetSeq() {
+  _seq = 0;
+}
+
+/** Create a valid compact-boundary marker directly (for test setup). */
+function makeMarker(
+  fromId: string,
+  toId: string,
+  summaryText = 'summary',
+  ts = 999_000,
+): Message {
+  return createCompactBoundaryMarker({
+    summaryText,
+    summarizedFromId: fromId,
+    summarizedToId: toId,
+    source: 'auto',
+    timestamp: ts,
+  });
+}
+
+/**
+ * Build a flat message array with the requested number of full rounds
+ * (user + assistant pairs).
+ */
+function buildRounds(count: number): Message[] {
+  const messages: Message[] = [];
+  for (let i = 0; i < count; i++) {
+    messages.push(msg('user'));
+    messages.push(msg('assistant'));
+  }
+  return messages;
+}
+
+// ---------------------------------------------------------------------------
+// isCompactBoundary
+// ---------------------------------------------------------------------------
+
+describe('isCompactBoundary', () => {
+  it('returns true for a valid marker (id prefix + payload)', () => {
+    const m = makeMarker('a', 'b');
+    expect(isCompactBoundary(m)).toBe(true);
+  });
+
+  it('returns false for an ordinary user message', () => {
+    resetSeq();
+    expect(isCompactBoundary(msg('user'))).toBe(false);
+  });
+
+  it('returns false for an ordinary assistant message', () => {
+    resetSeq();
+    expect(isCompactBoundary(msg('assistant'))).toBe(false);
+  });
+
+  it('returns false for a plain system message (isSystem=true, no prefix or payload)', () => {
+    resetSeq();
+    expect(isCompactBoundary(msg('system', { isSystem: true }))).toBe(false);
+  });
+
+  it('returns false when id has the prefix but compactBoundary payload is absent', () => {
+    resetSeq();
+    const m = msg('system', { id: `${COMPACT_BOUNDARY_ID_PREFIX}abc` });
+    expect(isCompactBoundary(m)).toBe(false);
+  });
+
+  it('returns false when compactBoundary payload is present but id prefix is wrong', () => {
+    const m = makeMarker('a', 'b');
+    const withBadId: Message = { ...m, id: 'no-prefix-here' };
+    expect(isCompactBoundary(withBadId)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findLastCompactBoundary
+// ---------------------------------------------------------------------------
+
+describe('findLastCompactBoundary', () => {
+  it('returns null for an empty array', () => {
+    expect(findLastCompactBoundary([])).toBeNull();
+  });
+
+  it('returns null when there are no markers', () => {
+    resetSeq();
+    expect(findLastCompactBoundary([msg('user'), msg('assistant')])).toBeNull();
+  });
+
+  it('returns the single marker with its correct index', () => {
+    resetSeq();
+    const u = msg('user');
+    const a = msg('assistant');
+    const m = makeMarker(u.id, a.id);
+    const result = findLastCompactBoundary([u, a, m]);
+    expect(result).not.toBeNull();
+    expect(result!.marker.id).toBe(m.id);
+    expect(result!.index).toBe(2);
+  });
+
+  it('returns the LAST (highest-index) marker when multiple markers exist', () => {
+    resetSeq();
+    const u1 = msg('user');
+    const a1 = msg('assistant');
+    const marker1 = makeMarker(u1.id, a1.id, 'first', 1001);
+    const u2 = msg('user');
+    const a2 = msg('assistant');
+    const marker2 = makeMarker(u2.id, a2.id, 'second', 1002);
+
+    const messages = [u1, a1, marker1, u2, a2, marker2];
+    const result = findLastCompactBoundary(messages);
+    expect(result).not.toBeNull();
+    expect(result!.marker.id).toBe(marker2.id);
+    expect(result!.index).toBe(5);
+  });
+
+  it('returns the first element when a single marker is at index 0', () => {
+    const m = makeMarker('x', 'y');
+    const result = findLastCompactBoundary([m]);
+    expect(result).not.toBeNull();
+    expect(result!.index).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createCompactBoundaryMarker
+// ---------------------------------------------------------------------------
+
+describe('createCompactBoundaryMarker', () => {
+  const TS = 1_700_000_000_000;
+
+  it('builds the id with prefix + base-36 timestamp + a random suffix (collision-safe)', () => {
+    const m = createCompactBoundaryMarker({
+      summaryText: 'text',
+      summarizedFromId: 'f',
+      summarizedToId: 't',
+      source: 'auto',
+      timestamp: TS,
+    });
+    expect(m.id).toMatch(new RegExp(`^${COMPACT_BOUNDARY_ID_PREFIX}${TS.toString(36)}-[a-z0-9]+$`));
+    // Two markers in the same millisecond must not collide.
+    const m2 = createCompactBoundaryMarker({
+      summaryText: 'text',
+      summarizedFromId: 'f',
+      summarizedToId: 't',
+      source: 'auto',
+      timestamp: TS,
+    });
+    expect(m.id).not.toBe(m2.id);
+  });
+
+  it('sets role to "system"', () => {
+    const m = createCompactBoundaryMarker({
+      summaryText: 'x',
+      summarizedFromId: 'f',
+      summarizedToId: 't',
+      source: 'manual',
+      timestamp: TS,
+    });
+    expect(m.role).toBe('system');
+  });
+
+  it('sets content to empty string', () => {
+    const m = createCompactBoundaryMarker({
+      summaryText: 'x',
+      summarizedFromId: 'f',
+      summarizedToId: 't',
+      source: 'auto',
+      timestamp: TS,
+    });
+    expect(m.content).toBe('');
+  });
+
+  it('does NOT set isSystem', () => {
+    const m = createCompactBoundaryMarker({
+      summaryText: 'x',
+      summarizedFromId: 'f',
+      summarizedToId: 't',
+      source: 'auto',
+      timestamp: TS,
+    });
+    expect(m.isSystem).toBeUndefined();
+  });
+
+  it('stores all payload fields correctly', () => {
+    const m = createCompactBoundaryMarker({
+      summaryText: 'hello',
+      summarizedFromId: 'from-id',
+      summarizedToId: 'to-id',
+      source: 'manual',
+      timestamp: TS,
+    });
+    const b = m.compactBoundary!;
+    expect(b.summaryText).toBe('hello');
+    expect(b.summarizedFromId).toBe('from-id');
+    expect(b.summarizedToId).toBe('to-id');
+    expect(b.source).toBe('manual');
+    expect(b.createdAt).toBe(TS);
+  });
+
+  it('sets timestamp on the Message itself equal to the param', () => {
+    const m = createCompactBoundaryMarker({
+      summaryText: 'x',
+      summarizedFromId: 'f',
+      summarizedToId: 't',
+      source: 'auto',
+      timestamp: TS,
+    });
+    expect(m.timestamp).toBe(TS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeCompactionPlan
+// ---------------------------------------------------------------------------
+
+describe('computeCompactionPlan', () => {
+  beforeEach(() => resetSeq());
+
+  it('returns null when the history is empty', () => {
+    expect(computeCompactionPlan([])).toBeNull();
+  });
+
+  it(`returns null when rounds ≤ ${RECENT_ROUNDS_TO_KEEP + 1} (not enough to compact)`, () => {
+    // RECENT_ROUNDS_TO_KEEP + 1 = 5 rounds → still null
+    const messages = buildRounds(RECENT_ROUNDS_TO_KEEP + 1);
+    expect(computeCompactionPlan(messages)).toBeNull();
+  });
+
+  it('returns null for exactly RECENT_ROUNDS_TO_KEEP rounds', () => {
+    const messages = buildRounds(RECENT_ROUNDS_TO_KEEP);
+    expect(computeCompactionPlan(messages)).toBeNull();
+  });
+
+  it(`returns a plan when rounds > ${RECENT_ROUNDS_TO_KEEP + 1}`, () => {
+    // 6 rounds: firstRound=0, middleRounds=[1], recentRounds=[2..5]
+    const messages = buildRounds(RECENT_ROUNDS_TO_KEEP + 2);
+    const plan = computeCompactionPlan(messages);
+    expect(plan).not.toBeNull();
+  });
+
+  it('middleMessages contains only the middle rounds (not firstRound, not recentRounds)', () => {
+    resetSeq();
+    // 8 rounds (indices 0..7)
+    // firstRound=0; recentRounds=4..7; middleRounds=1..3
+    const numRounds = RECENT_ROUNDS_TO_KEEP + 4; // 8
+    const messages = buildRounds(numRounds);
+
+    const plan = computeCompactionPlan(messages);
+    expect(plan).not.toBeNull();
+
+    const { middleMessages, summarizedFromId, summarizedToId } = plan!;
+
+    // First round = rounds[0] = messages[0..1]
+    const firstRoundIds = [messages[0].id, messages[1].id];
+    // Recent rounds = rounds[4..7] = messages[8..15]
+    const recentIds = messages.slice(8).map((m) => m.id);
+
+    for (const id of firstRoundIds) {
+      expect(middleMessages.map((m) => m.id)).not.toContain(id);
+    }
+    for (const id of recentIds) {
+      expect(middleMessages.map((m) => m.id)).not.toContain(id);
+    }
+
+    // Middle = messages[2..7] (rounds 1..3, i.e. 6 messages)
+    expect(middleMessages).toHaveLength(6);
+    expect(summarizedFromId).toBe(messages[2].id);
+    expect(summarizedToId).toBe(messages[7].id);
+  });
+
+  it('filters out existing markers before computing rounds', () => {
+    resetSeq();
+    // 6 rounds of real messages = RECENT_ROUNDS_TO_KEEP + 2 = 8 messages
+    const realMessages = buildRounds(RECENT_ROUNDS_TO_KEEP + 2);
+    // Inject a stale marker between round 0 and round 1
+    const staleMarker = makeMarker(realMessages[0].id, realMessages[1].id);
+    const mixed = [
+      realMessages[0],
+      realMessages[1],
+      staleMarker,
+      ...realMessages.slice(2),
+    ];
+
+    // With or without the marker the plan should be the same
+    const planWithout = computeCompactionPlan(realMessages);
+    const planWith = computeCompactionPlan(mixed);
+
+    expect(planWith).not.toBeNull();
+    expect(planWith!.summarizedFromId).toBe(planWithout!.summarizedFromId);
+    expect(planWith!.summarizedToId).toBe(planWithout!.summarizedToId);
+    expect(planWith!.middleMessages).toHaveLength(
+      planWithout!.middleMessages.length,
+    );
+  });
+
+  it('returns correct from/to ids for a minimal 6-round history', () => {
+    resetSeq();
+    // 6 rounds: [u1,a1] [u2,a2] [u3,a3] [u4,a4] [u5,a5] [u6,a6]
+    // firstRound = [u1,a1]
+    // recentRounds = last 4 = [u3..a6]
+    // middleRounds = [u2,a2]
+    const messages = buildRounds(6);
+    const plan = computeCompactionPlan(messages);
+
+    expect(plan).not.toBeNull();
+    // middleRounds = rounds[1] = messages[2..3]
+    expect(plan!.summarizedFromId).toBe(messages[2].id);
+    expect(plan!.summarizedToId).toBe(messages[3].id);
+    expect(plan!.middleMessages).toHaveLength(2);
+  });
+
+  describe('substantiveness + delta guard (opts.estimateTokens)', () => {
+    // 100 tokens per message — deterministic estimator for the guard.
+    const est = (msgs: { length: number }) => msgs.length * 100;
+
+    it('without estimateTokens, always plans (manual /compact path is unguarded)', () => {
+      resetSeq();
+      const messages = buildRounds(RECENT_ROUNDS_TO_KEEP + 2);
+      // no opts → no guard
+      expect(computeCompactionPlan(messages)).not.toBeNull();
+    });
+
+    it('no marker: returns null when the whole middle is below minNewTokens', () => {
+      resetSeq();
+      const messages = buildRounds(RECENT_ROUNDS_TO_KEEP + 2); // middle = 1 round = 2 msgs = 200 tokens
+      expect(computeCompactionPlan(messages, { estimateTokens: est, minNewTokens: 500 })).toBeNull();
+      expect(computeCompactionPlan(messages, { estimateTokens: est, minNewTokens: 100 })).not.toBeNull();
+    });
+
+    it('marker present: returns null when NEW content since the last marker is below the threshold (no per-turn re-fire)', () => {
+      resetSeq();
+      // 8 rounds → clean middle = msg[2..7] (6 msgs). Marker covers up to msg[5].
+      const messages = buildRounds(RECENT_ROUNDS_TO_KEEP + 4);
+      const marker = makeMarker(messages[2].id, messages[5].id);
+      const mixed = [...messages.slice(0, 6), marker, ...messages.slice(6)];
+      // NEW content after msg[5] = msg[6], msg[7] = 2 msgs = 200 tokens
+      expect(computeCompactionPlan(mixed, { estimateTokens: est, minNewTokens: 500 })).toBeNull();
+    });
+
+    it('marker present: plans again once NEW content since the last marker is substantial', () => {
+      resetSeq();
+      const messages = buildRounds(RECENT_ROUNDS_TO_KEEP + 4);
+      const marker = makeMarker(messages[2].id, messages[5].id);
+      const mixed = [...messages.slice(0, 6), marker, ...messages.slice(6)];
+      // 200 new tokens >= 100 → re-fire allowed
+      const plan = computeCompactionPlan(mixed, { estimateTokens: est, minNewTokens: 100 });
+      expect(plan).not.toBeNull();
+      // Still summarizes the whole raw middle (last-marker-wins send-side).
+      expect(plan!.summarizedToId).toBe(messages[7].id);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildContextFromBoundary
+// ---------------------------------------------------------------------------
+
+describe('buildContextFromBoundary', () => {
+  beforeEach(() => resetSeq());
+
+  it('returns the original array unchanged when there are no markers', () => {
+    resetSeq();
+    const messages = [msg('user'), msg('assistant'), msg('user')];
+    const result = buildContextFromBoundary(messages);
+    expect(result).toBe(messages); // same reference
+  });
+
+  it('returns original array unchanged for an empty array', () => {
+    const result = buildContextFromBoundary([]);
+    expect(result).toHaveLength(0);
+  });
+
+  describe('single marker', () => {
+    it('produces [firstRound, summaryMsg, ...recent] with no markers in output', () => {
+      resetSeq();
+      // Build: [u1,a1] [u2,a2] [u3,a3] [u4,a4] [u5,a5]  → marker summarises [u2..a3]
+      const u1 = msg('user');
+      const a1 = msg('assistant');
+      const u2 = msg('user');
+      const a2 = msg('assistant');
+      const u3 = msg('user');
+      const a3 = msg('assistant');
+      const u4 = msg('user');
+      const a4 = msg('assistant');
+      const u5 = msg('user');
+      const a5 = msg('assistant');
+      const marker = makeMarker(u2.id, a3.id, 'the summary', 99_000);
+      const messages = [u1, a1, u2, a2, u3, a3, u4, a4, u5, a5, marker];
+
+      const result = buildContextFromBoundary(messages);
+
+      // No markers in result
+      expect(result.every((m) => !isCompactBoundary(m))).toBe(true);
+
+      // First element: u1, a1 verbatim
+      expect(result[0].id).toBe(u1.id);
+      expect(result[1].id).toBe(a1.id);
+
+      // Third element: injected summary user message
+      expect(result[2].role).toBe('user');
+      expect(result[2].content).toMatch(/^\[对话历史摘要\]\n/);
+      expect(result[2].content).toContain('the summary');
+      expect(result[2].id).toBe(`context-summary-${marker.id}`);
+      expect(result[2].timestamp).toBe(99_000);
+
+      // Rest: u4, a4, u5, a5
+      expect(result[3].id).toBe(u4.id);
+      expect(result[4].id).toBe(a4.id);
+      expect(result[5].id).toBe(u5.id);
+      expect(result[6].id).toBe(a5.id);
+
+      expect(result).toHaveLength(7);
+    });
+
+    it('preserves messages before summarizedFromId verbatim', () => {
+      resetSeq();
+      const u1 = msg('user');
+      const a1 = msg('assistant');
+      const u2 = msg('user');
+      const a2 = msg('assistant');
+      const marker = makeMarker(u2.id, a2.id);
+      const messages = [u1, a1, u2, a2, marker];
+
+      const result = buildContextFromBoundary(messages);
+      expect(result[0].id).toBe(u1.id);
+      expect(result[1].id).toBe(a1.id);
+    });
+
+    it('preserves messages after summarizedToId verbatim', () => {
+      resetSeq();
+      const u1 = msg('user');
+      const a1 = msg('assistant');
+      const u2 = msg('user');
+      const a2 = msg('assistant');
+      const u3 = msg('user');
+      const a3 = msg('assistant');
+      const marker = makeMarker(u2.id, a2.id);
+      const messages = [u1, a1, u2, a2, u3, a3, marker];
+
+      const result = buildContextFromBoundary(messages);
+
+      // After summary: u3, a3
+      const ids = result.map((m) => m.id);
+      expect(ids).toContain(u3.id);
+      expect(ids).toContain(a3.id);
+    });
+
+    it('works when marker is appended at the very end', () => {
+      resetSeq();
+      const u1 = msg('user');
+      const a1 = msg('assistant');
+      const u2 = msg('user');
+      const a2 = msg('assistant');
+      const u3 = msg('user');
+      const a3 = msg('assistant');
+      // Marker appended last — realistic scenario
+      const marker = makeMarker(u2.id, u2.id, 'compact');
+      const messages = [u1, a1, u2, a2, u3, a3, marker];
+
+      const result = buildContextFromBoundary(messages);
+
+      expect(result.every((m) => !isCompactBoundary(m))).toBe(true);
+      // u2 is summarised; a2, u3, a3 appear after
+      const summaryIdx = result.findIndex((m) =>
+        m.id.startsWith('context-summary-'),
+      );
+      expect(summaryIdx).toBeGreaterThanOrEqual(0);
+      const after = result.slice(summaryIdx + 1).map((m) => m.id);
+      expect(after).toContain(a2.id);
+      expect(after).toContain(u3.id);
+      expect(after).toContain(a3.id);
+    });
+  });
+
+  describe('multiple markers', () => {
+    it('honours only the last marker', () => {
+      resetSeq();
+      const u1 = msg('user');
+      const a1 = msg('assistant');
+      const u2 = msg('user');
+      const a2 = msg('assistant');
+      const u3 = msg('user');
+      const a3 = msg('assistant');
+      const u4 = msg('user');
+      const a4 = msg('assistant');
+      const u5 = msg('user');
+      const a5 = msg('assistant');
+
+      const marker1 = makeMarker(u2.id, a2.id, 'first summary', 1_001);
+      const marker2 = makeMarker(u2.id, a3.id, 'second summary', 1_002);
+
+      const messages = [u1, a1, u2, a2, u3, a3, u4, a4, u5, a5, marker1, marker2];
+
+      const result = buildContextFromBoundary(messages);
+
+      // No markers in result
+      expect(result.every((m) => !isCompactBoundary(m))).toBe(true);
+
+      // Summary message from marker2 (not marker1)
+      const summaryMsg = result.find((m) =>
+        m.id.startsWith('context-summary-'),
+      )!;
+      expect(summaryMsg).toBeDefined();
+      expect(summaryMsg.content).toContain('second summary');
+      expect(summaryMsg.id).toBe(`context-summary-${marker2.id}`);
+
+      // u3, a3 should NOT appear (they are covered by marker2's range)
+      const ids = result.map((m) => m.id);
+      expect(ids).not.toContain(u3.id);
+      expect(ids).not.toContain(a3.id);
+
+      // u4, a4, u5, a5 should appear in the tail
+      expect(ids).toContain(u4.id);
+      expect(ids).toContain(a4.id);
+      expect(ids).toContain(u5.id);
+      expect(ids).toContain(a5.id);
+    });
+
+    it('earlier markers inside the covered range do not appear in the result', () => {
+      resetSeq();
+      const u1 = msg('user');
+      const a1 = msg('assistant');
+      const u2 = msg('user');
+      const a2 = msg('assistant');
+      const marker1 = makeMarker(u2.id, a2.id, 'old', 1_001);
+      const u3 = msg('user');
+      const a3 = msg('assistant');
+      const u4 = msg('user');
+      const a4 = msg('assistant');
+      const marker2 = makeMarker(u2.id, a3.id, 'new', 1_002);
+
+      // Realistic: marker1 is between messages, marker2 appended at tail
+      const messages = [u1, a1, u2, a2, marker1, u3, a3, u4, a4, marker2];
+
+      const result = buildContextFromBoundary(messages);
+
+      expect(result.every((m) => !isCompactBoundary(m))).toBe(true);
+
+      // marker1 should not appear (it falls within slice(toIdx+1) of marker2? No —
+      // marker1 is at index 4, toIdx for marker2 is index of a3 = 6).
+      // Actually marker1 is at index 4, and a3 is at index 6 → marker1 falls
+      // in slice(toIdx+1) and gets filtered by notMarker. Verified below.
+      const ids = result.map((m) => m.id);
+      expect(ids).not.toContain(marker1.id);
+      expect(ids).not.toContain(marker2.id);
+    });
+  });
+
+  describe('defensive cases', () => {
+    // A stale marker (anchor id gone / inverted range) must return the SAME array
+    // reference so the caller (agentLoop) treats it as "no usable marker" and
+    // falls through to the live 65% compression — never silently shipping the
+    // full un-compacted history as if it were compacted.
+    it('returns the same array reference when summarizedFromId is not found', () => {
+      resetSeq();
+      const u1 = msg('user');
+      const a1 = msg('assistant');
+      const marker = makeMarker('ghost-id', a1.id);
+      const messages = [u1, a1, marker];
+
+      const result = buildContextFromBoundary(messages);
+
+      expect(result).toBe(messages);
+    });
+
+    it('returns the same array reference when summarizedToId is not found', () => {
+      resetSeq();
+      const u1 = msg('user');
+      const a1 = msg('assistant');
+      const marker = makeMarker(u1.id, 'ghost-id');
+      const messages = [u1, a1, marker];
+
+      const result = buildContextFromBoundary(messages);
+
+      expect(result).toBe(messages);
+    });
+
+    it('returns the same array reference when toIdx < fromIdx (inverted range)', () => {
+      resetSeq();
+      const u1 = msg('user');
+      const a1 = msg('assistant');
+      // Inverted: fromId=a1 (index 1), toId=u1 (index 0)
+      const marker = makeMarker(a1.id, u1.id);
+      const messages = [u1, a1, marker];
+
+      const result = buildContextFromBoundary(messages);
+
+      expect(result).toBe(messages);
+    });
+
+    it('does not throw on a messages array containing only a marker', () => {
+      const marker = makeMarker('x', 'y');
+      expect(() => buildContextFromBoundary([marker])).not.toThrow();
+    });
+  });
+});

--- a/src/core/context/compactBoundary.test.ts
+++ b/src/core/context/compactBoundary.test.ts
@@ -337,6 +337,26 @@ describe('computeCompactionPlan', () => {
     expect(plan!.middleMessages).toHaveLength(2);
   });
 
+  describe('recentRoundsToKeep override (manual /compact)', () => {
+    it('a 5-round conversation is "too short" at the default keep=4 but compacts at the manual keep=1', () => {
+      resetSeq();
+      const messages = buildRounds(5); // 5 rounds, the reported /compact case
+      // Default (auto) keeps 4 recent rounds → 5 <= 4+1 → nothing to compact.
+      expect(computeCompactionPlan(messages)).toBeNull();
+      // Manual keeps 1 (WorkBuddy-aligned aggressive) → 5 > 1+1 → summarizes the middle.
+      const plan = computeCompactionPlan(messages, { recentRoundsToKeep: 1 });
+      expect(plan).not.toBeNull();
+      expect(plan!.middleMessages.length).toBeGreaterThan(0);
+    });
+
+    it('3 rounds compacts at keep=1; 2 rounds is the genuine floor (nothing to summarize)', () => {
+      resetSeq();
+      expect(computeCompactionPlan(buildRounds(3), { recentRoundsToKeep: 1 })).not.toBeNull();
+      resetSeq();
+      expect(computeCompactionPlan(buildRounds(2), { recentRoundsToKeep: 1 })).toBeNull();
+    });
+  });
+
   describe('substantiveness + delta guard (opts.estimateTokens)', () => {
     // 100 tokens per message — deterministic estimator for the guard.
     const est = (msgs: { length: number }) => msgs.length * 100;

--- a/src/core/context/compactBoundary.test.ts
+++ b/src/core/context/compactBoundary.test.ts
@@ -622,3 +622,83 @@ describe('buildContextFromBoundary', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// End-to-end: computeCompactionPlan → createCompactBoundaryMarker →
+// buildContextFromBoundary. Closes the gap between the anchors the plan emits
+// and the send-side reconstruction — the exact chain agentLoop Step 2.1 runs.
+// Also pins the append-only invariant: appending the marker never mutates the
+// original messages.
+// ---------------------------------------------------------------------------
+describe('round-trip: plan → marker → build', () => {
+  beforeEach(resetSeq);
+
+  it('reconstructs a marker-free compact context whose anchors resolve', () => {
+    const messages = buildRounds(RECENT_ROUNDS_TO_KEEP + 5); // plenty of middle
+    const originalSnapshot = messages.map((m) => m.id);
+
+    const plan = computeCompactionPlan(messages);
+    expect(plan).not.toBeNull();
+
+    const marker = createCompactBoundaryMarker({
+      summaryText: 'SUMMARY-BODY',
+      summarizedFromId: plan!.summarizedFromId,
+      summarizedToId: plan!.summarizedToId,
+      source: 'auto',
+      timestamp: 999_000,
+    });
+    // Append-only: marker goes to the END, originals untouched.
+    const history = [...messages, marker];
+    expect(messages.map((m) => m.id)).toEqual(originalSnapshot);
+
+    const built = buildContextFromBoundary(history);
+
+    // 1. No marker leaks into the send set.
+    expect(built.some(isCompactBoundary)).toBe(false);
+    // 2. The summary synthetic message is present with the marker's body.
+    const summary = built.find((m) => m.id.startsWith('context-summary-'));
+    expect(summary).toBeDefined();
+    expect(typeof summary!.content === 'string' && summary!.content).toContain('SUMMARY-BODY');
+    // 3. Every summarized middle message is gone from the send set.
+    const summarizedIds = new Set(plan!.middleMessages.map((m) => m.id));
+    expect(built.some((m) => summarizedIds.has(m.id))).toBe(false);
+    // 4. The first message (task context) survives ahead of the summary.
+    expect(built[0].id).toBe(messages[0].id);
+    // 5. The last real message (recent) survives after the summary.
+    expect(built[built.length - 1].id).toBe(messages[messages.length - 1].id);
+  });
+
+  it('is idempotent-safe when a second marker lands on top of the first', () => {
+    resetSeq();
+    const messages = buildRounds(RECENT_ROUNDS_TO_KEEP + 5);
+    const plan1 = computeCompactionPlan(messages)!;
+    const marker1 = createCompactBoundaryMarker({
+      summaryText: 'FIRST',
+      summarizedFromId: plan1.summarizedFromId,
+      summarizedToId: plan1.summarizedToId,
+      source: 'auto',
+      timestamp: 100,
+    });
+    const history1 = [...messages, marker1];
+
+    // A few more rounds arrive, then a second compaction lands.
+    const more = buildRounds(3);
+    const history2mid = [...history1, ...more];
+    const plan2 = computeCompactionPlan(history2mid)!;
+    const marker2 = createCompactBoundaryMarker({
+      summaryText: 'SECOND',
+      summarizedFromId: plan2.summarizedFromId,
+      summarizedToId: plan2.summarizedToId,
+      source: 'auto',
+      timestamp: 200,
+    });
+    const history2 = [...history2mid, marker2];
+
+    const built = buildContextFromBoundary(history2);
+    // Only the LAST marker governs; no marker in the output.
+    expect(built.some(isCompactBoundary)).toBe(false);
+    const summaries = built.filter((m) => m.id.startsWith('context-summary-'));
+    expect(summaries).toHaveLength(1);
+    expect(typeof summaries[0].content === 'string' && summaries[0].content).toContain('SECOND');
+  });
+});

--- a/src/core/context/compactBoundary.ts
+++ b/src/core/context/compactBoundary.ts
@@ -98,22 +98,30 @@ export function computeCompactionPlan(
     estimateTokens?: (msgs: Message[]) => number;
     /** Minimum NEW (un-summarized) tokens required to justify a compaction. */
     minNewTokens?: number;
+    /**
+     * How many recent rounds to keep verbatim (not summarized). Defaults to
+     * RECENT_ROUNDS_TO_KEEP (the conservative auto value). The manual /compact
+     * path passes a smaller value so an explicit user request compacts on a
+     * shorter conversation instead of being told "too short".
+     */
+    recentRoundsToKeep?: number;
   },
 ): {
   middleMessages: Message[];
   summarizedFromId: string;
   summarizedToId: string;
 } | null {
+  const keep = opts?.recentRoundsToKeep ?? RECENT_ROUNDS_TO_KEEP;
   // Work on the clean logical view (no markers)
   const clean = historyMessages.filter((m) => !isCompactBoundary(m));
   const rounds = identifyRounds(clean);
 
-  if (rounds.length <= RECENT_ROUNDS_TO_KEEP + 1) {
+  if (rounds.length <= keep + 1) {
     return null;
   }
 
-  // firstRound = rounds[0]; recentRounds = last N; middleRounds = in between
-  const middleRounds = rounds.slice(1, rounds.length - RECENT_ROUNDS_TO_KEEP);
+  // firstRound = rounds[0]; recentRounds = last `keep`; middleRounds = in between
+  const middleRounds = rounds.slice(1, rounds.length - keep);
   const middleMessages = middleRounds.flat();
 
   if (middleMessages.length === 0) {

--- a/src/core/context/compactBoundary.ts
+++ b/src/core/context/compactBoundary.ts
@@ -1,0 +1,208 @@
+/**
+ * Pure helpers for compact-boundary markers (long-conversation P1 Part A).
+ *
+ * A compact-boundary marker is a Message with:
+ *   - role: 'system'
+ *   - id prefix: COMPACT_BOUNDARY_ID_PREFIX
+ *   - compactBoundary payload set
+ *   - isSystem NOT set (must reach the UI renderer as a divider, not be hidden)
+ *
+ * Markers are append-only: they are pushed to the end of messages.jsonl and
+ * never mutate earlier entries. The send-side rebuilds a compact context on
+ * the fly by honouring the LAST marker in the array.
+ */
+
+import type { Message } from '@/types';
+import { identifyRounds, RECENT_ROUNDS_TO_KEEP } from './contextUtils';
+
+export const COMPACT_BOUNDARY_ID_PREFIX = 'compact-boundary-';
+
+/** True iff msg is a compaction boundary marker (id prefix + payload present). */
+export function isCompactBoundary(msg: Message): boolean {
+  return (
+    msg.id.startsWith(COMPACT_BOUNDARY_ID_PREFIX) &&
+    msg.compactBoundary !== undefined
+  );
+}
+
+/**
+ * Last (highest-index) marker in the array, or null. Reverse scan so that
+ * the common case (marker is at or near the tail) is O(1).
+ */
+export function findLastCompactBoundary(
+  messages: Message[],
+): { marker: Message; index: number } | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (isCompactBoundary(messages[i])) {
+      return { marker: messages[i], index: i };
+    }
+  }
+  return null;
+}
+
+/**
+ * Build a marker Message.
+ *
+ * id  = `${COMPACT_BOUNDARY_ID_PREFIX}${timestamp.toString(36)}`
+ * role = 'system', content = '', isSystem NOT set.
+ * timestamp is accepted as a parameter so callers can inject Date.now() —
+ * keeping this function pure and deterministic for tests.
+ */
+export function createCompactBoundaryMarker(params: {
+  summaryText: string;
+  summarizedFromId: string;
+  summarizedToId: string;
+  source: 'auto' | 'manual';
+  timestamp: number;
+}): Message {
+  const { summaryText, summarizedFromId, summarizedToId, source, timestamp } =
+    params;
+  // Random suffix follows the project id convention — two markers created in the
+  // same millisecond must not collide (appendMessage dedups by id and would drop
+  // the second; React keys would clash).
+  const suffix = Math.random().toString(36).slice(2, 8);
+  return {
+    id: `${COMPACT_BOUNDARY_ID_PREFIX}${timestamp.toString(36)}-${suffix}`,
+    role: 'system',
+    content: '',
+    timestamp,
+    compactBoundary: {
+      summaryText,
+      summarizedFromId,
+      summarizedToId,
+      createdAt: timestamp,
+      source,
+    },
+  };
+}
+
+/**
+ * Compute what a compaction would summarise from the raw (marker-free) history.
+ * Returns null if there are not enough rounds to compact.
+ *
+ * Algorithm:
+ *   1. Filter out all existing markers → clean logical view.
+ *   2. identifyRounds(clean).
+ *   3. Require rounds.length > RECENT_ROUNDS_TO_KEEP + 1, else return null.
+ *   4. firstRound = rounds[0]
+ *      recentRounds = last RECENT_ROUNDS_TO_KEEP rounds
+ *      middleRounds = everything in between
+ *   5. middleMessages = middleRounds.flat(); if empty → return null.
+ *   6. summarizedFromId = middleMessages[0].id
+ *      summarizedToId   = middleMessages[middleMessages.length - 1].id
+ */
+export function computeCompactionPlan(
+  historyMessages: Message[],
+  opts?: {
+    /** Token estimator; when provided, enables the substantiveness + delta guard. */
+    estimateTokens?: (msgs: Message[]) => number;
+    /** Minimum NEW (un-summarized) tokens required to justify a compaction. */
+    minNewTokens?: number;
+  },
+): {
+  middleMessages: Message[];
+  summarizedFromId: string;
+  summarizedToId: string;
+} | null {
+  // Work on the clean logical view (no markers)
+  const clean = historyMessages.filter((m) => !isCompactBoundary(m));
+  const rounds = identifyRounds(clean);
+
+  if (rounds.length <= RECENT_ROUNDS_TO_KEEP + 1) {
+    return null;
+  }
+
+  // firstRound = rounds[0]; recentRounds = last N; middleRounds = in between
+  const middleRounds = rounds.slice(1, rounds.length - RECENT_ROUNDS_TO_KEEP);
+  const middleMessages = middleRounds.flat();
+
+  if (middleMessages.length === 0) {
+    return null;
+  }
+
+  // Substantiveness + delta guard (auto path only — the manual /compact caller
+  // omits estimateTokens so it always compacts on explicit request). Without
+  // this, the anchor advances ~1 round per turn, so a still-large conversation
+  // would re-summarize and stack a NEW marker every single turn (divider spam +
+  // a blocking LLM call per turn). We only fire when there is enough NEW content
+  // that the LAST marker does not already cover.
+  if (opts?.estimateTokens) {
+    let newContent = middleMessages;
+    const last = findLastCompactBoundary(historyMessages);
+    if (last) {
+      const prevToId = last.marker.compactBoundary?.summarizedToId;
+      const prevIdx =
+        prevToId != null ? middleMessages.findIndex((m) => m.id === prevToId) : -1;
+      // Content after the previously-summarized point = what is genuinely new.
+      newContent = prevIdx >= 0 ? middleMessages.slice(prevIdx + 1) : middleMessages;
+    }
+    if (opts.estimateTokens(newContent) < (opts.minNewTokens ?? 500)) {
+      return null;
+    }
+  }
+
+  return {
+    middleMessages,
+    summarizedFromId: middleMessages[0].id,
+    summarizedToId: middleMessages[middleMessages.length - 1].id,
+  };
+}
+
+// Internal predicate — a message that is NOT a compact-boundary marker
+function notMarker(m: Message): boolean {
+  return !isCompactBoundary(m);
+}
+
+/**
+ * Send-side: rebuild the context array honouring the last marker.
+ *
+ * - No marker found → return historyMessages unchanged (no copy, same ref).
+ * - Find last marker; locate summarizedFromId / summarizedToId by id.
+ * - DEFENSIVE: if either id is missing, or toIdx < fromIdx → return
+ *   historyMessages with all markers filtered out (never crash the send path).
+ * - Otherwise build:
+ *     [ ...slice(0, fromIdx).filter(notMarker),   // firstRound verbatim
+ *       summaryMsg,                               // synthetic user message
+ *       ...slice(toIdx + 1).filter(notMarker) ]   // recent + anything appended after
+ *
+ *   summaryMsg = {
+ *     id:        `context-summary-${marker.id}`,
+ *     role:      'user',
+ *     content:   `[对话历史摘要]\n${boundary.summaryText}`,
+ *     timestamp: boundary.createdAt,
+ *   }
+ */
+export function buildContextFromBoundary(historyMessages: Message[]): Message[] {
+  const found = findLastCompactBoundary(historyMessages);
+  if (found === null) {
+    return historyMessages;
+  }
+
+  const { marker } = found;
+  const b = marker.compactBoundary!; // guaranteed by isCompactBoundary
+
+  const fromIdx = historyMessages.findIndex((m) => m.id === b.summarizedFromId);
+  const toIdx = historyMessages.findIndex((m) => m.id === b.summarizedToId);
+
+  // Defensive: an anchor id is gone (e.g. the user deleted a summarized message)
+  // or the range is inverted → the marker is stale and can't be applied. Return
+  // the SAME array reference so the caller's `boundaryView !== historyMessages`
+  // check is false and it falls through to the live 65% send-only compression,
+  // rather than silently shipping the full un-compacted history to the LLM.
+  if (fromIdx === -1 || toIdx === -1 || toIdx < fromIdx) {
+    return historyMessages;
+  }
+
+  const summaryMsg: Message = {
+    id: `context-summary-${marker.id}`,
+    role: 'user',
+    content: `[对话历史摘要]\n${b.summaryText}`,
+    timestamp: b.createdAt,
+  };
+
+  return [
+    ...historyMessages.slice(0, fromIdx).filter(notMarker),
+    summaryMsg,
+    ...historyMessages.slice(toIdx + 1).filter(notMarker),
+  ];
+}

--- a/src/core/context/compactionService.test.ts
+++ b/src/core/context/compactionService.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Message } from '@/types';
+
+// ── Mock chatStore ──
+// Must be hoisted-compatible: use plain const objects since they start with "mock"
+
+const mockConversations: Record<string, { messages: Message[] }> = {};
+const mockAddMessage = vi.fn();
+const mockClearContextCache = vi.fn();
+const mockSetIsCompressing = vi.fn();
+
+vi.mock('@/stores/chatStore', () => ({
+  useChatStore: {
+    getState: () => ({
+      conversations: mockConversations,
+      addMessage: mockAddMessage,
+      clearContextCache: mockClearContextCache,
+      setIsCompressing: mockSetIsCompressing,
+    }),
+  },
+}));
+
+// ── Mock settingsStore ──
+
+vi.mock('@/stores/settingsStore', () => ({
+  useSettingsStore: { getState: () => ({}) },
+  getActiveProvider: vi.fn().mockReturnValue({ apiFormat: 'anthropic-compatible', baseUrl: undefined }),
+  getActiveApiKey: vi.fn().mockReturnValue('test-api-key'),
+  getEffectiveModel: vi.fn().mockReturnValue('claude-haiku-4-5'),
+}));
+
+// ── Mock enterprise llm-resolver ──
+
+vi.mock('@/core/enterprise/llm-resolver', () => ({
+  resolveEffectiveLlmCreds: vi.fn().mockReturnValue({
+    apiKey: 'resolved-api-key',
+    baseUrl: undefined,
+    forceOpenAiCompatible: false,
+  }),
+}));
+
+// ── Mock LLM adapters (just need constructors to not throw) ──
+
+vi.mock('@/core/llm/claude', () => ({
+  ClaudeAdapter: vi.fn().mockImplementation(function () { return { chat: vi.fn() }; }),
+}));
+
+vi.mock('@/core/llm/openai-compatible', () => ({
+  OpenAICompatibleAdapter: vi.fn().mockImplementation(function () { return { chat: vi.fn() }; }),
+}));
+
+// ── Mock contextCompressor (whole module) ──
+// Use a module-level vi.fn so we can spy on it from tests.
+
+vi.mock('@/core/context/contextCompressor', () => ({
+  summarizeConversation: vi.fn(),
+}));
+
+// ── Import after all mocks ──
+
+import * as contextCompressor from '@/core/context/contextCompressor';
+import { compactConversationManually } from './compactionService';
+import { isCompactBoundary } from './compactBoundary';
+
+// Convenient alias
+const mockSummarize = contextCompressor.summarizeConversation as ReturnType<typeof vi.fn>;
+
+// ── Helpers ──
+
+let _seq = 0;
+
+function makeMsg(role: 'user' | 'assistant'): Message {
+  _seq++;
+  return {
+    id: `msg-${_seq}`,
+    role,
+    content: `content-${_seq}`,
+    timestamp: 1000 * _seq,
+  };
+}
+
+/** Build N user+assistant round pairs (2N messages). Need > 5 rounds for a non-null plan. */
+function buildRounds(count: number): Message[] {
+  const messages: Message[] = [];
+  for (let i = 0; i < count; i++) {
+    messages.push(makeMsg('user'));
+    messages.push(makeMsg('assistant'));
+  }
+  return messages;
+}
+
+const CONV_ID = 'test-conv-123';
+
+beforeEach(() => {
+  _seq = 0;
+  vi.mocked(contextCompressor.summarizeConversation).mockReset();
+  mockAddMessage.mockReset();
+  mockClearContextCache.mockReset();
+  mockSetIsCompressing.mockReset();
+  for (const key of Object.keys(mockConversations)) {
+    delete mockConversations[key];
+  }
+});
+
+// ── Tests ──
+
+describe('compactConversationManually', () => {
+  describe('no-conversation', () => {
+    it('returns no-conversation when convId is absent from store', async () => {
+      const result = await compactConversationManually(CONV_ID);
+      expect(result).toEqual({ compacted: false, reason: 'no-conversation' });
+    });
+
+    it('returns no-conversation for empty string convId', async () => {
+      const result = await compactConversationManually('');
+      expect(result).toEqual({ compacted: false, reason: 'no-conversation' });
+    });
+  });
+
+  describe('too-few', () => {
+    it('returns too-few when conversation has fewer rounds than threshold', async () => {
+      mockConversations[CONV_ID] = { messages: buildRounds(2) };
+      const result = await compactConversationManually(CONV_ID);
+      expect(result).toEqual({ compacted: false, reason: 'too-few' });
+      expect(mockSummarize).not.toHaveBeenCalled();
+    });
+
+    it('returns too-few for empty messages array', async () => {
+      mockConversations[CONV_ID] = { messages: [] };
+      const result = await compactConversationManually(CONV_ID);
+      expect(result).toEqual({ compacted: false, reason: 'too-few' });
+    });
+  });
+
+  describe('summarize-failed', () => {
+    it('returns summarize-failed when summarizeConversation throws', async () => {
+      mockConversations[CONV_ID] = { messages: buildRounds(6) };
+      vi.mocked(contextCompressor.summarizeConversation).mockRejectedValueOnce(new Error('network error'));
+
+      const result = await compactConversationManually(CONV_ID);
+      expect(result).toEqual({ compacted: false, reason: 'summarize-failed' });
+      expect(mockAddMessage).not.toHaveBeenCalled();
+    });
+
+    it('returns summarize-failed when summary is empty string', async () => {
+      mockConversations[CONV_ID] = { messages: buildRounds(6) };
+      vi.mocked(contextCompressor.summarizeConversation).mockResolvedValueOnce('');
+
+      const result = await compactConversationManually(CONV_ID);
+      expect(result).toEqual({ compacted: false, reason: 'summarize-failed' });
+      expect(mockAddMessage).not.toHaveBeenCalled();
+    });
+
+    it('returns summarize-failed when summary is whitespace only', async () => {
+      mockConversations[CONV_ID] = { messages: buildRounds(6) };
+      vi.mocked(contextCompressor.summarizeConversation).mockResolvedValueOnce('   ');
+
+      const result = await compactConversationManually(CONV_ID);
+      expect(result).toEqual({ compacted: false, reason: 'summarize-failed' });
+      expect(mockAddMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('successful compaction', () => {
+    it('returns compacted:true and reason:ok on success', async () => {
+      mockConversations[CONV_ID] = { messages: buildRounds(6) };
+      vi.mocked(contextCompressor.summarizeConversation).mockResolvedValueOnce('Summary of the conversation.');
+
+      const result = await compactConversationManually(CONV_ID);
+      expect(result).toEqual({ compacted: true, reason: 'ok' });
+    });
+
+    it('calls addMessage with a compact boundary marker', async () => {
+      mockConversations[CONV_ID] = { messages: buildRounds(6) };
+      vi.mocked(contextCompressor.summarizeConversation).mockResolvedValueOnce('A fine summary.');
+
+      await compactConversationManually(CONV_ID);
+
+      expect(mockAddMessage).toHaveBeenCalledOnce();
+      const [calledConvId, calledMarker] = mockAddMessage.mock.calls[0] as [string, Message];
+      expect(calledConvId).toBe(CONV_ID);
+      expect(isCompactBoundary(calledMarker)).toBe(true);
+    });
+
+    it('marker has source === "manual"', async () => {
+      mockConversations[CONV_ID] = { messages: buildRounds(6) };
+      vi.mocked(contextCompressor.summarizeConversation).mockResolvedValueOnce('manual summary');
+
+      await compactConversationManually(CONV_ID);
+
+      const [, marker] = mockAddMessage.mock.calls[0] as [string, Message];
+      expect(marker.compactBoundary?.source).toBe('manual');
+    });
+
+    it('marker summaryText matches trimmed LLM output', async () => {
+      mockConversations[CONV_ID] = { messages: buildRounds(6) };
+      vi.mocked(contextCompressor.summarizeConversation).mockResolvedValueOnce('  The actual summary.  ');
+
+      await compactConversationManually(CONV_ID);
+
+      const [, marker] = mockAddMessage.mock.calls[0] as [string, Message];
+      expect(marker.compactBoundary?.summaryText).toBe('The actual summary.');
+    });
+
+    it('calls clearContextCache with the correct convId', async () => {
+      mockConversations[CONV_ID] = { messages: buildRounds(6) };
+      vi.mocked(contextCompressor.summarizeConversation).mockResolvedValueOnce('summary');
+
+      await compactConversationManually(CONV_ID);
+
+      expect(mockClearContextCache).toHaveBeenCalledOnce();
+      expect(mockClearContextCache).toHaveBeenCalledWith(CONV_ID);
+    });
+
+    it('clearContextCache is called AFTER addMessage', async () => {
+      const callOrder: string[] = [];
+      mockAddMessage.mockImplementation(function () { callOrder.push('addMessage'); });
+      mockClearContextCache.mockImplementation(function () { callOrder.push('clearContextCache'); });
+
+      mockConversations[CONV_ID] = { messages: buildRounds(6) };
+      vi.mocked(contextCompressor.summarizeConversation).mockResolvedValueOnce('summary');
+
+      await compactConversationManually(CONV_ID);
+
+      expect(callOrder).toEqual(['addMessage', 'clearContextCache']);
+    });
+
+    it('toggles the in-progress indicator: setIsCompressing(true) before, (false) after', async () => {
+      const order: string[] = [];
+      mockSetIsCompressing.mockImplementation((_id: string, v: boolean) => order.push(`compressing:${v}`));
+      vi.mocked(contextCompressor.summarizeConversation).mockImplementation(async () => {
+        order.push('summarize');
+        return 'summary';
+      });
+      mockConversations[CONV_ID] = { messages: buildRounds(6) };
+
+      await compactConversationManually(CONV_ID);
+
+      expect(order).toEqual(['compressing:true', 'summarize', 'compressing:false']);
+    });
+
+    it('resets the in-progress indicator even when summarize throws', async () => {
+      mockConversations[CONV_ID] = { messages: buildRounds(6) };
+      vi.mocked(contextCompressor.summarizeConversation).mockRejectedValueOnce(new Error('boom'));
+
+      const result = await compactConversationManually(CONV_ID);
+
+      expect(result.reason).toBe('summarize-failed');
+      expect(mockSetIsCompressing).toHaveBeenLastCalledWith(CONV_ID, false);
+    });
+  });
+});

--- a/src/core/context/compactionService.test.ts
+++ b/src/core/context/compactionService.test.ts
@@ -79,7 +79,8 @@ function makeMsg(role: 'user' | 'assistant'): Message {
   };
 }
 
-/** Build N user+assistant round pairs (2N messages). Need > 5 rounds for a non-null plan. */
+/** Build N user+assistant round pairs (2N messages). Manual /compact keeps 1 recent
+ *  round (WorkBuddy-aligned), so a non-null plan needs > 2 rounds (>=3); auto needs > 5. */
 function buildRounds(count: number): Message[] {
   const messages: Message[] = [];
   for (let i = 0; i < count; i++) {
@@ -129,6 +130,17 @@ describe('compactConversationManually', () => {
       mockConversations[CONV_ID] = { messages: [] };
       const result = await compactConversationManually(CONV_ID);
       expect(result).toEqual({ compacted: false, reason: 'too-few' });
+    });
+
+    it('compacts a 5-round conversation (manual keeps only 2 recent — the reported /compact case)', async () => {
+      // Regression: /compact on a 5-round conversation used to report "too short"
+      // because it inherited the auto path's keep=4 gate (needed >=6 rounds).
+      // Manual now keeps 2, so 5 rounds compacts.
+      mockConversations[CONV_ID] = { messages: buildRounds(5) };
+      mockSummarize.mockResolvedValueOnce('summary');
+      const result = await compactConversationManually(CONV_ID);
+      expect(result).toEqual({ compacted: true, reason: 'ok' });
+      expect(mockSummarize).toHaveBeenCalled();
     });
   });
 

--- a/src/core/context/compactionService.ts
+++ b/src/core/context/compactionService.ts
@@ -1,0 +1,120 @@
+import { computeCompactionPlan, createCompactBoundaryMarker } from './compactBoundary';
+import { summarizeConversation } from './contextCompressor';
+import type { CompressionConfig } from './contextCompressor';
+import type { Message } from '@/types';
+import { useChatStore } from '@/stores/chatStore';
+import {
+  useSettingsStore,
+  getEffectiveModel,
+  getActiveProvider,
+  getActiveApiKey,
+} from '@/stores/settingsStore';
+import { resolveEffectiveLlmCreds } from '@/core/enterprise/llm-resolver';
+import { ClaudeAdapter } from '@/core/llm/claude';
+import { OpenAICompatibleAdapter } from '@/core/llm/openai-compatible';
+import type { LLMAdapter } from '@/core/llm/adapter';
+
+export type CompactionReason = 'ok' | 'too-few' | 'summarize-failed' | 'no-conversation';
+
+export interface CompactionResult {
+  compacted: boolean;
+  reason: CompactionReason;
+}
+
+/** A compaction plan (from computeCompactionPlan) — the range to summarize. */
+interface CompactionPlan {
+  middleMessages: Message[];
+  summarizedFromId: string;
+  summarizedToId: string;
+}
+
+/**
+ * Land a compact-boundary marker into a conversation (append-only).
+ *
+ * Shared by the auto path (agentLoop) and the manual /compact path so the
+ * marker-landing sequence lives in one place. addMessage pushes to store +
+ * disk without mutating any existing message; the stale ephemeral 65% cache
+ * (indexed by pre-marker positions) is invalidated.
+ */
+export function landCompactBoundaryMarker(
+  convId: string,
+  plan: CompactionPlan,
+  summaryText: string,
+  source: 'auto' | 'manual',
+): Message {
+  const marker = createCompactBoundaryMarker({
+    summaryText: summaryText.trim(),
+    summarizedFromId: plan.summarizedFromId,
+    summarizedToId: plan.summarizedToId,
+    source,
+    timestamp: Date.now(),
+  });
+  useChatStore.getState().addMessage(convId, marker);
+  useChatStore.getState().clearContextCache(convId);
+  return marker;
+}
+
+/**
+ * Resolve the LLM config for a summarization call from the current settings.
+ *
+ * Enterprise gateway mode forces the OpenAI-compatible adapter (LiteLLM exposes
+ * that interface) — matching llmCall.ts. Missing the `forceOpenAiCompatible`
+ * term would pick the Claude adapter under an enforced gateway and fail the call.
+ */
+function resolveSummarizeConfig(): CompressionConfig {
+  const settings = useSettingsStore.getState();
+  const provider = getActiveProvider(settings);
+  const creds = resolveEffectiveLlmCreds(getActiveApiKey(settings), provider?.baseUrl || undefined);
+  const adapter: LLMAdapter =
+    creds.forceOpenAiCompatible || provider?.apiFormat === 'openai-compatible'
+      ? new OpenAICompatibleAdapter()
+      : new ClaudeAdapter();
+  return {
+    adapter,
+    model: getEffectiveModel(settings),
+    apiKey: creds.apiKey,
+    baseUrl: creds.baseUrl,
+  };
+}
+
+/**
+ * Manual /compact: compact the conversation on explicit user request.
+ *
+ * Unlike the auto path, this is unguarded by the substantiveness/delta threshold
+ * (computeCompactionPlan is called without an estimator) — the user asked, so we
+ * compact whenever there are enough rounds.
+ */
+export async function compactConversationManually(
+  convId: string,
+): Promise<CompactionResult> {
+  const conv = useChatStore.getState().conversations[convId];
+  if (!conv) return { compacted: false, reason: 'no-conversation' };
+
+  const messages = conv.messages ?? [];
+  const plan = computeCompactionPlan(messages);
+  if (!plan) return { compacted: false, reason: 'too-few' };
+
+  // Show the in-progress indicator (same purple spinner the auto 65% path uses)
+  // while the summarization LLM call runs — otherwise manual /compact is silent
+  // for several seconds until the divider appears. Reset in finally on all paths.
+  //
+  // summarizeConversation() never throws by contract — timeout/adapter errors
+  // are swallowed internally and surface as an empty string (see
+  // contextCompressor.ts). The try/catch here is defensive-only, in case a
+  // caller-side error (e.g. resolveSummarizeConfig throwing on a misconfigured
+  // adapter) escapes before the await resolves.
+  let summaryText: string;
+  useChatStore.getState().setIsCompressing(convId, true);
+  try {
+    summaryText = await summarizeConversation(plan.middleMessages, resolveSummarizeConfig());
+  } catch {
+    return { compacted: false, reason: 'summarize-failed' };
+  } finally {
+    useChatStore.getState().setIsCompressing(convId, false);
+  }
+
+  if (!summaryText.trim()) return { compacted: false, reason: 'summarize-failed' };
+
+  landCompactBoundaryMarker(convId, plan, summaryText, 'manual');
+  return { compacted: true, reason: 'ok' };
+}

--- a/src/core/context/compactionService.ts
+++ b/src/core/context/compactionService.ts
@@ -16,6 +16,17 @@ import type { LLMAdapter } from '@/core/llm/adapter';
 
 export type CompactionReason = 'ok' | 'too-few' | 'summarize-failed' | 'no-conversation';
 
+// Manual /compact is aggressive, matching WorkBuddy / Claude Code: a user who
+// explicitly asks to compact wants it to act, so we summarize (nearly) the whole
+// conversation and keep only the single most recent round verbatim for the model
+// to continue from — no conservative "keep the last 4 rounds" reserve (that's an
+// auto-compaction concern) and no "too short" refusal beyond the genuine floor.
+// (WorkBuddy's compactAndSummarize summarizes conversation-so-far with the only
+// guard being "already compressing"; keeping 1 recent round is the closest
+// faithful mapping onto Abu's first-round + summary + recent marker model.)
+// Threshold drops to >=3 rounds (first round + last round + >=1 to summarize).
+const MANUAL_RECENT_ROUNDS_TO_KEEP = 1;
+
 export interface CompactionResult {
   compacted: boolean;
   reason: CompactionReason;
@@ -91,7 +102,9 @@ export async function compactConversationManually(
   if (!conv) return { compacted: false, reason: 'no-conversation' };
 
   const messages = conv.messages ?? [];
-  const plan = computeCompactionPlan(messages);
+  const plan = computeCompactionPlan(messages, {
+    recentRoundsToKeep: MANUAL_RECENT_ROUNDS_TO_KEEP,
+  });
   if (!plan) return { compacted: false, reason: 'too-few' };
 
   // Show the in-progress indicator (same purple spinner the auto 65% path uses)

--- a/src/core/context/contextCompressor.ts
+++ b/src/core/context/contextCompressor.ts
@@ -74,6 +74,89 @@ function messagesToText(messages: Message[]): string {
 }
 
 /**
+ * Summarize a set of (already-selected) messages into a single summary string
+ * via the LLM. Shared by the send-only compression path and the persistent
+ * compact-boundary path (agentLoop Step 2.1 / manual /compact). Best-effort:
+ * returns `{ text: '' }` on empty / timeout / error and never throws, so it can
+ * never block or crash the agent loop. Applies the same independent timeout as
+ * the send-only path.
+ */
+export async function summarizeConversation(
+  middleMessages: Message[],
+  config: CompressionConfig,
+): Promise<string> {
+  const middleText = messagesToText(middleMessages);
+
+  const summaryPrompt = `请将以下对话内容压缩为一段简洁的摘要，保留关键信息：
+- 用户的核心需求和意图
+- 重要的文件路径、变量名、代码片段
+- 关键决策和结论
+- 已完成的操作和结果
+- 未解决的问题
+
+注意：如果对话中 AI 曾声称"不支持"、"无法执行"或"没有某工具"，不要将此作为事实保留在摘要中。这类能力声明可能已过时，后续可能已安装了相关工具。
+
+对话内容：
+${middleText}
+
+请直接输出摘要，不要添加额外的标题或格式说明。摘要应当简洁明了，供 AI 助手理解上下文使用。`;
+
+  const summaryMessages: Message[] = [{
+    id: 'compress-prompt',
+    role: 'user',
+    content: summaryPrompt,
+    timestamp: Date.now(),
+  }];
+
+  let summaryText = '';
+  const timeoutMs = config.timeoutMs ?? DEFAULT_COMPRESSION_TIMEOUT_MS;
+  const timeoutController = new AbortController();
+  const combinedSignal = config.signal
+    ? anySignal([config.signal, timeoutController.signal])
+    : timeoutController.signal;
+  const chatOptions: ChatOptions = {
+    model: config.model,
+    apiKey: config.apiKey,
+    baseUrl: config.baseUrl,
+    maxTokens: SUMMARY_MAX_TOKENS,
+    signal: combinedSignal,
+  };
+
+  let timedOut = false;
+  let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const chatPromise = config.adapter.chat(summaryMessages, chatOptions, (event) => {
+      if (event.type === 'text') {
+        summaryText += event.text;
+      }
+    });
+    chatPromise.catch(() => { /* swallowed — handled via the race below */ });
+    await Promise.race([
+      chatPromise,
+      new Promise<never>((_, reject) => {
+        timeoutTimer = setTimeout(() => {
+          timedOut = true;
+          timeoutController.abort();
+          reject(new Error('summarization timeout'));
+        }, timeoutMs);
+      }),
+    ]);
+  } catch (err) {
+    if (timedOut) {
+      logger.warn('Conversation summarization timed out', { timeoutMs });
+      return '';
+    }
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    logger.warn('Conversation summarization failed', { error: errorMessage });
+    return '';
+  } finally {
+    if (timeoutTimer) clearTimeout(timeoutTimer);
+  }
+
+  return summaryText.trim();
+}
+
+/**
  * Check if context needs compression and compress if needed.
  *
  * Returns compressed messages if compression was performed, or original messages if not needed.

--- a/src/core/session/conversationStorage.test.ts
+++ b/src/core/session/conversationStorage.test.ts
@@ -49,11 +49,18 @@ function createMemoryFs() {
   // Route that command to the same in-memory fs so the tests see writes.
   (invoke as ReturnType<typeof vi.fn>).mockImplementation(async (
     cmd: string,
-    args?: { path?: string; content?: string },
+    args?: { path?: string; content?: string; data?: string },
   ) => {
     if (cmd === 'atomic_write_text' && args?.path !== undefined) {
       writeToMemory(args.path, args.content ?? '');
       return;
+    }
+    if (cmd === 'append_file_text') {
+      // Part B1: default to "native append unavailable" so every existing
+      // test (written against the read+atomic-write fallback) keeps
+      // exercising that path unchanged. Tests that specifically cover the
+      // native-append success path override this mock locally.
+      throw new Error('native append unavailable in test');
     }
     return undefined;
   });
@@ -133,6 +140,61 @@ describe('conversationStorage', () => {
     it('returns empty array for non-existent conversation', async () => {
       const loaded = await storage.loadMessages('nonexistent');
       expect(loaded).toHaveLength(0);
+    });
+  });
+
+  describe('appendToFile · native append (Part B1)', () => {
+    it('uses the native append_file_text command and skips the atomic-write fallback when it succeeds', async () => {
+      const calls: Array<{ cmd: string; args?: Record<string, unknown> }> = [];
+      (invoke as ReturnType<typeof vi.fn>).mockImplementation(async (
+        cmd: string,
+        args?: Record<string, unknown>,
+      ) => {
+        calls.push({ cmd, args });
+        if (cmd === 'append_file_text') {
+          // Simulate a successful native append — no read/rewrite of the file.
+          return undefined;
+        }
+        if (cmd === 'atomic_write_text') {
+          throw new Error('should not fall back to atomic_write_text when native append succeeds');
+        }
+        return undefined;
+      });
+
+      const msg = makeMsg({ id: 'native-1', content: 'native hello' });
+      await storage.appendMessage('conv-native', msg);
+      await storage.flushWrites();
+
+      const appendCalls = calls.filter((c) => c.cmd === 'append_file_text');
+      expect(appendCalls).toHaveLength(1);
+      expect(appendCalls[0].args?.path).toEqual(expect.stringContaining('conv-native'));
+      expect(appendCalls[0].args?.data).toEqual(expect.stringContaining('native hello'));
+
+      // Fallback path (atomicWrite → invoke('atomic_write_text')) must never fire.
+      expect(calls.some((c) => c.cmd === 'atomic_write_text')).toBe(false);
+    });
+
+    it('falls back to read + atomic-write when native append fails, and no data is lost', async () => {
+      // memFs's default mock (set up in createMemoryFs) already rejects
+      // append_file_text, so appendToFile should transparently fall back.
+      const seed = makeMsg({ id: 'seed', content: 'seed message' });
+      await storage.appendMessage('conv-fallback', seed);
+      await storage.flushWrites();
+
+      const appended = makeMsg({ id: 'fallback-1', content: 'fallback hello' });
+      await storage.appendMessage('conv-fallback', appended);
+      await storage.flushWrites();
+
+      // atomic_write_text must have been used (the fallback path).
+      const atomicWriteCalls = (invoke as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call) => call[0] === 'atomic_write_text',
+      );
+      expect(atomicWriteCalls.length).toBeGreaterThan(0);
+
+      const loaded = await storage.loadMessages('conv-fallback');
+      expect(loaded).toHaveLength(2);
+      expect(loaded[0].content).toBe('seed message');
+      expect(loaded[1].content).toBe('fallback hello');
     });
   });
 

--- a/src/core/session/conversationStorage.test.ts
+++ b/src/core/session/conversationStorage.test.ts
@@ -232,6 +232,25 @@ describe('conversationStorage', () => {
       expect(loaded).toEqual([]);
     });
 
+    it('dedups a duplicate line (non-idempotent native-append fallback)', async () => {
+      const line = JSON.stringify(makeMsg({ id: 'dup', content: 'once' }));
+      // Same line written twice — what a native append that durably wrote but
+      // whose invoke promise rejected leaves behind (fallback re-appends).
+      memFs.files.set(PATH, `${line}\n${line}\n`);
+      const loaded = await storage.loadMessages('corrupt-conv');
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0].id).toBe('dup');
+    });
+
+    it('keeps the last occurrence when a duplicate id has newer content', async () => {
+      const older = JSON.stringify(makeMsg({ id: 'x', content: 'old' }));
+      const newer = JSON.stringify(makeMsg({ id: 'x', content: 'new' }));
+      memFs.files.set(PATH, `${older}\n${newer}\n`);
+      const loaded = await storage.loadMessages('corrupt-conv');
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0].content).toBe('new');
+    });
+
     it('concurrent appendMessage + replaceMessageById do not race', async () => {
       // Seed: two messages on disk
       const seed1 = makeMsg({ id: 'seed-1', content: 'seed one' });

--- a/src/core/session/conversationStorage.ts
+++ b/src/core/session/conversationStorage.ts
@@ -214,7 +214,11 @@ async function appendToFile(filePath: string, data: string): Promise<void> {
       await invoke('append_file_text', { path: filePath, data });
       return;
     } catch {
-      // fall through to the existing read + atomic-write path
+      // Fall through to the read + atomic-write path. NOTE: this fallback is not
+      // idempotent — if the native append durably wrote `data` but its promise
+      // still rejected (IPC teardown / shutdown race), we re-append the same
+      // line here, producing a DUPLICATE (not a corrupt line). loadMessages
+      // dedups by id on read, so the duplicate never surfaces.
     }
     try {
       if (await exists(filePath)) {
@@ -511,8 +515,25 @@ export async function loadMessages(convId: string): Promise<Message[]> {
         `The affected messages are lost, but ${messages.length} intact message(s) recovered.`,
     );
   }
-  populateWrittenIds(messages);
-  return messages;
+  // Dedup by id, keeping the last occurrence. A duplicate line is not "corrupt"
+  // (so the skip-bad-lines net above can't catch it) but can arise from a
+  // non-idempotent append fallback: if the native O(1) append durably writes a
+  // line but its invoke promise still rejects (IPC teardown / shutdown race),
+  // appendToFile falls through to read+rewrite and appends the same line again.
+  // The last write reflects the most recent state; downstream consumers
+  // (chatStore, memdir extractor) don't dedup, so a duplicate would otherwise
+  // render — and be sent to the LLM — twice.
+  const deduped = dedupMessagesById(messages);
+  populateWrittenIds(deduped);
+  return deduped;
+}
+
+/** Keep the last occurrence of each message id, preserving order. */
+function dedupMessagesById(messages: Message[]): Message[] {
+  const lastIndex = new Map<string, number>();
+  messages.forEach((m, i) => lastIndex.set(m.id, i));
+  if (lastIndex.size === messages.length) return messages; // no dupes, fast path
+  return messages.filter((m, i) => lastIndex.get(m.id) === i);
 }
 
 /**

--- a/src/core/session/conversationStorage.ts
+++ b/src/core/session/conversationStorage.ts
@@ -22,6 +22,7 @@
  */
 
 import { exists, readTextFile, mkdir, remove, readDir } from '@tauri-apps/plugin-fs';
+import { invoke } from '@tauri-apps/api/core';
 import { appDataDir } from '@tauri-apps/api/path';
 import { joinPath } from '@/utils/pathUtils';
 import { atomicWrite } from '@/utils/atomicFs';
@@ -185,17 +186,36 @@ async function drainAll(): Promise<void> {
 
 /**
  * Append data to a file. Creates parent directory on first write.
- * Tauri's plugin-fs writeTextFile doesn't support native append, so we
- * read + append + atomic-write. For typical conversation files (<1MB) this is fine.
  *
- * Atomic writes (tempfile + fsync + rename) prevent partial writes on
- * crash / kill / power loss — readers either see the pre-append content
- * or the fully-appended content, never a truncated middle state.
+ * Part B1: tries the native `append_file_text` Rust command first — it opens
+ * the file in OS append mode and writes only `data`, no read of existing
+ * content, so cost is O(len(data)) instead of O(file size). If that command
+ * is unavailable (older bundled binary mid-upgrade, unexpected Rust-side
+ * failure) or throws for any other reason, we fall back to the previous
+ * read + atomic-write path below, which is O(file size) but was already
+ * battle-tested.
+ *
+ * Atomicity trade-off: the fallback's atomic writes (tempfile + fsync +
+ * rename) guarantee a reader never observes a half-written file. Native
+ * append does NOT have that guarantee — a crash mid-`write_all` can leave a
+ * half-written last line. This is an accepted trade-off (see
+ * `src-tauri/src/append_file.rs` doc comment): `loadMessages` below already
+ * tolerates and skips corrupt JSONL lines, so the worst case of a crash
+ * during native append is losing the one message that was mid-flight, never
+ * the messages already durably on disk before the call started.
  *
  * Serialized against concurrent mutations on the same path via `withFileLock`.
  */
 async function appendToFile(filePath: string, data: string): Promise<void> {
   return withFileLock(filePath, async () => {
+    try {
+      // Native O(1) append (Part B1). Falls back to read+atomic-rewrite below
+      // if the command is unavailable or fails.
+      await invoke('append_file_text', { path: filePath, data });
+      return;
+    } catch {
+      // fall through to the existing read + atomic-write path
+    }
     try {
       if (await exists(filePath)) {
         const current = await readTextFile(filePath);

--- a/src/core/session/imagePersistenceRoundtrip.integration.test.ts
+++ b/src/core/session/imagePersistenceRoundtrip.integration.test.ts
@@ -40,8 +40,12 @@ vi.mock('@tauri-apps/plugin-fs', () => ({
 }));
 
 // conversationStorage writes via atomicWrite → invoke('atomic_write_text').
+// appendToFile (Part B1) tries native invoke('append_file_text') first; reject
+// it here so this test keeps exercising the read+atomic-write fallback path
+// its assertions were written against.
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(async (cmd: string, args?: { path?: string; content?: string }) => {
+    if (cmd === 'append_file_text') throw new Error('native append unavailable in test');
     if (cmd === 'atomic_write_text' && args?.path) files.set(args.path, args.content ?? '');
     return undefined;
   }),

--- a/src/core/session/shareBundle.test.ts
+++ b/src/core/session/shareBundle.test.ts
@@ -25,6 +25,7 @@ vi.mock('@tauri-apps/plugin-fs', async () => {
 });
 
 import { buildShareBundle, SHARE_SCHEMA_VERSION } from './shareBundle';
+import { createCompactBoundaryMarker } from '@/core/context/compactBoundary';
 
 function makeConv(messages: Message[], overrides: Partial<Conversation> = {}): Conversation {
   return {
@@ -158,6 +159,25 @@ describe('buildShareBundle', () => {
     expect(bundle.messages).toHaveLength(2);
     expect(bundle.messages.map((m) => m.id)).toEqual(['real-1', 'real-2']);
     expect(JSON.stringify(bundle)).not.toContain('上次对话在第');
+  });
+
+  it('drops compact-boundary markers and never leaks their un-redacted summaryText', async () => {
+    const marker = createCompactBoundaryMarker({
+      summaryText: 'SENTINEL_SUMMARY_do_not_leak_this_verbatim',
+      summarizedFromId: 'real-1',
+      summarizedToId: 'real-1',
+      source: 'manual',
+      timestamp: 3,
+    });
+    const conv = makeConv([
+      { id: 'real-1', role: 'user', content: 'real question', timestamp: 1 },
+      marker,
+      { id: 'real-2', role: 'assistant', content: 'real answer', timestamp: 4 },
+    ]);
+    const bundle = await buildShareBundle(conv);
+    expect(bundle.messages).toHaveLength(2);
+    expect(bundle.messages.map((m) => m.id)).toEqual(['real-1', 'real-2']);
+    expect(JSON.stringify(bundle)).not.toContain('SENTINEL_SUMMARY_do_not_leak_this_verbatim');
   });
 
   it('does not mutate the source conversation object', async () => {

--- a/src/core/session/shareBundle.ts
+++ b/src/core/session/shareBundle.ts
@@ -23,6 +23,7 @@ import { uint8ArrayToBase64 } from '@/utils/base64';
 import { normalizeSeparators } from '@/utils/pathUtils';
 import { listSnapshots, readSnapshotBytes, type SnapshotEntry, type SnapshotSource } from './outputSnapshots';
 import { redactText, redactDeep, type RedactionSample } from './shareRedactor';
+import { isCompactBoundary } from '@/core/context/compactBoundary';
 
 export const SHARE_SCHEMA_VERSION = 1 as const;
 
@@ -93,7 +94,12 @@ export async function buildShareBundle(
   let redactionCount = 0;
 
   // Visible (non-system) messages only — matches ChatView's `!m.isSystem`.
-  const visible = conv.messages.filter((m) => !m.isSystem);
+  // Also drop compact-boundary markers: they render as an in-app divider (not
+  // a real message), carry empty content, and their compactBoundary.summaryText
+  // is a summary of the whole conversation that redactText would NOT scrub (it
+  // only scrubs `content`) — dropping them avoids leaking an un-redacted
+  // summary. The summarized messages themselves are still present and redacted.
+  const visible = conv.messages.filter((m) => !m.isSystem && !isCompactBoundary(m));
   const cleanedMessages: Message[] = [];
   let done = 0;
   for (const src of visible) {

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -393,6 +393,15 @@ const enUS: TranslationDict = {
     usageChipSubtitle: 'Cumulative API usage · Model-reported',
     errorEmptyBody: 'The request failed, but the service returned no error details.',
     errorNotFoundHint: 'The model or API endpoint was not found, or the endpoint does not support a parameter this request carried (e.g. thinking / tool calls). Check the service URL and this model’s capability settings under Settings → Models, or switch models.',
+    compactDivider: {
+      compacted: 'Context compacted',
+      compactedManual: 'Context compacted (manual)',
+    },
+    compactCommand: {
+      done: 'Context compacted',
+      tooFew: 'Conversation is short — no compaction needed',
+      failed: 'Compaction failed — please try again',
+    },
   },
 
   share: {

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -393,6 +393,15 @@ const zhCN: TranslationDict = {
     usageChipSubtitle: '累计调用 · 模型上报',
     errorEmptyBody: '请求失败，但服务未返回错误详情。',
     errorNotFoundHint: '未找到该模型或接口地址，或该接口不支持本次请求携带的参数（如思考 / 工具调用）。请到「设置 → 模型」检查服务地址与该模型的能力设置，或更换模型。',
+    compactDivider: {
+      compacted: '上下文已压缩',
+      compactedManual: '上下文已压缩（手动）',
+    },
+    compactCommand: {
+      done: '上下文已压缩',
+      tooFew: '对话较短，暂无需压缩',
+      failed: '压缩失败，请稍后重试',
+    },
   },
 
   share: {

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -404,6 +404,17 @@ export interface TranslationDict {
     errorEmptyBody: string;
     /** Hint appended to not_found errors: check endpoint URL / model capabilities. */
     errorNotFoundHint: string;
+    // Compact boundary divider
+    compactDivider: {
+      compacted: string;
+      compactedManual: string;
+    };
+    // /compact slash command toasts
+    compactCommand: {
+      done: string;
+      tooFew: string;
+      failed: string;
+    };
   };
 
   // Share (conversation export / import)

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1544,7 +1544,7 @@ export const useChatStore = create<ChatStore>()(
     })),
     {
       name: 'abu-chat',
-      version: 6,
+      version: 7,
       migrate: (persisted, version) => {
         const state = persisted as Record<string, unknown>;
         // v1 → v2: added executionSteps on Message (optional field, no-op migration)
@@ -1556,6 +1556,11 @@ export const useChatStore = create<ChatStore>()(
         // v5 → v6: added per-conversation `model` on ConversationMeta (optional field;
         // undefined = inherit global activeModel, pinned on first run, no-op migration)
         if (version < 6) { /* no transform needed */ }
+        // v6 → v7: added compact-boundary markers (long-conversation Part A).
+        // Markers are plain append-only Messages with an optional `compactBoundary`
+        // payload — persisted state (conversationIndex) is unchanged, so this is a
+        // no-op bump that just guards against older builds mis-reading the schema.
+        if (version < 7) { /* no transform needed */ }
         // v3 → v4: migrate conversations from localStorage to file system
         if (version < 4) {
           // Mark for async migration in onRehydrateStorage

--- a/src/stores/storeVersions.test.ts
+++ b/src/stores/storeVersions.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 // When adding a new persist store, add it to this list — otherwise this test fails.
 const PERSISTED_STORES = [
   { key: 'abu-settings', minVersion: 40 },
-  { key: 'abu-chat', minVersion: 6 },
+  { key: 'abu-chat', minVersion: 7 },
   { key: 'abu-scratchpad-store', minVersion: 1 },
   { key: 'abu-permissions', minVersion: 1 },
   { key: 'abu-workspace', minVersion: 1 },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -243,6 +243,33 @@ export interface Message {
   plannedSteps?: import('./execution').PlannedStep[];
   // System-injected messages (e.g. max_tokens recovery) — hidden from chat UI
   isSystem?: boolean;
+  // Compaction boundary marker payload (long-conversation Part A). Present only
+  // on marker messages (id prefix `compact-boundary-`). The message is appended
+  // to the log and never rewrites earlier entries; the send-side rebuilds a
+  // compact context from the LAST marker.
+  compactBoundary?: CompactBoundary;
+}
+
+/**
+ * Compaction boundary marker payload (long-conversation Part A).
+ *
+ * Persisted append-only as a Message (id prefix `compact-boundary-`). Original
+ * messages are NEVER rewritten or truncated — the send-side rebuilds a compact
+ * context on the fly by honouring the last marker. Range is expressed with
+ * message-id anchors (not array indices) so a deleted message invalidates the
+ * marker cleanly instead of silently shifting the summarized window.
+ */
+export interface CompactBoundary {
+  /** LLM-generated summary of the messages between the two anchors (inclusive). */
+  summaryText: string;
+  /** id of the first summarized message. */
+  summarizedFromId: string;
+  /** id of the last summarized message. */
+  summarizedToId: string;
+  /** Marker creation time (ms). */
+  createdAt: number;
+  /** Whether this boundary was created automatically or via manual /compact. */
+  source: 'auto' | 'manual';
 }
 
 // Simplified tool call info for LLM context building


### PR DESCRIPTION
## 概要
长会话稳健性大修的 **Part A(正确性)+ Part B1(性能)**。已 rebase 在最新 dev 之上,fast-forward。

### Part A — 压缩持久化(卖正确性)
- 压缩从"发送侧临时、重启即丢、每轮重算"升级为**往对话 log 追加一条持久 compact-boundary marker**;原始消息 append-only,**从不 rewrite/truncate**,数据丢失类从架构上不可能
- 发送侧读最后一条 marker 重建紧凑上下文,**marker 绝不发 LLM**(三层防御,含 adapter 层 system-role 兜底)
- 被动行内分隔线(对标 WorkBuddy / Codex)+ `/compact` 手动命令(逆向 WorkBuddy `compactAndSummarize`:手动激进、保留最近 1 轮、不因"太短"拒绝)
- 导出/分享丢弃 marker(summaryText 未脱敏,隐私)
- store v6→v7 no-op 迁移

### Part B1 — 原生 O(1) 落盘(卖性能)
- `appendToFile` 从"读全文 + 原子重写"(O(文件大小))改为 Rust 原生 append command(O(1)),失败 fallback 到旧路径
- load 侧按 id 去重(幂等,防 fallback 重复行)
- 原子性 trade-off 已注释(崩溃留半行,loadMessages 跳坏行兜底)

### 不在本 PR(拆独立)
- **B3 渲染分页**:与内联可视化(iframe)本质冲突(头部插入移动 iframe → 浏览器重载 → 闪烁),独立 PR 用 column-reverse 重做。备份分支 `backup-longconv-v2-with-b3`
- B2 懒分页:数据丢失风险,defer

## 验证
- `tsc` / `eslint` 干净 · **243 文件 / 3381 测试全绿**
- 三轮对抗式 code-review(Part A / B1+B3)处置干净
- 真机 tauri:dev smoke 通过:`/compact` 分隔线 · 重启不丢不重压 · B1 落盘持久 · 隐私导出 · 编辑删除

🤖 Generated with [Claude Code](https://claude.com/claude-code)
