### PR TITLE
fix(ci): enforce single dev integration line

### DIFF
--- a/.github/workflows/branch-policy.yml
+++ b/.github/workflows/branch-policy.yml
@@ -1,0 +1,40 @@
+name: Branch Policy
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  promotion-ready:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Verify main has no commits outside dev
+        run: |
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor origin/main HEAD; then
+            echo '::error::dev does not contain the complete main history. Reconcile main into dev before continuing.'
+            git log --oneline --left-right --boundary HEAD...origin/main -30
+            exit 1
+          fi
+
+  main-pr-source:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Allow only dev promotion pull requests
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [ "$HEAD_REF" != 'dev' ]; then
+            echo "::error::main accepts release promotion only from dev; got $HEAD_REF"
+            exit 1
+          fi

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,8 +16,13 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    # Guard hard on the actor: never touch human-authored PRs.
-    if: github.actor == 'dependabot[bot]'
+    # Guard hard on both actor and integration target. Dependabot security PRs
+    # may target the repository default branch (`main`) even though
+    # dependabot.yml points version updates at `dev`; those must never bypass
+    # the single integration line.
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.base.ref == 'dev'
     steps:
       - name: Fetch Dependabot metadata
         id: meta

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,25 @@
 # Abu Client: Codex Working Guide
 
-This worktree is the Electron-first integration line for the public Abu client.
-Treat the checked-out code and Git state as the source of truth. Historical
-reports and old agent instructions are useful evidence, not current status.
+This repository is the public Abu client. Treat the checked-out code and Git
+state as the source of truth. Historical reports and old agent instructions
+are useful evidence, not current status.
 
 ## Scope and Git Safety
 
-- `refactor-dev` is the active `dev` mainline for the Electron refactor. Start
-  each refactor task from it, use a focused feature branch when appropriate,
-  and merge verified refactor work back into `refactor-dev`. The older
-  `feat/electron-shell-p2-1` worktree has already been merged and is historical.
+- `dev` is the only active integration line. Start every feature/fix branch
+  from the latest `origin/dev` and merge verified work back into `dev`.
+- `main` is a stable release pointer, not a second development line. It may
+  only fast-forward to the exact commit already verified on `dev`.
+- `refactor-dev` and the older Electron feature worktrees are historical. Do
+  not start new work from them. Some historical worktrees still contain
+  user-owned reports, generated files, or uncommitted material; preserve them
+  until the user explicitly approves an archival or deletion policy.
 - Check `git status --short` and the current branch before making changes. This
   worktree currently contains user-owned uncommitted material; preserve it.
 - Do not commit or push unless the user explicitly asks. Do not force-push,
   reset, discard, delete, or move files without explicit approval.
-- Do not work directly on `main`. Release promotion remains a deliberate merge
-  decision, not an agent action.
+- Do not work directly on `main`. Release promotion remains a deliberate,
+  user-authorized fast-forward from `dev`, not an ordinary development action.
 
 ## Model Allocation
 
@@ -148,8 +152,8 @@ Do not publish update feeds or release artifacts without explicit user approval.
   Electron host. `npm run parity:check` is the static guard, not a substitute
   for real workflow tests.
 - Treat updater end-to-end behavior, Windows validation, packaged preview
-  inspection, and macOS computer-use/TCC permission behavior as release-readiness
-  work that still needs real-machine verification.
+  inspection, and macOS computer-use/TCC permission behavior as post-release
+  evidence that still needs real-machine verification.
 - The untracked `*-REPORT.md` files and `RUNTIME-LANDING-RUNBOOK.md` in this
   worktree are historical development records. Leave them in place unless the
   user explicitly chooses an archival policy. Do not blindly add them to the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,13 +22,14 @@ Inspired by Claude Code's Cowork mode. Features multi-agent architecture with ex
 ### Branches
 - **`main`**: Stable release branch. **禁止直接在 main 上开发或 push commit**，只接受从 `dev` 的 **merge**（不是 cherry-pick，见下方红线）。
 - **`dev`**: 日常开发分支，所有工作在这里进行；**永远是唯一集成线**，其他开发者从 `dev` 拉、开 feature 分支、PR 回 `dev`。
+- **`refactor-dev`**: Electron 重构期间的历史集成指针，已完成使命并退役。不得再从它创建新分支；保留相关 worktree 只是为了保护历史报告和未提交材料。
 
-- 🔴 **发版只用 `git merge dev`，绝不 cherry-pick dev→main**。cherry-pick 会把同一改动复制成"内容一样、SHA 不同"的孪生 commit，两条分支历史发散 → 下次 merge 满屏假冲突 → 逼你继续 cherry-pick → **雪球债**（2026-07 已滚到 dev/main 分叉 223/124，靠一次收敛合并才解开）。main 内容始终是 dev 的子集，走 merge 永远干净。
+- 🔴 **发版只用 `git merge --ff-only dev`，绝不 cherry-pick dev→main**。cherry-pick 会把同一改动复制成"内容一样、SHA 不同"的孪生 commit，两条分支历史发散 → 下次 merge 满屏假冲突 → 逼你继续 cherry-pick → **雪球债**（2026-07 已滚到 dev/main 分叉 223/124，靠一次收敛合并才解开）。main 始终是 dev 的历史子集，保留同一 SHA 才能避免再次分叉。
 - 🔴 **`main` 没有"特殊内容"**：企业登录（`EnterpriseLoginPage`/bootstrap/discovery/auth）是 **OSS 合法**的（`ENTERPRISE-BUILD.md` 把 device-flow bind 列为 ✅ OSS；泄漏门禁 deny-list 也不含它），且深度运行时门控（只有用户主动绑企业服务器才出现），随 dev 进 main 无碍。真正的闭源模块早已构建隔离在私有仓（见「Enterprise 代码隔离」红线）。**不要**因为"怕泄企业代码"就把 main 拆成精选线搞 cherry-pick——那是历史误解。
 
 ### Before Starting Work (每次开始工作前必做)
-1. `git branch --show-current` — 确认当前分支。如果在 `main`，先 `git checkout dev`。
-2. `git pull origin dev` — 拉取最新代码，避免冲突。
+1. `git branch --show-current` — 确认当前分支；禁止在 `main`、`refactor-dev` 或历史 Electron worktree 上开始新开发。
+2. `git fetch origin dev` — 刷新唯一集成线；新 feature/fix 分支必须从最新 `origin/dev` 创建。
 
 ### Commit Rules
 - **Conventional commits**: `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`。
@@ -52,12 +53,13 @@ Inspired by Claude Code's Cowork mode. Features multi-agent architecture with ex
      - CI publish job 把两份各抽该版段写进 `latest.json.notes_i18n`；**客户端 `checker.ts` 按 UI locale（`getLocale()`）选对应语言**推给更新弹窗，官网按页面语言取。
      - ⚠️ 两份同版号、结构对应，但**语言不混**：CHANGELOG.md 全英文、CHANGELOG.zh-CN.md 全中文。v0.31.0 之前的历史仅英文版有，不用回填。
    - ✅ **发版前跑 `npm run release:check`**（`scripts/release-preflight.mjs`）：校验四处版本号一致 + 两份 CHANGELOG 该版段都在且语言正确（英文版无 CJK、中文版有中文）。CI 也把它挂成 `release.yml` 的 `preflight` job（tag 一推先跑，**任一项不对就整个发版红、包都不出**）；本地先跑省一次 CI 往返。
-3. `git checkout main && git merge dev` — **只 merge，绝不 cherry-pick**。正常情况是干净快进/合并；若有冲突且分支已对齐，多半是真冲突，逐个解。
-4. `git tag vX.Y.Z` — 打 tag，格式为 `v` + 语义化版本号。
-5. `git push origin main` 然后**单独推这一个 tag**：`git push origin vX.Y.Z`。⚠️ **别用 `git push origin main --tags`** —— 一次推 >3 个 tag 会触发 GitHub「不为这些 tag 生成 push 事件」的限制，`Release` workflow 就不触发了（本会话踩过：害得删 tag 重推）。单独推这一个 tag 就没这问题。
+3. 在 `dev` 的候选提交上打一个最终 RC tag；等三平台原生构建、签名/公证、安装态冒烟和发布预检全部通过。
+4. `git checkout main && git pull --ff-only origin main && git merge --ff-only dev` — `main` 只 fast-forward 到这个已经在 `dev` 验证过的**同一 SHA**，不使用 GitHub squash/rebase/cherry-pick 生成孪生提交。
+5. `git push origin main`，然后 `git tag vX.Y.Z && git push origin vX.Y.Z`。主分支保护要求该 SHA 先在 `dev` 上获得 `promotion-ready`，任意 feature/main 直推都会被拒绝。⚠️ **别用 `git push origin main --tags`**。
 6. `Release` workflow 自动构建三平台，准备一个 draft GitHub Release，上传并回读校验 OSS 产物，发布三套 Electron 更新源，并在 v0.34 中最后切换旧 Tauri 更新入口；全部成功后才公开同一个 Release。不要手工创建重复 Release。
+7. 发布后验证 `git rev-list --left-right --count origin/dev...origin/main` 的 main-only 计数为 `0`；正式发布时两者应为 `0 0`。
 
-**热修（hotfix）也不许 cherry-pick**：要么在 `dev` 上修完走正常发版；要么从对应 tag 拉 `release/vX.Y` 分支修完打 tag，**再把该分支 merge 回 `dev`**（不留孤儿 commit）。目标永远是"任何进过 main 的东西，历史上都能从 dev 追溯到"。
+**热修（hotfix）也不许 cherry-pick**：可以从对应 tag 拉 `release/vX.Y` 分支定位和修复，但修复必须先通过 PR 进入 `dev`，再按上面的同-SHA fast-forward 流程发布。目标永远是“任何进过 main 的提交，已经先存在于 dev”。
 
 ### Release Notes Convention (核心要点)
 - **分档**：patch（vX.Y.Z++）用极简模板（根因 + 修复 2-3 行）；minor（vX.Y.0）用完整模板（Features / Fixes / English Summary）；major（vX.0.0）额外加 Migration Notes。
@@ -72,6 +74,7 @@ Inspired by Claude Code's Cowork mode. Features multi-agent architecture with ex
 ### Forbidden
 - ❌ 直接在 `main` 上 commit 或 push。
 - ❌ **cherry-pick `dev`→`main`**（发版/热修一律走 merge；热修用 `release/vX.Y` 分支再合回 dev，见 Release Process）。
+- ❌ 从 `main` 或已退役的 `refactor-dev` 创建普通 feature/fix 分支。
 - ❌ `git push --force` 到 `main` 或 `dev`（除非用户明确要求）。
 - ❌ 提交未通过 build 的代码。
 - ❌ 跳过 pre-commit 检查（`--no-verify`）。

--- a/ELECTRON-NEAR-TERM-ROADMAP.md
+++ b/ELECTRON-NEAR-TERM-ROADMAP.md
@@ -2,13 +2,13 @@
 
 Date: 2026-07-28
 
-Status: the original runtime roadmap, capability-model follow-up, and
-consequential-action approval are merged into `refactor-dev`.
-Consequential-action approval passed its automated gates; broader attended
-acceptance and Windows real-machine package/runtime verification are still
-required before release. This is not release approval.
+Status: historical execution record. The Electron runtime, capability model,
+and consequential-action work were integrated and released in v0.34.0. Do not
+use the branch instructions in this document to start new development; `dev`
+is now the only active integration line. Remaining attended checks and
+post-release hardening stay useful as evidence requirements.
 
-Base branch: `refactor-dev`
+Historical base branch: `refactor-dev` (retired)
 
 ## Outcome
 
@@ -534,7 +534,6 @@ signed updates, or visual composition. Those remain explicit attended checks.
 - product Memory expansion
 - Linux distribution
 - a second bundled Chromium
-- public release and update-feed publication
 
 ## Model Routing Evidence
 

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -9,6 +9,8 @@ convention in [`RELEASING.md`](./RELEASING.md). This page is the actionable sour
 - All release work is merged into `dev`; the release worktree is clean.
 - `dev` is up to date and CI is green. Resolve feature/main conflicts before
   promotion; do not repair them directly on `main`.
+- `git rev-list --right-only --count origin/dev...origin/main` returns `0`:
+  `main` must never contain a commit that is absent from `dev`.
 - The release commit contains no `.env.local`, signing material, private module,
   customer data, or internal-only URL.
 
@@ -45,17 +47,22 @@ bash scripts/enterprise-leak-guard.sh
       [`ELECTRON-TRANSITION-RELEASE.md`](./ELECTRON-TRANSITION-RELEASE.md).
 - [ ] Cut one final RC from the exact release commit and confirm macOS arm64,
       macOS x64, and Windows x64 native CI before creating the stable tag.
+- [ ] Confirm the candidate SHA has successful `check` and `promotion-ready`
+      statuses. `promotion-ready` is emitted only after the exact SHA lands on
+      `dev` and still contains the current `main` history.
 
 ## 3. Release
 
 ```bash
 git push origin dev
 git checkout main && git pull --ff-only origin main
-git merge dev                          # merge ONLY — never cherry-pick
+git merge --ff-only dev                # exact dev SHA ONLY — never cherry-pick
+git push origin main                   # protection requires promotion-ready
 git tag vX.Y.Z
-git push origin main
 git push origin vX.Y.Z                 # push the ONE tag — do NOT use --tags
 git checkout dev
+git fetch origin dev main
+git rev-list --left-right --count origin/dev...origin/main  # expect 0 0
 ```
 
 ## 4. CI does the rest (automatic, ~40 min)
@@ -83,6 +90,8 @@ switch the Tauri `latest.json` last.
 ## Red lines (don't)
 
 - ❌ **Never cherry-pick `dev` → `main`** — merge only. (Twin commits → divergence → fake-conflict snowball.)
+- ❌ **Never build a release branch by selecting commits from feature branches.** Every release commit must already be on `dev`.
+- ❌ **Never use a GitHub squash/rebase merge to promote `dev` → `main`.** Promotion preserves the exact verified SHA with `--ff-only`.
 - ❌ **Never `git push origin main --tags`** — pushing >3 tags at once makes GitHub skip the tag push events, so the `Release` workflow never fires. Push the single tag.
 - ❌ **Never mix languages** in a changelog file — `CHANGELOG.md` is English, `CHANGELOG.zh-CN.md` is Chinese. (`release:check` will fail the release if you do.)
 - ❌ **Never commit on `main`** or `git push --force` to `main`/`dev`.


### PR DESCRIPTION
## Summary
- retire refactor-dev and declare dev the only integration line
- require exact-SHA dev-to-main promotion through a promotion-ready check
- prevent Dependabot auto-merge from targeting main
- align release and agent documentation with fast-forward promotion

## Validation
- npm run release:check
- npm run test:electron:release-workflow
- npm run lint
- npm run typecheck
- bash scripts/enterprise-leak-guard.sh
- YAML parse + git diff --check