### PR TITLE
chore(deps): patch undici advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14242,9 +14242,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17395,9 +17395,9 @@
       "license": "ISC"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## What changed

- update the Electron download path from `undici@7.28.0` to `7.29.0`
- update the nested node-gyp path from `undici@6.27.0` to `6.28.0`
- keep the change lockfile-only; no application code or direct dependency declarations changed

## Why

GitHub Dependabot alert #159 reports GHSA-4cwx-7wf7-3272 against the locked `undici@7.28.0`. The patched versions also clear the other open undici advisories in both transitive dependency chains.

## Impact

No intended user-facing behavior change. This reduces development/build supply-chain exposure used by Electron tooling.

## Validation

- `npm ci`
- `npm run lint`
- `npm run typecheck`
- `npm test` (4,799 tests)
- `npm run build`
- `npm run parity:check`
- `bash scripts/enterprise-leak-guard.sh`
- `npm run electron:bootstrap-test`
- `npm run electron:host-ui-test`
- `npm run electron:security-test`
- `npm ls undici --all`

Full platform packaging remains covered by the PR's Windows Electron Build check. Unrelated npm-audit findings are intentionally outside this narrowly scoped Dependabot fix.
