### PR TITLE
chore: add test:integration + wire AGENTS.md §11 to TESTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -417,6 +417,8 @@ are a different concern from semantic status — keep those raw with a scoped
 - **Metadata pattern**: Separate metadata interface + full interface extending it (`SkillMetadata` → `Skill extends SkillMetadata`).
 
 ### 11. Testing
+- 🔴 **本仓测试的"宪法"是 [`TESTING.md`](./TESTING.md)** —— 分层（unit/integration/contract/e2e）、确定性铁律、门禁脚本、quarantine、覆盖率阈值、契约测试全在那，写/改测试前先读它。本节只是速览摘要。
+- **门禁**：`npm run verify` 退出码为 0 才算完（= `verify:full`：lint + typecheck + 全量 + 覆盖率）；秒级自检 `npm run verify:quick`；集成 `npm run test:integration`；E2E `npm run test:e2e`（外层门禁，独立于 verify）。跨端质量底线（DoD）见 `../AGENTS.md`。
 - **Vitest** with `happy-dom` environment. Config in `vitest.config.ts`.
 - **Test files co-located** next to source: `chatStore.ts` → `chatStore.test.ts`.
 - **Global mocks** in `src/test/setup.ts`: All Tauri APIs and external SDKs are mocked globally.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:changed": "vitest run --changed HEAD~1",
+    "test:integration": "vitest run --reporter=verbose integration",
     "test:quarantine": "vitest run --config vitest.quarantine.config.ts --passWithNoTests",
     "test:e2e": "playwright test",
     "test:e2e:electron": "playwright test -c playwright.electron.config.ts",


### PR DESCRIPTION
审计测试体系时发现的两个小 adherence 缺口：

- 加 `test:integration`（对齐 console 的同名脚本）——让 cheat-sheet 里"两仓命令同名"的承诺变真；现有 7 个 `*.integration.test.ts` 现在有专门的 runner（它们本来也在 verify 全量里跑）。
- AGENTS.md §11 现在**指向 `TESTING.md`**（测试"宪法"）并写明 `verify` exit 0 门禁——让在本仓工作的 agent 被路由到完整规范，而不是只靠内联摘要。

配套：console 侧同款 wiring 见 abu-console PR；跨端「质量底线(DoD)」已进 workspace 仓 root AGENTS.md。

🤖 Generated with [Claude Code](https://claude.com/claude-code)