### PR TITLE
fix(website): source homepage version + notes from the latest GitHub Release

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -556,7 +556,7 @@
                 if (versionEl) versionEl.textContent = 'Download information is temporarily unavailable. Refresh this page.';
             }
 
-            // ── Localized release notes (What's new), rendered from latest.json ──
+            // ── Localized release notes (What's new) ──
             function escapeHtml(s) {
                 return s.replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
             }
@@ -582,31 +582,68 @@
                 if (inList) html += '</ul>';
                 return html;
             }
+            const pageLocale = ((document.documentElement.lang || 'en').toLowerCase().indexOf('zh') === 0) ? 'zh' : 'en';
+
+            // Paint the "What's new" panel from a version label + Markdown body.
+            function paintNotes(version, notes) {
+                notes = (notes || '').trim();
+                const sec = document.getElementById('whatsnew');
+                const body = document.getElementById('wnBody');
+                const ver = document.getElementById('wnVersion');
+                // Skip the "See {github-url}" fallback stub — nothing useful to render.
+                if (!sec || !body || !notes || /^see\s+https?:\/\//i.test(notes)) return;
+                body.innerHTML = renderMarkdown(notes);
+                if (ver && version) ver.textContent = version;
+                sec.hidden = false;
+            }
+
+            // Notes from the OSS latest.json shape (fallback path only).
             function renderNotes(data) {
                 try {
-                    const raw = (document.documentElement.lang || 'en').toLowerCase();
-                    const key = raw.indexOf('zh') === 0 ? 'zh-CN' : 'en-US';
                     const i18n = data.notes_i18n || {};
-                    const notes = (i18n[key] || i18n['en-US'] || data.notes || '').trim();
-                    const sec = document.getElementById('whatsnew');
-                    const body = document.getElementById('wnBody');
-                    const ver = document.getElementById('wnVersion');
-                    // Skip the "See {github-url}" fallback stub — nothing useful to render.
-                    if (!sec || !body || !notes || /^see\s+https?:\/\//i.test(notes)) return;
-                    body.innerHTML = renderMarkdown(notes);
-                    if (ver && data.version) ver.textContent = data.version;
-                    sec.hidden = false;
+                    const key = pageLocale === 'zh' ? 'zh-CN' : 'en-US';
+                    paintNotes(data.version, i18n[key] || i18n['en-US'] || data.notes || '');
                 } catch (e) { /* leave the section hidden on any error */ }
             }
 
-            // GitHub is metadata-only fallback; users still download the installer from OSS.
-            fetch(OSS_LATEST, { cache: 'no-cache' })
+            // Pull the "## <tag>" section out of a CHANGELOG (e.g. CHANGELOG.zh-CN.md).
+            function changelogSection(text, tag) {
+                const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                const head = new RegExp('^##\\s+' + escaped + '(?:\\s|·|$)');
+                const out = [];
+                let capturing = false;
+                for (const line of text.split('\n')) {
+                    if (/^##\s+/.test(line)) {
+                        if (capturing) break;          // reached the next version → stop
+                        if (head.test(line)) capturing = true;  // skip the header line itself
+                        continue;
+                    }
+                    if (capturing) out.push(line);
+                }
+                return out.join('\n').trim();
+            }
+
+            // English notes come from the GitHub Release body (canonical). For the
+            // Chinese page, prefer CHANGELOG.zh-CN.md at that tag, falling back to English.
+            function renderReleaseNotes(tag, englishBody) {
+                if (pageLocale !== 'zh') { paintNotes(tag, englishBody); return; }
+                const url = `https://raw.githubusercontent.com/PM-Shawn/Abu-Cowork/${encodeURIComponent(tag)}/CHANGELOG.zh-CN.md`;
+                fetch(url, { cache: 'no-cache' })
+                    .then(r => { if (!r.ok) throw new Error(); return r.text(); })
+                    .then(text => paintNotes(tag, changelogSection(text, tag) || englishBody))
+                    .catch(() => paintNotes(tag, englishBody));
+            }
+
+            // The latest published GitHub Release is the source of truth for the version
+            // and release notes; installers still download from the OSS mirror. If the
+            // GitHub API is unreachable, fall back to the (possibly older) OSS pointer.
+            fetch(GH_API, { cache: 'no-cache' })
                 .then(r => { if (!r.ok) throw new Error(); return r.json(); })
-                .then(d => { applyFromOSS(d.version); renderNotes(d); })
+                .then(d => { applyFromOSS(d.tag_name); renderReleaseNotes(d.tag_name, (d.body || '').trim()); })
                 .catch(() =>
-                    fetch(GH_API)
+                    fetch(OSS_LATEST, { cache: 'no-cache' })
                         .then(r => { if (!r.ok) throw new Error(); return r.json(); })
-                        .then(d => applyFromOSS(d.tag_name))
+                        .then(d => { applyFromOSS(d.version); renderNotes(d); })
                         .catch(markDownloadUnavailable)
                 );
 

--- a/website/index.zh-CN.html
+++ b/website/index.zh-CN.html
@@ -553,7 +553,7 @@
                 if (versionEl) versionEl.textContent = '暂时无法获取下载信息，请刷新页面';
             }
 
-            // ── Localized release notes (What's new), rendered from latest.json ──
+            // ── Localized release notes (What's new) ──
             function escapeHtml(s) {
                 return s.replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
             }
@@ -579,31 +579,68 @@
                 if (inList) html += '</ul>';
                 return html;
             }
+            const pageLocale = ((document.documentElement.lang || 'en').toLowerCase().indexOf('zh') === 0) ? 'zh' : 'en';
+
+            // Paint the "What's new" panel from a version label + Markdown body.
+            function paintNotes(version, notes) {
+                notes = (notes || '').trim();
+                const sec = document.getElementById('whatsnew');
+                const body = document.getElementById('wnBody');
+                const ver = document.getElementById('wnVersion');
+                // Skip the "See {github-url}" fallback stub — nothing useful to render.
+                if (!sec || !body || !notes || /^see\s+https?:\/\//i.test(notes)) return;
+                body.innerHTML = renderMarkdown(notes);
+                if (ver && version) ver.textContent = version;
+                sec.hidden = false;
+            }
+
+            // Notes from the OSS latest.json shape (fallback path only).
             function renderNotes(data) {
                 try {
-                    const raw = (document.documentElement.lang || 'en').toLowerCase();
-                    const key = raw.indexOf('zh') === 0 ? 'zh-CN' : 'en-US';
                     const i18n = data.notes_i18n || {};
-                    const notes = (i18n[key] || i18n['en-US'] || data.notes || '').trim();
-                    const sec = document.getElementById('whatsnew');
-                    const body = document.getElementById('wnBody');
-                    const ver = document.getElementById('wnVersion');
-                    // Skip the "See {github-url}" fallback stub — nothing useful to render.
-                    if (!sec || !body || !notes || /^see\s+https?:\/\//i.test(notes)) return;
-                    body.innerHTML = renderMarkdown(notes);
-                    if (ver && data.version) ver.textContent = data.version;
-                    sec.hidden = false;
+                    const key = pageLocale === 'zh' ? 'zh-CN' : 'en-US';
+                    paintNotes(data.version, i18n[key] || i18n['en-US'] || data.notes || '');
                 } catch (e) { /* leave the section hidden on any error */ }
             }
 
-            // GitHub is metadata-only fallback; users still download the installer from OSS.
-            fetch(OSS_LATEST, { cache: 'no-cache' })
+            // Pull the "## <tag>" section out of a CHANGELOG (e.g. CHANGELOG.zh-CN.md).
+            function changelogSection(text, tag) {
+                const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                const head = new RegExp('^##\\s+' + escaped + '(?:\\s|·|$)');
+                const out = [];
+                let capturing = false;
+                for (const line of text.split('\n')) {
+                    if (/^##\s+/.test(line)) {
+                        if (capturing) break;          // reached the next version → stop
+                        if (head.test(line)) capturing = true;  // skip the header line itself
+                        continue;
+                    }
+                    if (capturing) out.push(line);
+                }
+                return out.join('\n').trim();
+            }
+
+            // English notes come from the GitHub Release body (canonical). For the
+            // Chinese page, prefer CHANGELOG.zh-CN.md at that tag, falling back to English.
+            function renderReleaseNotes(tag, englishBody) {
+                if (pageLocale !== 'zh') { paintNotes(tag, englishBody); return; }
+                const url = `https://raw.githubusercontent.com/PM-Shawn/Abu-Cowork/${encodeURIComponent(tag)}/CHANGELOG.zh-CN.md`;
+                fetch(url, { cache: 'no-cache' })
+                    .then(r => { if (!r.ok) throw new Error(); return r.text(); })
+                    .then(text => paintNotes(tag, changelogSection(text, tag) || englishBody))
+                    .catch(() => paintNotes(tag, englishBody));
+            }
+
+            // The latest published GitHub Release is the source of truth for the version
+            // and release notes; installers still download from the OSS mirror. If the
+            // GitHub API is unreachable, fall back to the (possibly older) OSS pointer.
+            fetch(GH_API, { cache: 'no-cache' })
                 .then(r => { if (!r.ok) throw new Error(); return r.json(); })
-                .then(d => { applyFromOSS(d.version); renderNotes(d); })
+                .then(d => { applyFromOSS(d.tag_name); renderReleaseNotes(d.tag_name, (d.body || '').trim()); })
                 .catch(() =>
-                    fetch(GH_API)
+                    fetch(OSS_LATEST, { cache: 'no-cache' })
                         .then(r => { if (!r.ok) throw new Error(); return r.json(); })
-                        .then(d => applyFromOSS(d.tag_name))
+                        .then(d => { applyFromOSS(d.version); renderNotes(d); })
                         .catch(markDownloadUnavailable)
                 );
 


### PR DESCRIPTION
## 问题
官网首页「最新更新」的版本号 + 更新日志读的是 OSS 根 `latest.json`，但 `release.yml` 里那个指针**只在 `v0.34.x` 发版时才重写**（`LEGACY_TRANSITION = startsWith(tag,'v0.34.')`，是冻结的 Tauri 过渡面）。从 v0.35.0 起它再也不更新，所以首页卡在 0.34.2——尽管 GitHub 最新 release 和客户端 electron-updater feed 都已经到 0.35.0。

## 改动
把**最新已发布的 GitHub Release 作为版本号 + 更新日志的事实源**；安装包仍从 OSS 镜像下载。
- 英文页更新日志用 Release `body`（英文 canonical）。
- 中文页拉 `CHANGELOG.zh-CN.md@<tag>` 里对应版本段（`raw.githubusercontent.com`，CORS `*`），失败回退英文 body。
- GitHub API 不可达时回退到（可能较旧的）OSS `latest.json`，保证下载始终可用。

## 验证
Headless Playwright 打真实端点：
- en (`index.html`) → v0.35.0 + 英文 notes + OSS v0.35.0 安装链接
- zh (`index.zh-CN.html`，zh-CN locale) → v0.35.0 + **中文** notes（取自 CHANGELOG.zh-CN.md）+ OSS 链接
- 无 console error；`node --test scripts/website-docs.test.mjs` 13/13。

## 备注
这是 A 方案。根 `latest.json` 作为「仅 v0.34.x Tauri 过渡指针」保持冻结不动，本 PR 只把官网的版本来源迁走。

🤖 Generated with [Claude Code](https://claude.com/claude-code)