### PR TITLE
test(website): update download-links gate for GitHub-primary metadata

### DIFF
--- a/scripts/website-download-links.test.mjs
+++ b/scripts/website-download-links.test.mjs
@@ -25,9 +25,17 @@ for (const page of pages) {
         `${page} ${id} must stay on the official website until metadata resolves`,
       );
     }
+    // The latest GitHub Release is the source of truth for the version; its tag
+    // is converted into OSS installer URLs. The OSS latest.json pointer stays as
+    // a fallback and likewise resolves to OSS URLs. Either way installers come
+    // from OSS, never from GitHub.
     assert.ok(
-      source.includes('.then(d => applyFromOSS(d.tag_name))'),
-      `${page} must convert fallback release metadata into OSS download URLs`,
+      source.includes('applyFromOSS(d.tag_name)'),
+      `${page} must convert the GitHub release tag into OSS download URLs`,
+    );
+    assert.ok(
+      source.includes('applyFromOSS(d.version)'),
+      `${page} must keep the OSS latest.json fallback resolving to OSS URLs`,
     );
     assert.ok(source.includes('.catch(markDownloadUnavailable)'), `${page} must fail closed on the homepage`);
     assert.ok(!source.includes('browser_download_url'), `${page} still links installers through GitHub`);


### PR DESCRIPTION
跟进 #166。首页版本源改为「最新 GitHub Release」后，`scripts/website-download-links.test.mjs` 里那条把 GitHub 路径钉成 `.then(d => applyFromOSS(d.tag_name))` **fallback** 的断言不再匹配（现在 GitHub 是主源）。

这个 `scripts/*.test.mjs` 只在**官网部署门禁**（`npm run test:website`）里跑，不在 PR 的 `check`/`e2e` 里，所以 #166 过了但部署 gate 红了——本 PR 修复。

改断言为按新架构表达**意图**（保护面不变）：
- GitHub release tag → OSS 安装 URL：`applyFromOSS(d.tag_name)`
- OSS latest.json fallback 同样解析成 OSS URL：`applyFromOSS(d.version)`
- 其余 fail-closed / 无 GitHub 直链 / 无 legacy Tauri 名 断言全部保留。

本地 `npm run test:website` 15/15 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)