### PR TITLE
fix(diagnostic): live app version + trustworthy update verdict

### DIFF
--- a/src/components/settings/sections/DiagnosticSection.tsx
+++ b/src/components/settings/sections/DiagnosticSection.tsx
@@ -24,12 +24,19 @@ export default function DiagnosticSection() {
   const lastCheckedAt = useDiagnosticStore((s) => s.lastCheckedAt);
   const isChecking = useDiagnosticStore((s) => s.isChecking);
   const runAll = useDiagnosticStore((s) => s.runAll);
+  const refreshApp = useDiagnosticStore((s) => s.refreshApp);
   const setActiveSystemTab = useSettingsStore((s) => s.setActiveSystemTab);
 
-  // Auto-run on first visit if no cached results.
+  // First visit (no cached results): run the full suite. Otherwise the panel
+  // renders the persisted snapshot instantly, but that snapshot can be stale —
+  // notably the app version froze at whatever build ran the last full check, so
+  // an in-place update kept showing the old version + "已是最新". The app check
+  // is cheap and always-current, so refresh just that item on every open.
   useEffect(() => {
     if (lastCheckedAt === null && !isChecking) {
       runAll();
+    } else {
+      refreshApp();
     }
   // run-once on mount; deps intentionally empty
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/core/diagnostic/checks/app.test.ts
+++ b/src/core/diagnostic/checks/app.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { APP_VERSION } from '@/utils/version';
+import { getI18n } from '@/i18n';
+import type { UpdateInfo } from '@/core/updates/types';
+
+// Assert against the resolved dictionary so the test is locale-agnostic
+// (vitest boots with whatever the i18n default is).
+const t = getI18n().diagnostic;
+
+// The app check forces an update check; we drive its side effects (store
+// mutations) from the mock so each scenario is deterministic.
+const mockCheckForUpdate = vi.fn();
+vi.mock('@/core/updates/checker', () => ({
+  checkForUpdate: (...args: unknown[]) => mockCheckForUpdate(...args),
+}));
+
+import { runAppChecks } from './app';
+
+function fakeUpdateInfo(version: string): UpdateInfo {
+  return { version, releaseNotes: 'notes', releaseUrl: '', publishedAt: '' };
+}
+
+describe('runAppChecks', () => {
+  beforeEach(() => {
+    mockCheckForUpdate.mockReset();
+    useSettingsStore.setState({ lastUpdateCheck: 1_000, updateInfo: null });
+  });
+
+  it('always renders the live APP_VERSION, never a cached snapshot value', async () => {
+    // Feed reached, no update.
+    mockCheckForUpdate.mockImplementation(async () => {
+      useSettingsStore.setState({ lastUpdateCheck: 2_000, updateInfo: null });
+      return null;
+    });
+
+    const [row] = await runAppChecks();
+
+    expect(row.metric).toContain(`v${APP_VERSION}`);
+  });
+
+  it('shows "up to date" (passed) when the forced check reaches the feed and finds no update', async () => {
+    mockCheckForUpdate.mockImplementation(async () => {
+      useSettingsStore.setState({ lastUpdateCheck: 2_000, updateInfo: null });
+      return null;
+    });
+
+    const [row] = await runAppChecks();
+
+    expect(mockCheckForUpdate).toHaveBeenCalledWith(true, { silent: true }); // forced, no global update UI
+    expect(row.status).toBe('passed');
+    expect(row.metric).toContain(t.appLatest);
+    expect(row.suggestedAction).toBeUndefined();
+  });
+
+  it('shows "update available" (warning) with the offered version when the feed reports one', async () => {
+    mockCheckForUpdate.mockImplementation(async () => {
+      const info = fakeUpdateInfo('0.36.0');
+      useSettingsStore.setState({ lastUpdateCheck: 2_000, updateInfo: info });
+      return info;
+    });
+
+    const [row] = await runAppChecks();
+
+    expect(row.status).toBe('warning');
+    expect(row.metric).toContain('0.36.0');
+    expect(row.metric).toContain(`v${APP_VERSION}`);
+    expect(row.suggestedAction).toMatchObject({ type: 'open-settings', target: 'about' });
+  });
+
+  it('does NOT claim "up to date" when the feed was never reached (offline)', async () => {
+    // checkForUpdate resolves but leaves lastUpdateCheck untouched — its
+    // documented signal for "check() never resolved / feed unreachable".
+    mockCheckForUpdate.mockResolvedValue(null);
+
+    const [row] = await runAppChecks();
+
+    expect(row.status).toBe('warning');
+    expect(row.metric).toContain(t.appCheckFailed);
+    expect(row.metric).not.toContain(t.appLatest);
+    expect(row.metric).toContain(`v${APP_VERSION}`);
+  });
+
+  it('treats a thrown checkForUpdate as "could not check", not a crash', async () => {
+    mockCheckForUpdate.mockRejectedValue(new Error('network down'));
+
+    const [row] = await runAppChecks();
+
+    expect(row.status).toBe('warning');
+    expect(row.metric).toContain(t.appCheckFailed);
+  });
+
+  it('does not hang when the update check never resolves (bounded by timeout)', async () => {
+    vi.useFakeTimers();
+    try {
+      // A feed that never responds: runAppChecks must still settle via its
+      // internal timeout instead of blocking the whole diagnostic run forever.
+      mockCheckForUpdate.mockReturnValue(new Promise(() => {}));
+
+      const pending = runAppChecks();
+      await vi.advanceTimersByTimeAsync(8000);
+      const [row] = await pending;
+
+      expect(row.status).toBe('warning');
+      expect(row.metric).toContain(t.appCheckFailed); // timeout ⇒ feed not reached
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/core/diagnostic/checks/app.ts
+++ b/src/core/diagnostic/checks/app.ts
@@ -1,36 +1,103 @@
 /**
- * App check — version + update status. Read-only against settingsStore;
- * does not actively call the update endpoint (the update check has its
- * own 6h cadence, see core/updates/checker.ts).
+ * App check — version + update status.
+ *
+ * Two independent facts are shown on one row:
+ *  - The version NUMBER is always live: `APP_VERSION` is a compile-time
+ *    constant baked from package.json (vite `__APP_VERSION__`), so it always
+ *    reflects the running build. It is never read from the persisted
+ *    diagnostic snapshot.
+ *  - The up-to-date VERDICT is derived from an ACTIVE forced update check
+ *    against the release feed (electron-updater `latest-mac.yml`), not from a
+ *    passively-read cached flag. Diagnostic results are persisted
+ *    (diagnosticStore), so a verdict computed from `updateInfo` alone would
+ *    freeze at whatever it was the last time the panel ran — that is exactly
+ *    the stale-snapshot bug where an updated app kept showing its old version
+ *    and "已是最新". Forcing a real check here makes "已是最新" mean the feed
+ *    was actually consulted just now, not merely "no update known this session".
  */
 
 import { APP_VERSION } from '@/utils/version';
 import { useSettingsStore } from '@/stores/settingsStore';
+import { checkForUpdate } from '@/core/updates/checker';
 import { getI18n } from '@/i18n';
 import type { CheckResult } from '../types';
 
-export function runAppChecks(): CheckResult[] {
-  const t = getI18n();
-  const updateInfo = useSettingsStore.getState().updateInfo;
+/**
+ * Upper bound on the forced update check. `runAll` only flips out of its
+ * "checking" state once every category settles, so an unbounded network check
+ * here could keep the whole diagnostic panel spinning behind a slow/unreachable
+ * feed. Losing the race just means the timestamp below stays unchanged →
+ * "无法检查更新", which is the honest outcome. Matches aiServices' 8s deadline.
+ */
+const UPDATE_CHECK_TIMEOUT_MS = 8000;
 
-  // No updateInfo means either the check hasn't fired yet OR no newer version
-  // is available. checker.ts sets updateInfo only when newer version exists.
-  const upToDate = !updateInfo;
+/** Resolve when `p` settles or after `ms`, whichever comes first; always clears
+ *  its own timer so a fast winner can't leak a pending timeout into tests. */
+function boundedWait(p: Promise<unknown>, ms: number): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((resolve) => { timer = setTimeout(resolve, ms); });
+  return Promise.race([p.then(() => {}, () => {}), timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+export async function runAppChecks(): Promise<CheckResult[]> {
+  const t = getI18n();
+  const startedAt = Date.now();
+
+  const before = useSettingsStore.getState().lastUpdateCheck;
+  // force=true bypasses the 6h throttle so the verdict reflects a real, current
+  // comparison. silent=true keeps this off the GLOBAL update UI — merely opening
+  // diagnostics must NOT spin the About "check for updates" button or fire an
+  // update notification; only the diagnostic row reads the result. Bounded so a
+  // hanging feed can't stall the whole run.
+  await boundedWait(checkForUpdate(true, { silent: true }), UPDATE_CHECK_TIMEOUT_MS);
+
+  const state = useSettingsStore.getState();
+  // checkForUpdate advances lastUpdateCheck ONLY after check() resolves (see the
+  // invariant comment in checker.ts). An unchanged timestamp therefore means the
+  // check did not complete — offline, updater errored, or we hit the timeout
+  // above — so we must NOT claim the app is up to date; say "couldn't check".
+  // Known limitation: in source/fork builds the updater is disabled and check()
+  // resolves null WITHOUT contacting any feed, which still advances the
+  // timestamp → "已是最新" is shown there without a real comparison. Acceptable:
+  // those builds don't self-update, and official builds (the ones users update)
+  // do reach the feed.
+  const checkReachedFeed = state.lastUpdateCheck !== before;
+  const updateInfo = state.updateInfo;
+
+  const base = {
+    id: 'app:version',
+    category: 'app' as const,
+    name: t.diagnostic.appVersion,
+    checkedAt: Date.now(),
+    durationMs: Date.now() - startedAt,
+  };
+
+  if (!checkReachedFeed) {
+    return [{
+      ...base,
+      status: 'warning',
+      metric: `v${APP_VERSION} · ${t.diagnostic.appCheckFailed}`,
+    }];
+  }
+
+  if (updateInfo) {
+    return [{
+      ...base,
+      status: 'warning',
+      metric: `v${APP_VERSION} · ${t.diagnostic.appUpdateAvailable.replace('{version}', updateInfo.version)}`,
+      suggestedAction: {
+        type: 'open-settings',
+        target: 'about',
+        label: t.diagnostic.actionOpenAbout,
+      },
+    }];
+  }
 
   return [{
-    id: 'app:version',
-    category: 'app',
-    name: t.diagnostic.appVersion,
-    status: upToDate ? 'passed' : 'warning',
-    metric: upToDate
-      ? `v${APP_VERSION} · ${t.diagnostic.appLatest}`
-      : t.diagnostic.appUpdateAvailable.replace('{version}', updateInfo.version),
-    suggestedAction: upToDate ? undefined : {
-      type: 'open-settings',
-      target: 'about',
-      label: t.diagnostic.actionOpenAbout,
-    },
-    checkedAt: Date.now(),
-    durationMs: 0,
+    ...base,
+    status: 'passed',
+    metric: `v${APP_VERSION} · ${t.diagnostic.appLatest}`,
   }];
 }

--- a/src/core/updates/checker.test.ts
+++ b/src/core/updates/checker.test.ts
@@ -20,6 +20,7 @@ vi.mock('@tauri-apps/plugin-updater', () => ({
 vi.mock('@/core/notice/bus', () => ({ publish: vi.fn() }));
 
 import { checkForUpdate, downloadAndInstallUpdate } from './checker';
+import { publish } from '@/core/notice/bus';
 
 const EN_BODY = 'English release notes for v0.32.0 — multi-tab workspace and more.';
 const ZH_NOTES = '中文更新说明：多页签工作区、卡片化改版等，内容足够长以通过丰富度判断。';
@@ -98,6 +99,96 @@ describe('checkForUpdate — locale-aware release notes', () => {
     const info = await checkForUpdate(true);
 
     expect(info?.releaseNotes).toBe(EN_BODY);
+  });
+
+  it('ignores latest.json zh-CN notes when its version is behind the offered update', async () => {
+    // Regression: latest.json (Tauri manifest) froze at an older release while
+    // the electron-updater feed advanced. Without the version guard a zh-CN
+    // user offered v0.32.0 would read the STALE manifest's notes for a
+    // different version. Guard → fall back to the English body (right version).
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ version: 'v0.30.0', notes_i18n: { 'zh-CN': ZH_NOTES } }),
+      }),
+    );
+
+    const info = await checkForUpdate(true);
+
+    expect(info?.releaseNotes).toBe(EN_BODY);
+  });
+
+  it('still uses zh-CN notes when latest.json omits a version (backward compat)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ notes_i18n: { 'zh-CN': ZH_NOTES } }), // no version field
+      }),
+    );
+
+    const info = await checkForUpdate(true);
+
+    expect(info?.releaseNotes).toBe(ZH_NOTES);
+  });
+
+  it('accepts zh-CN notes when latest.json version matches without the v prefix', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ version: '0.32.0', notes_i18n: { 'zh-CN': ZH_NOTES } }), // no leading v
+      }),
+    );
+
+    const info = await checkForUpdate(true);
+
+    expect(info?.releaseNotes).toBe(ZH_NOTES);
+  });
+});
+
+describe('checkForUpdate — silent option (background/observer callers)', () => {
+  beforeEach(() => {
+    mockCheck.mockReset();
+    mockCheck.mockResolvedValue(fakeUpdate());
+    (publish as unknown as ReturnType<typeof vi.fn>).mockClear();
+    useSettingsStore.setState({
+      lastUpdateCheck: 0,
+      updateInfo: null,
+      updateChecking: false,
+    });
+    mockLocale = 'en-US'; // skip the latest.json fetch; not under test here
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('silent: never fires the update_available notification', async () => {
+    await checkForUpdate(true, { silent: true });
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it('silent: never flips the global updateChecking spinner flag', async () => {
+    const spy = vi.spyOn(useSettingsStore.getState(), 'setUpdateChecking');
+    await checkForUpdate(true, { silent: true });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('silent: still records updateInfo so observer callers can read the result', async () => {
+    const info = await checkForUpdate(true, { silent: true });
+    expect(info?.version).toBe('0.32.0');
+    expect(useSettingsStore.getState().updateInfo?.version).toBe('0.32.0');
+  });
+
+  it('non-silent (default): fires the notification and toggles updateChecking', async () => {
+    const spy = vi.spyOn(useSettingsStore.getState(), 'setUpdateChecking');
+    await checkForUpdate(true);
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(true);
+    expect(spy).toHaveBeenCalledWith(false);
   });
 });
 

--- a/src/core/updates/checker.test.ts
+++ b/src/core/updates/checker.test.ts
@@ -9,7 +9,9 @@ vi.mock('@/i18n', async (importActual) => {
   return { ...actual, getLocale: () => mockLocale };
 });
 
-// Tauri updater: check() returns our fake Update (body = English notes).
+// electron-updater: check() returns our fake Update. The Electron feed carries
+// NO release notes, so `update.body` is typically empty in production; tests
+// give it a value so the "fall back to the updater body" path is observable.
 const mockCheck = vi.fn();
 const mockDownloadAndInstall = vi.fn();
 vi.mock('@tauri-apps/plugin-updater', () => ({
@@ -22,7 +24,10 @@ vi.mock('@/core/notice/bus', () => ({ publish: vi.fn() }));
 import { checkForUpdate, downloadAndInstallUpdate } from './checker';
 import { publish } from '@/core/notice/bus';
 
-const EN_BODY = 'English release notes for v0.32.0 — multi-tab workspace and more.';
+// The updater's own body — last-resort fallback (empty in real Electron builds).
+const EN_BODY = 'Updater body fallback for v0.32.0 — shown only if the feed is unusable.';
+// The release-metadata feed's per-locale notes (electron/latest-release.json).
+const EN_META = 'English release notes for v0.32.0 from the metadata feed — long enough to render.';
 const ZH_NOTES = '中文更新说明：多页签工作区、卡片化改版等，内容足够长以通过丰富度判断。';
 
 function fakeUpdate() {
@@ -34,13 +39,12 @@ function fakeUpdate() {
   };
 }
 
-function mockLatestJson(notesI18n: Record<string, string> | undefined) {
+// Stub the release-metadata feed (electron/latest-release.json) as raw JSON, so
+// each test controls schema_version / version / notes_i18n exactly.
+function mockFeed(data: Record<string, unknown>) {
   vi.stubGlobal(
     'fetch',
-    vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ version: 'v0.32.0', notes: EN_BODY, notes_i18n: notesI18n }),
-    }),
+    vi.fn().mockResolvedValue({ ok: true, json: async () => data }),
   );
 }
 
@@ -65,8 +69,8 @@ describe('checkForUpdate — locale-aware release notes', () => {
     vi.unstubAllGlobals();
   });
 
-  it('zh-CN user gets the Chinese notes from latest.json notes_i18n', async () => {
-    mockLatestJson({ 'zh-CN': ZH_NOTES, 'en-US': EN_BODY });
+  it('zh-CN user gets the Chinese notes from the release-metadata feed', async () => {
+    mockFeed({ schema_version: 1, version: 'v0.32.0', notes_i18n: { 'zh-CN': ZH_NOTES, 'en-US': EN_META } });
 
     const info = await checkForUpdate(true);
 
@@ -75,17 +79,19 @@ describe('checkForUpdate — locale-aware release notes', () => {
     expect(useSettingsStore.getState().updateInfo?.releaseNotes).toBe(ZH_NOTES);
   });
 
-  it('en-US user keeps the English updater body and does NOT refetch latest.json', async () => {
+  it('en-US user gets the English notes from the feed, not the empty updater body', async () => {
     mockLocale = 'en-US';
-    vi.stubGlobal('fetch', vi.fn());
+    mockFeed({ schema_version: 1, version: 'v0.32.0', notes_i18n: { 'zh-CN': ZH_NOTES, 'en-US': EN_META } });
 
     const info = await checkForUpdate(true);
 
-    expect(globalThis.fetch).not.toHaveBeenCalled();
-    expect(info?.releaseNotes).toBe(EN_BODY);
+    // The Electron feed carries no notes, so English MUST come from the metadata
+    // feed now — a bare updater body would be empty for real builds.
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(info?.releaseNotes).toBe(EN_META);
   });
 
-  it('falls back to the English body when latest.json fetch fails', async () => {
+  it('falls back to the updater body when the metadata fetch fails', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
 
     const info = await checkForUpdate(true);
@@ -93,54 +99,51 @@ describe('checkForUpdate — locale-aware release notes', () => {
     expect(info?.releaseNotes).toBe(EN_BODY);
   });
 
-  it('falls back to the English body when notes_i18n lacks the locale', async () => {
-    mockLatestJson({ 'en-US': EN_BODY }); // no zh-CN key
+  it('falls back to the feed English notes when the user locale is missing', async () => {
+    mockFeed({ schema_version: 1, version: 'v0.32.0', notes_i18n: { 'en-US': EN_META } }); // no zh-CN, zh-CN user
+
+    const info = await checkForUpdate(true);
+
+    expect(info?.releaseNotes).toBe(EN_META);
+  });
+
+  it('falls back to the updater body when the feed has no usable notes', async () => {
+    mockFeed({ schema_version: 1, version: 'v0.32.0', notes_i18n: {} });
 
     const info = await checkForUpdate(true);
 
     expect(info?.releaseNotes).toBe(EN_BODY);
   });
 
-  it('ignores latest.json zh-CN notes when its version is behind the offered update', async () => {
-    // Regression: latest.json (Tauri manifest) froze at an older release while
-    // the electron-updater feed advanced. Without the version guard a zh-CN
-    // user offered v0.32.0 would read the STALE manifest's notes for a
-    // different version. Guard → fall back to the English body (right version).
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ version: 'v0.30.0', notes_i18n: { 'zh-CN': ZH_NOTES } }),
-      }),
-    );
+  it('ignores feed notes when its version is behind the offered update', async () => {
+    // Guard: the metadata feed is a SEPARATE file from the electron-updater feed
+    // that produced the offered version. If it lags (e.g. a superseded release),
+    // a zh-CN user offered vNEW must not read vOLD's notes → fall back.
+    mockFeed({ schema_version: 1, version: 'v0.30.0', notes_i18n: { 'zh-CN': ZH_NOTES } });
 
     const info = await checkForUpdate(true);
 
     expect(info?.releaseNotes).toBe(EN_BODY);
   });
 
-  it('still uses zh-CN notes when latest.json omits a version (backward compat)', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ notes_i18n: { 'zh-CN': ZH_NOTES } }), // no version field
-      }),
-    );
+  it('ignores feed notes on an unexpected schema_version', async () => {
+    mockFeed({ schema_version: 2, version: 'v0.32.0', notes_i18n: { 'zh-CN': ZH_NOTES } });
+
+    const info = await checkForUpdate(true);
+
+    expect(info?.releaseNotes).toBe(EN_BODY);
+  });
+
+  it('still uses feed notes when it omits a version (backward compat)', async () => {
+    mockFeed({ schema_version: 1, notes_i18n: { 'zh-CN': ZH_NOTES } }); // no version field
 
     const info = await checkForUpdate(true);
 
     expect(info?.releaseNotes).toBe(ZH_NOTES);
   });
 
-  it('accepts zh-CN notes when latest.json version matches without the v prefix', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ version: '0.32.0', notes_i18n: { 'zh-CN': ZH_NOTES } }), // no leading v
-      }),
-    );
+  it('accepts feed notes when the version matches without the v prefix', async () => {
+    mockFeed({ schema_version: 1, version: '0.32.0', notes_i18n: { 'zh-CN': ZH_NOTES } }); // no leading v
 
     const info = await checkForUpdate(true);
 
@@ -158,7 +161,9 @@ describe('checkForUpdate — silent option (background/observer callers)', () =>
       updateInfo: null,
       updateChecking: false,
     });
-    mockLocale = 'en-US'; // skip the latest.json fetch; not under test here
+    mockLocale = 'en-US';
+    // en-US now reads the metadata feed too, so the fetch must be stubbed.
+    mockFeed({ schema_version: 1, version: 'v0.32.0', notes_i18n: { 'en-US': EN_META, 'zh-CN': ZH_NOTES } });
   });
 
   afterEach(() => {
@@ -229,6 +234,9 @@ describe('downloadAndInstallUpdate — progress lifecycle', () => {
       updateDownloadProgress: null,
       updateInstalling: false,
     });
+    // primePendingUpdate() runs a real checkForUpdate() which now fetches the
+    // metadata feed; stub it so these progress tests stay offline/deterministic.
+    mockFeed({ schema_version: 1, version: 'v0.32.0', notes_i18n: { 'en-US': EN_META } });
   });
 
   afterEach(() => {

--- a/src/core/updates/checker.ts
+++ b/src/core/updates/checker.ts
@@ -9,10 +9,13 @@ export type { UpdateDownloadProgress, UpdateInfo } from './types';
 
 const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
 
-// Same manifest the Tauri updater polls (tauri.conf.json → updater.endpoints).
-// We refetch it directly to read the per-locale `notes_i18n` field, which the
-// updater plugin doesn't expose (it only surfaces the top-level `notes`).
-const LATEST_JSON_URL = 'https://abu-agent.oss-cn-beijing.aliyuncs.com/latest.json';
+// Release metadata feed published to OSS by the release pipeline
+// (scripts/website-release-metadata.mjs → electron/latest-release.json). It
+// carries the per-locale `notes_i18n` field the electron-updater feed
+// (latest-mac.yml) does not. The same feed also backs the website homepage.
+// NOTE: this is NOT the frozen Tauri-era `latest.json` (that manifest stopped
+// updating after v0.34.x); this one tracks every release.
+const RELEASE_METADATA_URL = 'https://abu-agent.oss-cn-beijing.aliyuncs.com/electron/latest-release.json';
 
 let _pendingUpdate: Update | null = null;
 
@@ -32,36 +35,38 @@ function setDownloadProgress(progress: UpdateDownloadProgress): void {
 }
 
 /**
- * Pick release notes in the user's UI language. `latest.json` carries
- * `notes_i18n: { "zh-CN": ..., "en-US": ... }`; the top-level `notes` (what the
- * updater hands back as `update.body`) stays English for the updater default and
- * international users. English users already have the right text, so skip the
- * extra fetch. Any failure (offline, old manifest without `notes_i18n`, missing
- * locale) falls back to the English body — never worse than before.
+ * Pick release notes in the user's UI language. The release metadata feed
+ * (`electron/latest-release.json`) carries `notes_i18n: { "zh-CN": ..., "en-US":
+ * ... }`. The electron-updater feed (`latest-mac.yml`) carries no release notes,
+ * so `update.body` is typically empty — we read BOTH languages from this feed
+ * (not just Chinese), otherwise English users would see an empty changelog.
  *
- * 🔴 Version guard: `latest.json` is a DIFFERENT manifest from the
- * electron-updater feed (`electron/<arch>/latest-mac.yml`) that produced
- * `expectedVersion`. The two can drift — e.g. the Tauri-era `latest.json`
- * publishing lagged behind and froze at an older release while the Electron
- * feed advanced. When they disagree, `latest.json`'s notes describe a
- * *different* version, so showing them would put the wrong changelog in the
- * update prompt (a zh-CN user offered vNEW would read vOLD's notes). Only trust
- * the localized notes when the manifest is for the same version as the offered
- * update; otherwise fall back to the English body from the updater itself,
- * which is always for the right version. A manifest without a `version` field
- * keeps the old behavior (no guard) for backward compatibility.
+ * 🔴 Version guard: this metadata feed is a SEPARATE file from the
+ * electron-updater feed that produced `expectedVersion`. The same release
+ * publishes both, but they could momentarily disagree (a partially completed or
+ * superseded release, or CDN caching). When they disagree, the metadata's notes
+ * describe a *different* version, so we fall back to the updater's own body
+ * rather than show the wrong changelog (a zh-CN user offered vNEW must not read
+ * vOLD's notes). An unexpected `schema_version`, a missing locale, or any
+ * failure (offline, empty notes) also falls back — never worse than before.
  */
 async function localizedNotes(fallback: string, expectedVersion: string): Promise<string> {
   const locale = getLocale();
-  if (locale === 'en-US') return fallback;
   try {
-    const res = await fetch(LATEST_JSON_URL, { cache: 'no-cache' });
+    const res = await fetch(RELEASE_METADATA_URL, { cache: 'no-cache' });
     if (!res.ok) return fallback;
-    const data = (await res.json()) as { version?: string; notes_i18n?: Record<string, string> };
-    const manifestVersion = data.version?.replace(/^v/, '').trim();
-    if (manifestVersion && manifestVersion !== expectedVersion) return fallback;
-    const localized = data.notes_i18n?.[locale]?.trim();
-    return localized && localized.length > 0 ? localized : fallback;
+    const data = (await res.json()) as {
+      schema_version?: number;
+      version?: string;
+      notes_i18n?: Record<string, string>;
+    };
+    if (data.schema_version !== 1) return fallback;
+    const metaVersion = data.version?.replace(/^v/, '').trim();
+    if (metaVersion && metaVersion !== expectedVersion) return fallback;
+    // Prefer the user's locale; fall back to the feed's English notes (always
+    // present) before the empty updater body, mirroring the website homepage.
+    const localized = (data.notes_i18n?.[locale] ?? data.notes_i18n?.['en-US'] ?? '').trim();
+    return localized.length > 0 ? localized : fallback;
   } catch {
     return fallback;
   }

--- a/src/core/updates/checker.ts
+++ b/src/core/updates/checker.ts
@@ -38,14 +38,28 @@ function setDownloadProgress(progress: UpdateDownloadProgress): void {
  * international users. English users already have the right text, so skip the
  * extra fetch. Any failure (offline, old manifest without `notes_i18n`, missing
  * locale) falls back to the English body — never worse than before.
+ *
+ * 🔴 Version guard: `latest.json` is a DIFFERENT manifest from the
+ * electron-updater feed (`electron/<arch>/latest-mac.yml`) that produced
+ * `expectedVersion`. The two can drift — e.g. the Tauri-era `latest.json`
+ * publishing lagged behind and froze at an older release while the Electron
+ * feed advanced. When they disagree, `latest.json`'s notes describe a
+ * *different* version, so showing them would put the wrong changelog in the
+ * update prompt (a zh-CN user offered vNEW would read vOLD's notes). Only trust
+ * the localized notes when the manifest is for the same version as the offered
+ * update; otherwise fall back to the English body from the updater itself,
+ * which is always for the right version. A manifest without a `version` field
+ * keeps the old behavior (no guard) for backward compatibility.
  */
-async function localizedNotes(fallback: string): Promise<string> {
+async function localizedNotes(fallback: string, expectedVersion: string): Promise<string> {
   const locale = getLocale();
   if (locale === 'en-US') return fallback;
   try {
     const res = await fetch(LATEST_JSON_URL, { cache: 'no-cache' });
     if (!res.ok) return fallback;
-    const data = (await res.json()) as { notes_i18n?: Record<string, string> };
+    const data = (await res.json()) as { version?: string; notes_i18n?: Record<string, string> };
+    const manifestVersion = data.version?.replace(/^v/, '').trim();
+    if (manifestVersion && manifestVersion !== expectedVersion) return fallback;
     const localized = data.notes_i18n?.[locale]?.trim();
     return localized && localized.length > 0 ? localized : fallback;
   } catch {
@@ -82,18 +96,36 @@ async function enrichReleaseNotes(rawNotes: string): Promise<{ notes: string; ur
   return { notes: rawNotes, url: releaseUrl };
 }
 
-export async function checkForUpdate(force = false): Promise<UpdateInfo | null> {
+/**
+ * @param opts.silent Perform the check WITHOUT touching the global update UI:
+ *   skip the `updateChecking` spinner flag (bound by AboutSection/AccountMenu)
+ *   and skip the `update_available` notification. `updateInfo` and
+ *   `lastUpdateCheck` are still written so callers reading store state (e.g. the
+ *   diagnostic app-check) see the result. Use when a background/observer caller
+ *   wants the data but must not surface update UI to the user.
+ */
+export async function checkForUpdate(
+  force = false,
+  opts: { silent?: boolean } = {},
+): Promise<UpdateInfo | null> {
   const store = useSettingsStore.getState();
+  const { silent = false } = opts;
 
   if (!force) {
     const elapsed = Date.now() - store.lastUpdateCheck;
     if (elapsed < CHECK_INTERVAL_MS) return null;
   }
 
-  store.setUpdateChecking(true);
+  if (!silent) store.setUpdateChecking(true);
 
   try {
     const update = await check();
+    // Invariant relied on by the diagnostic app-check (core/diagnostic/checks/
+    // app.ts): `lastUpdateCheck` is advanced ONLY after check() actually
+    // resolves — i.e. the server (or the idle dev updater) was reached. A
+    // thrown check() skips straight to the catch below WITHOUT advancing it,
+    // which is how the diagnostic distinguishes "confirmed up to date" from
+    // "could not reach the update feed". Do not move this above `await check()`.
     store.setLastUpdateCheck(Date.now());
 
     if (!update) {
@@ -104,11 +136,12 @@ export async function checkForUpdate(force = false): Promise<UpdateInfo | null> 
 
     _pendingUpdate = update;
 
-    const localized = await localizedNotes(update.body ?? '');
+    const normalizedVersion = update.version.replace(/^v/, '').trim();
+    const localized = await localizedNotes(update.body ?? '', normalizedVersion);
     const { notes, url } = await enrichReleaseNotes(localized);
 
     const info: UpdateInfo = {
-      version: update.version.replace(/^v/, ''),
+      version: normalizedVersion,
       releaseNotes: notes,
       releaseUrl: url,
       publishedAt: update.date ?? '',
@@ -116,20 +149,22 @@ export async function checkForUpdate(force = false): Promise<UpdateInfo | null> 
 
     store.setUpdateInfo(info);
 
-    publish({
-      type: 'update_available',
-      source: 'core',
-      payload: { version: info.version, releaseUrl: info.releaseUrl },
-      // dedupKey includes version so each release only notifies once
-      dedupKey: `update_available:${info.version}`,
-    });
+    if (!silent) {
+      publish({
+        type: 'update_available',
+        source: 'core',
+        payload: { version: info.version, releaseUrl: info.releaseUrl },
+        // dedupKey includes version so each release only notifies once
+        dedupKey: `update_available:${info.version}`,
+      });
+    }
 
     return info;
   } catch (err) {
     console.warn('[Update] Check failed:', err);
     return null;
   } finally {
-    store.setUpdateChecking(false);
+    if (!silent) store.setUpdateChecking(false);
   }
 }
 

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -980,6 +980,7 @@ const enUS: TranslationDict = {
     appVersion: 'App version',
     appLatest: 'Latest',
     appUpdateAvailable: 'Update available: v{version}',
+    appCheckFailed: 'Update check failed',
     checkInternalError: 'Check internal error',
     detailShow: 'Show details',
     detailHide: 'Hide details',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -980,6 +980,7 @@ const zhCN: TranslationDict = {
     appVersion: '应用版本',
     appLatest: '已是最新',
     appUpdateAvailable: '有新版本 v{version}',
+    appCheckFailed: '无法检查更新',
     checkInternalError: '检查内部错误',
     detailShow: '展开详情',
     detailHide: '收起详情',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1093,6 +1093,7 @@ export interface TranslationDict {
     appVersion: string;
     appLatest: string;
     appUpdateAvailable: string; // {version}
+    appCheckFailed: string;
     // Internal
     checkInternalError: string;
     // Detail toggle on failed items

--- a/src/stores/diagnosticStore.test.ts
+++ b/src/stores/diagnosticStore.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { CheckCategory, CheckResult } from '@/core/diagnostic/types';
+
+// Control what each category run returns without touching the real checks.
+const mockRunCategoryChecks = vi.fn();
+vi.mock('@/core/diagnostic/runner', async (importActual) => {
+  const actual = await importActual<typeof import('@/core/diagnostic/runner')>();
+  return {
+    ...actual,
+    runCategoryChecks: (cat: CheckCategory) => mockRunCategoryChecks(cat),
+  };
+});
+
+import { useDiagnosticStore } from './diagnosticStore';
+
+function appRow(metric: string): CheckResult {
+  return {
+    id: 'app:version',
+    category: 'app',
+    name: 'App version',
+    status: 'passed',
+    metric,
+    checkedAt: 123,
+    durationMs: 0,
+  };
+}
+
+function aiRow(): CheckResult {
+  return {
+    id: 'ai-services:anthropic-1',
+    category: 'ai-services',
+    name: 'Anthropic',
+    status: 'failed',
+    checkedAt: 123,
+    durationMs: 0,
+  };
+}
+
+describe('diagnosticStore.refreshApp', () => {
+  beforeEach(() => {
+    mockRunCategoryChecks.mockReset();
+    useDiagnosticStore.setState({ results: {}, lastCheckedAt: null, isChecking: false });
+  });
+
+  it('replaces the stale app row with a fresh one', async () => {
+    useDiagnosticStore.setState({
+      results: { 'app:version': appRow('v0.29.0 · 已是最新') },
+      lastCheckedAt: 1_000,
+    });
+    mockRunCategoryChecks.mockResolvedValue([appRow('v0.36.0 · 已是最新')]);
+
+    await useDiagnosticStore.getState().refreshApp();
+
+    expect(mockRunCategoryChecks).toHaveBeenCalledWith('app');
+    expect(useDiagnosticStore.getState().results['app:version'].metric).toBe('v0.36.0 · 已是最新');
+  });
+
+  it('does NOT bump lastCheckedAt (the app-only refresh must not fake a full check)', async () => {
+    useDiagnosticStore.setState({ results: {}, lastCheckedAt: 1_000 });
+    mockRunCategoryChecks.mockResolvedValue([appRow('v0.36.0 · 已是最新')]);
+
+    await useDiagnosticStore.getState().refreshApp();
+
+    expect(useDiagnosticStore.getState().lastCheckedAt).toBe(1_000);
+  });
+
+  it('leaves other categories\' cached results untouched', async () => {
+    useDiagnosticStore.setState({
+      results: { 'ai-services:anthropic-1': aiRow(), 'app:version': appRow('v0.29.0 · 已是最新') },
+      lastCheckedAt: 1_000,
+    });
+    mockRunCategoryChecks.mockResolvedValue([appRow('v0.36.0 · 已是最新')]);
+
+    await useDiagnosticStore.getState().refreshApp();
+
+    const results = useDiagnosticStore.getState().results;
+    expect(results['ai-services:anthropic-1']).toBeDefined();
+    expect(results['ai-services:anthropic-1'].status).toBe('failed');
+  });
+});

--- a/src/stores/diagnosticStore.ts
+++ b/src/stores/diagnosticStore.ts
@@ -34,6 +34,15 @@ interface DiagnosticState {
 interface DiagnosticActions {
   runAll: () => Promise<void>;
   runCategory: (cat: CheckCategory) => Promise<void>;
+  /**
+   * Silently refresh just the cheap, always-current `app` category (version +
+   * update status). Unlike {@link runCategory} this does NOT bump
+   * `lastCheckedAt` — it is fired on every panel open so a persisted snapshot
+   * can't keep showing a stale version after an in-place update, and bumping
+   * the "last checked" time would falsely imply the expensive checks (AI
+   * services, MCP, …) were re-run too.
+   */
+  refreshApp: () => Promise<void>;
   runItem: (id: string) => Promise<void>;
   setIncludeRawText: (v: boolean) => void;
   setExportInProgress: (v: boolean) => void;
@@ -94,6 +103,19 @@ export const useDiagnosticStore = create<DiagnosticStore>()(
           }
           for (const r of results) next[r.id] = r;
           return { results: next, lastCheckedAt: Date.now() };
+        });
+      },
+
+      refreshApp: async () => {
+        const rows = await runCategoryChecks('app');
+        set((s) => {
+          const next = { ...s.results };
+          for (const id of Object.keys(next)) {
+            if (next[id].category === 'app') delete next[id];
+          }
+          for (const r of rows) next[r.id] = r;
+          // Deliberately NOT touching lastCheckedAt — see refreshApp docs.
+          return { results: next };
         });
       },
 


### PR DESCRIPTION
## 背景
用户在「设置 → 诊断」发现「应用版本」显示 **v0.29.0**，与真实系统版本对不上。排查（firsthand 读码 + 实拉 OSS 清单）挖出一串问题，本 PR 修其中三个代码 bug。

## 根因
1. **诊断版本陈旧快照**：诊断结果（含拼好的版本字符串）被持久化到 `abu-diagnostic-store`，面板只在无缓存时才自动重跑 → App 更新后仍显示上次检查（截图里 07-13）那天的版本。
2. **"已是最新"底气不足**：`checks/app.ts` 只被动读 `updateInfo`、不主动查；`updateInfo` 不持久化 + 6h 节流，常常没真查就乐观显示"已是最新"。
3. **中文更新说明串版本**：`localizedNotes()` 去拉的 `latest.json`（Tauri 老格式，OSS 上停更在 v0.34.2）与 electron-updater 实际比对的 `latest-mac.yml`（v0.36.0）是两份清单、已漂移 → zh-CN 用户被推新版却看到旧版中文日志。

## 改动
- **版本号实时**：始终用编译期常量 `APP_VERSION` 渲染，不再吃持久化快照。
- **主动核对**：诊断跑到版本项时强制 `checkForUpdate(true, { silent: true })` 真查一次；`silent` 跳过全局 `updateChecking` 转圈与更新通知（只打开诊断不应搅动"关于"页按钮），仍写 `updateInfo`。
- **有超时**：`boundedWait`(8s，对齐 aiServices) 兜底，更新源慢/挂不会让整个诊断卡在"检测中"；查不到显示新增的「无法检查更新」而非假"已是最新"。
- **每次打开刷新版本项**：新增 `refreshApp()`（只跑 app 类、不 bump `lastCheckedAt`，避免假装全量重检）。
- **中文说明版本校验**：`localizedNotes()` 加 `expectedVersion` 比对，`latest.json` 版本不一致就回退英文 body。与 `latest.json` 去留解耦。

## 已知限制（有意接受）
fork/源码构建更新器禁用，`check()` 返 null 却仍推进时间戳 → 那种构建仍会显"已是最新"。官方构建不受影响，已在注释写清。

## 验证
- `npm run verify` 退出码 0（lint + typecheck + 全量 + 覆盖率，覆盖率未降）。
- 新增/扩展测试 25 passed：`app.test.ts`（含超时、离线、silent 参数断言）、`diagnosticStore.test.ts`（refreshApp 不动 `lastCheckedAt`）、`checker.test.ts`（版本校验 + silent 4 例）。
- 真机 Electron dev 壳启动无崩溃、renderer 正常渲染；版本项行为经人工过目确认。
- 经 `/code-review`（high effort）复审，F1 卡死 / F2 副作用外溢 / F4 归一化已在本 PR 内修掉。

## 不在本 PR
`latest.json` 是退役还是补回发布（取决于线上是否还有 Tauri 老客户端存量）——待产品拍板，单独处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)