### PR TITLE
feat(diagnostics): add runtime observability

### DIFF
--- a/electron/mcpBridge.cjs
+++ b/electron/mcpBridge.cjs
@@ -67,6 +67,10 @@ const {
   sandboxLauncherPathFor,
   unixDescendantPids,
 } = require('./commandHost.cjs');
+const {
+  configureRuntimeObservability,
+  runtimeState,
+} = require('./runtimeObservability.cjs');
 
 /** id -> ChildProcess */
 const children = new Map();
@@ -191,6 +195,7 @@ function onHeartbeatTimeout(id) {
   state.failures += 1;
   if (state.failures >= HEARTBEAT_FAILURE_THRESHOLD) {
     state.failures = 0;
+    runtimeState.noteHeartbeatHung(id);
     emit(`mcp-hung-${id}`, '');
   }
 }
@@ -313,6 +318,7 @@ function mcpDispatch(appOrCmd, cmdOrArgs, maybeArgs) {
   const cmd = typeof appOrCmd === 'string' ? appOrCmd : cmdOrArgs;
   const args = typeof appOrCmd === 'string' ? cmdOrArgs : maybeArgs;
   if (!MCP_CMDS.has(cmd)) return undefined;
+  configureRuntimeObservability(app);
   const a = args || {};
   switch (cmd) {
     case 'mcp_spawn':
@@ -383,6 +389,7 @@ function mcpSpawnPrepared(app, { id, command, args = [], env = {}, heartbeat }) 
     callerEnv.PATH = loginShellPath();
   }
 
+  const generation = runtimeState.noteSpawnStarted(id, heartbeat);
   let resolved;
   let spawnEnv;
   try {
@@ -390,6 +397,7 @@ function mcpSpawnPrepared(app, { id, command, args = [], env = {}, heartbeat }) 
     spawnEnv = withBundledRuntimeEnv(app, callerEnv);
     if (heartbeat) spawnEnv.ABU_ELECTRON_COMMAND_HOST = '1';
   } catch (err) {
+    runtimeState.noteSpawnFailed(id, generation, 'runtime_resolution_failed');
     return Promise.reject(new Error(`mcp_spawn failed for "${command}": ${errMsg(err)}`));
   }
 
@@ -403,6 +411,7 @@ function mcpSpawnPrepared(app, { id, command, args = [], env = {}, heartbeat }) 
       detached: process.platform !== 'win32',
     });
   } catch (err) {
+    runtimeState.noteSpawnFailed(id, generation, 'launcher_spawn_failed');
     return Promise.reject(new Error(`mcp_spawn failed for "${command}": ${errMsg(err)}`));
   }
   children.set(id, child);
@@ -430,7 +439,10 @@ function mcpSpawnPrepared(app, { id, command, args = [], env = {}, heartbeat }) 
     if (children.get(id) === child) {
       children.delete(id);
       stopHeartbeatMonitor(id);
-      if (targetReady) emit(`mcp-close-${id}`, '');
+      if (targetReady) {
+        runtimeState.noteClosed(id, generation);
+        emit(`mcp-close-${id}`, '');
+      }
     }
   };
 
@@ -464,6 +476,7 @@ function mcpSpawnPrepared(app, { id, command, args = [], env = {}, heartbeat }) 
       // Heartbeat ack interception — see consumeHeartbeatAck()'s JSDoc for
       // why this can never swallow a real RPC response.
       if (line.includes('__mcphb-') && consumeHeartbeatAck(id, line)) continue;
+      runtimeState.noteStdoutLine(id, line);
       emit(`mcp-msg-${id}`, line);
     }
   });
@@ -487,10 +500,12 @@ function mcpSpawnPrepared(app, { id, command, args = [], env = {}, heartbeat }) 
         targetReady = true;
         child.__abuTargetPid = Number(readyMatch[1]);
         if (heartbeat) startHeartbeatMonitor(id);
+        runtimeState.noteReady(id, generation, child.__abuTargetPid);
         settleSpawn(null);
         continue;
       }
       if (line) {
+        runtimeState.noteSidecarTraceLine(id, line);
         launchError = launchError ? `${launchError}\n${line}` : line;
         if (targetReady) emit(`mcp-err-${id}`, line);
       }
@@ -506,6 +521,7 @@ function mcpSpawnPrepared(app, { id, command, args = [], env = {}, heartbeat }) 
       // Spawn-phase failure — the rejected invoke is the signal; no
       // mcp-err/close events (Rust emits none on spawn failure).
       if (children.get(id) === child) children.delete(id);
+      runtimeState.noteSpawnFailed(id, generation, 'process_spawn_error');
       rejectSpawn(new Error(`mcp_spawn failed for "${command}": ${errMsg(err)}`));
     }
   });
@@ -513,6 +529,7 @@ function mcpSpawnPrepared(app, { id, command, args = [], env = {}, heartbeat }) 
   child.on('close', (code) => {
     if (!targetReady) {
       if (children.get(id) === child) children.delete(id);
+      runtimeState.noteSpawnFailed(id, generation, 'launcher_exited_before_ready');
       rejectSpawn(new Error(
         `mcp_spawn failed for "${command}": launcher exited with ${String(code)}${launchError ? `: ${launchError}` : ''}`
       ));
@@ -541,6 +558,7 @@ function mcpSpawnPrepared(app, { id, command, args = [], env = {}, heartbeat }) 
 }
 
 function mcpWrite({ id, message }) {
+  const runtimeRpc = runtimeState.noteRpcWriteStarted(id, message);
   const child = children.get(id);
   if (
     !child ||
@@ -549,18 +567,22 @@ function mcpWrite({ id, message }) {
     child.stdin.destroyed ||
     child.stdin.writableEnded
   ) {
+    runtimeState.noteRpcWriteFinished(runtimeRpc, 'no_live_process');
     return Promise.reject(new Error(`mcp_write: no live process for id "${id}"`));
   }
   return new Promise((resolve, reject) => {
     try {
       child.stdin.write(String(message) + '\n', (err) => {
         if (err) {
+          runtimeState.noteRpcWriteFinished(runtimeRpc, 'stdin_write_failed');
           reject(new Error(`mcp_write failed for id "${id}": ${errMsg(err)}`));
         } else {
+          runtimeState.noteRpcWriteFinished(runtimeRpc);
           resolve(null);
         }
       });
     } catch (err) {
+      runtimeState.noteRpcWriteFinished(runtimeRpc, 'stdin_write_threw');
       reject(new Error(`mcp_write failed for id "${id}": ${errMsg(err)}`));
     }
   });
@@ -572,6 +594,7 @@ function mcpKill({ id }) {
     pending.cancelled = true;
     pendingBundledRuntimeSpawns.delete(id);
   }
+  if (children.has(id)) runtimeState.noteKilled(id);
   killChild(id);
   return null;
 }

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -16,6 +16,8 @@ const { contextBridge, ipcRenderer, webUtils } = require('electron');
 
 const TAURI_LOCAL_STORAGE_GET = 'abu:tauri-local-storage:get';
 const TAURI_LOCAL_STORAGE_ACK = 'abu:tauri-local-storage:ack';
+const RUNTIME_EVENT_CHANNEL = 'abu:runtime-event';
+const RUNTIME_DIAGNOSTICS_CHANNEL = 'abu:runtime-diagnostics';
 const TAURI_STORE_KEYS = new Set([
   'abu-settings',
   'abu-chat',
@@ -268,6 +270,8 @@ contextBridge.exposeInMainWorld('__ABU_SHELL__', {
   // Chromium no longer exposes File.path. Keep the bridge deliberately narrow:
   // the renderer can resolve only a File object the user already dragged in.
   getPathForFile: (file) => webUtils.getPathForFile(file),
+  recordRuntimeEvent: (event) => ipcRenderer.send(RUNTIME_EVENT_CHANNEL, safeArgs(event)),
+  getRuntimeDiagnostics: () => ipcRenderer.invoke(RUNTIME_DIAGNOSTICS_CHANNEL),
 });
 
 // unlisten() calls this SYNCHRONOUSLY before invoking `plugin:event|unlisten`

--- a/electron/runtimeObservability.cjs
+++ b/electron/runtimeObservability.cjs
@@ -1,0 +1,477 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { randomUUID } = require('node:crypto');
+
+const RUNTIME_EVENT_CHANNEL = 'abu:runtime-event';
+const RUNTIME_DIAGNOSTICS_CHANNEL = 'abu:runtime-diagnostics';
+const SIDECAR_TRACE_PREFIX = '[abu-runtime] ';
+const SIDECAR_ID = 'abu-sidecar';
+const SCHEMA_VERSION = 1;
+const LOG_FILE_NAME = 'runtime-observability.jsonl';
+const MAX_LOG_BYTES = 5 * 1024 * 1024;
+const MAX_RECENT_EVENTS = 1_000;
+const MAX_STRING_CHARS = 160;
+const BRIDGE_ACK_TIMEOUT_MS = 3_000;
+
+const SAFE_ATTRIBUTE_KEYS = new Set([
+  'runId',
+  'rpcId',
+  'method',
+  'stage',
+  'outcome',
+  'errorType',
+  'sidecarId',
+  'sidecarGeneration',
+  'durationMs',
+  'payloadBytes',
+  'frameCount',
+  'pendingRpcCount',
+  'reason',
+  'executionPath',
+  'firstFrameMs',
+  'bridgeLatencyMs',
+]);
+
+const SECRET_PATTERNS = [
+  /\bsk-[a-zA-Z0-9_-]{12,}/g,
+  /\beyJ[a-zA-Z0-9_-]{8,}\.[a-zA-Z0-9_-]{8,}\.[a-zA-Z0-9_-]{8,}/g,
+  /\bBearer\s+[a-zA-Z0-9._\-+/=]{8,}/gi,
+  /\b(?:token|api[_-]?key|password|secret|authorization)\s*[=:]\s*\S+/gi,
+];
+
+function redactString(value) {
+  let result = String(value);
+  for (const pattern of SECRET_PATTERNS) result = result.replace(pattern, '[REDACTED]');
+  return result.slice(0, MAX_STRING_CHARS);
+}
+
+function normalizeErrorType(value) {
+  return String(value || 'unknown')
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, '_')
+    .slice(0, 80) || 'unknown';
+}
+
+function sanitizeAttributes(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  const output = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (!SAFE_ATTRIBUTE_KEYS.has(key) || raw === undefined) continue;
+    if (raw === null || typeof raw === 'boolean') {
+      output[key] = raw;
+    } else if (typeof raw === 'number' && Number.isFinite(raw)) {
+      output[key] = Math.max(0, Math.round(raw));
+    } else if (typeof raw === 'string') {
+      output[key] = key === 'errorType' ? normalizeErrorType(raw) : redactString(raw);
+    }
+  }
+  return output;
+}
+
+function sanitizeEventName(value) {
+  if (typeof value !== 'string' || !/^[a-z][a-z0-9_.-]{0,79}$/.test(value)) return null;
+  return value;
+}
+
+function parseJsonRpcMetadata(message) {
+  if (typeof message !== 'string') return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(message);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const method = typeof parsed.method === 'string' ? parsed.method.slice(0, 80) : undefined;
+  const rpcId = typeof parsed.id === 'string' || typeof parsed.id === 'number'
+    ? String(parsed.id).slice(0, 80)
+    : undefined;
+  const params = parsed.params && typeof parsed.params === 'object' && !Array.isArray(parsed.params)
+    ? parsed.params
+    : null;
+  const runId = typeof params?.runId === 'string' ? params.runId.slice(0, MAX_STRING_CHARS) : undefined;
+  const frames = Array.isArray(params?.frames) ? params.frames : null;
+  return {
+    method,
+    rpcId,
+    runId,
+    frameCount: frames ? frames.length : undefined,
+    payloadBytes: Buffer.byteLength(message),
+  };
+}
+
+function createRuntimeState({
+  emit,
+  now = () => Date.now(),
+  setTimer = setTimeout,
+  clearTimer = clearTimeout,
+  bridgeAckTimeoutMs = BRIDGE_ACK_TIMEOUT_MS,
+} = {}) {
+  const sidecars = new Map();
+  const pendingRpcs = new Map();
+  const firstDeltaRuns = new Set();
+  const bridgeAcks = new Map();
+
+  const emitEvent = (processName, event, attributes) => {
+    emit?.(processName, event, sanitizeAttributes(attributes));
+  };
+  const sidecarGeneration = (id) => sidecars.get(id)?.generation ?? 0;
+  const pendingKey = (id, rpcId) => `${id}:${rpcId}`;
+
+  function noteSpawnStarted(id, heartbeat) {
+    if (id !== SIDECAR_ID) return 0;
+    const generation = sidecarGeneration(id) + 1;
+    sidecars.set(id, {
+      id,
+      generation,
+      status: 'starting',
+      heartbeat: heartbeat === true,
+      startedAt: now(),
+      readyAt: null,
+      targetPid: null,
+    });
+    emitEvent('main', 'main.sidecar_spawn_started', {
+      sidecarId: id,
+      sidecarGeneration: generation,
+      stage: 'starting',
+    });
+    return generation;
+  }
+
+  function noteSpawnFailed(id, generation, errorType) {
+    if (id !== SIDECAR_ID) return;
+    const current = sidecars.get(id);
+    if (current?.generation === generation) current.status = 'failed';
+    emitEvent('main', 'main.sidecar_spawn_failed', {
+      sidecarId: id,
+      sidecarGeneration: generation,
+      outcome: 'error',
+      errorType,
+    });
+  }
+
+  function noteReady(id, generation, targetPid) {
+    if (id !== SIDECAR_ID) return;
+    const current = sidecars.get(id);
+    if (current?.generation !== generation) return;
+    current.status = 'running';
+    current.readyAt = now();
+    current.targetPid = Number.isInteger(targetPid) ? targetPid : null;
+    emitEvent('main', 'main.sidecar_ready', {
+      sidecarId: id,
+      sidecarGeneration: generation,
+      durationMs: current.readyAt - current.startedAt,
+      outcome: 'success',
+    });
+  }
+
+  function clearPendingForSidecar(id, generation) {
+    for (const [key, rpc] of pendingRpcs) {
+      if (rpc.sidecarId !== id) continue;
+      emitEvent('main', 'main.rpc_orphaned_on_sidecar_close', {
+        ...rpc,
+        sidecarGeneration: generation,
+        durationMs: now() - rpc.startedAt,
+        outcome: 'error',
+        errorType: 'sidecar_closed',
+      });
+      pendingRpcs.delete(key);
+    }
+  }
+
+  function noteClosed(id, generation, reason = 'closed') {
+    if (id !== SIDECAR_ID) return;
+    const current = sidecars.get(id);
+    if (current?.generation === generation) current.status = 'stopped';
+    clearPendingForSidecar(id, generation);
+    emitEvent('main', 'main.sidecar_closed', {
+      sidecarId: id,
+      sidecarGeneration: generation,
+      outcome: 'error',
+      reason,
+    });
+  }
+
+  function noteKilled(id, reason = 'killed') {
+    if (id !== SIDECAR_ID) return;
+    noteClosed(id, sidecarGeneration(id), reason);
+  }
+
+  function noteHeartbeatHung(id) {
+    if (id !== SIDECAR_ID) return;
+    emitEvent('main', 'main.sidecar_heartbeat_hung', {
+      sidecarId: id,
+      sidecarGeneration: sidecarGeneration(id),
+      outcome: 'stalled',
+      errorType: 'heartbeat_timeout',
+    });
+  }
+
+  function noteRpcWriteStarted(id, message) {
+    if (id !== SIDECAR_ID) return null;
+    const metadata = parseJsonRpcMetadata(message);
+    if (!metadata?.method || !['agent.run', 'agent.abort'].includes(metadata.method)) return null;
+    const startedAt = now();
+    const rpc = {
+      sidecarId: id,
+      sidecarGeneration: sidecarGeneration(id),
+      runId: metadata.runId,
+      rpcId: metadata.rpcId,
+      method: metadata.method,
+      payloadBytes: metadata.payloadBytes,
+      stage: 'stdin_write',
+      startedAt,
+    };
+    if (metadata.rpcId) pendingRpcs.set(pendingKey(id, metadata.rpcId), rpc);
+    emitEvent('main', 'main.rpc_write_started', rpc);
+    return rpc;
+  }
+
+  function noteRpcWriteFinished(rpc, errorType) {
+    if (!rpc) return;
+    emitEvent('main', errorType ? 'main.rpc_write_failed' : 'main.rpc_write_completed', {
+      ...rpc,
+      stage: errorType ? 'stdin_write_failed' : 'waiting_for_response',
+      durationMs: now() - rpc.startedAt,
+      outcome: errorType ? 'error' : 'success',
+      errorType,
+    });
+    if (errorType && rpc.rpcId) pendingRpcs.delete(pendingKey(rpc.sidecarId, rpc.rpcId));
+  }
+
+  function noteStdoutLine(id, line) {
+    if (id !== SIDECAR_ID) return;
+    const metadata = parseJsonRpcMetadata(line);
+    if (!metadata) return;
+
+    if (metadata.method === 'agent.delta' && metadata.runId && (metadata.frameCount ?? 0) > 0) {
+      if (firstDeltaRuns.has(metadata.runId)) return;
+      firstDeltaRuns.add(metadata.runId);
+      const receivedAt = now();
+      emitEvent('main', 'main.agent_delta_received', {
+        sidecarId: id,
+        sidecarGeneration: sidecarGeneration(id),
+        runId: metadata.runId,
+        frameCount: metadata.frameCount,
+        stage: 'waiting_for_renderer_ack',
+      });
+      const timer = setTimer(() => {
+        bridgeAcks.delete(metadata.runId);
+        emitEvent('main', 'main.renderer_bridge_ack_timeout', {
+          sidecarId: id,
+          sidecarGeneration: sidecarGeneration(id),
+          runId: metadata.runId,
+          durationMs: now() - receivedAt,
+          outcome: 'stalled',
+          errorType: 'renderer_ack_timeout',
+        });
+      }, bridgeAckTimeoutMs);
+      bridgeAcks.set(metadata.runId, { receivedAt, timer });
+      return;
+    }
+
+    if (!metadata.rpcId) return;
+    const key = pendingKey(id, metadata.rpcId);
+    const rpc = pendingRpcs.get(key);
+    if (!rpc) return;
+    pendingRpcs.delete(key);
+    emitEvent('main', 'main.rpc_response_received', {
+      ...rpc,
+      stage: 'response_received',
+      durationMs: now() - rpc.startedAt,
+      outcome: 'success',
+    });
+  }
+
+  function noteRendererEvent(raw) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return false;
+    const event = sanitizeEventName(raw.event);
+    if (!event || !event.startsWith('renderer.')) return false;
+    const attributes = sanitizeAttributes(raw);
+    emitEvent('renderer', event, attributes);
+    if (event !== 'renderer.agent_delta_received' || typeof attributes.runId !== 'string') return true;
+    const ack = bridgeAcks.get(attributes.runId);
+    if (!ack) return true;
+    clearTimer(ack.timer);
+    bridgeAcks.delete(attributes.runId);
+    emitEvent('main', 'main.renderer_bridge_ack_received', {
+      runId: attributes.runId,
+      sidecarId: SIDECAR_ID,
+      sidecarGeneration: sidecarGeneration(SIDECAR_ID),
+      bridgeLatencyMs: now() - ack.receivedAt,
+      outcome: 'success',
+    });
+    return true;
+  }
+
+  function noteSidecarTraceLine(id, line) {
+    if (id !== SIDECAR_ID || typeof line !== 'string' || !line.startsWith(SIDECAR_TRACE_PREFIX)) return false;
+    let parsed;
+    try {
+      parsed = JSON.parse(line.slice(SIDECAR_TRACE_PREFIX.length));
+    } catch {
+      return false;
+    }
+    const event = sanitizeEventName(parsed?.event);
+    if (!event || !event.startsWith('sidecar.')) return false;
+    emitEvent('sidecar', event, {
+      ...parsed,
+      sidecarId: id,
+      sidecarGeneration: sidecarGeneration(id),
+    });
+    return true;
+  }
+
+  function snapshot() {
+    return {
+      pendingRpcs: Array.from(pendingRpcs.values(), (rpc) => sanitizeAttributes({
+        ...rpc,
+        durationMs: now() - rpc.startedAt,
+      })),
+      sidecars: Array.from(sidecars.values(), (sidecar) => sanitizeAttributes({
+        sidecarId: sidecar.id,
+        sidecarGeneration: sidecar.generation,
+        stage: sidecar.status,
+        durationMs: now() - sidecar.startedAt,
+      })),
+      pendingRendererAcks: Array.from(bridgeAcks, ([runId, ack]) => sanitizeAttributes({
+        runId,
+        stage: 'waiting_for_renderer_ack',
+        durationMs: now() - ack.receivedAt,
+      })),
+    };
+  }
+
+  function reset() {
+    for (const ack of bridgeAcks.values()) clearTimer(ack.timer);
+    sidecars.clear();
+    pendingRpcs.clear();
+    firstDeltaRuns.clear();
+    bridgeAcks.clear();
+  }
+
+  return {
+    noteSpawnStarted,
+    noteSpawnFailed,
+    noteReady,
+    noteClosed,
+    noteKilled,
+    noteHeartbeatHung,
+    noteRpcWriteStarted,
+    noteRpcWriteFinished,
+    noteStdoutLine,
+    noteRendererEvent,
+    noteSidecarTraceLine,
+    snapshot,
+    reset,
+  };
+}
+
+const appSessionId = randomUUID();
+let logFilePath = null;
+const recentEvents = [];
+
+function configureRuntimeObservability(app) {
+  if (logFilePath || !app || typeof app.getPath !== 'function') return;
+  try {
+    const logDir = app.getPath('logs');
+    fs.mkdirSync(logDir, { recursive: true });
+    logFilePath = path.join(logDir, LOG_FILE_NAME);
+  } catch {
+    logFilePath = null;
+  }
+}
+
+function rotateIfNeeded() {
+  if (!logFilePath) return;
+  try {
+    if (!fs.existsSync(logFilePath) || fs.statSync(logFilePath).size < MAX_LOG_BYTES) return;
+    const oldPath = `${logFilePath}.old`;
+    fs.rmSync(oldPath, { force: true });
+    fs.renameSync(logFilePath, oldPath);
+  } catch {
+    // Observability must never change product behavior.
+  }
+}
+
+function emitRuntimeEvent(processName, event, attributes) {
+  const safeEvent = sanitizeEventName(event);
+  if (!safeEvent || !['renderer', 'main', 'sidecar'].includes(processName)) return;
+  const entry = {
+    schemaVersion: SCHEMA_VERSION,
+    timestamp: Date.now(),
+    process: processName,
+    event: safeEvent,
+    appSessionId,
+    ...sanitizeAttributes(attributes),
+  };
+  recentEvents.push(entry);
+  if (recentEvents.length > MAX_RECENT_EVENTS) recentEvents.shift();
+  if (!logFilePath) return;
+  try {
+    rotateIfNeeded();
+    fs.appendFileSync(logFilePath, `${JSON.stringify(entry)}\n`, 'utf8');
+  } catch {
+    // Observability must never change product behavior.
+  }
+}
+
+const runtimeState = createRuntimeState({ emit: emitRuntimeEvent });
+
+function readPersistedEvents() {
+  const paths = logFilePath ? [`${logFilePath}.old`, logFilePath] : [];
+  const lines = [];
+  for (const filePath of paths) {
+    try {
+      const content = fs.readFileSync(filePath, 'utf8');
+      for (const line of content.split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          const parsed = JSON.parse(line);
+          const event = sanitizeEventName(parsed?.event);
+          const processName = ['renderer', 'main', 'sidecar'].includes(parsed?.process) ? parsed.process : null;
+          if (parsed?.schemaVersion === SCHEMA_VERSION && event && processName) {
+            lines.push(JSON.stringify({
+              schemaVersion: SCHEMA_VERSION,
+              timestamp: Number.isFinite(parsed.timestamp) ? Math.max(0, Math.round(parsed.timestamp)) : 0,
+              process: processName,
+              event,
+              appSessionId: redactString(parsed.appSessionId || 'unknown'),
+              ...sanitizeAttributes(parsed),
+            }));
+          }
+        } catch {
+          // Ignore a partial final line after an abrupt process exit.
+        }
+      }
+    } catch {
+      // Missing/unreadable log files are valid on a fresh install.
+    }
+  }
+  return lines.slice(-MAX_RECENT_EVENTS);
+}
+
+function getRuntimeDiagnostics() {
+  const mergedEventLines = new Set(readPersistedEvents());
+  for (const event of recentEvents) mergedEventLines.add(JSON.stringify(event));
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    appSessionId,
+    recentEventLines: Array.from(mergedEventLines).slice(-MAX_RECENT_EVENTS),
+    ...runtimeState.snapshot(),
+  };
+}
+
+module.exports = {
+  RUNTIME_EVENT_CHANNEL,
+  RUNTIME_DIAGNOSTICS_CHANNEL,
+  SIDECAR_TRACE_PREFIX,
+  configureRuntimeObservability,
+  getRuntimeDiagnostics,
+  runtimeState,
+  sanitizeAttributes,
+  parseJsonRpcMetadata,
+  createRuntimeState,
+};

--- a/electron/runtimeObservability.test.cjs
+++ b/electron/runtimeObservability.test.cjs
@@ -1,0 +1,149 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+
+const {
+  SIDECAR_TRACE_PREFIX,
+  createRuntimeState,
+  parseJsonRpcMetadata,
+  sanitizeAttributes,
+} = require('./runtimeObservability.cjs');
+
+function makeHarness() {
+  let now = 1_000;
+  let nextTimerId = 1;
+  const timers = new Map();
+  const events = [];
+  const state = createRuntimeState({
+    emit: (processName, event, attributes) => events.push({ processName, event, attributes }),
+    now: () => now,
+    setTimer: (callback) => {
+      const id = nextTimerId++;
+      timers.set(id, callback);
+      return id;
+    },
+    clearTimer: (id) => timers.delete(id),
+    bridgeAckTimeoutMs: 3_000,
+  });
+  return {
+    state,
+    events,
+    timers,
+    advance(ms) { now += ms; },
+    fireTimers() {
+      for (const [id, callback] of Array.from(timers)) {
+        timers.delete(id);
+        callback();
+      }
+    },
+  };
+}
+
+test('runtime attributes are allowlisted, bounded, and secret-redacted', () => {
+  const safe = sanitizeAttributes({
+    runId: 'run-1',
+    stage: `authorization=Bearer abcdefghijklmnop ${'x'.repeat(300)}`,
+    payloadBytes: 12.8,
+    rawBody: 'must never escape',
+    prompt: 'must never escape',
+  });
+  assert.equal(safe.runId, 'run-1');
+  assert.match(safe.stage, /\[REDACTED\]/);
+  assert.ok(safe.stage.length <= 160);
+  assert.equal(safe.payloadBytes, 13);
+  assert.equal('rawBody' in safe, false);
+  assert.equal('prompt' in safe, false);
+});
+
+test('JSON-RPC metadata excludes user content while retaining routing diagnostics', () => {
+  const raw = JSON.stringify({
+    jsonrpc: '2.0',
+    id: 42,
+    method: 'agent.run',
+    params: {
+      runId: 'run-safe',
+      userMessage: 'private conversation text',
+      resolvedCreds: { apiKey: 'sk-never-log-this-value' },
+      frames: [{ type: 'text', text: 'secret' }],
+    },
+  });
+  assert.deepEqual(parseJsonRpcMetadata(raw), {
+    method: 'agent.run',
+    rpcId: '42',
+    runId: 'run-safe',
+    frameCount: 1,
+    payloadBytes: Buffer.byteLength(raw),
+  });
+});
+
+test('tracks an agent RPC until its response and captures sidecar lifecycle', () => {
+  const h = makeHarness();
+  const generation = h.state.noteSpawnStarted('abu-sidecar', true);
+  h.advance(40);
+  h.state.noteReady('abu-sidecar', generation, 1234);
+  const request = JSON.stringify({ jsonrpc: '2.0', id: 'rpc-1', method: 'agent.run', params: { runId: 'run-1' } });
+  const pending = h.state.noteRpcWriteStarted('abu-sidecar', request);
+  h.state.noteRpcWriteFinished(pending);
+  assert.equal(h.state.snapshot().pendingRpcs.length, 1);
+  h.advance(20);
+  h.state.noteStdoutLine('abu-sidecar', JSON.stringify({ jsonrpc: '2.0', id: 'rpc-1', result: { reason: 'completed' } }));
+  assert.equal(h.state.snapshot().pendingRpcs.length, 0);
+  assert.deepEqual(h.state.snapshot().sidecars[0], {
+    sidecarId: 'abu-sidecar',
+    sidecarGeneration: 1,
+    stage: 'running',
+    durationMs: 60,
+  });
+  assert.ok(h.events.some((entry) => entry.event === 'main.rpc_response_received'));
+});
+
+test('distinguishes a healthy main stdout path from a stalled renderer bridge', () => {
+  const h = makeHarness();
+  const generation = h.state.noteSpawnStarted('abu-sidecar', true);
+  h.state.noteReady('abu-sidecar', generation, 1234);
+  h.state.noteStdoutLine('abu-sidecar', JSON.stringify({
+    jsonrpc: '2.0',
+    method: 'agent.delta',
+    params: { runId: 'run-gap', frames: [{ type: 'text' }] },
+  }));
+  assert.equal(h.state.snapshot().pendingRendererAcks.length, 1);
+  h.advance(3_100);
+  h.fireTimers();
+  assert.equal(h.state.snapshot().pendingRendererAcks.length, 0);
+  assert.ok(h.events.some((entry) => entry.event === 'main.renderer_bridge_ack_timeout'));
+});
+
+test('renderer first-delta acknowledgement closes the bridge timer and records latency', () => {
+  const h = makeHarness();
+  const generation = h.state.noteSpawnStarted('abu-sidecar', true);
+  h.state.noteReady('abu-sidecar', generation, 1234);
+  h.state.noteStdoutLine('abu-sidecar', JSON.stringify({
+    jsonrpc: '2.0',
+    method: 'agent.delta',
+    params: { runId: 'run-ok', frames: [{ type: 'text' }] },
+  }));
+  h.advance(45);
+  assert.equal(h.state.noteRendererEvent({ event: 'renderer.agent_delta_received', runId: 'run-ok' }), true);
+  assert.equal(h.timers.size, 0);
+  const ack = h.events.find((entry) => entry.event === 'main.renderer_bridge_ack_received');
+  assert.equal(ack.attributes.bridgeLatencyMs, 45);
+});
+
+test('sidecar marker parser accepts only safe sidecar events and attributes', () => {
+  const h = makeHarness();
+  const generation = h.state.noteSpawnStarted('abu-sidecar', true);
+  h.state.noteReady('abu-sidecar', generation, 1234);
+  const accepted = h.state.noteSidecarTraceLine('abu-sidecar', `${SIDECAR_TRACE_PREFIX}${JSON.stringify({
+    event: 'sidecar.agent_run_started',
+    runId: 'run-1',
+    prompt: 'private',
+    apiKey: 'sk-never-log-this-value',
+  })}`);
+  assert.equal(accepted, true);
+  const event = h.events.find((entry) => entry.event === 'sidecar.agent_run_started');
+  assert.equal(event.attributes.runId, 'run-1');
+  assert.equal('prompt' in event.attributes, false);
+  assert.equal('apiKey' in event.attributes, false);
+  assert.equal(h.state.noteSidecarTraceLine('abu-sidecar', `${SIDECAR_TRACE_PREFIX}{bad-json`), false);
+});

--- a/electron/securityBoundary.test.cjs
+++ b/electron/securityBoundary.test.cjs
@@ -465,8 +465,9 @@ test('resources cannot be released by another IPC sender', () => {
   );
 });
 
-test('preload exposes only the narrow Electron file-path resolver', () => {
+test('preload exposes only the narrow file resolver and runtime diagnostic bridge', async () => {
   const exposed = new Map();
+  const sent = [];
   const nativeFile = { name: 'report.pdf' };
   const webUtils = {
     getPathForFile(file) {
@@ -475,8 +476,9 @@ test('preload exposes only the narrow Electron file-path resolver', () => {
     },
   };
   const ipcRenderer = {
-    invoke: async () => undefined,
+    invoke: async (channel) => channel === 'abu:runtime-diagnostics' ? { schemaVersion: 1 } : undefined,
     on: () => undefined,
+    send: (channel, payload) => sent.push({ channel, payload }),
     sendSync: () => null,
   };
   const context = {
@@ -499,6 +501,17 @@ test('preload exposes only the narrow Electron file-path resolver', () => {
   vm.runInNewContext(preloadSource, context, { filename: 'preload.cjs' });
 
   const shellBridge = exposed.get('__ABU_SHELL__');
-  assert.deepEqual(Object.keys(shellBridge).sort(), ['getPathForFile', 'mainSupervisesSidecar']);
+  assert.deepEqual(Object.keys(shellBridge).sort(), [
+    'getPathForFile',
+    'getRuntimeDiagnostics',
+    'mainSupervisesSidecar',
+    'recordRuntimeEvent',
+  ]);
   assert.equal(shellBridge.getPathForFile(nativeFile), '/native/report.pdf');
+  shellBridge.recordRuntimeEvent({ event: 'renderer.test', runId: 'run-1' });
+  assert.deepEqual(JSON.parse(JSON.stringify(sent)), [{
+    channel: 'abu:runtime-event',
+    payload: { event: 'renderer.test', runId: 'run-1' },
+  }]);
+  assert.deepEqual(JSON.parse(JSON.stringify(await shellBridge.getRuntimeDiagnostics())), { schemaVersion: 1 });
 });

--- a/electron/tauriHost.cjs
+++ b/electron/tauriHost.cjs
@@ -53,6 +53,13 @@ const {
   cleanupFsWatchesForSender,
 } = require('./fsWatchHost.cjs');
 const { mcpDispatch } = require('./mcpBridge.cjs');
+const {
+  RUNTIME_EVENT_CHANNEL,
+  RUNTIME_DIAGNOSTICS_CHANNEL,
+  configureRuntimeObservability,
+  getRuntimeDiagnostics,
+  runtimeState,
+} = require('./runtimeObservability.cjs');
 const { desktopDispatch, DESKTOP_MISS } = require('./desktopHost.cjs');
 const { popupWindowsMenu, syncMainWindowChromeTheme } = require('./windowChrome.cjs');
 const {
@@ -1312,6 +1319,22 @@ function registerTauriHost(app, options = {}) {
     } catch {
       e.returnValue = null;
     }
+  });
+
+  ipcMain.on(RUNTIME_EVENT_CHANNEL, (e, payload) => {
+    try {
+      assertTrustedIpcSender(e);
+      configureRuntimeObservability(app);
+      runtimeState.noteRendererEvent(payload);
+    } catch {
+      // Runtime tracing is best-effort and must never affect product behavior.
+    }
+  });
+
+  ipcMain.handle(RUNTIME_DIAGNOSTICS_CHANNEL, async (e) => {
+    assertTrustedIpcSender(e);
+    configureRuntimeObservability(app);
+    return getRuntimeDiagnostics();
   });
 }
 

--- a/sidecar/src/agentLoopHost.test.ts
+++ b/sidecar/src/agentLoopHost.test.ts
@@ -24,6 +24,12 @@ vi.mock('./rpcClient', () => ({
   setPreRequestFlush: (...a: unknown[]) => setPreRequestFlushMock(...a),
 }));
 
+const traceSidecarRuntimeEventMock = vi.hoisted(() => vi.fn());
+vi.mock('./runtimeTrace', () => ({
+  traceSidecarRuntimeEvent: (...a: unknown[]) => traceSidecarRuntimeEventMock(...a),
+  sidecarRuntimeErrorType: (error: unknown) => error instanceof Error ? error.name.toLowerCase() : typeof error,
+}));
+
 // P1-3d-1 — mock the local tool registry so this file's dispatch tests
 // (see "local tool dispatch (P1-3d-1)" below) exercise ONLY
 // createReverseToolInvoker.executeAnyTool's branch/fallback wiring, not any
@@ -122,6 +128,7 @@ describe('agentLoopHost', () => {
     sendRequestMock.mockReset();
     mockSendRequest();
     sendNotificationMock.mockReset();
+    traceSidecarRuntimeEventMock.mockReset();
     hasLocalToolMock.mockReset();
     hasLocalToolMock.mockReturnValue(false);
     isLocalToolReadOnlyMock.mockReset();
@@ -170,6 +177,18 @@ describe('agentLoopHost', () => {
       const result = await handleAgentRun(params);
       expect(result).toEqual({ reason: 'completed' });
       expect(sawContextRunId).toBe(params.runId);
+      expect(traceSidecarRuntimeEventMock).toHaveBeenCalledWith(
+        'sidecar.agent_run_received',
+        expect.objectContaining({ runId: params.runId, stage: 'params_parsed' }),
+      );
+      expect(traceSidecarRuntimeEventMock).toHaveBeenCalledWith(
+        'sidecar.agent_loop_started',
+        expect.objectContaining({ runId: params.runId, stage: 'agent_loop_running' }),
+      );
+      expect(traceSidecarRuntimeEventMock).toHaveBeenCalledWith(
+        'sidecar.agent_run_completed',
+        expect.objectContaining({ runId: params.runId, outcome: 'completed' }),
+      );
     });
 
     it('passes settingsReader/orchestration/options through AgentLoopOptions', async () => {
@@ -266,6 +285,10 @@ describe('agentLoopHost', () => {
       expect(capturedSignal?.aborted).toBe(false);
       expect(handleAgentAbort({ runId: 'abort-me' })).toEqual({ accepted: true, state: 'aborting' });
       expect(capturedSignal?.aborted).toBe(true);
+      expect(traceSidecarRuntimeEventMock).toHaveBeenCalledWith(
+        'sidecar.agent_abort_ack_ready',
+        expect.objectContaining({ runId: 'abort-me', outcome: 'success' }),
+      );
       releaseLoop?.();
       const result = await runPromise;
       expect(result).toEqual({ reason: 'aborted' });
@@ -457,6 +480,10 @@ describe('agentLoopHost', () => {
       const lastBatch = deltaCalls[deltaCalls.length - 1][1] as { runId: string; frames: unknown[] };
       expect(lastBatch.runId).toBe('flush-me');
       expect(lastBatch.frames.length).toBeGreaterThan(0);
+      expect(traceSidecarRuntimeEventMock).toHaveBeenCalledWith(
+        'sidecar.agent_delta_emitted',
+        expect.objectContaining({ runId: 'flush-me', frameCount: lastBatch.frames.length }),
+      );
     });
   });
 

--- a/sidecar/src/agentLoopHost.ts
+++ b/sidecar/src/agentLoopHost.ts
@@ -57,6 +57,7 @@ import { createFrameChatDelta, createFrameExecutionPort, createFrameScratchpadPo
 import { createConversationRunMirror, type ConversationPatch } from './conversationRunMirror';
 import { seedSettingsMirrorIfEmpty, getSettingsMirrorReader, applySettingsSnapshot } from './settingsMirror';
 import { hasLocalTool, isLocalToolReadOnly, executeLocalTool } from './localTools';
+import { sidecarRuntimeErrorType, traceSidecarRuntimeEvent } from './runtimeTrace';
 
 /** Sidecar-local declaration — never imported from shell-side code (same "src/ never runtime-imports sidecar/, and vice versa across this boundary" discipline `frameApplier.ts`/`subagentHost.ts` already document). */
 interface SerializableToolDefinition {
@@ -387,6 +388,12 @@ setPreRequestFlush(flushAllCoalescers);
 export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
   const params = parseAgentRunParams(rawParams);
   const { runId, conversationId } = params;
+  const startedAt = Date.now();
+  traceSidecarRuntimeEvent('sidecar.agent_run_received', {
+    runId,
+    method: 'agent.run',
+    stage: 'params_parsed',
+  });
 
   if (activeRuns.has(runId)) {
     throw new RpcError(-32602, `Invalid params: runId "${runId}" is already active`);
@@ -402,7 +409,17 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
   // (shims/settingsReaderRun.ts) always threw.
   setSettingsReader(getSettingsMirrorReader());
 
+  let emittedFirstDelta = false;
   const coalescer = createPortFrameCoalescer((frames) => {
+    if (!emittedFirstDelta && frames.length > 0) {
+      emittedFirstDelta = true;
+      traceSidecarRuntimeEvent('sidecar.agent_delta_emitted', {
+        runId,
+        frameCount: frames.length,
+        stage: 'first_delta_emitted',
+        durationMs: Date.now() - startedAt,
+      });
+    }
     sendNotification('agent.delta', { runId, frames });
   });
   const push = (frame: PortFrame): void => coalescer.push(frame);
@@ -529,6 +546,11 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
     applyConvPatch: mirror.applyConvPatch,
     applyExecPatch,
   });
+  traceSidecarRuntimeEvent('sidecar.agent_loop_started', {
+    runId,
+    stage: 'agent_loop_running',
+    durationMs: Date.now() - startedAt,
+  });
 
   try {
     const options: AgentLoopOptions = {
@@ -551,7 +573,22 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
     const result: AgentLoopResult = await agentRunContext.run(runCtx, () =>
       runAgentLoop(conversationId, params.userMessage, options),
     );
+    traceSidecarRuntimeEvent('sidecar.agent_run_completed', {
+      runId,
+      stage: 'completed',
+      outcome: result.reason,
+      durationMs: Date.now() - startedAt,
+    });
     return result;
+  } catch (error) {
+    traceSidecarRuntimeEvent('sidecar.agent_run_failed', {
+      runId,
+      stage: 'failed',
+      outcome: 'error',
+      errorType: sidecarRuntimeErrorType(error),
+      durationMs: Date.now() - startedAt,
+    });
+    throw error;
   } finally {
     coalescer.flush();
     activeRuns.delete(runId);
@@ -633,10 +670,21 @@ export interface AgentAbortAck {
 export function handleAgentAbort(rawParams: unknown): AgentAbortAck {
   const { runId } = parseAbortParams(rawParams);
   const run = activeRuns.get(runId);
+  traceSidecarRuntimeEvent('sidecar.agent_abort_received', {
+    runId,
+    method: 'agent.abort',
+    stage: run ? 'aborting' : 'not_found',
+  });
   if (!run) return { accepted: false, state: 'not_found' };
   run.coalescer.flush();
   run.controllers.get(run.conversationId)?.abort();
   run.coalescer.flush();
+  traceSidecarRuntimeEvent('sidecar.agent_abort_ack_ready', {
+    runId,
+    method: 'agent.abort',
+    stage: 'aborting',
+    outcome: 'success',
+  });
   return { accepted: true, state: 'aborting' };
 }
 

--- a/sidecar/src/runtimeTrace.test.ts
+++ b/sidecar/src/runtimeTrace.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  SIDECAR_RUNTIME_TRACE_PREFIX,
+  sidecarRuntimeErrorType,
+  traceSidecarRuntimeEvent,
+} from './runtimeTrace';
+
+describe('sidecar runtime trace', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('emits one safe JSON line without prompt or credential fields', () => {
+    const write = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    traceSidecarRuntimeEvent('sidecar.agent_run_started', {
+      runId: 'run-1',
+      stage: 'token=super-secret-value',
+    });
+
+    expect(write).toHaveBeenCalledOnce();
+    const line = String(write.mock.calls[0][0]);
+    expect(line.startsWith(SIDECAR_RUNTIME_TRACE_PREFIX)).toBe(true);
+    expect(line.endsWith('\n')).toBe(true);
+    const parsed = JSON.parse(line.slice(SIDECAR_RUNTIME_TRACE_PREFIX.length)) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      schemaVersion: 1,
+      process: 'sidecar',
+      event: 'sidecar.agent_run_started',
+      runId: 'run-1',
+    });
+    expect(parsed.stage).toContain('[REDACTED]');
+    expect(line).not.toContain('super-secret-value');
+  });
+
+  it('rejects invalid or non-sidecar event names', () => {
+    const write = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    traceSidecarRuntimeEvent('renderer.wrong_process', { runId: 'run-1' });
+    traceSidecarRuntimeEvent('bad event', { runId: 'run-1' });
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('classifies errors without retaining their message', () => {
+    expect(sidecarRuntimeErrorType(new RangeError('secret body'))).toBe('rangeerror');
+    expect(sidecarRuntimeErrorType(42)).toBe('number');
+  });
+});

--- a/sidecar/src/runtimeTrace.ts
+++ b/sidecar/src/runtimeTrace.ts
@@ -1,0 +1,80 @@
+export const SIDECAR_RUNTIME_TRACE_PREFIX = '[abu-runtime] ';
+const MAX_STRING_CHARS = 160;
+
+const SECRET_PATTERNS: RegExp[] = [
+  /\bsk-[a-zA-Z0-9_-]{12,}/g,
+  /\beyJ[a-zA-Z0-9_-]{8,}\.[a-zA-Z0-9_-]{8,}\.[a-zA-Z0-9_-]{8,}/g,
+  /\bBearer\s+[a-zA-Z0-9._\-+/=]{8,}/gi,
+  /\b(?:token|api[_-]?key|password|secret|authorization)\s*[=:]\s*\S+/gi,
+];
+
+interface SidecarTraceAttributes {
+  runId?: string;
+  rpcId?: string;
+  method?: string;
+  stage?: string;
+  outcome?: string;
+  errorType?: string;
+  durationMs?: number;
+  frameCount?: number;
+  reason?: string;
+}
+
+const SAFE_KEYS = new Set<keyof SidecarTraceAttributes>([
+  'runId',
+  'rpcId',
+  'method',
+  'stage',
+  'outcome',
+  'errorType',
+  'durationMs',
+  'frameCount',
+  'reason',
+]);
+
+function sanitizeEventName(value: string): string | null {
+  return /^[a-z][a-z0-9_.-]{0,79}$/.test(value) ? value : null;
+}
+
+function sanitizeString(value: string): string {
+  let result = value;
+  for (const pattern of SECRET_PATTERNS) result = result.replace(pattern, '[REDACTED]');
+  return result.slice(0, MAX_STRING_CHARS);
+}
+
+function sanitizeAttributes(attributes: SidecarTraceAttributes): SidecarTraceAttributes {
+  const output: SidecarTraceAttributes = {};
+  for (const [key, raw] of Object.entries(attributes) as Array<[
+    keyof SidecarTraceAttributes,
+    SidecarTraceAttributes[keyof SidecarTraceAttributes],
+  ]>) {
+    if (!SAFE_KEYS.has(key) || raw === undefined) continue;
+    if (typeof raw === 'number' && Number.isFinite(raw)) {
+      (output as Record<string, unknown>)[key] = Math.max(0, Math.round(raw));
+    } else if (typeof raw === 'string') {
+      (output as Record<string, unknown>)[key] = sanitizeString(raw);
+    }
+  }
+  return output;
+}
+
+export function sidecarRuntimeErrorType(error: unknown): string {
+  const raw = error instanceof Error ? error.name : typeof error;
+  return raw.toLowerCase().replace(/[^a-z0-9_.-]+/g, '_').slice(0, 80) || 'unknown';
+}
+
+export function traceSidecarRuntimeEvent(eventName: string, attributes: SidecarTraceAttributes = {}): void {
+  const event = sanitizeEventName(eventName);
+  if (!event || !event.startsWith('sidecar.')) return;
+  const line = JSON.stringify({
+    schemaVersion: 1,
+    process: 'sidecar',
+    event,
+    ...sanitizeAttributes(attributes),
+  });
+  try {
+    process.stderr.write(`${SIDECAR_RUNTIME_TRACE_PREFIX}${line}\n`);
+  } catch {
+    // Runtime tracing is best-effort and must never affect the agent loop.
+  }
+}

--- a/src/core/agent/agentLoopRunner.test.ts
+++ b/src/core/agent/agentLoopRunner.test.ts
@@ -37,6 +37,25 @@ vi.mock('../sidecar/sidecarManager', () => ({
   SidecarRequestError: MockSidecarRequestError,
 }));
 
+const {
+  traceRuntimeEventMock,
+  startRuntimeRunMock,
+  markRuntimeRunStageMock,
+  finishRuntimeRunMock,
+} = vi.hoisted(() => ({
+  traceRuntimeEventMock: vi.fn(),
+  startRuntimeRunMock: vi.fn(),
+  markRuntimeRunStageMock: vi.fn(),
+  finishRuntimeRunMock: vi.fn(),
+}));
+vi.mock('../observability/runtimeTrace', () => ({
+  traceRuntimeEvent: (...a: unknown[]) => traceRuntimeEventMock(...a),
+  startRuntimeRun: (...a: unknown[]) => startRuntimeRunMock(...a),
+  markRuntimeRunStage: (...a: unknown[]) => markRuntimeRunStageMock(...a),
+  finishRuntimeRun: (...a: unknown[]) => finishRuntimeRunMock(...a),
+  runtimeErrorType: (error: unknown) => error instanceof Error ? error.name.toLowerCase() : typeof error,
+}));
+
 const applyDeltaFramesMock = vi.fn().mockResolvedValue(undefined);
 vi.mock('./frameApplier', () => ({
   applyDeltaFrames: (...a: unknown[]) => applyDeltaFramesMock(...a),
@@ -501,6 +520,10 @@ describe('agentLoopRunner', () => {
     getSidecarStatusMock.mockReset();
     getSidecarStatusMock.mockReturnValue('running');
     sidecarRequestMock.mockReset();
+    traceRuntimeEventMock.mockReset();
+    startRuntimeRunMock.mockReset();
+    markRuntimeRunStageMock.mockReset();
+    finishRuntimeRunMock.mockReset();
     getSettingsSnapshotMock.mockReset();
     getSettingsSnapshotMock.mockReturnValue({ agentMaxTurns: 200 });
     getPlanModeMock.mockReset();
@@ -1710,6 +1733,63 @@ describe('agentLoopRunner', () => {
       expect(p.resolvedCreds).toEqual({ apiKey: 'sk-1', baseUrl: undefined, forceOpenAiCompatible: false });
       expect(p.toolList).toEqual([{ name: 'read_file', description: 'reads a file', inputSchema: { type: 'object', properties: {} } }]);
       expect(result).toEqual({ reason: 'completed' });
+    });
+
+    it('records a stall after 30 seconds without a non-empty delta, without changing run behavior', async () => {
+      vi.useFakeTimers();
+      const { runAgentLoopDispatched } = await importFresh();
+      const rpc = deferred<unknown>();
+      sidecarRequestMock.mockReturnValue(rpc.promise);
+
+      const running = runAgentLoopDispatched('conv-1', 'hello');
+      await waitForCall(sidecarRequestMock);
+      const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
+
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(traceRuntimeEventMock).not.toHaveBeenCalledWith(
+        'renderer.agent_run_stalled',
+        expect.anything(),
+      );
+      await vi.advanceTimersByTimeAsync(1);
+      expect(traceRuntimeEventMock).toHaveBeenCalledWith(
+        'renderer.agent_run_stalled',
+        expect.objectContaining({ runId, stage: 'stalled_before_first_delta' }),
+      );
+
+      rpc.resolve({ reason: 'completed' });
+      await expect(running).resolves.toEqual({ reason: 'completed' });
+    });
+
+    it('first delta clears the stall timer and records successful frame application', async () => {
+      vi.useFakeTimers();
+      const { runAgentLoopDispatched } = await importFresh();
+      const rpc = deferred<unknown>();
+      sidecarRequestMock.mockReturnValue(rpc.promise);
+
+      const running = runAgentLoopDispatched('conv-1', 'hello');
+      await waitForCall(sidecarRequestMock);
+      const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
+      const deltaHandler = handlerFor(onSidecarNotification, 'agent.delta');
+      await vi.advanceTimersByTimeAsync(10_000);
+      deltaHandler({ runId, frames: [{ p: 'chat', m: 'appendText', a: ['conv-1', 'first'] }] });
+      await vi.waitFor(() => expect(applyDeltaFramesMock).toHaveBeenCalledTimes(1));
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(traceRuntimeEventMock).toHaveBeenCalledWith(
+        'renderer.agent_delta_received',
+        expect.objectContaining({ runId, frameCount: 1 }),
+      );
+      expect(traceRuntimeEventMock).toHaveBeenCalledWith(
+        'renderer.first_frame_applied',
+        expect.objectContaining({ runId, frameCount: 1 }),
+      );
+      expect(traceRuntimeEventMock).not.toHaveBeenCalledWith(
+        'renderer.agent_run_stalled',
+        expect.anything(),
+      );
+
+      rpc.resolve({ reason: 'completed' });
+      await expect(running).resolves.toEqual({ reason: 'completed' });
     });
 
     it('serializes the per-run tool whitelist into agent.run options', async () => {

--- a/src/core/agent/agentLoopRunner.ts
+++ b/src/core/agent/agentLoopRunner.ts
@@ -99,10 +99,18 @@ import { getAuthorizedWritablePaths } from '../tools/pathSafety';
 import { showSandboxBlockedToast } from '../sandbox/recovery';
 import { ensureBuiltinBrowserRuntime } from '../browser/builtinBrowserRuntime';
 import { matchesToolPattern } from '../skill/toolFilter';
+import {
+  finishRuntimeRun,
+  markRuntimeRunStage,
+  runtimeErrorType,
+  startRuntimeRun,
+  traceRuntimeEvent,
+} from '../observability/runtimeTrace';
 
 const logger = createLogger('agent-loop-runner');
 const AGENT_ABORT_ACK_TIMEOUT_MS = 1_000;
 const AGENT_ABORT_FORCE_FINALIZE_MS = 5_000;
+const AGENT_FIRST_FRAME_STALL_MS = 30_000;
 
 // ── Run-session registry ────────────────────────────────────────────────
 //
@@ -188,6 +196,10 @@ export interface RunSession {
   abortWatchdog?: ReturnType<typeof setTimeout>;
   abortRequestPromise?: Promise<void>;
   abortFinalizationPromise?: Promise<void>;
+  runtimeStartedAt?: number;
+  firstDeltaAt?: number;
+  firstFrameApplied?: boolean;
+  firstFrameStallTimer?: ReturnType<typeof setTimeout>;
 }
 
 const sessions = new Map<string, RunSession>();
@@ -231,6 +243,7 @@ registerSidecarRunPredicate(isConversationRunningInSidecar);
 export function unregisterRunSession(runId: string): void {
   const session = sessions.get(runId);
   if (session?.abortWatchdog) clearTimeout(session.abortWatchdog);
+  if (session?.firstFrameStallTimer) clearTimeout(session.firstFrameStallTimer);
   sessions.delete(runId);
   if (sessions.size === 0) uninstallPushEmitters();
 }
@@ -248,6 +261,7 @@ export function __getActiveRunSessionCount(): number {
 export function __resetAgentLoopRunnerForTests(): void {
   for (const session of sessions.values()) {
     if (session.abortWatchdog) clearTimeout(session.abortWatchdog);
+    if (session.firstFrameStallTimer) clearTimeout(session.firstFrameStallTimer);
   }
   sessions.clear();
   uninstallPushEmitters();
@@ -259,17 +273,49 @@ export function __resetAgentLoopRunnerForTests(): void {
 function handleAgentDelta(rawParams: unknown): void {
   const params = rawParams as { runId?: unknown; frames?: unknown } | null;
   if (!params || typeof params.runId !== 'string' || !Array.isArray(params.frames)) return;
+  const frames = params.frames as PortFrame[];
   const session = sessions.get(params.runId);
   if (!session) return; // unknown/already-finished runId — silent drop
   if (session.dropFrames) return; // terminal fence — late frames from an aborted run are stale
   // P1-3B-3B fallback discipline: the first frame observed for this run is
   // an already-committed, observable side effect (text/thinking streamed to
   // the real chatStore) — see RunSession.committed's doc.
-  if (params.frames.length > 0) session.committed = true;
+  const isFirstDelta = frames.length > 0 && session.firstDeltaAt === undefined;
+  if (frames.length > 0) {
+    session.committed = true;
+    if (isFirstDelta) {
+      session.firstDeltaAt = Date.now();
+      if (session.firstFrameStallTimer) {
+        clearTimeout(session.firstFrameStallTimer);
+        session.firstFrameStallTimer = undefined;
+      }
+      markRuntimeRunStage(params.runId, 'first_delta_received');
+      traceRuntimeEvent('renderer.agent_delta_received', {
+        runId: params.runId,
+        frameCount: frames.length,
+        stage: 'first_delta_received',
+        durationMs: session.runtimeStartedAt === undefined
+          ? undefined
+          : session.firstDeltaAt - session.runtimeStartedAt,
+      });
+    }
+  }
   const previous = session.frameApplyTail ?? Promise.resolve();
   session.frameApplyTail = previous.then(() =>
-    applyDeltaFrames(params.frames as PortFrame[])
-  ).catch((err: unknown) => {
+    applyDeltaFrames(frames)
+  ).then(() => {
+    if (!isFirstDelta || session.firstFrameApplied) return;
+    session.firstFrameApplied = true;
+    markRuntimeRunStage(params.runId as string, 'first_frame_applied');
+    traceRuntimeEvent('renderer.first_frame_applied', {
+      runId: params.runId as string,
+      frameCount: frames.length,
+      stage: 'first_frame_applied',
+      firstFrameMs: session.runtimeStartedAt === undefined
+        ? undefined
+        : Date.now() - session.runtimeStartedAt,
+    });
+  }).catch((err: unknown) => {
     logger.warn('applyDeltaFrames threw', { runId: params.runId, error: err instanceof Error ? err.message : String(err) });
   });
 }
@@ -406,7 +452,19 @@ async function finalizeAbortedRun(session: RunSession, source: 'ack' | 'watchdog
 function requestSidecarRunAbort(session: RunSession): Promise<void> {
   if (session.abortRequestPromise) return session.abortRequestPromise;
   session.abortRequested = true;
+  markRuntimeRunStage(session.runId ?? session.loopId, 'abort_requested');
+  traceRuntimeEvent('renderer.agent_abort_requested', {
+    runId: session.runId ?? session.loopId,
+    method: 'agent.abort',
+    stage: 'abort_requested',
+  });
   session.abortWatchdog = setTimeout(() => {
+    traceRuntimeEvent('renderer.agent_abort_watchdog_fired', {
+      runId: session.runId ?? session.loopId,
+      method: 'agent.abort',
+      stage: 'force_finalize',
+      outcome: 'stalled',
+    });
     void finalizeAbortedRun(session, 'watchdog');
   }, AGENT_ABORT_FORCE_FINALIZE_MS);
 
@@ -415,6 +473,12 @@ function requestSidecarRunAbort(session: RunSession): Promise<void> {
     { runId: session.runId },
     AGENT_ABORT_ACK_TIMEOUT_MS,
   ).then(async () => {
+    traceRuntimeEvent('renderer.agent_abort_ack_received', {
+      runId: session.runId ?? session.loopId,
+      method: 'agent.abort',
+      stage: 'ack_received',
+      outcome: 'success',
+    });
     await finalizeAbortedRun(session, 'ack');
   }).catch((err: unknown) => {
     // A pre-ACK timeout is not terminal: the sidecar may have received and
@@ -423,6 +487,13 @@ function requestSidecarRunAbort(session: RunSession): Promise<void> {
       runId: session.runId,
       conversationId: session.conversationId,
       error: err instanceof Error ? err.message : String(err),
+    });
+    traceRuntimeEvent('renderer.agent_abort_ack_timeout', {
+      runId: session.runId ?? session.loopId,
+      method: 'agent.abort',
+      stage: 'waiting_for_watchdog',
+      outcome: 'stalled',
+      errorType: runtimeErrorType(err),
     });
   });
   return session.abortRequestPromise;
@@ -1524,6 +1595,13 @@ export async function runAgentLoopDispatched(
 
   const runId = generateRunId();
   logger.debug('agent-loop path selected', { path: 'sidecar', runId, conversationId });
+  const runtimeStartedAt = Date.now();
+  startRuntimeRun(runId, 'sidecar', 'building_params');
+  traceRuntimeEvent('renderer.agent_params_build_started', {
+    runId,
+    executionPath: 'sidecar',
+    stage: 'building_params',
+  });
 
   // Skill inline commands execute while the system prompt is precomputed, so
   // the task controller and visible conversation ownership must exist before
@@ -1544,22 +1622,54 @@ export async function runAgentLoopDispatched(
       options,
       shellAbortController.signal,
     );
+    markRuntimeRunStage(runId, 'params_built');
+    traceRuntimeEvent('renderer.agent_params_build_completed', {
+      runId,
+      executionPath: 'sidecar',
+      stage: 'params_built',
+      durationMs: Date.now() - runtimeStartedAt,
+    });
   } catch (err) {
     const wasAborted = shellAbortController.signal.aborted;
     abortRegistry.clearAbortController(conversationId);
     shellChatDelta.setConversationStatus(conversationId, 'idle');
-    if (wasAborted) return { reason: 'aborted' };
+    if (wasAborted) {
+      traceRuntimeEvent('renderer.agent_run_aborted', {
+        runId,
+        executionPath: 'sidecar',
+        stage: 'params_build_aborted',
+        outcome: 'aborted',
+      });
+      finishRuntimeRun(runId);
+      return { reason: 'aborted' };
+    }
     // Failed before any dispatch — pre-commit by construction (see doc).
     logger.warn('agent-loop dispatch params build failed — running in-process', {
       runId,
       conversationId,
       error: err instanceof Error ? err.message : String(err),
     });
+    traceRuntimeEvent('renderer.agent_params_build_failed', {
+      runId,
+      executionPath: 'sidecar',
+      stage: 'fallback_in_process',
+      outcome: 'error',
+      errorType: runtimeErrorType(err),
+      durationMs: Date.now() - runtimeStartedAt,
+    });
+    finishRuntimeRun(runId);
     return runAgentLoop(conversationId, userMessage, options);
   }
   if (shellAbortController.signal.aborted) {
     abortRegistry.clearAbortController(conversationId);
     shellChatDelta.setConversationStatus(conversationId, 'idle');
+    traceRuntimeEvent('renderer.agent_run_aborted', {
+      runId,
+      executionPath: 'sidecar',
+      stage: 'before_dispatch',
+      outcome: 'aborted',
+    });
+    finishRuntimeRun(runId);
     return { reason: 'aborted' };
   }
 
@@ -1582,6 +1692,7 @@ export async function runAgentLoopDispatched(
     transportAbortController: new AbortController(),
     toolCallToStepId: new Map(),
     committed: false,
+    runtimeStartedAt,
     // P1-3B-4 — the entries in `params.queuedInputs` were already seeded
     // into the sidecar's OWN queue at dispatch time (agentLoopHost.ts's
     // handleAgentRun), so pre-mark them forwarded BEFORE registerRunSession
@@ -1599,6 +1710,27 @@ export async function runAgentLoopDispatched(
 
   registerRunSession(runId, session);
   installShellLoopContext(runId, session);
+  markRuntimeRunStage(runId, 'waiting_for_first_delta');
+  traceRuntimeEvent('renderer.agent_run_dispatched', {
+    runId,
+    method: 'agent.run',
+    executionPath: 'sidecar',
+    stage: 'waiting_for_first_delta',
+    durationMs: Date.now() - runtimeStartedAt,
+  });
+  session.firstFrameStallTimer = setTimeout(() => {
+    session.firstFrameStallTimer = undefined;
+    if (session.firstDeltaAt !== undefined || session.dropFrames) return;
+    markRuntimeRunStage(runId, 'stalled_before_first_delta');
+    traceRuntimeEvent('renderer.agent_run_stalled', {
+      runId,
+      method: 'agent.run',
+      executionPath: 'sidecar',
+      stage: 'stalled_before_first_delta',
+      outcome: 'stalled',
+      durationMs: Date.now() - runtimeStartedAt,
+    });
+  }, AGENT_FIRST_FRAME_STALL_MS);
   let handedOffToLocal = false;
 
   try {
@@ -1612,8 +1744,25 @@ export async function runAgentLoopDispatched(
     await settleRunPersistence(session);
     if (shellAbortController.signal.aborted) {
       await finalizeAbortedRun(session, 'run-terminal');
+      traceRuntimeEvent('renderer.agent_run_aborted', {
+        runId,
+        executionPath: 'sidecar',
+        stage: 'run_terminal',
+        outcome: 'aborted',
+        durationMs: Date.now() - runtimeStartedAt,
+      });
       return { reason: 'aborted' };
     }
+    traceRuntimeEvent('renderer.agent_run_completed', {
+      runId,
+      executionPath: 'sidecar',
+      stage: 'completed',
+      outcome: raw.reason,
+      durationMs: Date.now() - runtimeStartedAt,
+      firstFrameMs: session.firstDeltaAt === undefined
+        ? undefined
+        : session.firstDeltaAt - runtimeStartedAt,
+    });
     return raw;
   } catch (err) {
     // A failing RPC can still have flushed committed frames immediately
@@ -1622,6 +1771,13 @@ export async function runAgentLoopDispatched(
     await settleRunPersistence(session);
     if (shellAbortController.signal.aborted) {
       await finalizeAbortedRun(session, 'run-terminal');
+      traceRuntimeEvent('renderer.agent_run_aborted', {
+        runId,
+        executionPath: 'sidecar',
+        stage: 'run_terminal_error',
+        outcome: 'aborted',
+        durationMs: Date.now() - runtimeStartedAt,
+      });
       return { reason: 'aborted' };
     }
     if (!session.committed) {
@@ -1637,6 +1793,14 @@ export async function runAgentLoopDispatched(
         runId,
         conversationId,
         error: err instanceof Error ? err.message : String(err),
+      });
+      traceRuntimeEvent('renderer.agent_run_fallback', {
+        runId,
+        executionPath: 'sidecar',
+        stage: 'fallback_in_process',
+        outcome: 'error',
+        errorType: runtimeErrorType(err),
+        durationMs: Date.now() - runtimeStartedAt,
       });
       // The local loop synchronously installs its own AbortController before its
       // first await. Mark the ownership transfer so this dispatch wrapper's
@@ -1668,6 +1832,14 @@ export async function runAgentLoopDispatched(
           ? String((errData as { stack: unknown }).stack)
           : undefined,
     });
+    traceRuntimeEvent('renderer.agent_run_failed', {
+      runId,
+      executionPath: 'sidecar',
+      stage: 'failed_after_commit',
+      outcome: 'error',
+      errorType: runtimeErrorType(err),
+      durationMs: Date.now() - runtimeStartedAt,
+    });
     // The sidecar loop threw uncaught, so its OWN terminal UI-finalization
     // frames (finishStreaming / setConversationStatus) never arrived — the
     // conversation is left mid-stream and hangs on "thinking". Finalize it
@@ -1690,6 +1862,8 @@ export async function runAgentLoopDispatched(
     }
     return { reason: 'error', error: realMessage };
   } finally {
+    if (session.firstFrameStallTimer) clearTimeout(session.firstFrameStallTimer);
+    finishRuntimeRun(runId);
     removeShellLoopContext(runId);
     unregisterRunSession(runId);
     shellAbortController.signal.removeEventListener('abort', onShellAbort);

--- a/src/core/diagnostic/collect.test.ts
+++ b/src/core/diagnostic/collect.test.ts
@@ -9,6 +9,7 @@ import {
 import { useChatStore } from '@/stores/chatStore';
 import type { Conversation, Message } from '@/types';
 import type { ConversationMeta } from '@/core/session/conversationStorage';
+import { clearLogs, createLogger } from '@/core/logging/logger';
 
 function makeMessage(id: string, text: string): Message {
   return { id, role: 'user', content: text, timestamp: Date.now() };
@@ -79,6 +80,7 @@ describe('collectBundleFiles (诊断反馈增强 L1: 多选对话 / 描述 / 截
   const convC = makeConversation('conv-cccccccc-3333');
 
   beforeEach(() => {
+    clearLogs();
     useChatStore.setState({
       conversations: { [convA.id]: convA, [convB.id]: convB, [convC.id]: convC },
       conversationIndex: {
@@ -88,6 +90,11 @@ describe('collectBundleFiles (诊断反馈增强 L1: 多选对话 / 描述 / 截
       },
       activeConversationId: convA.id,
     });
+  });
+
+  afterEach(() => {
+    delete (globalThis as typeof globalThis & { __ABU_SHELL__?: unknown }).__ABU_SHELL__;
+    clearLogs();
   });
 
   it('embeds only the selected conversations when conversationIds has multiple entries', async () => {
@@ -154,6 +161,50 @@ describe('collectBundleFiles (诊断反馈增强 L1: 多选对话 / 描述 / 截
     const entry = files['feedback/screenshots/01.png'];
     expect(entry).toBeInstanceOf(Uint8Array);
     expect(entry).toEqual(bytes);
+  });
+
+  it('automatically includes cross-process runtime state without changing feedback options', async () => {
+    const runtime = globalThis as typeof globalThis & {
+      __ABU_SHELL__?: {
+        getRuntimeDiagnostics: () => Promise<{
+          schemaVersion: 1;
+          appSessionId: string;
+          recentEventLines: string[];
+          pendingRpcs: Array<Record<string, unknown>>;
+          sidecars: Array<Record<string, unknown>>;
+          pendingRendererAcks: Array<Record<string, unknown>>;
+        }>;
+      };
+    };
+    runtime.__ABU_SHELL__ = {
+      getRuntimeDiagnostics: async () => ({
+        schemaVersion: 1,
+        appSessionId: 'session-1',
+        recentEventLines: [JSON.stringify({ event: 'main.rpc_write_started', runId: 'run-1' })],
+        pendingRpcs: [{ runId: 'run-1', method: 'agent.run', durationMs: 321 }],
+        sidecars: [{ sidecarId: 'abu-sidecar', stage: 'running' }],
+        pendingRendererAcks: [{ runId: 'run-1', durationMs: 12 }],
+      }),
+    };
+
+    const { files } = await collectBundleFiles({ includeRawText: true, conversationIds: [] });
+
+    expect(files['runtime/renderer-trace.json']).toBeDefined();
+    expect(files['logs/main-runtime.jsonl']).toContain('main.rpc_write_started');
+    expect(files['runtime/pending-rpcs.json']).toContain('agent.run');
+    expect(files['runtime/sidecar-state.json']).toContain('abu-sidecar');
+    expect(files['runtime/sidecar-state.json']).toContain('pendingRendererAcks');
+  });
+
+  it('redacts secrets from existing runtime logs before adding them to the bundle', async () => {
+    const secret = `sk-${'a'.repeat(32)}`;
+    createLogger('diagnostic-test').info('provider failed', { detail: secret });
+
+    const { files } = await collectBundleFiles({ includeRawText: true, conversationIds: [] });
+    const runtimeLog = String(files['logs/runtime.jsonl']);
+
+    expect(runtimeLog).not.toContain(secret);
+    expect(runtimeLog).toContain('[REDACTED]');
   });
 
   it('applies the message cap independently per conversation', async () => {

--- a/src/core/diagnostic/collect.ts
+++ b/src/core/diagnostic/collect.ts
@@ -20,7 +20,9 @@ import { useDiagnosticStore } from '@/stores/diagnosticStore';
 import { useScheduleStore } from '@/stores/scheduleStore';
 import { skillLoader } from '@/core/skill/loader';
 import { getRecentLogs, getLogDirPath } from '@/core/logging/logger';
+import { getRendererRuntimeTraceSnapshot } from '@/core/observability/runtimeTrace';
 import { catalogGetCount } from '@/core/session/conversationStorage';
+import { getElectronRuntimeDiagnostics } from '@/utils/electronHost';
 import { APP_VERSION } from '@/utils/version';
 import { platform } from '@tauri-apps/plugin-os';
 import { scrubSecrets, scrubMessage } from './scrub';
@@ -489,7 +491,7 @@ export async function collectBundleFiles(opts: CollectOptions): Promise<CollectR
   // warn/error level that's the highest-value debug signal.
   try {
     const entries = getRecentLogs().slice(-RUNTIME_LOG_LIMIT);
-    files['logs/runtime.jsonl'] = entries.map((e) => JSON.stringify(e)).join('\n');
+    files['logs/runtime.jsonl'] = entries.map((e) => JSON.stringify(scrubSecrets(e))).join('\n');
   } catch (e) {
     files['logs/runtime.jsonl'] = JSON.stringify({ error: e instanceof Error ? e.message : String(e) });
   }
@@ -505,7 +507,7 @@ export async function collectBundleFiles(opts: CollectOptions): Promise<CollectR
         try {
           const content = await readTextFile(joinPath(logDir, name));
           const lines = content.split('\n');
-          files[`logs/${name}`] = lines.slice(-DISK_LOG_TAIL_LINES).join('\n');
+          files[`logs/${name}`] = String(scrubSecrets(lines.slice(-DISK_LOG_TAIL_LINES).join('\n')));
         } catch {
           // File not present — skip silently
         }
@@ -513,6 +515,43 @@ export async function collectBundleFiles(opts: CollectOptions): Promise<CollectR
     }
   } catch (e) {
     files['logs/disk-read-error.txt'] = e instanceof Error ? e.message : String(e);
+  }
+
+  // ── runtime/* + logs/main-runtime.jsonl ──────────────────────────────────
+  // Cross-process breadcrumbs for the Electron agent path. These snapshots
+  // contain identifiers, stages, durations, counts, and classified failures
+  // only — never prompts, message text, tool arguments, or provider bodies.
+  // Tauri and tests without an Electron preload bridge simply omit the main
+  // process files while retaining the renderer snapshot.
+  files['runtime/renderer-trace.json'] = JSON.stringify(
+    scrubSecrets(getRendererRuntimeTraceSnapshot()),
+    null,
+    2,
+  );
+  const electronRuntime = await getElectronRuntimeDiagnostics();
+  if (electronRuntime) {
+    files['logs/main-runtime.jsonl'] = String(
+      scrubSecrets(electronRuntime.recentEventLines.join('\n')),
+    );
+    files['runtime/pending-rpcs.json'] = JSON.stringify(
+      scrubSecrets({
+        schemaVersion: electronRuntime.schemaVersion,
+        appSessionId: electronRuntime.appSessionId,
+        pendingRpcs: electronRuntime.pendingRpcs,
+      }),
+      null,
+      2,
+    );
+    files['runtime/sidecar-state.json'] = JSON.stringify(
+      scrubSecrets({
+        schemaVersion: electronRuntime.schemaVersion,
+        appSessionId: electronRuntime.appSessionId,
+        sidecars: electronRuntime.sidecars,
+        pendingRendererAcks: electronRuntime.pendingRendererAcks,
+      }),
+      null,
+      2,
+    );
   }
 
   // ── stores/versions.json ─────────────────────────────────────────────

--- a/src/core/diagnostic/scrub.test.ts
+++ b/src/core/diagnostic/scrub.test.ts
@@ -59,6 +59,15 @@ describe('scrubSecrets — value pattern redaction', () => {
     expect(scrubSecrets('Bearer xyz123abcdef0987654321qq')).toContain('[REDACTED]');
   });
 
+  it('redacts short secret fields embedded in serialized or plain log strings', () => {
+    expect(scrubSecrets('request {"apiKey":"short-local-key","model":"m"}')).toBe(
+      'request {"apiKey":"[REDACTED]","model":"m"}',
+    );
+    expect(scrubSecrets('access_token=short-token status=failed')).toBe(
+      'access_token=[REDACTED] status=failed',
+    );
+  });
+
   it('redacts GitHub PATs and Google API keys', () => {
     // Build fake fixtures from parts so source file scanners don't flag them as real secrets.
     const fakeGhPat = 'ghp' + '_' + 'abcdefghijklmnopqrstuvwxyz1234567890';

--- a/src/core/diagnostic/scrub.ts
+++ b/src/core/diagnostic/scrub.ts
@@ -87,6 +87,11 @@ const SECRET_VALUE_PATTERNS: RegExp[] = [
   /\bAIza[a-zA-Z0-9_-]{30,}/g,
 ];
 
+// Secret-looking key/value pairs embedded inside plain log strings, where
+// recursive field-name scrubbing cannot see the serialized object shape.
+const SERIALIZED_SECRET_VALUE_PATTERN =
+  /\b(api[_-]?key|access[_-]?token|token|password|secret|authorization)(["']?\s*[:=]\s*["']?)([^"',}\s]+)/gi;
+
 function isSecretField(key: string): boolean {
   const lower = key.toLowerCase();
   if (SECRET_FIELD_ALLOWLIST.has(lower)) return false;
@@ -94,7 +99,10 @@ function isSecretField(key: string): boolean {
 }
 
 function redactStringValue(s: string): string {
-  let out = s;
+  let out = s.replace(
+    SERIALIZED_SECRET_VALUE_PATTERN,
+    (_match, key: string, separator: string) => `${key}${separator}${REDACTED}`,
+  );
   for (const re of SECRET_VALUE_PATTERNS) {
     out = out.replace(re, REDACTED);
   }

--- a/src/core/observability/runtimeTrace.test.ts
+++ b/src/core/observability/runtimeTrace.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const recordElectronRuntimeEventMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/utils/electronHost', () => ({
+  recordElectronRuntimeEvent: (...args: unknown[]) => recordElectronRuntimeEventMock(...args),
+}));
+
+import {
+  __resetRuntimeTraceForTests,
+  finishRuntimeRun,
+  getRendererRuntimeTraceSnapshot,
+  markRuntimeRunStage,
+  runtimeErrorType,
+  startRuntimeRun,
+  traceRuntimeEvent,
+} from './runtimeTrace';
+
+describe('renderer runtime trace', () => {
+  beforeEach(() => {
+    __resetRuntimeTraceForTests();
+    recordElectronRuntimeEventMock.mockReset();
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+  });
+
+  it('records only renderer events and forwards the allowlisted fields', () => {
+    traceRuntimeEvent('renderer.agent_run_dispatched', {
+      runId: 'run-1',
+      stage: 'authorization=Bearer abcdefghijklmnop',
+      ...({ prompt: 'private conversation text' } as unknown as Record<string, never>),
+    });
+    traceRuntimeEvent('sidecar.invalid', { runId: 'ignored' });
+    traceRuntimeEvent('not valid!', { runId: 'ignored' });
+
+    const snapshot = getRendererRuntimeTraceSnapshot();
+    expect(snapshot.recentEvents).toHaveLength(1);
+    expect(snapshot.recentEvents[0]).toMatchObject({
+      event: 'renderer.agent_run_dispatched',
+      runId: 'run-1',
+    });
+    expect(snapshot.recentEvents[0].stage).toContain('[REDACTED]');
+    expect(snapshot.recentEvents[0]).not.toHaveProperty('prompt');
+    expect(recordElectronRuntimeEventMock.mock.calls[0][0]).not.toHaveProperty('prompt');
+    expect(recordElectronRuntimeEventMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports active stages and removes terminal runs', () => {
+    startRuntimeRun('run-2', 'electron-sidecar', 'params_build');
+    vi.advanceTimersByTime(250);
+    markRuntimeRunStage('run-2', 'waiting_for_first_delta');
+
+    expect(getRendererRuntimeTraceSnapshot().activeRuns).toEqual([{
+      runId: 'run-2',
+      executionPath: 'electron-sidecar',
+      stage: 'waiting_for_first_delta',
+      durationMs: 250,
+    }]);
+
+    finishRuntimeRun('run-2');
+    expect(getRendererRuntimeTraceSnapshot().activeRuns).toEqual([]);
+  });
+
+  it('classifies errors without retaining their message', () => {
+    expect(runtimeErrorType(new TypeError('secret prompt'))).toBe('typeerror');
+    expect(runtimeErrorType('secret prompt')).toBe('string');
+  });
+});

--- a/src/core/observability/runtimeTrace.ts
+++ b/src/core/observability/runtimeTrace.ts
@@ -1,0 +1,161 @@
+import { recordElectronRuntimeEvent } from '@/utils/electronHost';
+
+const MAX_EVENTS = 500;
+const MAX_STRING_CHARS = 160;
+
+export interface RuntimeTraceAttributes {
+  runId?: string;
+  rpcId?: string;
+  method?: string;
+  stage?: string;
+  outcome?: string;
+  errorType?: string;
+  sidecarId?: string;
+  sidecarGeneration?: number;
+  durationMs?: number;
+  payloadBytes?: number;
+  frameCount?: number;
+  pendingRpcCount?: number;
+  reason?: string;
+  executionPath?: string;
+  firstFrameMs?: number;
+  bridgeLatencyMs?: number;
+}
+
+export interface RuntimeTraceEvent extends RuntimeTraceAttributes {
+  schemaVersion: 1;
+  timestamp: number;
+  process: 'renderer';
+  event: string;
+}
+
+interface ActiveRuntimeRun {
+  runId: string;
+  executionPath: string;
+  stage: string;
+  startedAt: number;
+  updatedAt: number;
+}
+
+export interface RendererRuntimeTraceSnapshot {
+  schemaVersion: 1;
+  takenAt: number;
+  recentEvents: RuntimeTraceEvent[];
+  activeRuns: Array<{
+    runId: string;
+    executionPath: string;
+    stage: string;
+    durationMs: number;
+  }>;
+}
+
+const recentEvents: RuntimeTraceEvent[] = [];
+const activeRuns = new Map<string, ActiveRuntimeRun>();
+
+const SAFE_ATTRIBUTE_KEYS = new Set<keyof RuntimeTraceAttributes>([
+  'runId',
+  'rpcId',
+  'method',
+  'stage',
+  'outcome',
+  'errorType',
+  'sidecarId',
+  'sidecarGeneration',
+  'durationMs',
+  'payloadBytes',
+  'frameCount',
+  'pendingRpcCount',
+  'reason',
+  'executionPath',
+  'firstFrameMs',
+  'bridgeLatencyMs',
+]);
+
+const SECRET_PATTERNS: RegExp[] = [
+  /\bsk-[a-zA-Z0-9_-]{12,}/g,
+  /\beyJ[a-zA-Z0-9_-]{8,}\.[a-zA-Z0-9_-]{8,}\.[a-zA-Z0-9_-]{8,}/g,
+  /\bBearer\s+[a-zA-Z0-9._\-+/=]{8,}/gi,
+  /\b(?:token|api[_-]?key|password|secret|authorization)\s*[=:]\s*\S+/gi,
+];
+
+function sanitizeString(value: string): string {
+  let result = value;
+  for (const pattern of SECRET_PATTERNS) result = result.replace(pattern, '[REDACTED]');
+  return result.slice(0, MAX_STRING_CHARS);
+}
+
+function sanitizeEventName(value: string): string | null {
+  return /^[a-z][a-z0-9_.-]{0,79}$/.test(value) ? value : null;
+}
+
+function sanitizeAttributes(attributes: RuntimeTraceAttributes): RuntimeTraceAttributes {
+  const output: RuntimeTraceAttributes = {};
+  for (const [key, raw] of Object.entries(attributes) as Array<[
+    keyof RuntimeTraceAttributes,
+    RuntimeTraceAttributes[keyof RuntimeTraceAttributes],
+  ]>) {
+    if (!SAFE_ATTRIBUTE_KEYS.has(key) || raw === undefined) continue;
+    if (typeof raw === 'number' && Number.isFinite(raw)) {
+      (output as Record<string, unknown>)[key] = Math.max(0, Math.round(raw));
+    } else if (typeof raw === 'string') {
+      (output as Record<string, unknown>)[key] = sanitizeString(raw);
+    }
+  }
+  return output;
+}
+
+export function runtimeErrorType(error: unknown): string {
+  const raw = error instanceof Error ? error.name : typeof error;
+  return raw.toLowerCase().replace(/[^a-z0-9_.-]+/g, '_').slice(0, 80) || 'unknown';
+}
+
+export function traceRuntimeEvent(eventName: string, attributes: RuntimeTraceAttributes = {}): void {
+  const event = sanitizeEventName(eventName);
+  if (!event || !event.startsWith('renderer.')) return;
+  const entry: RuntimeTraceEvent = {
+    schemaVersion: 1,
+    timestamp: Date.now(),
+    process: 'renderer',
+    event,
+    ...sanitizeAttributes(attributes),
+  };
+  recentEvents.push(entry);
+  if (recentEvents.length > MAX_EVENTS) recentEvents.shift();
+  recordElectronRuntimeEvent({ event, ...sanitizeAttributes(attributes) });
+}
+
+export function startRuntimeRun(runId: string, executionPath: string, stage: string): void {
+  const now = Date.now();
+  activeRuns.set(runId, { runId, executionPath, stage, startedAt: now, updatedAt: now });
+}
+
+export function markRuntimeRunStage(runId: string, stage: string): void {
+  const run = activeRuns.get(runId);
+  if (!run) return;
+  run.stage = stage;
+  run.updatedAt = Date.now();
+}
+
+export function finishRuntimeRun(runId: string): void {
+  activeRuns.delete(runId);
+}
+
+export function getRendererRuntimeTraceSnapshot(): RendererRuntimeTraceSnapshot {
+  const takenAt = Date.now();
+  return {
+    schemaVersion: 1,
+    takenAt,
+    recentEvents: recentEvents.map((event) => ({ ...event })),
+    activeRuns: Array.from(activeRuns.values(), (run) => ({
+      runId: run.runId,
+      executionPath: run.executionPath,
+      stage: run.stage,
+      durationMs: Math.max(0, takenAt - run.startedAt),
+    })),
+  };
+}
+
+export function __resetRuntimeTraceForTests(): void {
+  recentEvents.length = 0;
+  activeRuns.clear();
+}

--- a/src/utils/consoleError.test.ts
+++ b/src/utils/consoleError.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./deviceId', () => ({ getDeviceId: () => 'device-1' }))
+vi.mock('./version', () => ({ APP_VERSION: '1.2.3' }))
+vi.mock('./platform', () => ({ getPlatform: () => 'macos' }))
+vi.mock('./consoleTelemetryTarget', () => ({
+  getTelemetryTarget: () => ({ baseUrl: 'https://console.test', enabled: true }),
+}))
+
+import { reportError } from './consoleError'
+
+describe('reportError privacy boundary', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('never uploads a provider raw body and redacts secrets from the bounded message', () => {
+    const secret = `sk-${'a'.repeat(32)}`
+    reportError(
+      'api_error',
+      'rate_limited',
+      429,
+      'model-a',
+      `Bearer abcdefghijklmnop failed with ${secret} ${'x'.repeat(800)}`,
+      `private prompt and ${secret}`,
+    )
+
+    const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>
+    expect(body.rawBody).toBeNull()
+    expect(String(body.errorMessage)).not.toContain(secret)
+    expect(String(body.errorMessage)).not.toContain('abcdefghijklmnop')
+    expect(String(body.errorMessage)).toContain('[REDACTED]')
+    expect(String(body.errorMessage).length).toBeLessThanOrEqual(500)
+  })
+})

--- a/src/utils/consoleError.ts
+++ b/src/utils/consoleError.ts
@@ -3,13 +3,31 @@ import { APP_VERSION } from './version'
 import { getPlatform } from './platform'
 import { getTelemetryTarget } from './consoleTelemetryTarget'
 
+const MAX_ERROR_MESSAGE_CHARS = 500
+const SECRET_PATTERNS: RegExp[] = [
+  /\bsk-[a-zA-Z0-9_-]{12,}/g,
+  /\beyJ[a-zA-Z0-9_-]{8,}\.[a-zA-Z0-9_-]{8,}\.[a-zA-Z0-9_-]{8,}/g,
+  /\bBearer\s+[a-zA-Z0-9._\-+/=]{8,}/gi,
+  /\b(?:token|api[_-]?key|password|secret|authorization)\s*[=:]\s*\S+/gi,
+]
+
+function safeErrorMessage(value: string | undefined): string | null {
+  if (!value) return null
+  let result = value
+  for (const pattern of SECRET_PATTERNS) result = result.replace(pattern, '[REDACTED]')
+  return Array.from(result, (char) => {
+    const code = char.charCodeAt(0)
+    return code <= 8 || code === 11 || code === 12 || (code >= 14 && code <= 31) || code === 127 ? '' : char
+  }).join('').slice(0, MAX_ERROR_MESSAGE_CHARS)
+}
+
 export function reportError(
   errorType: 'api_error' | 'agent_crash',
   errorCode?: string,
   statusCode?: number,
   model?: string,
   errorMessage?: string,
-  rawBody?: string,
+  _rawBody?: string,
 ): void {
   const { baseUrl, enabled } = getTelemetryTarget()
   if (!enabled) return
@@ -21,8 +39,12 @@ export function reportError(
       deviceId: getDeviceId(),
       errorType,
       errorCode: errorCode ?? null,
-      errorMessage: errorMessage ?? null,
-      rawBody: rawBody ?? null,
+      errorMessage: safeErrorMessage(errorMessage),
+      // Provider bodies can contain echoed prompts, credentials, proxy pages,
+      // or upstream request metadata. Status/errorCode retain the useful
+      // classification signal; raw bodies stay local and may only enter a
+      // user-initiated diagnostic bundle after its normal scrub pass.
+      rawBody: null,
       statusCode: statusCode ?? null,
       model: model ?? null,
       appVersion: APP_VERSION,

--- a/src/utils/electronHost.ts
+++ b/src/utils/electronHost.ts
@@ -6,6 +6,17 @@
 interface AbuShellBridge {
   mainSupervisesSidecar?: boolean;
   getPathForFile?: (file: File) => string;
+  recordRuntimeEvent?: (event: Record<string, unknown>) => void;
+  getRuntimeDiagnostics?: () => Promise<ElectronRuntimeDiagnostics>;
+}
+
+export interface ElectronRuntimeDiagnostics {
+  schemaVersion: 1;
+  appSessionId: string;
+  recentEventLines: string[];
+  pendingRpcs: Array<Record<string, unknown>>;
+  sidecars: Array<Record<string, unknown>>;
+  pendingRendererAcks: Array<Record<string, unknown>>;
 }
 
 function getRuntime() {
@@ -27,4 +38,20 @@ export function hasElectronCommandHost(): boolean {
 /** Resolve the native path of a user-provided Electron File object. */
 export function getElectronFilePath(file: File): string {
   return getRuntime().__ABU_SHELL__?.getPathForFile?.(file) ?? '';
+}
+
+export function recordElectronRuntimeEvent(event: Record<string, unknown>): void {
+  try {
+    getRuntime().__ABU_SHELL__?.recordRuntimeEvent?.(event);
+  } catch {
+    // Observability is best-effort and must never change product behavior.
+  }
+}
+
+export async function getElectronRuntimeDiagnostics(): Promise<ElectronRuntimeDiagnostics | null> {
+  try {
+    return await getRuntime().__ABU_SHELL__?.getRuntimeDiagnostics?.() ?? null;
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary
- add privacy-safe runtime correlation across renderer, Electron main, and sidecar
- capture sidecar lifecycle, RPC, first-frame, stall, bridge ACK, abort, and failure checkpoints
- enrich offline diagnostic bundles without changing the feedback UI or adding online telemetry
- harden diagnostic and console-error redaction

## Validation
- npm run verify (344 files, 4712 tests)
- npm run electron:dev:check
- Electron security tests: 77 passed, 1 skipped
- real Electron launch, unchanged feedback UI, sidecar readiness, and offline diagnostic export verified