### PR TITLE
fix(ci): harden Windows smoke process-Path guards against shutdown race

### DIFF
--- a/scripts/electron-windows-installed-smoke.ps1
+++ b/scripts/electron-windows-installed-smoke.ps1
@@ -135,12 +135,19 @@ try {
       $installedProcesses = @(
         Get-Process -Name "Abu" -ErrorAction SilentlyContinue |
           Where-Object {
-            $beforePids -notcontains $_.Id -and
-            $_.Path -and
-            [System.IO.Path]::GetFullPath($_.Path).Equals(
-              $installedPath,
-              [System.StringComparison]::OrdinalIgnoreCase
-            )
+            try {
+              $beforePids -notcontains $_.Id -and
+              $_.Path -and
+              [System.IO.Path]::GetFullPath($_.Path).Equals(
+                $installedPath,
+                [System.StringComparison]::OrdinalIgnoreCase
+              )
+            } catch {
+              # A process exiting mid-shutdown can expose an empty/unreadable
+              # Path; treat it as not-a-match instead of crashing the smoke
+              # (mirrors the try/catch already guarding the Un_* scan below).
+              $false
+            }
           }
       )
       if ($installedProcesses | Where-Object { $_.MainWindowHandle -ne 0 }) {
@@ -162,12 +169,19 @@ try {
       $installedProcesses = @(
         Get-Process -Name "Abu" -ErrorAction SilentlyContinue |
           Where-Object {
-            $beforePids -notcontains $_.Id -and
-            $_.Path -and
-            [System.IO.Path]::GetFullPath($_.Path).Equals(
-              $installedPath,
-              [System.StringComparison]::OrdinalIgnoreCase
-            )
+            try {
+              $beforePids -notcontains $_.Id -and
+              $_.Path -and
+              [System.IO.Path]::GetFullPath($_.Path).Equals(
+                $installedPath,
+                [System.StringComparison]::OrdinalIgnoreCase
+              )
+            } catch {
+              # A process exiting mid-shutdown can expose an empty/unreadable
+              # Path; treat it as not-a-match instead of crashing the smoke
+              # (mirrors the try/catch already guarding the Un_* scan below).
+              $false
+            }
           }
       )
     } while ($installedProcesses.Count -gt 0 -and [DateTime]::UtcNow -lt $shutdownDeadline)
@@ -290,11 +304,18 @@ finally {
       $remainingInstalledProcesses = @(
         Get-Process -Name "Abu" -ErrorAction SilentlyContinue |
           Where-Object {
-            $_.Path -and
-            [System.IO.Path]::GetFullPath($_.Path).Equals(
-              $installedPath,
-              [System.StringComparison]::OrdinalIgnoreCase
-            )
+            try {
+              $_.Path -and
+              [System.IO.Path]::GetFullPath($_.Path).Equals(
+                $installedPath,
+                [System.StringComparison]::OrdinalIgnoreCase
+              )
+            } catch {
+              # A process exiting mid-shutdown can expose an empty/unreadable
+              # Path; treat it as not-a-match instead of crashing the smoke
+              # (mirrors the try/catch already guarding the Un_* scan below).
+              $false
+            }
           }
       )
       foreach ($process in $remainingInstalledProcesses) {


### PR DESCRIPTION
## 问题
`build-windows` 的安装冒烟间歇性红，报：

```
GetFullPath: The path is empty. (Parameter 'path')
```

失败在 `scripts/electron-windows-installed-smoke.ps1` 的进程清理扫描里。三处 Abu 进程过滤会解析每个进程的 `Path` 并和安装路径比对；在 force-stop / 卸载的关停窗口里，`Get-Process` 仍能枚举到正在退出的 Abu 进程，但它的 `.Path` 已变空/不可读，于是 `[IO.Path]::GetFullPath` 抛异常、整个冒烟中止。这跟脚本近期一串「stabilize Windows rollback uninstall / NSIS uninstall convergence」是同一类竞态。

## 修法
把这三处 `Where-Object` 谓词包进 `try/catch → $false`：解析不到 Path 的进程当「不匹配」跳过，而不是让冒烟崩掉。**这正是同脚本里 `Un_*` 卸载器扫描早就用的 try/catch 写法**——三处 Abu 扫描只是当初没跟上。块 D（Un_* 扫描）保持不变。

## 说明 / 验证
- 与 app 代码无关，纯 **CI-only flake 修复**（非必需检查，此前也不阻塞合并）。
- 本机无 PowerShell，无法本地语法验证 → **靠本 PR 的 Windows runner（build-windows）实跑验证**。
- 独立于 #170（已合并的 updater notes 修复）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)