### PR TITLE
fix: reflect custom web search configuration status

### DIFF
--- a/src/components/settings/sections/AIServicesSection.test.tsx
+++ b/src/components/settings/sections/AIServicesSection.test.tsx
@@ -1,0 +1,58 @@
+/// <reference types="@testing-library/jest-dom" />
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AIServicesSection from './AIServicesSection';
+import { initLanguage } from '@/i18n';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+describe('AIServicesSection web search status', () => {
+  beforeEach(() => {
+    initLanguage('en-US');
+    useSettingsStore.setState((state) => ({
+      providers: state.providers.map((provider) => ({
+        ...provider,
+        enabled: false,
+        apiKey: '',
+        userAdded: false,
+      })),
+      auxiliaryServices: {},
+      imageGeneration: { backends: [] },
+    }));
+  });
+
+  afterEach(cleanup);
+
+  it('updates from custom required to configured as the user enters an API key', async () => {
+    const user = userEvent.setup();
+    render(<AIServicesSection />);
+
+    expect(screen.getByRole('button', { name: /Custom required/ })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Custom required/ }));
+    const apiKeyInput = screen.getByPlaceholderText('Enter search service API Key');
+    await user.type(apiKeyInput, 'tavily-api-key');
+
+    expect(screen.getByRole('button', { name: /Configured/ })).toBeInTheDocument();
+
+    await user.clear(apiKeyInput);
+
+    expect(screen.getByRole('button', { name: /Custom required/ })).toBeInTheDocument();
+  });
+
+  it('treats a SearXNG service URL as a complete custom configuration', () => {
+    useSettingsStore.setState({
+      auxiliaryServices: {
+        webSearch: {
+          provider: 'searxng',
+          apiKey: '',
+          baseUrl: 'http://localhost:8080',
+        },
+      },
+    });
+
+    render(<AIServicesSection />);
+
+    expect(screen.getByRole('button', { name: /Configured/ })).toBeInTheDocument();
+  });
+});

--- a/src/components/settings/sections/AIServicesSection.tsx
+++ b/src/components/settings/sections/AIServicesSection.tsx
@@ -19,6 +19,7 @@ export default function AIServicesSection() {
   const isEnterprise = useEnterpriseStore(s => s.mode.kind !== 'personal');
   const providers = useSettingsStore((s) => s.providers);
   const activeModel = useSettingsStore((s) => s.activeModel);
+  const customWebSearch = useSettingsStore((s) => s.auxiliaryServices.webSearch);
   const clearAllStoredKeys = useSettingsStore((s) => s.clearAllStoredKeys);
   // Hooks must run unconditionally before the isEnterprise early return below.
   const imageGenBackends = useSettingsStore((s) => s.imageGeneration.backends);
@@ -46,6 +47,10 @@ export default function AIServicesSection() {
   const enabledProviders = providers.filter(p => p.enabled);
   const hasBuiltinSearch = enabledProviders.some(p => !!p.capabilities?.webSearch);
   const searchProviderName = enabledProviders.find(p => !!p.capabilities?.webSearch)?.name;
+  const hasCustomSearch = customWebSearch?.provider === 'searxng'
+    ? (customWebSearch.baseUrl?.trim().length ?? 0) > 0
+    : (customWebSearch?.apiKey?.trim().length ?? 0) > 0;
+  const hasSearch = hasBuiltinSearch || hasCustomSearch;
   // Image generation is an independent config (design doc §3.1, "C-a") — no
   // longer derived from chat providers, so no "builtin via provider X" case.
 
@@ -124,7 +129,7 @@ export default function AIServicesSection() {
           <div className="px-4 py-3">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
-                {hasBuiltinSearch ? (
+                {hasSearch ? (
                   <CircleCheck className="h-4 w-4 text-[var(--abu-success)] shrink-0" />
                 ) : (
                   <CircleAlert className="h-4 w-4 text-[var(--abu-warning)] shrink-0" />
@@ -143,11 +148,13 @@ export default function AIServicesSection() {
                     onClick={() => setSearchExpanded(!searchExpanded)}
                     className={cn(
                       'text-minor px-1.5 py-0.5 rounded cursor-pointer transition-colors',
-                      'bg-[var(--abu-warning-bg)] text-[var(--abu-warning)] hover:bg-[var(--abu-warning-bg)]'
+                      hasCustomSearch
+                        ? 'bg-[var(--abu-success-bg)] text-[var(--abu-success)] hover:bg-[var(--abu-success-bg)]'
+                        : 'bg-[var(--abu-warning-bg)] text-[var(--abu-warning)] hover:bg-[var(--abu-warning-bg)]'
                     )}
                   >
                     <span className="flex items-center gap-1">
-                      {t.settings.builtinNotSupported}
+                      {hasCustomSearch ? t.settings.configured : t.settings.builtinNotSupported}
                       <ChevronDown className={cn('h-3 w-3 transition-transform', searchExpanded && 'rotate-180')} />
                     </span>
                   </button>


### PR DESCRIPTION
## What changed

- Make the web-search capability status react to custom search configuration.
- Show a green **Configured** badge when Tavily, Brave, or Bing has an API key.
- Treat a configured SearXNG service URL as complete configuration.
- Keep the custom-search panel expandable for editing.
- Add regression coverage for API-key entry/clearing and SearXNG URL configuration.

## Why

The status badge only checked whether an enabled model provider offered built-in web search. It ignored the custom search settings directly below it, so users still saw **Custom required** after entering a valid configuration.

## Validation

- `npm run verify` — 347 test files / 4732 tests passed, coverage gate passed.
- `npm run build` — passed.
- Targeted component tests — 2 passed.
- Verified manually in the real Electron dev shell.
