### PR TITLE
feat: make agent runs durable and recoverable

### DIFF
--- a/electron/commandHost.cjs
+++ b/electron/commandHost.cjs
@@ -333,9 +333,40 @@ function quotePosixShell(value) {
   return `'${String(value).replace(/'/g, `'\\''`)}'`;
 }
 
-function shellCommandWithBundledPath(app, command) {
-  if (process.platform === 'win32') return command;
-  const layout = runtimeLayout(app);
+function quotePowerShellLiteral(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+/**
+ * PowerShell does not expose the bundled python.exe under the Unix-style
+ * `python3` aliases. Rewrite only the command's first, bare executable token;
+ * explicit paths and later pipeline/statement tokens remain untouched.
+ */
+function rewriteWindowsBundledPythonCommand(app, command, options = {}) {
+  const platform = options.platform || process.platform;
+  if (platform !== 'win32') return command;
+  const match = /^(\s*)(?:&\s*)?(python(?:3(?:\.\d+)?)?|py)(?:\.(?:exe|cmd))?(?=\s|$)/i.exec(command);
+  if (!match) return command;
+  const resolved = resolveBundledProgram(app, match[2], [], { ...options, platform });
+  if (!resolved.bundled || resolved.runtime !== 'python') return command;
+  let remainder = command.slice(match[0].length);
+  // `py -3` / `py -3.12` use a launcher-only interpreter selector. Once the
+  // command is bound to Abu's bundled Python executable the selector must be
+  // consumed; CPython itself treats `-3.12` as an invalid option.
+  if (/^py$/i.test(match[2])) {
+    const selector = /^\s+-3(?:\.\d+)?(?=\s|$)/i.exec(remainder);
+    if (selector) {
+      const afterSelector = remainder.slice(selector[0].length).trimStart();
+      remainder = afterSelector ? ` ${afterSelector}` : '';
+    }
+  }
+  return `${match[1]}& ${quotePowerShellLiteral(resolved.file)} -B${remainder}`;
+}
+
+function shellCommandWithBundledPath(app, command, options = {}) {
+  const platform = options.platform || process.platform;
+  if (platform === 'win32') return rewriteWindowsBundledPythonCommand(app, command, options);
+  const layout = runtimeLayout(app, options);
   const prefix = [layout.node.binDir, layout.python.binDir]
     .filter((entry, index, entries) => entries.indexOf(entry) === index)
     .join(':');
@@ -842,4 +873,5 @@ module.exports = {
   __resetCommandHostForTests,
   unixDescendantPids,
   sandboxLauncherPathFor,
+  rewriteWindowsBundledPythonCommand,
 };

--- a/electron/commandHost.sandbox-launcher.test.cjs
+++ b/electron/commandHost.sandbox-launcher.test.cjs
@@ -14,10 +14,49 @@ const {
   buildSandboxedArgvCommandSpec,
   makeLauncherConfig,
   generateSeatbeltProfile,
+  rewriteWindowsBundledPythonCommand,
   __resetCommandHostForTests,
 } = require('./commandHost.cjs');
 
 const app = { isPackaged: false, once() {} };
+
+test('Windows shell rewrites bare Python aliases to the bundled executable', () => {
+  const resourceRoot = tmpDir();
+  const pythonExecutable = path.join(resourceRoot, 'python-runtime', 'python.exe');
+  fs.mkdirSync(path.dirname(pythonExecutable), { recursive: true });
+  fs.writeFileSync(pythonExecutable, '');
+  const packagedApp = { isPackaged: true };
+  const options = { platform: 'win32', resourceRoot };
+
+  for (const alias of ['python', 'python3', 'python3.12', 'py', 'PYTHON3.EXE']) {
+    assert.equal(
+      rewriteWindowsBundledPythonCommand(packagedApp, `${alias} script.py --flag`, options),
+      `& '${pythonExecutable}' -B script.py --flag`,
+    );
+  }
+  assert.equal(
+    rewriteWindowsBundledPythonCommand(packagedApp, 'py -3.12 script.py --flag', options),
+    `& '${pythonExecutable}' -B script.py --flag`,
+  );
+  assert.equal(
+    rewriteWindowsBundledPythonCommand(packagedApp, 'py -3 -c "print(1)"', options),
+    `& '${pythonExecutable}' -B -c "print(1)"`,
+  );
+});
+
+test('Windows shell preserves explicit paths and non-leading Python tokens', () => {
+  const options = { platform: 'win32', resourceRoot: tmpDir() };
+  const packagedApp = { isPackaged: true };
+
+  for (const command of [
+    'C:\\Tools\\python.exe script.py',
+    '.\\python3 script.py',
+    'Write-Output python3',
+    'echo ready; python3 script.py',
+  ]) {
+    assert.equal(rewriteWindowsBundledPythonCommand(packagedApp, command, options), command);
+  }
+});
 
 function tmpDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'abu-command-host-'));

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -85,6 +85,10 @@ if (allowE2EAppDataRedirect && Object.hasOwn(process.env, E2E_APP_DATA_ROOT_ENV)
   // Redirect both so installed/packaged migration tests cannot read or back up
   // a developer's real Local Storage, cookies, or other persistent state.
   app.setPath('userData', path.join(appDataRoot, 'Abu-e2e-user-data'));
+  // Offline diagnostic export is part of the real-Electron E2E journey.
+  // Keep its Downloads write inside the launch-specific temp root so the
+  // test never leaves artifacts in a developer's real ~/Downloads folder.
+  app.setPath('downloads', path.join(appDataRoot, 'Downloads'));
   e2eTauriStorageRoot = path.join(appDataRoot, 'tauri-webview-user-data');
 }
 

--- a/electron/runtimeObservability.cjs
+++ b/electron/runtimeObservability.cjs
@@ -17,6 +17,7 @@ const BRIDGE_ACK_TIMEOUT_MS = 3_000;
 
 const SAFE_ATTRIBUTE_KEYS = new Set([
   'runId',
+  'clientMessageId',
   'rpcId',
   'method',
   'stage',
@@ -32,6 +33,8 @@ const SAFE_ATTRIBUTE_KEYS = new Set([
   'executionPath',
   'firstFrameMs',
   'bridgeLatencyMs',
+  'acceptedAt',
+  'replayCount',
 ]);
 
 const SECRET_PATTERNS = [

--- a/electron/runtimeResolver.cjs
+++ b/electron/runtimeResolver.cjs
@@ -100,11 +100,14 @@ function bundledCommandName(program, platform) {
     const parsed = path.win32.parse(program);
     if (parsed.dir) return null;
     const lowerExt = parsed.ext.toLowerCase();
-    if (lowerExt && !WINDOWS_EXTENSIONS.has(lowerExt)) return null;
-    const base = (lowerExt ? parsed.name : program).toLowerCase();
+    const recognizedExecutableSuffix = WINDOWS_EXTENSIONS.has(lowerExt);
+    const base = (recognizedExecutableSuffix ? parsed.name : program).toLowerCase();
+    if (base === 'py' || /^python3\.\d+$/.test(base)) return 'python3';
+    if (lowerExt && !recognizedExecutableSuffix) return null;
     return BUNDLED_COMMANDS.has(base) ? base : null;
   }
 
+  if (program === 'py' || /^python3\.\d+$/.test(program)) return 'python3';
   return BUNDLED_COMMANDS.has(program) ? program : null;
 }
 

--- a/electron/runtimeResolver.test.cjs
+++ b/electron/runtimeResolver.test.cjs
@@ -186,6 +186,14 @@ test('resolveBundledProgram maps Windows commands case-insensitively with exe an
     bundled: true,
     runtime: 'python',
   });
+  for (const alias of ['py', 'PY.EXE', 'python3.11', 'Python3.12.exe']) {
+    assert.deepEqual(resolveBundledProgram(app, alias, ['script.py'], options), {
+      file: tree.python.executable,
+      args: ['-B', 'script.py'],
+      bundled: true,
+      runtime: 'python',
+    });
+  }
   assert.deepEqual(resolveBundledProgram(app, 'C:\\Tools\\node.exe', [], options), {
     file: 'C:\\Tools\\node.exe',
     args: [],

--- a/sidecar/src/agentLoopHost.test.ts
+++ b/sidecar/src/agentLoopHost.test.ts
@@ -52,6 +52,8 @@ vi.mock('./localTools', () => ({
 
 import {
   handleAgentRun,
+  handleAgentStart,
+  handleAgentGetState,
   handleAgentAbort,
   handleAgentEnqueueInput,
   handleStateConvPatch,
@@ -60,6 +62,7 @@ import {
   handleStatePlanMode,
   shutdownAllAgentRuns,
   __getActiveAgentRunCount,
+  __resetAgentRunRegistryForTests,
 } from './agentLoopHost';
 import { getCurrentAgentRunContext } from './agentRunContext';
 // Real (unmocked) module — this file doesn't mock '@/core/agent/userInputQueue',
@@ -133,6 +136,73 @@ describe('agentLoopHost', () => {
     hasLocalToolMock.mockReturnValue(false);
     isLocalToolReadOnlyMock.mockReset();
     executeLocalToolMock.mockReset();
+    __resetAgentRunRegistryForTests();
+  });
+
+  describe('Reliable Run Protocol start registry', () => {
+    function reliableParams(overrides: Record<string, unknown> = {}) {
+      const params = baseParams(overrides);
+      return {
+        ...params,
+        clientMessageId: `msg-${params.runId}`,
+        payloadDigest: `digest-${params.runId}`,
+        options: { prePersistedUserMessageId: `msg-${params.runId}` },
+      };
+    }
+
+    it('acknowledges ownership before execution and exposes accepted state', () => {
+      const params = reliableParams({ runId: 'start-accepted' });
+      expect(handleAgentStart(params)).toEqual(expect.objectContaining({
+        version: 1,
+        runId: 'start-accepted',
+        clientMessageId: 'msg-start-accepted',
+        state: 'accepted',
+        replay: false,
+      }));
+      expect(runAgentLoopMock).not.toHaveBeenCalled();
+      expect(handleAgentGetState({ runId: 'start-accepted' })).toEqual(expect.objectContaining({
+        state: 'accepted',
+        clientMessageId: 'msg-start-accepted',
+      }));
+    });
+
+    it('replays the same acceptance without executing twice and rejects conflicting reuse', () => {
+      const params = reliableParams({ runId: 'start-replay' });
+      handleAgentStart(params);
+      expect(handleAgentStart(params)).toEqual(expect.objectContaining({ replay: true, state: 'accepted' }));
+      expect(() => handleAgentStart({ ...params, payloadDigest: 'different' })).toThrow(RpcError);
+      expect(runAgentLoopMock).not.toHaveBeenCalled();
+    });
+
+    it('caches the ordered terminal for getState and later start replays', async () => {
+      const params = reliableParams({ runId: 'start-terminal' });
+      handleAgentStart(params);
+      runAgentLoopMock.mockResolvedValueOnce({ reason: 'completed' });
+      await handleAgentRun(params);
+
+      expect(handleAgentGetState({ runId: params.runId })).toEqual(expect.objectContaining({
+        state: 'terminal',
+        terminal: expect.objectContaining({ state: 'completed', result: { reason: 'completed' } }),
+      }));
+      expect(handleAgentStart(params)).toEqual(expect.objectContaining({
+        replay: true,
+        state: 'terminal',
+        terminal: expect.objectContaining({ state: 'completed' }),
+      }));
+      expect(runAgentLoopMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('accepts Stop between ACK and execution and never enters the loop', async () => {
+      const params = reliableParams({ runId: 'start-cancelled' });
+      handleAgentStart(params);
+      expect(handleAgentAbort({ runId: params.runId })).toEqual({ accepted: true, state: 'aborting' });
+      await expect(handleAgentRun(params)).resolves.toEqual({ reason: 'aborted' });
+      expect(runAgentLoopMock).not.toHaveBeenCalled();
+      expect(handleAgentGetState({ runId: params.runId })).toEqual(expect.objectContaining({
+        state: 'terminal',
+        terminal: expect.objectContaining({ state: 'interrupted' }),
+      }));
+    });
   });
 
   describe('param validation', () => {
@@ -227,6 +297,17 @@ describe('agentLoopHost', () => {
       const errParams = baseParams();
       await expect(handleAgentRun(errParams)).rejects.toThrow('boom');
       expect(__getActiveAgentRunCount()).toBe(before);
+      expect(sendNotificationMock).toHaveBeenCalledWith('agent.terminal', {
+        version: 1,
+        runId: errParams.runId,
+        state: 'failed',
+        result: { reason: 'error', error: 'boom' },
+        failure: {
+          errorType: 'error',
+          message: 'boom',
+          stack: expect.stringContaining('Error: boom'),
+        },
+      });
     });
   });
 
@@ -480,6 +561,19 @@ describe('agentLoopHost', () => {
       const lastBatch = deltaCalls[deltaCalls.length - 1][1] as { runId: string; frames: unknown[] };
       expect(lastBatch.runId).toBe('flush-me');
       expect(lastBatch.frames.length).toBeGreaterThan(0);
+      expect(sendNotificationMock).toHaveBeenCalledWith('agent.terminal', {
+        version: 1,
+        runId: 'flush-me',
+        state: 'completed',
+        result: { reason: 'completed' },
+      });
+      const deltaOrder = sendNotificationMock.mock.invocationCallOrder[
+        sendNotificationMock.mock.calls.findLastIndex((call) => call[0] === 'agent.delta')
+      ];
+      const terminalOrder = sendNotificationMock.mock.invocationCallOrder[
+        sendNotificationMock.mock.calls.findIndex((call) => call[0] === 'agent.terminal')
+      ];
+      expect(deltaOrder).toBeLessThan(terminalOrder);
       expect(traceSidecarRuntimeEventMock).toHaveBeenCalledWith(
         'sidecar.agent_delta_emitted',
         expect.objectContaining({ runId: 'flush-me', frameCount: lastBatch.frames.length }),

--- a/sidecar/src/agentLoopHost.ts
+++ b/sidecar/src/agentLoopHost.ts
@@ -44,6 +44,10 @@ import type { ToolInvoker } from '@/core/agent/ports/toolInvoker';
 import type { CapsPort } from '@/core/agent/ports/capsPort';
 import type { PlanModeState } from '@/core/agent/planMode';
 import { runAgentLoop, type AgentLoopOptions, type AgentLoopResult } from '@/core/agent/agentLoop';
+import {
+  createAgentRunTerminal,
+  type AgentRunTerminal,
+} from '@/core/agent/agentRunTerminal';
 import { enqueueUserInputWithId } from '@/core/agent/userInputQueue';
 import { applyPlanModeState } from '@/core/agent/planMode';
 import { TOOL_NAMES } from '@/core/tools/toolNames';
@@ -76,6 +80,8 @@ interface CapsSnapshotEntry {
 
 export interface AgentRunParams {
   runId: string;
+  clientMessageId?: string;
+  payloadDigest?: string;
   conversationId: string;
   userMessage: string;
   options: {
@@ -83,6 +89,7 @@ export interface AgentRunParams {
     blockedTools?: string[];
     allowedTools?: string[];
     imContext?: IMContext;
+    prePersistedUserMessageId?: string;
   };
   orchestration: { route: RouteResult; systemPromptSections: PromptSection[] };
   conversationSnapshot: Conversation;
@@ -115,6 +122,12 @@ function parseAgentRunParams(params: unknown): AgentRunParams {
   if (!isRecord(params)) throw new RpcError(-32602, 'Invalid params: expected object');
   const { runId, conversationId, userMessage, options, orchestration, conversationSnapshot, settingsSnapshot, resolvedCreds, toolList, locale } = params;
   if (typeof runId !== 'string' || !runId) throw new RpcError(-32602, 'Invalid params: runId must be a non-empty string');
+  if (params.clientMessageId !== undefined && (typeof params.clientMessageId !== 'string' || !params.clientMessageId)) {
+    throw new RpcError(-32602, 'Invalid params: clientMessageId must be a non-empty string');
+  }
+  if (params.payloadDigest !== undefined && (typeof params.payloadDigest !== 'string' || !params.payloadDigest)) {
+    throw new RpcError(-32602, 'Invalid params: payloadDigest must be a non-empty string');
+  }
   if (typeof conversationId !== 'string' || !conversationId) throw new RpcError(-32602, 'Invalid params: conversationId must be a non-empty string');
   if (typeof userMessage !== 'string') throw new RpcError(-32602, 'Invalid params: userMessage must be a string');
   if (!isRecord(options)) throw new RpcError(-32602, 'Invalid params: options must be an object');
@@ -123,6 +136,11 @@ function parseAgentRunParams(params: unknown): AgentRunParams {
     if (value !== undefined && (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string'))) {
       throw new RpcError(-32602, `Invalid params: options.${field} must be a string array`);
     }
+  }
+  if (options.prePersistedUserMessageId !== undefined && (
+    typeof options.prePersistedUserMessageId !== 'string' || !options.prePersistedUserMessageId
+  )) {
+    throw new RpcError(-32602, 'Invalid params: options.prePersistedUserMessageId must be a non-empty string');
   }
   if (!isRecord(orchestration) || !isRecord((orchestration as { route?: unknown }).route)) {
     throw new RpcError(-32602, 'Invalid params: orchestration.route must be an object');
@@ -371,6 +389,143 @@ interface ActiveRun {
 
 const activeRuns = new Map<string, ActiveRun>();
 
+export interface AgentStartAck {
+  version: 1;
+  runId: string;
+  clientMessageId: string;
+  acceptedAt: number;
+  state: 'accepted' | 'running' | 'terminal';
+  replay: boolean;
+  terminal?: AgentRunTerminal;
+}
+
+export interface AgentRunStateResult {
+  version: 1;
+  runId: string;
+  state: 'not_found' | 'accepted' | 'running' | 'terminal';
+  clientMessageId?: string;
+  acceptedAt?: number;
+  terminal?: AgentRunTerminal;
+}
+
+interface RunRegistryEntry {
+  params: AgentRunParams;
+  payloadDigest: string;
+  clientMessageId: string;
+  acceptedAt: number;
+  state: 'accepted' | 'running' | 'terminal';
+  cancelRequested: boolean;
+  terminal?: AgentRunTerminal;
+  terminalAt?: number;
+}
+
+const RUN_REGISTRY_MAX_ENTRIES = 128;
+const RUN_REGISTRY_TERMINAL_TTL_MS = 60 * 60 * 1_000;
+const runRegistry = new Map<string, RunRegistryEntry>();
+
+function pruneRunRegistry(now = Date.now()): void {
+  for (const [runId, entry] of runRegistry) {
+    if (
+      entry.state === 'terminal'
+      && now - (entry.terminalAt ?? entry.acceptedAt) > RUN_REGISTRY_TERMINAL_TTL_MS
+    ) {
+      runRegistry.delete(runId);
+    }
+  }
+  if (runRegistry.size <= RUN_REGISTRY_MAX_ENTRIES) return;
+  const terminalEntries = [...runRegistry.entries()]
+    .filter(([, entry]) => entry.state === 'terminal')
+    .sort((a, b) => (a[1].terminalAt ?? 0) - (b[1].terminalAt ?? 0));
+  for (const [runId] of terminalEntries) {
+    if (runRegistry.size <= RUN_REGISTRY_MAX_ENTRIES) break;
+    runRegistry.delete(runId);
+  }
+}
+
+function toStartAck(entry: RunRegistryEntry, replay: boolean): AgentStartAck {
+  return {
+    version: 1,
+    runId: entry.params.runId,
+    clientMessageId: entry.clientMessageId,
+    acceptedAt: entry.acceptedAt,
+    state: entry.state,
+    replay,
+    ...(entry.terminal ? { terminal: entry.terminal } : {}),
+  };
+}
+
+function rememberTerminal(runId: string, terminal: AgentRunTerminal): void {
+  const entry = runRegistry.get(runId);
+  if (!entry || entry.terminal) return;
+  entry.state = 'terminal';
+  entry.terminal = terminal;
+  entry.terminalAt = Date.now();
+  pruneRunRegistry(entry.terminalAt);
+}
+
+/**
+ * Reliable Run Protocol V1 phase 1: acknowledge ownership immediately, then
+ * execute independently from the request that carried the start command.
+ * Replaying the same ids/digest returns the existing fact and never starts a
+ * second loop; conflicting reuse of a runId fails closed.
+ */
+export function handleAgentStart(rawParams: unknown): AgentStartAck {
+  const params = parseAgentRunParams(rawParams);
+  if (!params.clientMessageId || !params.payloadDigest) {
+    throw new RpcError(-32602, 'Invalid params: agent.start requires clientMessageId and payloadDigest');
+  }
+  pruneRunRegistry();
+  const existing = runRegistry.get(params.runId);
+  if (existing) {
+    if (
+      existing.payloadDigest !== params.payloadDigest
+      || existing.clientMessageId !== params.clientMessageId
+    ) {
+      throw new RpcError(-32602, `Conflicting replay for runId "${params.runId}"`);
+    }
+    traceSidecarRuntimeEvent('sidecar.agent_start_replayed', {
+      runId: params.runId,
+      method: 'agent.start',
+      stage: existing.state,
+    });
+    return toStartAck(existing, true);
+  }
+
+  const entry: RunRegistryEntry = {
+    params,
+    payloadDigest: params.payloadDigest,
+    clientMessageId: params.clientMessageId,
+    acceptedAt: Date.now(),
+    state: 'accepted',
+    cancelRequested: false,
+  };
+  runRegistry.set(params.runId, entry);
+  traceSidecarRuntimeEvent('sidecar.agent_start_accepted', {
+    runId: params.runId,
+    method: 'agent.start',
+    stage: 'accepted',
+  });
+
+  return toStartAck(entry, false);
+}
+
+export function handleAgentGetState(rawParams: unknown): AgentRunStateResult {
+  if (!isRecord(rawParams) || typeof rawParams.runId !== 'string' || !rawParams.runId) {
+    throw new RpcError(-32602, 'Invalid params: runId must be a non-empty string');
+  }
+  pruneRunRegistry();
+  const entry = runRegistry.get(rawParams.runId);
+  if (!entry) return { version: 1, runId: rawParams.runId, state: 'not_found' };
+  return {
+    version: 1,
+    runId: rawParams.runId,
+    state: entry.state,
+    clientMessageId: entry.clientMessageId,
+    acceptedAt: entry.acceptedAt,
+    ...(entry.terminal ? { terminal: entry.terminal } : {}),
+  };
+}
+
 /**
  * Flushes EVERY active run's coalescer, not just the one issuing the
  * outbound request — `rpcClient.ts`'s `setPreRequestFlush` hook is
@@ -389,6 +544,18 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
   const params = parseAgentRunParams(rawParams);
   const { runId, conversationId } = params;
   const startedAt = Date.now();
+  const registryEntry = runRegistry.get(runId);
+  if (registryEntry?.state === 'terminal' && registryEntry.terminal) {
+    return registryEntry.terminal.result;
+  }
+  if (registryEntry?.cancelRequested) {
+    const result: AgentLoopResult = { reason: 'aborted' };
+    const terminal = createAgentRunTerminal(runId, result);
+    rememberTerminal(runId, terminal);
+    sendNotification('agent.terminal', terminal);
+    return result;
+  }
+  if (registryEntry) registryEntry.state = 'running';
   traceSidecarRuntimeEvent('sidecar.agent_run_received', {
     runId,
     method: 'agent.run',
@@ -558,6 +725,7 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
       blockedTools: params.options.blockedTools,
       allowedTools: params.options.allowedTools,
       imContext: params.options.imContext,
+      prePersistedUserMessageId: params.options.prePersistedUserMessageId,
       settingsReader: getSettingsMirrorReader(),
       orchestration: params.orchestration,
       // P1-3B-3B: use the shell-known runId as the loop's internal loopId
@@ -579,6 +747,13 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
       outcome: result.reason,
       durationMs: Date.now() - startedAt,
     });
+    // Terminal fact is ordered AFTER every final delta frame and BEFORE the
+    // RPC response. If that response is lost, the shell can still settle the
+    // run from this idempotent notification without re-executing any work.
+    coalescer.flush();
+    const terminal = createAgentRunTerminal(runId, result);
+    rememberTerminal(runId, terminal);
+    sendNotification('agent.terminal', terminal);
     return result;
   } catch (error) {
     traceSidecarRuntimeEvent('sidecar.agent_run_failed', {
@@ -588,6 +763,19 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
       errorType: sidecarRuntimeErrorType(error),
       durationMs: Date.now() - startedAt,
     });
+    coalescer.flush();
+    const message = error instanceof Error ? error.message : String(error);
+    const terminal = createAgentRunTerminal(
+      runId,
+      { reason: 'error', error: message },
+      {
+        errorType: sidecarRuntimeErrorType(error),
+        message,
+        ...(error instanceof Error && error.stack ? { stack: error.stack } : {}),
+      },
+    );
+    rememberTerminal(runId, terminal);
+    sendNotification('agent.terminal', terminal);
     throw error;
   } finally {
     coalescer.flush();
@@ -675,7 +863,14 @@ export function handleAgentAbort(rawParams: unknown): AgentAbortAck {
     method: 'agent.abort',
     stage: run ? 'aborting' : 'not_found',
   });
-  if (!run) return { accepted: false, state: 'not_found' };
+  if (!run) {
+    const registered = runRegistry.get(runId);
+    if (!registered || registered.state === 'terminal') {
+      return { accepted: false, state: 'not_found' };
+    }
+    registered.cancelRequested = true;
+    return { accepted: true, state: 'aborting' };
+  }
   run.coalescer.flush();
   run.controllers.get(run.conversationId)?.abort();
   run.coalescer.flush();
@@ -733,6 +928,9 @@ export function handleStatePlanMode(rawParams: unknown): void {
 
 /** Abort every in-flight `agent.run` — used by the `shutdown` notification handler before exit (mirrors `subagentHost.ts`'s `shutdownAllSubagentRuns`). */
 export function shutdownAllAgentRuns(): void {
+  for (const entry of runRegistry.values()) {
+    if (entry.state !== 'terminal') entry.cancelRequested = true;
+  }
   for (const run of activeRuns.values()) {
     for (const controller of run.controllers.values()) controller.abort();
   }
@@ -741,4 +939,9 @@ export function shutdownAllAgentRuns(): void {
 /** Test-only accessor. */
 export function __getActiveAgentRunCount(): number {
   return activeRuns.size;
+}
+
+/** Test-only reset for the bounded idempotency registry. */
+export function __resetAgentRunRegistryForTests(): void {
+  runRegistry.clear();
 }

--- a/sidecar/src/main.ts
+++ b/sidecar/src/main.ts
@@ -129,6 +129,8 @@ import { fsReadTextFile, fsReadFile, fsWriteTextFile, fsReadDir, fsExists, fsSta
 import { handleSubagentRun, handleSubagentAbort, shutdownAllSubagentRuns } from './subagentHost';
 import {
   handleAgentRun,
+  handleAgentStart,
+  handleAgentGetState,
   handleAgentAbort,
   handleAgentEnqueueInput,
   handleStateConvPatch,
@@ -349,6 +351,18 @@ function handleMessage(raw: string): void {
     // flight, plus receives state.* push notifications for this or other
     // runs the whole time.
     runAsyncRequest(id, () => handleAgentRun(params));
+    return;
+  }
+
+  if (method === 'agent.start') {
+    if (isNotification) return;
+    runAsyncRequest(id, () => Promise.resolve(handleAgentStart(params)));
+    return;
+  }
+
+  if (method === 'run.getState') {
+    if (isNotification) return;
+    runAsyncRequest(id, () => Promise.resolve(handleAgentGetState(params)));
     return;
   }
 

--- a/src/__tests__/agentPipeline.integration.test.ts
+++ b/src/__tests__/agentPipeline.integration.test.ts
@@ -39,6 +39,10 @@ vi.mock('../core/llm/tauriFetch', () => ({
   getTauriFetch: vi.fn().mockResolvedValue(vi.fn()),
 }));
 
+vi.mock('../utils/consoleError', () => ({
+  reportError: vi.fn(),
+}));
+
 // Mock tool registry
 vi.mock('../core/tools/registry', () => ({
   getAllTools: vi.fn().mockReturnValue([
@@ -91,10 +95,26 @@ vi.mock('../core/skill/loader', () => ({
 
 // Mock context modules
 vi.mock('../core/context/contextManager', () => ({
-  // Real prepareContextMessages returns Message[] — mirror that. (Previously
-  // returned an object, which was silently tolerated until the send path
-  // started calling array methods on the result via rehydrateImageData.)
-  prepareContextMessages: vi.fn().mockImplementation((msgs) => msgs),
+  ContextBudgetError: class ContextBudgetError extends Error {
+    code: string;
+    estimatedTokens: number;
+    inputBudget: number;
+
+    constructor(code: string, estimatedTokens: number, inputBudget: number) {
+      super(code);
+      this.code = code;
+      this.estimatedTokens = estimatedTokens;
+      this.inputBudget = inputBudget;
+    }
+  },
+  enforceContextBudget: vi.fn().mockImplementation((msgs) => ({
+    messages: msgs,
+    tokensBefore: 1,
+    tokensAfter: 1,
+    inputBudget: 100000,
+    safetyMarginTokens: 1000,
+    strategy: 'unchanged',
+  })),
   trimOldScreenshots: vi.fn().mockImplementation((msgs) => msgs),
 }));
 
@@ -297,6 +317,7 @@ import { escalateMaxOutputTokens } from '../core/agent/loopGuards';
 import type { StreamEvent, Message } from '../types';
 // Mocked module reference — used to override token estimator per-test
 import * as tokenEstimatorModule from '../core/context/tokenEstimator';
+import * as contextManagerModule from '../core/context/contextManager';
 
 describe('Agent Pipeline Integration', () => {
   beforeEach(() => {
@@ -387,6 +408,22 @@ describe('Agent Pipeline Integration', () => {
     // User and assistant messages should share the same loopId (one logical turn).
     expect(userMsg?.loopId).toBeDefined();
     expect(userMsg?.loopId).toBe(errorMsg?.loopId);
+  });
+
+  it('shows an actionable local error and skips the provider when the latest input is too large', async () => {
+    vi.mocked(contextManagerModule.enforceContextBudget).mockImplementationOnce(() => {
+      throw new contextManagerModule.ContextBudgetError('INPUT_TOO_LARGE', 20_000, 10_000);
+    });
+
+    const convId = useChatStore.getState().createConversation();
+    await runAgentLoop(convId, 'oversized input');
+
+    expect(mockClaudeChat).not.toHaveBeenCalled();
+    const assistantText = useChatStore.getState().conversations[convId].messages
+      .filter((message) => message.role === 'assistant')
+      .map((message) => typeof message.content === 'string' ? message.content : '')
+      .join('\n');
+    expect(assistantText).toMatch(/上下文容量|too large/i);
   });
 
   it('escalateMaxOutputTokens pure function works correctly', () => {
@@ -697,10 +734,10 @@ describe('Agent Pipeline Integration', () => {
       expect(staged).toBeDefined();
     });
 
-    it('image-only send during a running loop starts a normal loop instead of staging (F6)', async () => {
-      // Regression: the concurrency guard staged EVERY interactive send into
-      // the text-only queue — an image-only send was swallowed entirely.
-      // Image/empty sends must fall through to a normal loop start.
+    it('rejects an image-only send during a running in-process loop instead of starting a second stream (F6)', async () => {
+      // The mid-run queue is text-only. An image send must stay with the
+      // composer and wait for the current run; falling through replaces the
+      // live AbortController and races two streams on one conversation.
       const { enqueueUserInput } = await import('../core/agent/userInputQueue');
       const convId = useChatStore.getState().createConversation();
       let release!: () => void;
@@ -722,11 +759,42 @@ describe('Agent Pipeline Integration', () => {
         images: [{ id: 'img-1', data: 'aGk=', mediaType: 'image/png' }],
       });
 
-      expect(second.reason).not.toBe('enqueued');
+      expect(second.reason).toBe('error');
       expect(vi.mocked(enqueueUserInput)).not.toHaveBeenCalled();
 
       release();
       await first;
+      expect(streamCalls).toBe(1);
+    });
+
+    it('rejects a headless send during a running in-process loop instead of starting a second stream', async () => {
+      const { enqueueUserInput } = await import('../core/agent/userInputQueue');
+      const convId = useChatStore.getState().createConversation(undefined, {
+        scheduledTaskId: 'schedule-1',
+        skipActivate: true,
+      });
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => { release = resolve; });
+      let streamCalls = 0;
+      mockClaudeChat.mockImplementation(
+        async (_m: unknown, _o: unknown, onEvent: (e: StreamEvent) => void) => {
+          streamCalls++;
+          await gate;
+          onEvent({ type: 'text', text: 'done' });
+          onEvent({ type: 'done', stopReason: 'end_turn' });
+        },
+      );
+
+      const first = runAgentLoop(convId, 'scheduled first');
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      const second = await runAgentLoop(convId, 'overlapping scheduler delivery');
+
+      expect(second.reason).toBe('error');
+      expect(vi.mocked(enqueueUserInput)).not.toHaveBeenCalled();
+      release();
+      await first;
+      expect(streamCalls).toBe(1);
     });
   });
 

--- a/src/__tests__/contextManager.integration.test.ts
+++ b/src/__tests__/contextManager.integration.test.ts
@@ -3,13 +3,13 @@
  * Validates the full pipeline of context preparation with truncation
  */
 import { describe, it, expect } from 'vitest';
-import { prepareContextMessages } from '../core/context/contextManager';
+import { enforceContextBudget } from '../core/context/contextManager';
 import { estimateTokens, estimateMessageTokens } from '../core/context/tokenEstimator';
 import { truncateToolResult } from '../core/context/truncation';
 import type { Message } from '../types';
 
 function makeMsg(role: 'user' | 'assistant', content: string): Message {
-  return { id: Math.random().toString(36), role, content, timestamp: Date.now() };
+  return { id: `${role}-${content.slice(0, 12)}`, role, content, timestamp: 1_800_000_000_000 };
 }
 
 describe('contextManager integration', () => {
@@ -46,11 +46,12 @@ describe('contextManager integration', () => {
 
     const contextWindow = 8000;
     const reserveForOutput = 2000;
-    const result = prepareContextMessages(messages, systemPrompt, contextWindow, reserveForOutput);
+    const budgetResult = enforceContextBudget(messages, systemPrompt, contextWindow, reserveForOutput);
+    const result = budgetResult.messages;
 
     // Result should fit within the budget
     const resultTokens = estimateTokens(systemPrompt) + estimateMessageTokens(result);
-    expect(resultTokens).toBeLessThanOrEqual(contextWindow);
+    expect(resultTokens).toBeLessThanOrEqual(budgetResult.inputBudget);
 
     // First user message should be preserved
     const firstUser = result.find((m) => m.role === 'user');
@@ -61,7 +62,7 @@ describe('contextManager integration', () => {
     const textMsg: Message = {
       id: '1', role: 'user',
       content: 'Hello world',
-      timestamp: Date.now(),
+      timestamp: 1_800_000_000_000,
     };
 
     const multimodalMsg: Message = {
@@ -70,7 +71,7 @@ describe('contextManager integration', () => {
         { type: 'text', text: 'Hello world' },
         { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'abc' } },
       ],
-      timestamp: Date.now(),
+      timestamp: 1_800_000_000_000,
     };
 
     const textTokens = estimateMessageTokens([textMsg]);

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -691,6 +691,13 @@ export default function ChatInput({ variant, onSend, disabled, scenarioPlacehold
     // Mid-task input: if agent is running, stage the message in the queue
     // strip above the composer (cancellable) instead of starting a new loop.
     // It becomes a transcript bubble only when the loop drains it.
+    if (isRunning && images.length > 0) {
+      useToastStore.getState().addToast({
+        type: 'warning',
+        title: t.chat.attachmentDuringRun,
+      });
+      return;
+    }
     if (isRunning && activeConv?.id && message) {
       enqueueUserInput(activeConv.id, message);
       resetInput();

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -6,6 +6,7 @@ import ToolCallsGroup, { InlineToolResultImages } from './ToolCallsGroup';
 import { useChatStore, useActiveConversation } from '@/stores/chatStore';
 import { sendFeedback } from '@/utils/consoleFeedback';
 import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
 import { usePreviewStore } from '@/stores/previewStore';
 import { useTodosStore } from '@/stores/todosStore';
 import { useLabsFlag } from '@/core/labs/resolve';
@@ -477,6 +478,24 @@ export default function MessageBubble({
     }
   };
 
+  const handleRunRetry = async () => {
+    if (!convId || !activeConv || message.role !== 'user') return;
+    const originalImages = getImageBlocks(message.content);
+    const imageAttachments = originalImages.map((img, i) => ({
+      id: `run-retry-${Date.now()}-${i}`,
+      data: img.source.data,
+      mediaType: img.source.media_type,
+    }));
+    const routedContent = reattachRoutingPrefix(getTextContent(message.content), message);
+    if (message.loopId) useChatStore.getState().deleteLoopMessages(convId, message.loopId);
+    else useChatStore.getState().deleteMessage(convId, message.id);
+    await runAgentLoopDispatched(
+      convId,
+      routedContent,
+      imageAttachments.length > 0 ? { images: imageAttachments } : undefined,
+    );
+  };
+
   const handleRegenerate = async () => {
     if (!convId || !activeConv) return;
     const messages = activeConv.messages;
@@ -621,6 +640,34 @@ export default function MessageBubble({
                       </div>
                     );
                   })()}
+                </div>
+              )}
+              {message.runState && message.runState !== 'completed' && (
+                <div
+                  className={cn(
+                    'flex items-center gap-1.5 text-caption',
+                    message.runState === 'failed'
+                      ? 'text-[var(--abu-danger)]'
+                      : 'text-[var(--abu-text-muted)]',
+                  )}
+                  title={message.runError}
+                >
+                  {(message.runState === 'pending' || message.runState === 'accepted' || message.runState === 'running') && (
+                    <RefreshCw className="h-3 w-3 animate-spin" />
+                  )}
+                  <span>
+                    {message.runState === 'pending' && t.chat.runPending}
+                    {message.runState === 'accepted' && t.chat.runAccepted}
+                    {message.runState === 'running' && t.chat.runRunning}
+                    {message.runState === 'failed' && t.chat.runFailed}
+                    {message.runState === 'interrupted' && t.chat.runInterrupted}
+                  </span>
+                  {message.runState === 'failed' && !isConvRunning && (
+                    <Button variant="ghost" size="xs" onClick={handleRunRetry}>
+                      <RefreshCw className="h-3 w-3" />
+                      {t.chat.runRetry}
+                    </Button>
+                  )}
                 </div>
               )}
               {/* Actions + timestamp row below bubble */}

--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -31,7 +31,11 @@ import { substituteVariables } from '../skill/preprocessor';
 import { joinPath } from '../../utils/pathUtils';
 import { matchesToolName, parseToolPatterns } from '../skill/toolFilter';
 import { notifyTaskCompleted, notifyTaskError } from '../../utils/notifications';
-import { prepareContextMessages, trimOldScreenshots } from '../context/contextManager';
+import {
+  ContextBudgetError,
+  enforceContextBudget,
+  trimOldScreenshots,
+} from '../context/contextManager';
 import { compressContextIfNeeded, summarizeConversation } from '../context/contextCompressor';
 import {
   buildContextFromBoundary,
@@ -164,7 +168,7 @@ async function saveUserImagesToDisk(
  * Persists images to disk so they survive localStorage stripping. Used by both the normal
  * agent loop path and the API-key-missing early-return path so user input is never dropped.
  */
-async function buildUserMessageContent(
+export async function buildUserMessageContent(
   conversationId: string,
   text: string,
   images: ImageAttachment[] | undefined,
@@ -424,6 +428,12 @@ export interface AgentLoopOptions {
    * `generateId()` every run).
    */
   loopId?: string;
+  /**
+   * Shell-owned user message already appended and durably flushed before a
+   * sidecar run starts. When present, the loop must consume that message from
+   * the conversation snapshot instead of appending a duplicate.
+   */
+  prePersistedUserMessageId?: string;
 }
 
 /** Exit reason returned by runAgentLoop so callers (scheduler, trigger) can
@@ -509,31 +519,35 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
   // runAgentLoop on a running conversation would race it unstoppably (the UI's
   // isRunning check is React state and can lag a rapid double-send). Route the
   // message into the running loop's input queue instead — same behavior as
-  // ChatInput's mid-task path. Interactive desktop only: headless callers
-  // (scheduler / trigger / IM) manage their own conversations. Only stage when
-  // there is stageable text and no images — the queue is text-only, and
-  // silently losing an image is worse than the rare double-loop race, so
-  // image/empty sends fall through to a normal loop start.
+  // ChatInput's mid-task path. Only interactive text can be staged because the
+  // queue is text-only. Every other request is rejected while the conversation
+  // is owned; allowing images or headless callers to fall through would replace
+  // the live AbortController and start a second LLM stream.
   {
     const runningConv = getConversationReader().getConversation(conversationId);
-    if (
-      runningConv?.status === 'running'
-      && getAbortRegistry().hasAbortController(conversationId)
-      && isInteractiveDesktop(options, runningConv)
-      && userMessage.trim().length > 0
-      && !(options?.images?.length)
-    ) {
-      if (options?.requireNewRun) {
-        return {
-          reason: 'error',
-          error: 'A restricted recovery run cannot join an existing agent loop',
-        };
+    if (runningConv?.status === 'running' && getAbortRegistry().hasAbortController(conversationId)) {
+      const interactive = isInteractiveDesktop(options, runningConv);
+      const hasImages = Boolean(options?.images?.length);
+      const stageable = userMessage.trim().length > 0 && !hasImages;
+      if (interactive && stageable) {
+        if (options?.requireNewRun) {
+          return {
+            reason: 'error',
+            error: 'A restricted recovery run cannot join an existing agent loop',
+          };
+        }
+        // Codex-style staging: the message lives in the cancellable queue strip
+        // above the composer and becomes a transcript bubble only when the
+        // running loop drains it (see the drainQueuedInputs block below).
+        enqueueUserInput(conversationId, userMessage);
+        return { reason: 'enqueued' };
       }
-      // Codex-style staging: the message lives in the cancellable queue strip
-      // above the composer and becomes a transcript bubble only when the
-      // running loop drains it (see the drainQueuedInputs block below).
-      enqueueUserInput(conversationId, userMessage);
-      return { reason: 'enqueued' };
+      return {
+        reason: 'error',
+        error: hasImages
+          ? getI18n().chat.attachmentDuringRun
+          : getI18n().chat.conversationBusy,
+      };
     }
   }
 
@@ -600,14 +614,16 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
     // Persist the user's input first so the chat history isn't an orphan warning.
     // Use raw userMessage (orchestrator hasn't run); skill metadata is intentionally omitted —
     // the user needs to configure a key before any skill/agent routing takes effect.
-    const userContent = await buildUserMessageContent(conversationId, userMessage, options?.images);
-    chatDelta.addMessage(conversationId, {
-      id: generateId(),
-      role: 'user',
-      content: userContent,
-      timestamp: Date.now(),
-      loopId,
-    });
+    if (!options?.prePersistedUserMessageId) {
+      const userContent = await buildUserMessageContent(conversationId, userMessage, options?.images);
+      chatDelta.addMessage(conversationId, {
+        id: generateId(),
+        role: 'user',
+        content: userContent,
+        timestamp: Date.now(),
+        loopId,
+      });
+    }
     chatDelta.addMessage(conversationId, {
       id: generateId(),
       role: 'assistant',
@@ -728,23 +744,25 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
 
   // Add user message with loopId (use cleanInput for display)
   // Include skill info if a skill was triggered; build multimodal content if images are attached
-  const userContent = await buildUserMessageContent(conversationId, route.cleanInput, options?.images);
+  if (!options?.prePersistedUserMessageId) {
+    const userContent = await buildUserMessageContent(conversationId, route.cleanInput, options?.images);
 
-  chatDelta.addMessage(conversationId, {
-    id: generateId(),
-    role: 'user',
-    content: userContent,
-    timestamp: Date.now(),
-    loopId,
-    skill: route.type === 'skill' && route.skill ? {
-      name: route.skill.name,
-      description: route.skill.description,
-    } : undefined,
-    delegateAgent: route.type === 'delegate' && route.delegateAgent ? {
-      name: route.delegateAgent.name,
-      description: route.delegateAgent.description,
-    } : undefined,
-  });
+    chatDelta.addMessage(conversationId, {
+      id: generateId(),
+      role: 'user',
+      content: userContent,
+      timestamp: Date.now(),
+      loopId,
+      skill: route.type === 'skill' && route.skill ? {
+        name: route.skill.name,
+        description: route.skill.description,
+      } : undefined,
+      delegateAgent: route.type === 'delegate' && route.delegateAgent ? {
+        name: route.delegateAgent.name,
+        description: route.delegateAgent.description,
+      } : undefined,
+    });
+  }
 
   // Enterprise mode always uses OpenAI-compatible adapter (LiteLLM exposes that interface).
   // selectChatAdapter routes through the sidecar transport when it's healthy
@@ -1285,7 +1303,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
           // No valid cache AND the auto-compact circuit breaker is not tripped —
           // attempt compression. When the breaker IS tripped (repeated provider
           // failures/timeouts), skip the LLM call entirely; the deterministic
-          // truncation (prepareContextMessages) below still guarantees the request
+          // context budget gate below still guarantees the request
           // fits, so a doomed provider can't re-stall every turn.
           chatDelta.setIsCompressing(conversationId, true);
           try {
@@ -1461,13 +1479,14 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       const trimmedMessages = trimOldScreenshots(messagesForContext, usagePercent);
 
       // Step 3: Hard truncation as safety net
-      let preparedMessages = prepareContextMessages(
+      const initialBudgetResult = enforceContextBudget(
         trimmedMessages,
         effectiveSystemPrompt,
         contextWindowSize,
         maxOutputTokens,
         toolTokens
       );
+      let preparedMessages = initialBudgetResult.messages;
 
       // Step 4: Rehydrate stripped image base64 from disk before sending.
       // Persisted images keep only `filePath` (base64 cleared to save disk); the
@@ -1481,6 +1500,29 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         workspacePath: getConversationReader().getConversation(conversationId)?.workspacePath ?? null,
         cache: imageBase64Cache,
       });
+
+      // The final provider-boundary invariant. Re-run after image rehydration so
+      // every primary send is checked in its actual outbound shape, not merely
+      // against the persisted (base64-stripped) history representation.
+      const finalBudgetResult = enforceContextBudget(
+        preparedMessages,
+        effectiveSystemPrompt,
+        contextWindowSize,
+        maxOutputTokens,
+        toolTokens,
+      );
+      preparedMessages = finalBudgetResult.messages;
+      if (initialBudgetResult.strategy !== 'unchanged' || finalBudgetResult.strategy !== 'unchanged') {
+        logger.info('Context budget gate applied', {
+          tokensBefore: initialBudgetResult.tokensBefore,
+          tokensAfter: finalBudgetResult.tokensAfter,
+          inputBudget: finalBudgetResult.inputBudget,
+          safetyMarginTokens: finalBudgetResult.safetyMarginTokens,
+          strategy: initialBudgetResult.strategy === 'unchanged'
+            ? finalBudgetResult.strategy
+            : initialBudgetResult.strategy,
+        });
+      }
 
       // Resolve apiKey + baseUrl — enterprise gateway overrides personal creds.
       // Throws EnterpriseLlmUnavailableError if enforced but gateway unreachable.
@@ -1725,15 +1767,19 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
           // and persist it. Pattern: "maximum context length is N tokens"
           // (OpenAI-compatible style). Next request will use this as a cap.
           const ctxMatch = /maximum context length is (\d+) tokens/i.exec(retryErr.message);
-          if (ctxMatch && activeProvider) {
+          let recoveryContextWindowSize = contextWindowSize;
+          if (ctxMatch) {
             const discoveredWindow = parseInt(ctxMatch[1], 10);
             if (Number.isFinite(discoveredWindow) && discoveredWindow > 0) {
-              getCapsPort().recordContextWindow(activeProvider.id, effectiveModelId, discoveredWindow);
-              logger.info('Persisted discovered context window', {
-                providerId: activeProvider.id,
-                modelId: effectiveModelId,
-                contextWindow: discoveredWindow,
-              });
+              recoveryContextWindowSize = Math.min(contextWindowSize, discoveredWindow);
+              if (activeProvider) {
+                getCapsPort().recordContextWindow(activeProvider.id, effectiveModelId, discoveredWindow);
+                logger.info('Persisted discovered context window', {
+                  providerId: activeProvider.id,
+                  modelId: effectiveModelId,
+                  contextWindow: discoveredWindow,
+                });
+              }
             }
           }
 
@@ -1771,13 +1817,13 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
                 toolTokens
               );
               if (compressionResult.compressed) {
-                preparedMessages = prepareContextMessages(
+                preparedMessages = enforceContextBudget(
                   compressionResult.messages,
                   effectiveSystemPrompt,
-                  contextWindowSize,
+                  recoveryContextWindowSize,
                   maxOutputTokens,
                   toolTokens
-                );
+                ).messages;
                 autoCompactTracker.recordSuccess();
                 recovered = true;
                 logger.info('Context recovered via semantic compression');
@@ -1813,6 +1859,21 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
             conversationId,
             workspacePath: getConversationReader().getConversation(conversationId)?.workspacePath ?? null,
             cache: imageBase64Cache,
+          });
+          const recoveryBudgetResult = enforceContextBudget(
+            preparedMessages,
+            effectiveSystemPrompt,
+            recoveryContextWindowSize,
+            maxOutputTokens,
+            toolTokens,
+          );
+          preparedMessages = recoveryBudgetResult.messages;
+          logger.info('Context recovery budget gate applied', {
+            tokensBefore: recoveryBudgetResult.tokensBefore,
+            tokensAfter: recoveryBudgetResult.tokensAfter,
+            inputBudget: recoveryBudgetResult.inputBudget,
+            safetyMarginTokens: recoveryBudgetResult.safetyMarginTokens,
+            strategy: recoveryBudgetResult.strategy,
           });
           try {
             await adapter.chat(preparedMessages, chatOptions, eventHandler);
@@ -2271,7 +2332,11 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
 
       clearLoopContext(loopId);
       const errorMessage = err instanceof Error ? err.message : String(err);
-      const errorCode = err instanceof LLMError ? err.code : undefined;
+      const errorCode = err instanceof LLMError
+        ? err.code
+        : err instanceof ContextBudgetError
+        ? err.code
+        : undefined;
       logger.error('LLM call failed', {
         error: errorMessage,
         code: errorCode,
@@ -2289,7 +2354,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
           recordProviderCallOutcome(getActiveProvider(settingsForModel)?.id, { ok: false, code: err.code, at: Date.now() });
         }
       } else {
-        reportError('agent_crash', 'unknown', undefined, effectiveModelId, errorMessage);
+        reportError('agent_crash', errorCode ?? 'unknown', undefined, effectiveModelId, errorMessage);
       }
       logger.info('Agent loop ended', { conversationId, loopId, turnCount, reason: 'error' });
 
@@ -2305,8 +2370,13 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         && err instanceof LLMError && err.statusCode === 403
         && /^forbidden\s*$/i.test(err.message.trim());
       const isEnterpriseGatewayUnavailable = err instanceof EnterpriseLlmUnavailableError;
+      const isContextBudgetError = err instanceof ContextBudgetError;
       let displayError = isEnterpriseGatewayUnavailable
         ? getI18n().chat.gatewayUnreachable
+        : isContextBudgetError && err.code === 'INPUT_TOO_LARGE'
+        ? getI18n().chat.contextInputTooLarge
+        : isContextBudgetError
+        ? getI18n().chat.contextFixedTooLarge
         : isLikelyVisionError
         ? getI18n().chat.visionUnsupported
         : isOllamaForbidden

--- a/src/core/agent/agentLoopRunner.test.ts
+++ b/src/core/agent/agentLoopRunner.test.ts
@@ -28,12 +28,29 @@ class MockSidecarRequestError extends Error {
 }
 const getSidecarStatusMock = vi.fn().mockReturnValue('running');
 const sidecarRequestMock = vi.fn();
+const agentStartRequestMock = vi.fn((_params: { runId: string; clientMessageId: string }) => Promise.resolve({
+  version: 1,
+  runId: _params.runId,
+  clientMessageId: _params.clientMessageId,
+  acceptedAt: 1,
+  state: 'accepted',
+  replay: false,
+}));
+const runGetStateRequestMock = vi.fn((params: { runId: string }) => Promise.resolve({
+  version: 1,
+  runId: params.runId,
+  state: 'not_found',
+}));
 vi.mock('../sidecar/sidecarManager', () => ({
   onSidecarNotification: (...a: unknown[]) => onSidecarNotification(...a),
   onSidecarRequest: (...a: unknown[]) => onSidecarRequest(...a),
   notifySidecar: (...a: unknown[]) => notifySidecar(...a),
   getSidecarStatus: (...a: unknown[]) => getSidecarStatusMock(...a),
-  request: (...a: unknown[]) => sidecarRequestMock(...a),
+  request: (method: string, params: unknown, ...rest: unknown[]) => {
+    if (method === 'agent.start') return agentStartRequestMock(params as { runId: string; clientMessageId: string }, ...rest);
+    if (method === 'run.getState') return runGetStateRequestMock(params as { runId: string }, ...rest);
+    return sidecarRequestMock(method, params, ...rest);
+  },
   SidecarRequestError: MockSidecarRequestError,
 }));
 
@@ -182,9 +199,11 @@ vi.mock('./ports/abortRegistry', () => ({
 
 const runAgentLoopMock = vi.fn().mockResolvedValue({ reason: 'completed' });
 const isInteractiveDesktopMock = vi.fn().mockReturnValue(true);
+const buildUserMessageContentMock = vi.fn(async (_conversationId: string, text: string) => text);
 vi.mock('./agentLoop', () => ({
   runAgentLoop: (...a: unknown[]) => runAgentLoopMock(...a),
   isInteractiveDesktop: (...a: unknown[]) => isInteractiveDesktopMock(...a),
+  buildUserMessageContent: (...a: [string, string, unknown]) => buildUserMessageContentMock(...a),
 }));
 
 const precomputeOrchestrationMock = vi.fn().mockResolvedValue({
@@ -346,10 +365,16 @@ const chatSubscribeMock = vi.fn((cb: () => void) => {
   return chatUnsubMock;
 });
 const waitForConversationPersistenceMock = vi.fn().mockResolvedValue(undefined);
+const chatStoreAddMessageMock = vi.fn();
+const chatStoreUpdateUserMessageRunMock = vi.fn();
 vi.mock('../../stores/chatStore', () => ({
   useChatStore: {
     subscribe: (...a: [() => void]) => chatSubscribeMock(...a),
-    getState: () => chatState,
+    getState: () => ({
+      ...chatState,
+      addMessage: (...a: unknown[]) => chatStoreAddMessageMock(...a),
+      updateUserMessageRun: (...a: unknown[]) => chatStoreUpdateUserMessageRunMock(...a),
+    }),
   },
   waitForConversationPersistence: (...a: unknown[]) => waitForConversationPersistenceMock(...a),
 }));
@@ -375,6 +400,9 @@ vi.mock('../../i18n', () => ({
   getI18n: () => ({
     chat: {
       sidecarInterrupted: '后台服务意外中断，正在自动恢复。请稍后重新发送刚才的请求。',
+      messageSaveFailed: '消息未能写入磁盘，阿布没有启动任务。请检查磁盘权限后重试。',
+      attachmentDuringRun: '请等待当前任务结束后再发送图片，草稿已为你保留。',
+      conversationBusy: '当前会话已有任务在运行，请等待结束后再启动新任务。',
     },
   }),
   getLocale: () => 'zh-CN',
@@ -520,6 +548,25 @@ describe('agentLoopRunner', () => {
     getSidecarStatusMock.mockReset();
     getSidecarStatusMock.mockReturnValue('running');
     sidecarRequestMock.mockReset();
+    agentStartRequestMock.mockReset();
+    agentStartRequestMock.mockImplementation((params: { runId: string; clientMessageId: string }) => Promise.resolve({
+      version: 1,
+      runId: params.runId,
+      clientMessageId: params.clientMessageId,
+      acceptedAt: 1,
+      state: 'accepted',
+      replay: false,
+    }));
+    runGetStateRequestMock.mockReset();
+    runGetStateRequestMock.mockImplementation((params: { runId: string }) => Promise.resolve({
+      version: 1,
+      runId: params.runId,
+      state: 'not_found',
+    }));
+    chatStoreAddMessageMock.mockReset();
+    chatStoreUpdateUserMessageRunMock.mockReset();
+    buildUserMessageContentMock.mockReset();
+    buildUserMessageContentMock.mockImplementation(async (_conversationId: string, text: string) => text);
     traceRuntimeEventMock.mockReset();
     startRuntimeRunMock.mockReset();
     markRuntimeRunStageMock.mockReset();
@@ -552,20 +599,19 @@ describe('agentLoopRunner', () => {
       ensureHandlersRegistered();
       ensureHandlersRegistered();
 
-      // 11 notifications (9 own — the 9th being P1-3B-4's input.consumed,
-      // the 10th being P1-3d A-write's workspace.bindFromWrite, the 11th
-      // being P1-3d-5 slice 2a's shell.sandboxBlocked — + hook.notify via the
+      // 12 notifications (including the ordered agent.terminal fact and
+      // hook.notify via the
       // shared hookBridge) and 8 requests (native.invoke/tool.list/
       // session.isMessageWrittenToDisk/approval.check — P1-3d-3 — /
       // snapshot.beforeAiEdit — P1-3d A-write — /
       // workspace.authorizedWritablePaths — P1-3d-5 slice 2a — /
       // tool.invoke via the router / hook.emit via the shared hookBridge).
-      expect(onSidecarNotification).toHaveBeenCalledTimes(11);
+      expect(onSidecarNotification).toHaveBeenCalledTimes(12);
       expect(onSidecarRequest).toHaveBeenCalledTimes(8);
 
       const notifiedMethods = onSidecarNotification.mock.calls.map((c) => c[0]);
       expect(notifiedMethods).toEqual(
-        expect.arrayContaining(['agent.delta', 'approval.drain', 'plan.clear', 'caps.record', 'shell.notifyTask', 'cu.setState', 'skillHooks.clearAll', 'input.consumed', 'workspace.bindFromWrite', 'shell.sandboxBlocked', 'hook.notify']),
+        expect.arrayContaining(['agent.delta', 'agent.terminal', 'approval.drain', 'plan.clear', 'caps.record', 'shell.notifyTask', 'cu.setState', 'skillHooks.clearAll', 'input.consumed', 'workspace.bindFromWrite', 'shell.sandboxBlocked', 'hook.notify']),
       );
       const requestedMethods = onSidecarRequest.mock.calls.map((c) => c[0]);
       expect(requestedMethods).toEqual(
@@ -636,6 +682,52 @@ describe('agentLoopRunner', () => {
       expect(() => handler(null)).not.toThrow();
       expect(() => handler({ runId: 123, frames: [] })).not.toThrow();
       expect(applyDeltaFramesMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('agent.terminal handler', () => {
+    it('accepts the first valid terminal, fences late frames, and ignores a conflicting duplicate', async () => {
+      const { ensureHandlersRegistered, registerRunSession, getRunSession } = await importFresh();
+      ensureHandlersRegistered();
+      registerRunSession('run-terminal', makeSession());
+
+      const terminalHandler = handlerFor(onSidecarNotification, 'agent.terminal');
+      const deltaHandler = handlerFor(onSidecarNotification, 'agent.delta');
+      terminalHandler({
+        version: 1,
+        runId: 'run-terminal',
+        state: 'completed',
+        result: { reason: 'completed' },
+      });
+      terminalHandler({
+        version: 1,
+        runId: 'run-terminal',
+        state: 'failed',
+        result: { reason: 'error', error: 'late conflict' },
+        failure: { errorType: 'error', message: 'late conflict' },
+      });
+      deltaHandler({ runId: 'run-terminal', frames: [{ p: 'chat', m: 'appendText', a: ['conv-1', 'late'] }] });
+
+      expect(getRunSession('run-terminal')?.terminal).toEqual({
+        version: 1,
+        runId: 'run-terminal',
+        state: 'completed',
+        result: { reason: 'completed' },
+      });
+      expect(applyDeltaFramesMock).not.toHaveBeenCalled();
+    });
+
+    it('drops malformed terminals and terminals for unknown runs', async () => {
+      const { ensureHandlersRegistered, registerRunSession, getRunSession } = await importFresh();
+      ensureHandlersRegistered();
+      registerRunSession('known-run', makeSession());
+      const terminalHandler = handlerFor(onSidecarNotification, 'agent.terminal');
+
+      terminalHandler({ version: 2, runId: 'known-run', state: 'completed', result: { reason: 'completed' } });
+      terminalHandler({ version: 1, runId: 'known-run', state: 'completed', result: { reason: 'error' } });
+      terminalHandler({ version: 1, runId: 'missing-run', state: 'completed', result: { reason: 'completed' } });
+
+      expect(getRunSession('known-run')?.terminal).toBeUndefined();
     });
   });
 
@@ -1116,6 +1208,17 @@ describe('agentLoopRunner', () => {
       registerRunSession('run-1', session);
 
       getQueuedInputsMock.mockReturnValue([{ id: 'leftover-1', text: 'already seeded', timestamp: 1 }]);
+      capturedQueueCb?.();
+
+      expect(notifySidecar).not.toHaveBeenCalledWith('agent.enqueueInput', expect.anything());
+    });
+
+    it('Stop is a synchronous barrier that freezes new queue forwarding', async () => {
+      const { registerRunSession } = await importFresh();
+      const session = { ...makeSession({ conversationId: 'conv-1' }), abortRequested: true };
+      registerRunSession('run-1', session);
+      getQueuedInputsMock.mockReturnValue([{ id: 'q-after-stop', text: 'must stay local', timestamp: 1 }]);
+
       capturedQueueCb?.();
 
       expect(notifySidecar).not.toHaveBeenCalledWith('agent.enqueueInput', expect.anything());
@@ -1735,6 +1838,268 @@ describe('agentLoopRunner', () => {
       expect(result).toEqual({ reason: 'completed' });
     });
 
+    it('persists the user message before the bounded start handshake', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      sidecarRequestMock.mockResolvedValue({ reason: 'completed' });
+
+      await runAgentLoopDispatched('conv-1', 'hello');
+
+      expect(chatStoreAddMessageMock).toHaveBeenCalledWith('conv-1', expect.objectContaining({
+        role: 'user',
+        content: 'hello',
+        runState: 'pending',
+        runId: expect.any(String),
+        clientMessageId: expect.any(String),
+      }));
+      expect(chatStoreAddMessageMock.mock.invocationCallOrder[0])
+        .toBeLessThan(agentStartRequestMock.mock.invocationCallOrder[0]);
+      expect(waitForConversationPersistenceMock).toHaveBeenCalledWith('conv-1');
+      const startParams = agentStartRequestMock.mock.calls[0][0] as {
+        runId: string;
+        clientMessageId: string;
+        payloadDigest: string;
+        options: { prePersistedUserMessageId?: string };
+      };
+      expect(startParams.clientMessageId).toBe(`msg-${startParams.runId}`);
+      expect(startParams.payloadDigest).toMatch(/^rrp1-/);
+      expect(startParams.options.prePersistedUserMessageId).toBe(startParams.clientMessageId);
+    });
+
+    it('does not start or fall back when the durable user-message append fails', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      waitForConversationPersistenceMock
+        .mockRejectedValueOnce(new Error('disk unavailable'))
+        .mockRejectedValueOnce(new Error('disk unavailable'));
+
+      await expect(runAgentLoopDispatched('conv-1', 'hello')).resolves.toEqual({
+        reason: 'error',
+        error: '消息未能写入磁盘，阿布没有启动任务。请检查磁盘权限后重试。',
+      });
+
+      expect(agentStartRequestMock).not.toHaveBeenCalled();
+      expect(sidecarRequestMock).not.toHaveBeenCalled();
+      expect(runAgentLoopMock).not.toHaveBeenCalled();
+      expect(markRuntimeRunStageMock).not.toHaveBeenCalledWith(expect.any(String), 'local_message_persisted');
+      expect(traceRuntimeEventMock).toHaveBeenCalledWith(
+        'renderer.local_message_persist_failed',
+        expect.objectContaining({ stage: 'local_message_persist_failed' }),
+      );
+    });
+
+    it('recovers a lost start ACK from run.getState without replaying execution', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      agentStartRequestMock.mockRejectedValueOnce(new Error('ACK lost'));
+      runGetStateRequestMock.mockImplementationOnce((params: { runId: string }) => Promise.resolve({
+        version: 1,
+        runId: params.runId,
+        state: 'running',
+      }));
+      sidecarRequestMock.mockResolvedValue({ reason: 'completed' });
+
+      await expect(runAgentLoopDispatched('conv-1', 'hello')).resolves.toEqual({ reason: 'completed' });
+      expect(agentStartRequestMock).toHaveBeenCalledTimes(1);
+      expect(runGetStateRequestMock).toHaveBeenCalledTimes(1);
+      expect(sidecarRequestMock).toHaveBeenCalledTimes(1);
+      expect(chatStoreUpdateUserMessageRunMock).toHaveBeenCalledWith(
+        'conv-1',
+        expect.any(String),
+        expect.objectContaining({ state: 'running' }),
+      );
+    });
+
+    it('replays agent.start once with identical ids when state is not found', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      agentStartRequestMock
+        .mockRejectedValueOnce(new Error('ACK lost'))
+        .mockImplementationOnce((params: { runId: string; clientMessageId: string }) => Promise.resolve({
+          version: 1,
+          runId: params.runId,
+          clientMessageId: params.clientMessageId,
+          acceptedAt: 2,
+          state: 'accepted',
+          replay: false,
+        }));
+      sidecarRequestMock.mockResolvedValue({ reason: 'completed' });
+
+      await runAgentLoopDispatched('conv-1', 'hello');
+
+      expect(agentStartRequestMock).toHaveBeenCalledTimes(2);
+      const first = agentStartRequestMock.mock.calls[0][0] as { runId: string; clientMessageId: string; payloadDigest: string };
+      const second = agentStartRequestMock.mock.calls[1][0] as typeof first;
+      expect(second).toMatchObject(first);
+    });
+
+    it('reattaches to an accepted running sidecar run after the execution RPC transport closes', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      sidecarRequestMock.mockRejectedValueOnce(new Error('execution response transport closed'));
+      runGetStateRequestMock.mockImplementationOnce((params: { runId: string }) => Promise.resolve({
+        version: 1,
+        runId: params.runId,
+        state: 'running',
+      }));
+
+      const running = runAgentLoopDispatched('conv-1', 'hello');
+      await waitForCall(sidecarRequestMock);
+      const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
+      for (let i = 0; i < 20 && runGetStateRequestMock.mock.calls.length === 0; i++) await Promise.resolve();
+      handlerFor(onSidecarNotification, 'agent.terminal')({
+        version: 1,
+        runId,
+        state: 'completed',
+        result: { reason: 'completed' },
+      });
+
+      await expect(running).resolves.toEqual({ reason: 'completed' });
+      expect(runAgentLoopMock).not.toHaveBeenCalled();
+      expect(sidecarRequestMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('replays execution once after a pre-commit sidecar restart reports not_found', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      sidecarRequestMock
+        .mockRejectedValueOnce(new Error('sidecar restarted'))
+        .mockResolvedValueOnce({ reason: 'completed' });
+
+      await expect(runAgentLoopDispatched('conv-1', 'hello')).resolves.toEqual({ reason: 'completed' });
+
+      expect(sidecarRequestMock.mock.calls.filter((call) => call[0] === 'agent.run')).toHaveLength(2);
+      expect(agentStartRequestMock).toHaveBeenCalledTimes(2);
+      const starts = agentStartRequestMock.mock.calls.map((call) => call[0] as {
+        runId: string;
+        clientMessageId: string;
+        payloadDigest: string;
+      });
+      expect(starts[1]).toMatchObject(starts[0]);
+      expect(runAgentLoopMock).not.toHaveBeenCalled();
+    });
+
+    it('uses a cached terminal returned by run.getState and never replays work', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      sidecarRequestMock.mockRejectedValueOnce(new Error('response lost'));
+      runGetStateRequestMock.mockImplementationOnce((params: { runId: string }) => Promise.resolve({
+        version: 1,
+        runId: params.runId,
+        state: 'terminal',
+        terminal: {
+          version: 1,
+          runId: params.runId,
+          state: 'completed',
+          result: { reason: 'completed' },
+        },
+      }));
+
+      await expect(runAgentLoopDispatched('conv-1', 'hello')).resolves.toEqual({ reason: 'completed' });
+      expect(sidecarRequestMock).toHaveBeenCalledTimes(1);
+      expect(agentStartRequestMock).toHaveBeenCalledTimes(1);
+      expect(runAgentLoopMock).not.toHaveBeenCalled();
+    });
+
+    it('settles from agent.terminal when the RPC response is lost, without surfacing an error or rerunning', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      let runSignal: AbortSignal | undefined;
+      sidecarRequestMock.mockImplementation((_method: string, _params: unknown, _timeout: number, signal?: AbortSignal) => {
+        runSignal = signal;
+        return new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+        });
+      });
+
+      const running = runAgentLoopDispatched('conv-1', 'hello');
+      await waitForCall(sidecarRequestMock);
+      const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
+      const terminalHandler = handlerFor(onSidecarNotification, 'agent.terminal');
+      terminalHandler({ version: 1, runId, state: 'completed', result: { reason: 'completed' } });
+
+      await expect(running).resolves.toEqual({ reason: 'completed' });
+      expect(runSignal?.aborted).toBe(true);
+      expect(runAgentLoopMock).not.toHaveBeenCalled();
+      expect(chatDeltaAppendTextMock).not.toHaveBeenCalledWith('conv-1', expect.stringContaining('Error'));
+    });
+
+    it('keeps the first completed terminal when Stop races with renderer cleanup', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      const shellController = new AbortController();
+      getAbortControllerMock.mockReturnValue(shellController);
+      sidecarRequestMock.mockImplementation((_method: string, _params: unknown, _timeout: number, signal?: AbortSignal) => (
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+        })
+      ));
+
+      const running = runAgentLoopDispatched('conv-1', 'hello');
+      await waitForCall(sidecarRequestMock);
+      const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
+      const terminalHandler = handlerFor(onSidecarNotification, 'agent.terminal');
+      terminalHandler({ version: 1, runId, state: 'completed', result: { reason: 'completed' } });
+      shellController.abort();
+
+      await expect(running).resolves.toEqual({ reason: 'completed' });
+      expect(sidecarRequestMock).not.toHaveBeenCalledWith('agent.abort', expect.anything(), expect.anything());
+      expect(chatDeltaCancelStreamingMock).not.toHaveBeenCalled();
+    });
+
+    it('uses a failed terminal before any delta as authoritative and finalizes the UI exactly once', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      sidecarRequestMock.mockImplementation((_method: string, _params: unknown, _timeout: number, signal?: AbortSignal) => (
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+        })
+      ));
+
+      const running = runAgentLoopDispatched('conv-1', 'hello');
+      await waitForCall(sidecarRequestMock);
+      const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
+      const terminalHandler = handlerFor(onSidecarNotification, 'agent.terminal');
+      const failed = {
+        version: 1,
+        runId,
+        state: 'failed',
+        result: { reason: 'error', error: 'provider failed' },
+        failure: { errorType: 'provider_error', message: 'provider failed', stack: 'provider stack' },
+      };
+      terminalHandler(failed);
+      terminalHandler(failed);
+
+      await expect(running).resolves.toEqual({ reason: 'error', error: 'provider failed' });
+      expect(runAgentLoopMock).not.toHaveBeenCalled();
+      expect(chatDeltaAppendTextMock).toHaveBeenCalledTimes(1);
+      expect(chatDeltaAppendTextMock).toHaveBeenCalledWith('conv-1', expect.stringContaining('provider failed'));
+      expect(chatDeltaFinishStreamingMock).toHaveBeenCalledTimes(1);
+      expect(chatDeltaSetConversationStatusMock).toHaveBeenCalledWith('conv-1', 'error');
+    });
+
+    it('does not settle a failed terminal until its failed lifecycle is durable', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      const failurePersistence = deferred<void>();
+      waitForConversationPersistenceMock.mockImplementation(() => (
+        waitForConversationPersistenceMock.mock.calls.length === 4
+          ? failurePersistence.promise
+          : Promise.resolve()
+      ));
+      sidecarRequestMock.mockImplementation((_method: string, _params: unknown, _timeout: number, signal?: AbortSignal) => (
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+        })
+      ));
+
+      let settled = false;
+      const running = runAgentLoopDispatched('conv-1', 'hello').finally(() => { settled = true; });
+      await waitForCall(sidecarRequestMock);
+      const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
+      handlerFor(onSidecarNotification, 'agent.terminal')({
+        version: 1,
+        runId,
+        state: 'failed',
+        result: { reason: 'error', error: 'provider failed' },
+        failure: { errorType: 'provider_error', message: 'provider failed' },
+      });
+
+      await vi.waitFor(() => expect(waitForConversationPersistenceMock).toHaveBeenCalledTimes(4));
+      expect(settled).toBe(false);
+      failurePersistence.resolve();
+      await expect(running).resolves.toEqual({ reason: 'error', error: 'provider failed' });
+    });
+
     it('records a stall after 30 seconds without a non-empty delta, without changing run behavior', async () => {
       vi.useFakeTimers();
       const { runAgentLoopDispatched } = await importFresh();
@@ -1830,6 +2195,53 @@ describe('agentLoopRunner', () => {
       expect(runAgentLoopMock).not.toHaveBeenCalled();
       expect(clearAbortControllerMock).toHaveBeenLastCalledWith('conv-1');
       expect(chatDeltaSetConversationStatusMock).toHaveBeenLastCalledWith('conv-1', 'idle');
+    });
+
+    it('propagates a durability failure for an interrupted run aborted during parameter construction', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      const controller = new AbortController();
+      getAbortControllerMock.mockReturnValue(controller);
+      const orchestration = deferred<{
+        route: { type: 'general'; name: string; cleanInput: string };
+        systemPromptSections: never[];
+      }>();
+      precomputeOrchestrationMock.mockReturnValue(orchestration.promise);
+      waitForConversationPersistenceMock
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('interrupted lifecycle not durable'));
+
+      const running = runAgentLoopDispatched('conv-1', 'hello');
+      await waitForCall(precomputeOrchestrationMock);
+      controller.abort();
+      orchestration.reject(new Error('prompt construction aborted'));
+
+      await expect(running).rejects.toThrow('interrupted lifecycle not durable');
+      expect(sidecarRequestMock).not.toHaveBeenCalled();
+      expect(chatStoreUpdateUserMessageRunMock).toHaveBeenCalledWith(
+        'conv-1',
+        expect.any(String),
+        { state: 'interrupted' },
+      );
+    });
+
+    it('propagates a durability failure for an interrupted run aborted immediately before dispatch', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      const controller = new AbortController();
+      getAbortControllerMock.mockReturnValue(controller);
+      waitForConversationPersistenceMock
+        .mockResolvedValueOnce(undefined)
+        .mockImplementationOnce(async () => { controller.abort(); })
+        .mockRejectedValueOnce(new Error('pre-dispatch lifecycle not durable'));
+
+      const running = runAgentLoopDispatched('conv-1', 'hello');
+
+      await expect(running).rejects.toThrow('pre-dispatch lifecycle not durable');
+      expect(sidecarRequestMock).not.toHaveBeenCalled();
+      expect(chatStoreUpdateUserMessageRunMock).toHaveBeenCalledWith(
+        'conv-1',
+        expect.any(String),
+        { state: 'interrupted' },
+      );
     });
 
     it('buildAgentRunParams includes a queuedInputs snapshot of the shell queue at dispatch time (P1-3B-4, wire-safe shape)', async () => {
@@ -1950,6 +2362,34 @@ describe('agentLoopRunner', () => {
       expect(clearAbortControllerMock).toHaveBeenCalledWith('conv-1');
     });
 
+    it('does not report Stop as settled when the interrupted lifecycle cannot be persisted', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      const shellController = new AbortController();
+      getAbortControllerMock.mockReturnValue(shellController);
+      waitForConversationPersistenceMock
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('stop lifecycle not durable'));
+      sidecarRequestMock.mockImplementation((method: string, _params: unknown, _timeout: number, signal?: AbortSignal) => {
+        if (method === 'agent.abort') return Promise.resolve({ accepted: true, state: 'aborting' });
+        return new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+        });
+      });
+
+      const running = runAgentLoopDispatched('conv-1', 'hello');
+      await waitForCall(sidecarRequestMock);
+      shellController.abort();
+
+      await expect(running).rejects.toThrow('stop lifecycle not durable');
+      expect(chatStoreUpdateUserMessageRunMock).toHaveBeenCalledWith(
+        'conv-1',
+        expect.any(String),
+        { state: 'interrupted' },
+      );
+      expect(clearAbortControllerMock).toHaveBeenCalledWith('conv-1');
+    });
+
     it('force-finalizes after 5s when the sidecar never acknowledges Stop', async () => {
       vi.useFakeTimers();
       const { runAgentLoopDispatched } = await importFresh();
@@ -2034,7 +2474,10 @@ describe('agentLoopRunner', () => {
       const persistence = deferred<void>();
       sidecarRequestMock.mockReturnValue(rpc.promise);
       applyDeltaFramesMock.mockReturnValueOnce(frame.promise);
-      waitForConversationPersistenceMock.mockReturnValueOnce(persistence.promise);
+      waitForConversationPersistenceMock
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockReturnValueOnce(persistence.promise);
 
       const running = runAgentLoopDispatched('conv-1', 'hello');
       await waitForCall(sidecarRequestMock);
@@ -2053,7 +2496,7 @@ describe('agentLoopRunner', () => {
       await Promise.resolve();
       expect(settled).toBe(false);
       expect(getRunSession(runId)).toBeDefined();
-      expect(waitForConversationPersistenceMock).not.toHaveBeenCalled();
+      expect(waitForConversationPersistenceMock).toHaveBeenCalledTimes(2);
 
       frame.resolve();
       await frame.promise;
@@ -2075,7 +2518,10 @@ describe('agentLoopRunner', () => {
       const result = await runAgentLoopDispatched('conv-1', 'hello');
 
       expect(runAgentLoopMock).toHaveBeenCalledTimes(1);
-      expect(runAgentLoopMock).toHaveBeenCalledWith('conv-1', 'hello', undefined);
+      expect(runAgentLoopMock).toHaveBeenCalledWith('conv-1', 'hello', expect.objectContaining({
+        loopId: expect.any(String),
+        prePersistedUserMessageId: expect.any(String),
+      }));
       expect(result).toEqual({ reason: 'completed' });
     });
 
@@ -2166,6 +2612,30 @@ describe('agentLoopRunner', () => {
       expect(chatDeltaSetAgentStatusMock).toHaveBeenCalledWith('idle');
     });
 
+    it('rejects a post-commit failure result when its terminal state cannot be persisted', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      const d = deferred<unknown>();
+      waitForConversationPersistenceMock.mockImplementation(() => (
+        waitForConversationPersistenceMock.mock.calls.length === 4
+          ? Promise.reject(new Error('disk unavailable'))
+          : Promise.resolve()
+      ));
+      sidecarRequestMock.mockReturnValue(d.promise);
+
+      const running = runAgentLoopDispatched('conv-1', 'hello');
+      await waitForCall(sidecarRequestMock);
+      const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
+      handlerFor(onSidecarNotification, 'agent.delta')({
+        runId,
+        frames: [{ p: 'chat', m: 'appendText', a: ['conv-1', 'thinking…'] }],
+      });
+      d.reject(new Error('sidecar crashed mid-run'));
+
+      await expect(running).rejects.toThrow('disk unavailable');
+      expect(runAgentLoopMock).not.toHaveBeenCalled();
+      expect(chatDeltaSetConversationStatusMock).toHaveBeenCalledWith('conv-1', 'error');
+    });
+
     it('shows a localized recovery message when the sidecar process closes after commit', async () => {
       const { runAgentLoopDispatched } = await importFresh();
       const d = deferred<unknown>();
@@ -2244,6 +2714,50 @@ describe('agentLoopRunner', () => {
       expect(result).toEqual({ reason: 'completed' });
     });
 
+    it('upgrades the durable raw message to multimodal content before an early in-process fallback', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      getConversationMock.mockReturnValue({
+        id: 'conv-1',
+        title: 't',
+        status: 'idle',
+        messages: [{ id: expect.any(String), role: 'user', content: 'look', timestamp: 1 }],
+      });
+      // The generated client id is not known ahead of time; make the reader
+      // reflect the user row inserted by the runner.
+      chatStoreAddMessageMock.mockImplementation((_convId, message) => {
+        getConversationMock.mockReturnValue({
+          id: 'conv-1',
+          title: 't',
+          status: 'running',
+          messages: [message],
+        });
+      });
+      const multimodal = [{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'x' } }];
+      buildUserMessageContentMock.mockResolvedValue(multimodal);
+      resolveEffectiveLlmCredsMock.mockImplementation(() => { throw new Error('EnterpriseLlmUnavailableError'); });
+
+      await expect(runAgentLoopDispatched('conv-1', 'look', {
+        images: [{ id: 'i1', data: 'x', mediaType: 'image/png' }],
+      })).resolves.toEqual({ reason: 'completed' });
+
+      expect(buildUserMessageContentMock).toHaveBeenCalledWith(
+        'conv-1',
+        'look',
+        [{ id: 'i1', data: 'x', mediaType: 'image/png' }],
+      );
+      expect(chatStoreUpdateUserMessageRunMock).toHaveBeenCalledWith(
+        'conv-1',
+        expect.any(String),
+        expect.objectContaining({ content: multimodal }),
+      );
+      expect(runAgentLoopMock).toHaveBeenCalledWith(
+        'conv-1',
+        'look',
+        expect.objectContaining({ prePersistedUserMessageId: expect.any(String) }),
+      );
+      expect(sidecarRequestMock).not.toHaveBeenCalled();
+    });
+
     it('a malformed agent.run response is treated as a failure (pre-commit → falls back in-process)', async () => {
       const { runAgentLoopDispatched } = await importFresh();
       sidecarRequestMock.mockResolvedValue({ notReason: 'oops' });
@@ -2255,6 +2769,41 @@ describe('agentLoopRunner', () => {
     });
 
     describe('concurrency guard', () => {
+      it('rejects an image send against a live in-process run even when the sidecar is down', async () => {
+        const { runAgentLoopDispatched } = await importFresh();
+        getSidecarStatusMock.mockReturnValue('stopped');
+        getConversationMock.mockReturnValue({ id: 'conv-1', title: 't', messages: [], status: 'running' });
+        hasAbortControllerMock.mockReturnValue(true);
+
+        const result = await runAgentLoopDispatched('conv-1', '', {
+          images: [{ id: 'img-1', data: 'aGk=', mediaType: 'image/png' }],
+        });
+
+        expect(result).toEqual({
+          reason: 'error',
+          error: '请等待当前任务结束后再发送图片，草稿已为你保留。',
+        });
+        expect(runAgentLoopMock).not.toHaveBeenCalled();
+        expect(sidecarRequestMock).not.toHaveBeenCalled();
+      });
+
+      it('rejects a headless send against a live in-process run even when the sidecar is down', async () => {
+        const { runAgentLoopDispatched } = await importFresh();
+        getSidecarStatusMock.mockReturnValue('stopped');
+        getConversationMock.mockReturnValue({ id: 'conv-1', title: 't', messages: [], status: 'running' });
+        hasAbortControllerMock.mockReturnValue(true);
+        isInteractiveDesktopMock.mockReturnValue(false);
+
+        const result = await runAgentLoopDispatched('conv-1', 'headless overlap');
+
+        expect(result).toEqual({
+          reason: 'error',
+          error: '当前会话已有任务在运行，请等待结束后再启动新任务。',
+        });
+        expect(runAgentLoopMock).not.toHaveBeenCalled();
+        expect(sidecarRequestMock).not.toHaveBeenCalled();
+      });
+
       it('stages the message into an existing sidecar RunSession via agent.enqueueInput instead of dispatching a second agent.run', async () => {
         const { runAgentLoopDispatched, registerRunSession } = await importFresh();
         registerRunSession('run-existing', makeSession({ conversationId: 'conv-1' }));
@@ -2353,7 +2902,7 @@ describe('agentLoopRunner', () => {
         expect(sidecarRequestMock).toHaveBeenCalledTimes(1);
       });
 
-      it('does NOT enqueue for an image send even when a run is already active (falls through to a normal dispatch, same as the in-process guard)', async () => {
+      it('rejects an image send while a run is active instead of starting a second agent run', async () => {
         const { runAgentLoopDispatched, registerRunSession } = await importFresh();
         registerRunSession('run-existing', makeSession({ conversationId: 'conv-1' }));
         sidecarRequestMock.mockResolvedValue({ reason: 'completed' });
@@ -2361,20 +2910,27 @@ describe('agentLoopRunner', () => {
         const result = await runAgentLoopDispatched('conv-1', 'look at this', { images: [{ id: 'i1', data: 'x', mediaType: 'image/png' }] });
 
         expect(notifySidecar).not.toHaveBeenCalledWith('agent.enqueueInput', expect.anything());
-        expect(sidecarRequestMock).toHaveBeenCalledTimes(1);
-        expect(result).toEqual({ reason: 'completed' });
+        expect(sidecarRequestMock).not.toHaveBeenCalled();
+        expect(result).toEqual({
+          reason: 'error',
+          error: '请等待当前任务结束后再发送图片，草稿已为你保留。',
+        });
       });
 
-      it('does NOT enqueue for a headless (non-interactive-desktop) caller — dispatches normally even with an existing session', async () => {
+      it('rejects a headless caller when the conversation already has a live run', async () => {
         const { runAgentLoopDispatched, registerRunSession } = await importFresh();
         isInteractiveDesktopMock.mockReturnValue(false);
         registerRunSession('run-existing', makeSession({ conversationId: 'conv-1' }));
         sidecarRequestMock.mockResolvedValue({ reason: 'completed' });
 
-        await runAgentLoopDispatched('conv-1', 'scheduled prompt');
+        const result = await runAgentLoopDispatched('conv-1', 'scheduled prompt');
 
         expect(notifySidecar).not.toHaveBeenCalledWith('agent.enqueueInput', expect.anything());
-        expect(sidecarRequestMock).toHaveBeenCalledTimes(1);
+        expect(sidecarRequestMock).not.toHaveBeenCalled();
+        expect(result).toEqual({
+          reason: 'error',
+          error: '当前会话已有任务在运行，请等待结束后再启动新任务。',
+        });
       });
     });
   });

--- a/src/core/agent/agentLoopRunner.ts
+++ b/src/core/agent/agentLoopRunner.ts
@@ -80,10 +80,16 @@ import { getI18n, getLocale } from '../../i18n';
 import { createLogger } from '../logging/logger';
 import {
   runAgentLoop,
+  buildUserMessageContent,
   isInteractiveDesktop,
   type AgentLoopOptions,
   type AgentLoopResult,
 } from './agentLoop';
+import {
+  areAgentRunTerminalsEqual,
+  isAgentRunTerminal,
+  type AgentRunTerminal,
+} from './agentRunTerminal';
 import { precomputeOrchestration } from './entryOrchestration';
 import type { RouteResult, IMContext } from './orchestrator';
 import type { PromptSection } from '../llm/promptSections';
@@ -111,6 +117,8 @@ const logger = createLogger('agent-loop-runner');
 const AGENT_ABORT_ACK_TIMEOUT_MS = 1_000;
 const AGENT_ABORT_FORCE_FINALIZE_MS = 5_000;
 const AGENT_FIRST_FRAME_STALL_MS = 30_000;
+const AGENT_START_ACK_TIMEOUT_MS = 3_000;
+const AGENT_STATE_QUERY_TIMEOUT_MS = 2_000;
 
 // ── Run-session registry ────────────────────────────────────────────────
 //
@@ -147,6 +155,11 @@ export interface RunSession {
    * caller passed.
    */
   runId?: string;
+  clientMessageId?: string;
+  userMessageId?: string;
+  payloadDigest?: string;
+  accepted?: boolean;
+  transportReplayCount?: number;
   /**
    * Flips `true` the instant EITHER the first `tool.invoke` for this run
    * arrives OR the first `agent.delta` frame is applied — P1-3B-3B's
@@ -196,6 +209,13 @@ export interface RunSession {
   abortWatchdog?: ReturnType<typeof setTimeout>;
   abortRequestPromise?: Promise<void>;
   abortFinalizationPromise?: Promise<void>;
+  /** First valid terminal fact wins. Later duplicates are idempotent and a
+   * conflicting terminal is ignored, so transport retries cannot rewrite an
+   * already-observed outcome. */
+  terminal?: AgentRunTerminal;
+  terminalPromise?: Promise<AgentRunTerminal>;
+  resolveTerminal?: (terminal: AgentRunTerminal) => void;
+  failureFinalizationPromise?: Promise<void>;
   runtimeStartedAt?: number;
   firstDeltaAt?: number;
   firstFrameApplied?: boolean;
@@ -284,6 +304,7 @@ function handleAgentDelta(rawParams: unknown): void {
   if (frames.length > 0) {
     session.committed = true;
     if (isFirstDelta) {
+      updateSessionMessageState(session, 'running');
       session.firstDeltaAt = Date.now();
       if (session.firstFrameStallTimer) {
         clearTimeout(session.firstFrameStallTimer);
@@ -320,9 +341,163 @@ function handleAgentDelta(rawParams: unknown): void {
   });
 }
 
+/** `agent.terminal` (NOTIFICATION) — first valid terminal wins per run. */
+function handleAgentTerminal(rawParams: unknown): void {
+  if (!isAgentRunTerminal(rawParams)) return;
+  const session = sessions.get(rawParams.runId);
+  if (!session) return;
+
+  if (session.terminal) {
+    if (!areAgentRunTerminalsEqual(session.terminal, rawParams)) {
+      logger.warn('conflicting agent terminal ignored', {
+        runId: rawParams.runId,
+        firstState: session.terminal.state,
+        conflictingState: rawParams.state,
+      });
+    }
+    return;
+  }
+
+  session.terminal = rawParams;
+  session.dropFrames = true;
+  if (session.firstFrameStallTimer) {
+    clearTimeout(session.firstFrameStallTimer);
+    session.firstFrameStallTimer = undefined;
+  }
+  markRuntimeRunStage(rawParams.runId, 'terminal_received');
+  traceRuntimeEvent('renderer.agent_terminal_received', {
+    runId: rawParams.runId,
+    executionPath: 'sidecar',
+    stage: 'terminal_received',
+    outcome: rawParams.result.reason,
+    durationMs: session.runtimeStartedAt === undefined
+      ? undefined
+      : Date.now() - session.runtimeStartedAt,
+  });
+  session.resolveTerminal?.(rawParams);
+}
+
+function updateSessionMessageState(
+  session: RunSession,
+  state: NonNullable<Conversation['messages'][number]['runState']>,
+  error?: string,
+): void {
+  if (!session.userMessageId) return;
+  useChatStore.getState().updateUserMessageRun(
+    session.conversationId,
+    session.userMessageId,
+    { state, ...(error ? { error } : {}) },
+  );
+}
+
+async function runInProcessWithPersistedMessage(
+  conversationId: string,
+  userMessage: string,
+  runId: string,
+  clientMessageId: string,
+  options?: AgentLoopOptions,
+): Promise<AgentLoopResult> {
+  // Params preparation can fail before it upgrades the durable raw message
+  // to multimodal content. Do that here before the in-process handoff so a
+  // pre-dispatch failure never drops an attached image merely because the
+  // local loop is told not to append a duplicate user row.
+  const persistedMessage = getConversationReader()
+    .getConversation(conversationId)
+    ?.messages.find((message) => message.id === clientMessageId);
+  if (options?.images?.length && typeof persistedMessage?.content === 'string') {
+    const content = await buildUserMessageContent(conversationId, userMessage, options.images);
+    useChatStore.getState().updateUserMessageRun(conversationId, clientMessageId, {
+      state: 'pending',
+      content,
+    });
+    await waitForConversationPersistence(conversationId);
+  }
+  useChatStore.getState().updateUserMessageRun(conversationId, clientMessageId, { state: 'running' });
+  try {
+    const result = await runAgentLoop(conversationId, userMessage, {
+      ...options,
+      loopId: runId,
+      prePersistedUserMessageId: clientMessageId,
+    });
+    const state = result.reason === 'aborted'
+      ? 'interrupted'
+      : result.reason === 'error'
+        ? 'failed'
+        : 'completed';
+    useChatStore.getState().updateUserMessageRun(conversationId, clientMessageId, {
+      state,
+      ...(result.error ? { error: result.error } : {}),
+    });
+    await waitForConversationPersistence(conversationId);
+    return result;
+  } catch (error) {
+    useChatStore.getState().updateUserMessageRun(conversationId, clientMessageId, {
+      state: 'failed',
+      error: error instanceof Error ? error.message : String(error),
+    });
+    await waitForConversationPersistence(conversationId);
+    throw error;
+  }
+}
+
+async function finalizePreDispatchInterruptedRun(
+  conversationId: string,
+  clientMessageId: string,
+  runId: string,
+  stage: 'params_build_aborted' | 'before_dispatch',
+  runtimeStartedAt: number,
+): Promise<AgentLoopResult> {
+  useChatStore.getState().updateUserMessageRun(conversationId, clientMessageId, {
+    state: 'interrupted',
+  });
+  getAbortRegistry().clearAbortController(conversationId);
+  getChatDelta().setConversationStatus(conversationId, 'idle');
+  traceRuntimeEvent('renderer.agent_run_aborted', {
+    runId,
+    executionPath: 'sidecar',
+    stage,
+    outcome: 'aborted',
+    durationMs: Date.now() - runtimeStartedAt,
+  });
+  try {
+    await waitForConversationPersistence(conversationId);
+  } finally {
+    finishRuntimeRun(runId);
+  }
+  return { reason: 'aborted' };
+}
+
 async function settleRunPersistence(session: RunSession): Promise<void> {
   await (session.frameApplyTail ?? Promise.resolve());
   await waitForConversationPersistence(session.conversationId);
+}
+
+async function finalizeFailedRun(session: RunSession, displayMessage: string): Promise<void> {
+  if (session.failureFinalizationPromise) return session.failureFinalizationPromise;
+
+  session.failureFinalizationPromise = (async () => {
+    session.dropFrames = true;
+    updateSessionMessageState(session, 'failed', displayMessage);
+    await (session.frameApplyTail ?? Promise.resolve());
+    try {
+      const chatDelta = getChatDelta();
+      chatDelta.appendText(session.conversationId, `\n\n**Error:** ${displayMessage}`);
+      chatDelta.finishStreaming(session.conversationId);
+      chatDelta.setAgentStatus('idle');
+      chatDelta.setConversationStatus(session.conversationId, 'error');
+    } catch (cleanupErr) {
+      logger.warn('terminal UI finalization failed', {
+        conversationId: session.conversationId,
+        error: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+      });
+    }
+    // Both the user lifecycle row and the finalized assistant/error state are
+    // part of the terminal contract. Never report a failed run as settled
+    // while either write is still pending or has failed.
+    await waitForConversationPersistence(session.conversationId);
+  })();
+
+  return session.failureFinalizationPromise;
 }
 
 /**
@@ -336,22 +511,24 @@ async function finalizeAbortedRun(session: RunSession, source: 'ack' | 'watchdog
   if (session.abortFinalizationPromise) return session.abortFinalizationPromise;
 
   session.abortFinalizationPromise = (async () => {
-    session.dropFrames = true;
-    if (session.abortWatchdog) {
-      clearTimeout(session.abortWatchdog);
-      session.abortWatchdog = undefined;
-    }
+    try {
+      session.dropFrames = true;
+      updateSessionMessageState(session, 'interrupted');
+      if (session.abortWatchdog) {
+        clearTimeout(session.abortWatchdog);
+        session.abortWatchdog = undefined;
+      }
 
-    await (session.frameApplyTail ?? Promise.resolve());
+      await (session.frameApplyTail ?? Promise.resolve());
 
-    // Permission dialogs live in the shell and must not survive a force-stop.
-    drainConfirmationQueue();
-    drainFilePermissionQueue();
-    drainWorkspaceRequest();
-    drainUserQuestions();
+      // Permission dialogs live in the shell and must not survive a force-stop.
+      drainConfirmationQueue();
+      drainFilePermissionQueue();
+      drainWorkspaceRequest();
+      drainUserQuestions();
 
-    if (getConversationReader().getConversation(session.conversationId)) {
-      const chatDelta = getChatDelta();
+      if (getConversationReader().getConversation(session.conversationId)) {
+        const chatDelta = getChatDelta();
 
       // Drop an untouched streaming placeholder before cancelStreaming, so
       // Stop-before-first-token cannot leave a blank assistant bubble.
@@ -411,8 +588,9 @@ async function finalizeAbortedRun(session: RunSession, source: 'ack' | 'watchdog
       chatDelta.setAgentStatus('idle');
       chatDelta.setConversationStatus(session.conversationId, 'idle');
       getExecutionPort().cancelExecution(session.loopId);
-      await waitForConversationPersistence(session.conversationId);
-
+        await waitForConversationPersistence(session.conversationId);
+      }
+    } finally {
       // These are best-effort shell resources; a force-finalized sidecar run
       // can no longer be trusted to send its normal cleanup notifications.
       void import('../capabilityPlugins/setupBridge')
@@ -424,14 +602,15 @@ async function finalizeAbortedRun(session: RunSession, source: 'ack' | 'watchdog
       void import('../tools/definitions/computerTools')
         .then(({ closeAxSession }) => closeAxSession())
         .catch(() => {});
-    }
 
-    // Reject only this run's never-ending RPC. Its catch path sees the UI
-    // controller already aborted and returns `{ reason: 'aborted' }`.
-    if (!session.transportAbortController?.signal.aborted) {
-      const error = new Error(`agent.run transport closed after abort ${source}`);
-      error.name = 'AbortError';
-      session.transportAbortController?.abort(error);
+      // Reject only this run's never-ending RPC. This must happen even when
+      // the durability barrier fails, while that persistence error still
+      // propagates to the caller instead of being disguised as a settled run.
+      if (!session.transportAbortController?.signal.aborted) {
+        const error = new Error(`agent.run transport closed after abort ${source}`);
+        error.name = 'AbortError';
+        session.transportAbortController?.abort(error);
+      }
     }
   })().catch((err: unknown) => {
     logger.warn('abort finalization failed', {
@@ -440,10 +619,7 @@ async function finalizeAbortedRun(session: RunSession, source: 'ack' | 'watchdog
       source,
       error: err instanceof Error ? err.message : String(err),
     });
-    // Even if store cleanup failed, release the hung transport/session.
-    if (!session.transportAbortController?.signal.aborted) {
-      session.transportAbortController?.abort(err);
-    }
+    throw err;
   });
 
   return session.abortFinalizationPromise;
@@ -465,7 +641,7 @@ function requestSidecarRunAbort(session: RunSession): Promise<void> {
       stage: 'force_finalize',
       outcome: 'stalled',
     });
-    void finalizeAbortedRun(session, 'watchdog');
+    void finalizeAbortedRun(session, 'watchdog').catch(() => undefined);
   }, AGENT_ABORT_FORCE_FINALIZE_MS);
 
   session.abortRequestPromise = sidecarRequest(
@@ -990,6 +1166,7 @@ export function ensureHandlersRegistered(): void {
   ensureHookBridgeRegistered();
 
   onSidecarNotification('agent.delta', handleAgentDelta);
+  onSidecarNotification('agent.terminal', handleAgentTerminal);
   onSidecarNotification('approval.drain', handleApprovalDrain);
   onSidecarNotification('plan.clear', handlePlanClear);
   onSidecarNotification('caps.record', handleCapsRecord);
@@ -1176,6 +1353,9 @@ function forwardQueuedInputsForActiveSessions(): void {
   const seenConversationIds = new Set<string>();
   for (const session of sessions.values()) {
     if (!session.runId) continue;
+    // Stop is a synchronous local barrier: once requested, no pending or new
+    // composer input may cross into the old run and later "come back to life".
+    if (session.abortRequested || session.dropFrames) continue;
     if (seenConversationIds.has(session.conversationId)) continue;
     seenConversationIds.add(session.conversationId);
 
@@ -1320,9 +1500,17 @@ export function removeShellLoopContext(runId: string): void {
  */
 interface AgentRunParams {
   runId: string;
+  clientMessageId: string;
+  payloadDigest: string;
   conversationId: string;
   userMessage: string;
-  options: { images?: ImageAttachment[]; blockedTools?: string[]; allowedTools?: string[]; imContext?: IMContext };
+  options: {
+    images?: ImageAttachment[];
+    blockedTools?: string[];
+    allowedTools?: string[];
+    imContext?: IMContext;
+    prePersistedUserMessageId?: string;
+  };
   orchestration: { route: RouteResult; systemPromptSections: PromptSection[] };
   conversationSnapshot: Conversation;
   indexEntrySnapshot?: ConversationMeta;
@@ -1350,10 +1538,64 @@ function isAgentLoopResult(v: unknown): v is AgentLoopResult {
   return typeof v === 'object' && v !== null && typeof (v as Record<string, unknown>).reason === 'string';
 }
 
+interface AgentStartAck {
+  version: 1;
+  runId: string;
+  clientMessageId: string;
+  acceptedAt: number;
+  state: 'accepted' | 'running' | 'terminal';
+  replay: boolean;
+  terminal?: AgentRunTerminal;
+}
+
+interface AgentRunStateResult {
+  version: 1;
+  runId: string;
+  state: 'not_found' | 'accepted' | 'running' | 'terminal';
+  terminal?: AgentRunTerminal;
+}
+
+function isAgentStartAck(value: unknown, runId: string, clientMessageId: string): value is AgentStartAck {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return candidate.version === 1
+    && candidate.runId === runId
+    && candidate.clientMessageId === clientMessageId
+    && typeof candidate.acceptedAt === 'number'
+    && (candidate.state === 'accepted' || candidate.state === 'running' || candidate.state === 'terminal')
+    && typeof candidate.replay === 'boolean'
+    && (candidate.terminal === undefined || isAgentRunTerminal(candidate.terminal));
+}
+
+function isAgentRunStateResult(value: unknown, runId: string): value is AgentRunStateResult {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return candidate.version === 1
+    && candidate.runId === runId
+    && (
+      candidate.state === 'not_found'
+      || candidate.state === 'accepted'
+      || candidate.state === 'running'
+      || candidate.state === 'terminal'
+    )
+    && (candidate.terminal === undefined || isAgentRunTerminal(candidate.terminal));
+}
+
 let runIdCounter = 0;
 function generateRunId(): string {
   runIdCounter += 1;
   return `agl-${Date.now().toString(36)}-${runIdCounter.toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function digestRunPayload(value: string): string {
+  let left = 0x811c9dc5;
+  let right = 0x9e3779b9;
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    left = Math.imul(left ^ code, 0x01000193);
+    right = Math.imul(right ^ code, 0x85ebca6b);
+  }
+  return `rrp1-${value.length.toString(16)}-${(left >>> 0).toString(16).padStart(8, '0')}${(right >>> 0).toString(16).padStart(8, '0')}`;
 }
 
 /**
@@ -1376,6 +1618,144 @@ function resolveEntrySettings(conversationId: string): { settings: SettingsState
   const settingsForModel: SettingsState =
     baseModel === settings.activeModel ? settings : { ...settings, activeModel: baseModel };
   return { settings, settingsForModel };
+}
+
+async function establishAgentStart(
+  params: AgentRunParams,
+  session: RunSession,
+): Promise<AgentStartAck> {
+  const accept = (raw: unknown): AgentStartAck => {
+    if (!isAgentStartAck(raw, params.runId, params.clientMessageId)) {
+      throw new Error('agent.start response did not match the expected acknowledgement shape');
+    }
+    session.accepted = true;
+    updateSessionMessageState(session, raw.state === 'running' ? 'running' : 'accepted');
+    markRuntimeRunStage(params.runId, raw.state === 'running' ? 'running' : 'accepted');
+    traceRuntimeEvent('renderer.agent_start_accepted', {
+      runId: params.runId,
+      clientMessageId: params.clientMessageId,
+      executionPath: 'sidecar',
+      stage: raw.state,
+      replayCount: raw.replay ? 1 : 0,
+      acceptedAt: raw.acceptedAt,
+    });
+    if (raw.terminal) handleAgentTerminal(raw.terminal);
+    return raw;
+  };
+
+  try {
+    return accept(await sidecarRequest('agent.start', params, AGENT_START_ACK_TIMEOUT_MS));
+  } catch (startError) {
+    traceRuntimeEvent('renderer.agent_start_ack_missing', {
+      runId: params.runId,
+      clientMessageId: params.clientMessageId,
+      executionPath: 'sidecar',
+      stage: 'querying_state',
+      errorType: runtimeErrorType(startError),
+    });
+
+    try {
+      const rawState = await sidecarRequest(
+        'run.getState',
+        { runId: params.runId },
+        AGENT_STATE_QUERY_TIMEOUT_MS,
+      );
+      if (!isAgentRunStateResult(rawState, params.runId)) {
+        throw new Error('run.getState response did not match the expected shape', { cause: startError });
+      }
+      if (rawState.state !== 'not_found') {
+        if (rawState.terminal) handleAgentTerminal(rawState.terminal);
+        return accept({
+          version: 1,
+          runId: params.runId,
+          clientMessageId: params.clientMessageId,
+          acceptedAt: Date.now(),
+          state: rawState.state === 'terminal' ? 'terminal' : rawState.state,
+          replay: true,
+          ...(rawState.terminal ? { terminal: rawState.terminal } : {}),
+        });
+      }
+    } catch (stateError) {
+      logger.warn('run state query failed after missing start ACK; replaying idempotent start', {
+        runId: params.runId,
+        error: stateError instanceof Error ? stateError.message : String(stateError),
+      });
+    }
+
+    // Same runId/clientMessageId/payloadDigest: the sidecar either accepts it
+    // once or replays the existing fact. It can never execute twice.
+    return accept(await sidecarRequest('agent.start', params, AGENT_START_ACK_TIMEOUT_MS));
+  }
+}
+
+type TransportRecovery =
+  | { action: 'terminal'; terminal: AgentRunTerminal }
+  | { action: 'reattach' }
+  | { action: 'replay_execution' }
+  | { action: 'not_found' }
+  | { action: 'unavailable' };
+
+function recoveryDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function queryRunForTransportRecovery(
+  params: AgentRunParams,
+): Promise<TransportRecovery> {
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    if (getSidecarStatus() === 'running') {
+      try {
+        const raw = await sidecarRequest(
+          'run.getState',
+          { runId: params.runId },
+          AGENT_STATE_QUERY_TIMEOUT_MS,
+        );
+        if (isAgentRunStateResult(raw, params.runId)) {
+          if (raw.terminal) return { action: 'terminal', terminal: raw.terminal };
+          if (raw.state === 'running') return { action: 'reattach' };
+          if (raw.state === 'accepted') return { action: 'replay_execution' };
+          if (raw.state === 'not_found') return { action: 'not_found' };
+        }
+      } catch {
+        // The supervisor may be between process generations. Bounded retry
+        // below; no user work is replayed until a concrete state is known.
+      }
+    }
+    if (attempt < 3) await recoveryDelay(500 * attempt);
+  }
+  return { action: 'unavailable' };
+}
+
+async function waitForReattachedTerminal(
+  params: AgentRunParams,
+  session: RunSession,
+): Promise<AgentRunTerminal> {
+  let unavailableChecks = 0;
+  while (true) {
+    const tick = recoveryDelay(2_000).then(() => ({ kind: 'tick' as const }));
+    const terminal = session.terminalPromise!.then((value) => ({ kind: 'terminal' as const, value }));
+    const outcome = await Promise.race([terminal, tick]);
+    if (outcome.kind === 'terminal') return outcome.value;
+    if (session.shellAbortController.signal.aborted) {
+      throw session.shellAbortController.signal.reason ?? new Error('Agent run aborted while reattaching');
+    }
+    const recovery = await queryRunForTransportRecovery(params);
+    if (recovery.action === 'terminal') {
+      handleAgentTerminal(recovery.terminal);
+      return recovery.terminal;
+    }
+    if (recovery.action === 'not_found') {
+      throw new Error('Sidecar lost an accepted agent run before terminal state was observed');
+    }
+    if (recovery.action === 'unavailable') {
+      unavailableChecks += 1;
+      if (unavailableChecks >= 3) {
+        throw new Error('Sidecar run state remained unavailable during reattach');
+      }
+    } else {
+      unavailableChecks = 0;
+    }
+  }
 }
 
 /**
@@ -1407,13 +1787,14 @@ function resolveEntrySettings(conversationId: string): { settings: SettingsState
  */
 async function buildAgentRunParams(
   runId: string,
+  clientMessageId: string,
   conversationId: string,
   userMessage: string,
   options: AgentLoopOptions | undefined,
   abortSignal?: AbortSignal,
 ): Promise<AgentRunParams> {
-  const conversationSnapshot = getConversationReader().getConversation(conversationId);
-  if (!conversationSnapshot) {
+  const initialConversationSnapshot = getConversationReader().getConversation(conversationId);
+  if (!initialConversationSnapshot) {
     throw new Error(`buildAgentRunParams: no conversation record for "${conversationId}"`);
   }
   const indexEntrySnapshot = getConversationReader().getIndexEntry(conversationId);
@@ -1456,6 +1837,29 @@ async function buildAgentRunParams(
 
   const toolList = getToolInvoker().getAllTools().map(toSerializableTool);
 
+  const userContent = await buildUserMessageContent(
+    conversationId,
+    orchestration.route.cleanInput,
+    options?.images,
+  );
+  useChatStore.getState().updateUserMessageRun(conversationId, clientMessageId, {
+    state: 'pending',
+    content: userContent,
+    skill: orchestration.route.type === 'skill' && orchestration.route.skill ? {
+      name: orchestration.route.skill.name,
+      description: orchestration.route.skill.description,
+    } : undefined,
+    delegateAgent: orchestration.route.type === 'delegate' && orchestration.route.delegateAgent ? {
+      name: orchestration.route.delegateAgent.name,
+      description: orchestration.route.delegateAgent.description,
+    } : undefined,
+  });
+  await waitForConversationPersistence(conversationId);
+  const conversationSnapshot = getConversationReader().getConversation(conversationId);
+  if (!conversationSnapshot) {
+    throw new Error(`buildAgentRunParams: conversation "${conversationId}" disappeared before dispatch`);
+  }
+
   // P1-3B-4 — snapshot the shell's userInputQueue for this conversation at
   // dispatch time (projected to the wire-safe shape — id/text/isSystem,
   // dropping the shell-local `timestamp`). See AgentRunParams.queuedInputs's
@@ -1466,8 +1870,10 @@ async function buildAgentRunParams(
     ...(qi.isSystem ? { isSystem: qi.isSystem } : {}),
   }));
 
-  return {
+  const payloadDigest = digestRunPayload(JSON.stringify({
+    version: 1,
     runId,
+    clientMessageId,
     conversationId,
     userMessage,
     options: {
@@ -1475,6 +1881,21 @@ async function buildAgentRunParams(
       blockedTools: options?.blockedTools,
       allowedTools: options?.allowedTools,
       imContext: options?.imContext,
+    },
+  }));
+
+  return {
+    runId,
+    clientMessageId,
+    payloadDigest,
+    conversationId,
+    userMessage,
+    options: {
+      images: options?.images,
+      blockedTools: options?.blockedTools,
+      allowedTools: options?.allowedTools,
+      imContext: options?.imContext,
+      prePersistedUserMessageId: clientMessageId,
     },
     orchestration,
     conversationSnapshot: conversationSnapshot as Conversation,
@@ -1522,10 +1943,9 @@ async function buildAgentRunParams(
  *      between the two paths) → stage directly via the real
  *      `enqueueUserInput` (same call the in-process guard itself makes).
  * Same staging preconditions as the in-process guard: interactive-desktop
- * only, non-empty trimmed text, no images (an image/empty send falls
- * through to a normal dispatch — "silently losing an image is worse than
- * the rare double-loop race", same acceptance the in-process guard's own
- * comment documents).
+ * only and non-empty trimmed text. Attachments cannot be represented by the
+ * current text-only mid-run queue, so an attachment send is rejected while
+ * preserving the composer draft; it must never start a concurrent run.
  *
  * ## Fallback / re-run discipline
  *
@@ -1548,26 +1968,25 @@ export async function runAgentLoopDispatched(
   userMessage: string,
   options?: AgentLoopOptions,
 ): Promise<AgentLoopResult> {
-  // The bundled browser is a first-party Electron capability, not a Skill or
-  // user-configured MCP server. App startup normally connects it; this
-  // idempotent preflight closes the small startup/reload race before tools and
-  // the system prompt are snapshotted for either execution venue.
-  await ensureBuiltinBrowserRuntime();
+  const sidecarRunning = getSidecarStatus() === 'running';
 
-  if (getSidecarStatus() !== 'running') {
-    return runAgentLoop(conversationId, userMessage, options);
-  }
-
-  ensureHandlersRegistered();
-
-  // ── Concurrency guard — see doc above for the two-venue rationale.
+  // ── Concurrency guard — see doc above for the two-venue rationale. This
+  // runs before venue selection so sidecar-down/fallback callers cannot bypass
+  // the same one-live-run-per-conversation invariant.
   {
     const runningConv = getConversationReader().getConversation(conversationId);
-    const interactive = isInteractiveDesktop(options, runningConv);
-    const stageable = userMessage.trim().length > 0 && !(options?.images?.length);
-    if (interactive && stageable) {
-      const runningSession = findRunSessionForConversation(conversationId);
-      if (runningSession?.runId) {
+    const hasImages = Boolean(options?.images?.length);
+    const stageable = userMessage.trim().length > 0 && !hasImages;
+    const getBusyError = (): string => hasImages
+      ? getI18n().chat.attachmentDuringRun
+      : getI18n().chat.conversationBusy;
+    const runningSession = findRunSessionForConversation(conversationId);
+    if (runningSession?.runId) {
+      const interactive = isInteractiveDesktop(options, runningConv);
+      if (!interactive || hasImages || !stageable) {
+        return { reason: 'error', error: getBusyError() };
+      }
+      if (stageable) {
         if (options?.requireNewRun) {
           return {
             reason: 'error',
@@ -1577,7 +1996,13 @@ export async function runAgentLoopDispatched(
         notifySidecar('agent.enqueueInput', { runId: runningSession.runId, userMessage });
         return { reason: 'enqueued' };
       }
-      if (runningConv?.status === 'running' && getAbortRegistry().hasAbortController(conversationId)) {
+    }
+    if (runningConv?.status === 'running' && getAbortRegistry().hasAbortController(conversationId)) {
+      const interactive = isInteractiveDesktop(options, runningConv);
+      if (!interactive || hasImages || !stageable) {
+        return { reason: 'error', error: getBusyError() };
+      }
+      if (stageable) {
         if (options?.requireNewRun) {
           return {
             reason: 'error',
@@ -1593,10 +2018,67 @@ export async function runAgentLoopDispatched(
     }
   }
 
+  if (!sidecarRunning) {
+    await ensureBuiltinBrowserRuntime();
+    return runAgentLoop(conversationId, userMessage, options);
+  }
+
+  ensureHandlersRegistered();
+
   const runId = generateRunId();
+  const clientMessageId = `msg-${runId}`;
   logger.debug('agent-loop path selected', { path: 'sidecar', runId, conversationId });
   const runtimeStartedAt = Date.now();
-  startRuntimeRun(runId, 'sidecar', 'building_params');
+  startRuntimeRun(runId, 'sidecar', 'local_message_persisting');
+
+  const abortRegistry = getAbortRegistry();
+  abortRegistry.clearAbortController(conversationId);
+  const shellAbortController = abortRegistry.getAbortController(conversationId);
+  const shellChatDelta = getChatDelta();
+  useChatStore.getState().addMessage(conversationId, {
+    id: clientMessageId,
+    clientMessageId,
+    runId,
+    runState: 'pending',
+    role: 'user',
+    content: userMessage,
+    timestamp: runtimeStartedAt,
+    loopId: runId,
+  });
+  shellChatDelta.setConversationStatus(conversationId, 'running');
+  try {
+    await waitForConversationPersistence(conversationId);
+  } catch (error) {
+    const displayMessage = getI18n().chat.messageSaveFailed;
+    useChatStore.getState().updateUserMessageRun(conversationId, clientMessageId, {
+      state: 'failed',
+      error: displayMessage,
+    });
+    abortRegistry.clearAbortController(conversationId);
+    shellChatDelta.setConversationStatus(conversationId, 'error');
+    traceRuntimeEvent('renderer.local_message_persist_failed', {
+      runId,
+      clientMessageId,
+      executionPath: 'sidecar',
+      stage: 'local_message_persist_failed',
+      outcome: 'error',
+      errorType: runtimeErrorType(error),
+      durationMs: Date.now() - runtimeStartedAt,
+    });
+    finishRuntimeRun(runId);
+    // Let the failed lifecycle replacement attempt settle in the background;
+    // execution remains fenced regardless of whether the disk is still down.
+    void waitForConversationPersistence(conversationId).catch(() => undefined);
+    return { reason: 'error', error: displayMessage };
+  }
+  markRuntimeRunStage(runId, 'local_message_persisted');
+  traceRuntimeEvent('renderer.local_message_persisted', {
+    runId,
+    clientMessageId,
+    executionPath: 'sidecar',
+    stage: 'local_message_persisted',
+    durationMs: Date.now() - runtimeStartedAt,
+  });
   traceRuntimeEvent('renderer.agent_params_build_started', {
     runId,
     executionPath: 'sidecar',
@@ -1607,16 +2089,15 @@ export async function runAgentLoopDispatched(
   // the task controller and visible conversation ownership must exist before
   // buildAgentRunParams starts. This closes the rapid double-send window:
   // ChatInput shows Stop, while another textual send is routed into the queue.
-  const abortRegistry = getAbortRegistry();
-  abortRegistry.clearAbortController(conversationId);
-  const shellAbortController = abortRegistry.getAbortController(conversationId);
-  const shellChatDelta = getChatDelta();
-  shellChatDelta.setConversationStatus(conversationId, 'running');
-
   let params: AgentRunParams;
   try {
+    // Browser readiness and prompt preparation happen only after the user
+    // message is visible and durable, so either operation can fail without
+    // making the user's input disappear.
+    await ensureBuiltinBrowserRuntime();
     params = await buildAgentRunParams(
       runId,
+      clientMessageId,
       conversationId,
       userMessage,
       options,
@@ -1631,18 +2112,17 @@ export async function runAgentLoopDispatched(
     });
   } catch (err) {
     const wasAborted = shellAbortController.signal.aborted;
+    if (wasAborted) {
+      return finalizePreDispatchInterruptedRun(
+        conversationId,
+        clientMessageId,
+        runId,
+        'params_build_aborted',
+        runtimeStartedAt,
+      );
+    }
     abortRegistry.clearAbortController(conversationId);
     shellChatDelta.setConversationStatus(conversationId, 'idle');
-    if (wasAborted) {
-      traceRuntimeEvent('renderer.agent_run_aborted', {
-        runId,
-        executionPath: 'sidecar',
-        stage: 'params_build_aborted',
-        outcome: 'aborted',
-      });
-      finishRuntimeRun(runId);
-      return { reason: 'aborted' };
-    }
     // Failed before any dispatch — pre-commit by construction (see doc).
     logger.warn('agent-loop dispatch params build failed — running in-process', {
       runId,
@@ -1658,19 +2138,22 @@ export async function runAgentLoopDispatched(
       durationMs: Date.now() - runtimeStartedAt,
     });
     finishRuntimeRun(runId);
-    return runAgentLoop(conversationId, userMessage, options);
+    return runInProcessWithPersistedMessage(
+      conversationId,
+      userMessage,
+      runId,
+      clientMessageId,
+      options,
+    );
   }
   if (shellAbortController.signal.aborted) {
-    abortRegistry.clearAbortController(conversationId);
-    shellChatDelta.setConversationStatus(conversationId, 'idle');
-    traceRuntimeEvent('renderer.agent_run_aborted', {
+    return finalizePreDispatchInterruptedRun(
+      conversationId,
+      clientMessageId,
       runId,
-      executionPath: 'sidecar',
-      stage: 'before_dispatch',
-      outcome: 'aborted',
-    });
-    finishRuntimeRun(runId);
-    return { reason: 'aborted' };
+      'before_dispatch',
+      runtimeStartedAt,
+    );
   }
 
   // ── Shell-side session + abort wiring ────────────────────────────────
@@ -1679,9 +2162,16 @@ export async function runAgentLoopDispatched(
   // (chatStore.ts's `abortControllers` map), so the Stop button needs ZERO
   // changes (design doc §3's abortRegistry row) — its `.abort()` call fires
   // the listener below, which forwards to the sidecar.
+  let resolveTerminal!: (terminal: AgentRunTerminal) => void;
+  const terminalPromise = new Promise<AgentRunTerminal>((resolve) => {
+    resolveTerminal = resolve;
+  });
   const session: RunSession = {
     conversationId,
     loopId: runId, // same id as runId by convention — see agentLoop.ts's AgentLoopOptions.loopId doc.
+    clientMessageId,
+    userMessageId: clientMessageId,
+    payloadDigest: params.payloadDigest,
     options: {
       requestCommandConfirmation: options?.commandConfirmCallback,
       requestFilePermission: options?.filePermissionCallback,
@@ -1690,6 +2180,8 @@ export async function runAgentLoopDispatched(
     },
     shellAbortController,
     transportAbortController: new AbortController(),
+    terminalPromise,
+    resolveTerminal,
     toolCallToStepId: new Map(),
     committed: false,
     runtimeStartedAt,
@@ -1703,6 +2195,10 @@ export async function runAgentLoopDispatched(
   };
 
   const onShellAbort = (): void => {
+    // Once the ordered terminal fact has arrived, the run is already over.
+    // A click racing with renderer cleanup must not rewrite that first-wins
+    // outcome from completed to aborted.
+    if (session.terminal) return;
     void requestSidecarRunAbort(session);
   };
   session.onShellAbort = onShellAbort;
@@ -1713,7 +2209,7 @@ export async function runAgentLoopDispatched(
   markRuntimeRunStage(runId, 'waiting_for_first_delta');
   traceRuntimeEvent('renderer.agent_run_dispatched', {
     runId,
-    method: 'agent.run',
+    method: 'agent.start',
     executionPath: 'sidecar',
     stage: 'waiting_for_first_delta',
     durationMs: Date.now() - runtimeStartedAt,
@@ -1724,7 +2220,7 @@ export async function runAgentLoopDispatched(
     markRuntimeRunStage(runId, 'stalled_before_first_delta');
     traceRuntimeEvent('renderer.agent_run_stalled', {
       runId,
-      method: 'agent.run',
+      method: 'agent.start',
       executionPath: 'sidecar',
       stage: 'stalled_before_first_delta',
       outcome: 'stalled',
@@ -1733,8 +2229,91 @@ export async function runAgentLoopDispatched(
   }, AGENT_FIRST_FRAME_STALL_MS);
   let handedOffToLocal = false;
 
+  const settleFromTerminal = async (terminal: AgentRunTerminal): Promise<AgentLoopResult> => {
+    await settleRunPersistence(session);
+    if (session.abortRequested) {
+      await finalizeAbortedRun(session, 'run-terminal');
+      traceRuntimeEvent('renderer.agent_run_aborted', {
+        runId,
+        executionPath: 'sidecar',
+        stage: 'run_terminal',
+        outcome: 'aborted',
+        durationMs: Date.now() - runtimeStartedAt,
+      });
+      return { reason: 'aborted' };
+    }
+
+    if (terminal.state === 'failed') {
+      const realMessage = terminal.result.error || 'Agent run failed';
+      const displayMessage = realMessage === 'Sidecar process closed'
+        ? getI18n().chat.sidecarInterrupted
+        : realMessage;
+      logger.warn('agent loop reported a failed terminal', {
+        runId,
+        conversationId,
+        sidecarCause: realMessage,
+        sidecarErrorType: terminal.failure?.errorType,
+        sidecarStack: terminal.failure?.stack,
+      });
+      traceRuntimeEvent('renderer.agent_run_failed', {
+        runId,
+        executionPath: 'sidecar',
+        stage: 'failed_terminal',
+        outcome: 'error',
+        errorType: terminal.failure?.errorType,
+        durationMs: Date.now() - runtimeStartedAt,
+      });
+      await finalizeFailedRun(session, displayMessage);
+      return { reason: 'error', error: realMessage };
+    }
+
+    const eventName = terminal.state === 'interrupted'
+      ? 'renderer.agent_run_aborted'
+      : 'renderer.agent_run_completed';
+    traceRuntimeEvent(eventName, {
+      runId,
+      executionPath: 'sidecar',
+      stage: terminal.state === 'interrupted' ? 'interrupted_terminal' : 'completed',
+      outcome: terminal.result.reason,
+      durationMs: Date.now() - runtimeStartedAt,
+      firstFrameMs: session.firstDeltaAt === undefined
+        ? undefined
+        : session.firstDeltaAt - runtimeStartedAt,
+    });
+    updateSessionMessageState(
+      session,
+      terminal.state === 'interrupted' ? 'interrupted' : 'completed',
+    );
+    await waitForConversationPersistence(conversationId);
+    return terminal.result;
+  };
+
   try {
-    const raw = await sidecarRequest('agent.run', params, 0, session.transportAbortController!.signal);
+    await establishAgentStart(params, session);
+    if (session.terminal) return await settleFromTerminal(session.terminal);
+
+    const rpcOutcome = sidecarRequest(
+      'agent.run',
+      params,
+      0,
+      session.transportAbortController!.signal,
+    ).then((raw) => ({ source: 'rpc' as const, raw }));
+    const terminalOutcome = terminalPromise.then((terminal) => ({ source: 'terminal' as const, terminal }));
+    const outcome = await Promise.race([rpcOutcome, terminalOutcome]);
+
+    if (outcome.source === 'terminal') {
+      // The terminal notification is the primary completion contract. Close
+      // the now-redundant pending RPC so a lost response cannot leave a
+      // request entry alive indefinitely.
+      if (!session.transportAbortController!.signal.aborted) {
+        const terminalReceived = new Error('agent.run terminal received');
+        terminalReceived.name = 'AbortError';
+        session.transportAbortController!.abort(terminalReceived);
+      }
+      return await settleFromTerminal(outcome.terminal);
+    }
+
+    const raw = outcome.raw;
     if (!isAgentLoopResult(raw)) {
       throw new Error('agent.run response did not match the expected AgentLoopResult shape');
     }
@@ -1742,6 +2321,10 @@ export async function runAgentLoopDispatched(
     // preserves byte order. Await the shell-side FIFO plus the store's
     // fire-and-forget JSONL writes before exposing a completed turn.
     await settleRunPersistence(session);
+    // A new sidecar always writes agent.terminal before its RPC response.
+    // Prefer that first-wins fact if both became observable in the same tick;
+    // the raw response remains the compatibility path for older sidecars.
+    if (session.terminal) return await settleFromTerminal(session.terminal);
     if (shellAbortController.signal.aborted) {
       await finalizeAbortedRun(session, 'run-terminal');
       traceRuntimeEvent('renderer.agent_run_aborted', {
@@ -1763,12 +2346,26 @@ export async function runAgentLoopDispatched(
         ? undefined
         : session.firstDeltaAt - runtimeStartedAt,
     });
+    updateSessionMessageState(
+      session,
+      raw.reason === 'aborted' ? 'interrupted' : raw.reason === 'error' ? 'failed' : 'completed',
+      raw.error,
+    );
+    await waitForConversationPersistence(conversationId);
     return raw;
   } catch (err) {
+    let transportError = err;
     // A failing RPC can still have flushed committed frames immediately
     // before its error response. Land those frames before deciding fallback
     // or applying the shell-owned error finalization.
     await settleRunPersistence(session);
+    // The RPC may reject after a terminal notification was already received
+    // (for example, the response line is lost or the transport closes between
+    // the two). The terminal is authoritative even when no delta/tool call
+    // marked the run committed, so never fall back and execute it twice.
+    if (session.terminal) {
+      return await settleFromTerminal(session.terminal);
+    }
     if (shellAbortController.signal.aborted) {
       await finalizeAbortedRun(session, 'run-terminal');
       traceRuntimeEvent('renderer.agent_run_aborted', {
@@ -1779,6 +2376,76 @@ export async function runAgentLoopDispatched(
         durationMs: Date.now() - runtimeStartedAt,
       });
       return { reason: 'aborted' };
+    }
+    if (session.accepted) {
+      const recovery = await queryRunForTransportRecovery(params);
+      traceRuntimeEvent('renderer.agent_run_recovery_state', {
+        runId,
+        clientMessageId,
+        executionPath: 'sidecar',
+        stage: recovery.action,
+        replayCount: session.transportReplayCount ?? 0,
+      });
+      if (recovery.action === 'terminal') {
+        handleAgentTerminal(recovery.terminal);
+        return await settleFromTerminal(recovery.terminal);
+      }
+      if (recovery.action === 'reattach') {
+        try {
+          return await settleFromTerminal(await waitForReattachedTerminal(params, session));
+        } catch (reattachError) {
+          transportError = reattachError;
+        }
+      }
+      if (
+        (recovery.action === 'replay_execution' || recovery.action === 'not_found')
+        && !session.committed
+        && (session.transportReplayCount ?? 0) < 1
+      ) {
+        session.transportReplayCount = (session.transportReplayCount ?? 0) + 1;
+        try {
+          if (recovery.action === 'not_found') {
+            session.accepted = false;
+            await establishAgentStart(params, session);
+          }
+          traceRuntimeEvent('renderer.agent_run_transport_replayed', {
+            runId,
+            clientMessageId,
+            executionPath: 'sidecar',
+            stage: 'replay_execution',
+            replayCount: session.transportReplayCount,
+          });
+          const replayRpc = sidecarRequest(
+            'agent.run',
+            params,
+            0,
+            session.transportAbortController!.signal,
+          ).then((raw) => ({ source: 'rpc' as const, raw }));
+          const replayTerminal = terminalPromise.then((terminal) => ({ source: 'terminal' as const, terminal }));
+          const replayOutcome = await Promise.race([replayRpc, replayTerminal]);
+          if (replayOutcome.source === 'terminal') {
+            return await settleFromTerminal(replayOutcome.terminal);
+          }
+          if (!isAgentLoopResult(replayOutcome.raw)) {
+            throw new Error('replayed agent.run response did not match the expected result shape', { cause: err });
+          }
+          await settleRunPersistence(session);
+          if (session.terminal) return await settleFromTerminal(session.terminal);
+          updateSessionMessageState(
+            session,
+            replayOutcome.raw.reason === 'aborted'
+              ? 'interrupted'
+              : replayOutcome.raw.reason === 'error'
+                ? 'failed'
+                : 'completed',
+            replayOutcome.raw.error,
+          );
+          await waitForConversationPersistence(conversationId);
+          return replayOutcome.raw;
+        } catch (replayError) {
+          transportError = replayError;
+        }
+      }
     }
     if (!session.committed) {
       // Release the shell-side ownership before entering the in-process loop.
@@ -1792,32 +2459,38 @@ export async function runAgentLoopDispatched(
       logger.warn('agent-loop transport failed before commit — retrying in-process', {
         runId,
         conversationId,
-        error: err instanceof Error ? err.message : String(err),
+        error: transportError instanceof Error ? transportError.message : String(transportError),
       });
       traceRuntimeEvent('renderer.agent_run_fallback', {
         runId,
         executionPath: 'sidecar',
         stage: 'fallback_in_process',
         outcome: 'error',
-        errorType: runtimeErrorType(err),
+        errorType: runtimeErrorType(transportError),
         durationMs: Date.now() - runtimeStartedAt,
       });
       // The local loop synchronously installs its own AbortController before its
       // first await. Mark the ownership transfer so this dispatch wrapper's
       // finally block cannot delete that replacement controller.
       handedOffToLocal = true;
-      return runAgentLoop(conversationId, userMessage, options);
+      return runInProcessWithPersistedMessage(
+        conversationId,
+        userMessage,
+        runId,
+        clientMessageId,
+        options,
+      );
     }
     // Surface the REAL sidecar-side cause: a thrown handler comes back as a
     // generic `-32603 Internal error`, but `errorFromCaught` (sidecar
     // protocol.ts) carries the real message/stack in the error's `data`.
     // Logging only `err.message` (the generic wrapper) threw that away — pull
     // `data` out so the on-disk log names the actual failure.
-    const errData = (err as { data?: unknown } | null)?.data;
+    const errData = (transportError as { data?: unknown } | null)?.data;
     const realMessage =
       errData && typeof errData === 'object' && 'message' in errData
         ? String((errData as { message: unknown }).message)
-        : err instanceof Error ? err.message : String(err);
+        : transportError instanceof Error ? transportError.message : String(transportError);
     const displayMessage =
       realMessage === 'Sidecar process closed'
         ? getI18n().chat.sidecarInterrupted
@@ -1825,7 +2498,7 @@ export async function runAgentLoopDispatched(
     logger.warn('agent-loop transport failed after commit — surfacing error, no rerun', {
       runId,
       conversationId,
-      error: err instanceof Error ? err.message : String(err),
+      error: transportError instanceof Error ? transportError.message : String(transportError),
       sidecarCause: realMessage,
       sidecarStack:
         errData && typeof errData === 'object' && 'stack' in errData
@@ -1837,7 +2510,7 @@ export async function runAgentLoopDispatched(
       executionPath: 'sidecar',
       stage: 'failed_after_commit',
       outcome: 'error',
-      errorType: runtimeErrorType(err),
+      errorType: runtimeErrorType(transportError),
       durationMs: Date.now() - runtimeStartedAt,
     });
     // The sidecar loop threw uncaught, so its OWN terminal UI-finalization
@@ -1848,18 +2521,7 @@ export async function runAgentLoopDispatched(
     // delta frames were already flushed (sidecar handleAgentRun's finally
     // runs coalescer.flush() before the error propagates), so this runs after
     // them, not racing.
-    try {
-      const chatDelta = getChatDelta();
-      chatDelta.appendText(conversationId, `\n\n**Error:** ${displayMessage}`);
-      chatDelta.finishStreaming(conversationId);
-      chatDelta.setAgentStatus('idle');
-      chatDelta.setConversationStatus(conversationId, 'error');
-    } catch (cleanupErr) {
-      logger.warn('post-commit UI finalization failed', {
-        conversationId,
-        error: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
-      });
-    }
+    await finalizeFailedRun(session, displayMessage);
     return { reason: 'error', error: realMessage };
   } finally {
     if (session.firstFrameStallTimer) clearTimeout(session.firstFrameStallTimer);

--- a/src/core/agent/agentRunTerminal.test.ts
+++ b/src/core/agent/agentRunTerminal.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createAgentRunTerminal,
+  isAgentRunTerminal,
+  terminalStateForAgentLoopResult,
+} from './agentRunTerminal';
+
+describe('agentRunTerminal', () => {
+  it.each([
+    [{ reason: 'completed' } as const, 'completed'],
+    [{ reason: 'max_turns' } as const, 'completed'],
+    [{ reason: 'awaiting_user' } as const, 'completed'],
+    [{ reason: 'aborted' } as const, 'interrupted'],
+    [{ reason: 'error', error: 'boom' } as const, 'failed'],
+  ])('maps result %j to %s', (result, state) => {
+    expect(terminalStateForAgentLoopResult(result)).toBe(state);
+    expect(createAgentRunTerminal('run-1', result)).toEqual({
+      version: 1,
+      runId: 'run-1',
+      state,
+      result,
+      ...(state === 'failed' ? {
+        failure: { errorType: 'agent_loop_error', message: 'boom' },
+      } : {}),
+    });
+  });
+
+  it('validates version, result shape, and state/result consistency', () => {
+    expect(isAgentRunTerminal({
+      version: 1,
+      runId: 'run-1',
+      state: 'failed',
+      result: { reason: 'error', error: 'boom' },
+      failure: { errorType: 'provider_error', message: 'boom', stack: 'stack' },
+    })).toBe(true);
+    expect(isAgentRunTerminal({
+      version: 1,
+      runId: 'run-1',
+      state: 'completed',
+      result: { reason: 'error', error: 'boom' },
+      failure: { errorType: 'provider_error', message: 'boom' },
+    })).toBe(false);
+    expect(isAgentRunTerminal({
+      version: 2,
+      runId: 'run-1',
+      state: 'completed',
+      result: { reason: 'completed' },
+    })).toBe(false);
+    expect(isAgentRunTerminal({
+      version: 1,
+      runId: '',
+      state: 'completed',
+      result: { reason: 'completed' },
+    })).toBe(false);
+  });
+});

--- a/src/core/agent/agentRunTerminal.ts
+++ b/src/core/agent/agentRunTerminal.ts
@@ -1,0 +1,96 @@
+import type { AgentLoopExitReason, AgentLoopResult } from './agentLoop';
+
+export const AGENT_RUN_TERMINAL_VERSION = 1 as const;
+
+export type AgentRunTerminalState = 'completed' | 'failed' | 'interrupted';
+
+export interface AgentRunTerminalFailure {
+  errorType: string;
+  message: string;
+  stack?: string;
+}
+
+/**
+ * Ordered, idempotent terminal fact for one sidecar-hosted agent run.
+ *
+ * The sidecar emits this only after flushing its final `agent.delta` batch
+ * and before settling the `agent.run` RPC. The shell therefore has an
+ * authoritative outcome even when the RPC response is lost after the work
+ * and UI frames have already completed.
+ */
+export interface AgentRunTerminal {
+  version: typeof AGENT_RUN_TERMINAL_VERSION;
+  runId: string;
+  state: AgentRunTerminalState;
+  result: AgentLoopResult;
+  failure?: AgentRunTerminalFailure;
+}
+
+const AGENT_LOOP_EXIT_REASONS = new Set<AgentLoopExitReason>([
+  'completed',
+  'aborted',
+  'error',
+  'max_turns',
+  'no_progress',
+  'awaiting_user',
+  'enqueued',
+]);
+
+export function terminalStateForAgentLoopResult(result: AgentLoopResult): AgentRunTerminalState {
+  if (result.reason === 'error') return 'failed';
+  if (result.reason === 'aborted') return 'interrupted';
+  return 'completed';
+}
+
+export function createAgentRunTerminal(
+  runId: string,
+  result: AgentLoopResult,
+  failure?: AgentRunTerminalFailure,
+): AgentRunTerminal {
+  const state = terminalStateForAgentLoopResult(result);
+  return {
+    version: AGENT_RUN_TERMINAL_VERSION,
+    runId,
+    state,
+    result,
+    ...(state === 'failed' ? {
+      failure: failure ?? {
+        errorType: 'agent_loop_error',
+        message: result.error || 'Agent run failed',
+      },
+    } : {}),
+  };
+}
+
+export function isAgentRunTerminal(value: unknown): value is AgentRunTerminal {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  if (candidate.version !== AGENT_RUN_TERMINAL_VERSION) return false;
+  if (typeof candidate.runId !== 'string' || candidate.runId.length === 0) return false;
+  if (candidate.state !== 'completed' && candidate.state !== 'failed' && candidate.state !== 'interrupted') return false;
+  if (typeof candidate.result !== 'object' || candidate.result === null) return false;
+
+  const result = candidate.result as Record<string, unknown>;
+  if (typeof result.reason !== 'string' || !AGENT_LOOP_EXIT_REASONS.has(result.reason as AgentLoopExitReason)) return false;
+  if (result.error !== undefined && typeof result.error !== 'string') return false;
+
+  if (candidate.state !== terminalStateForAgentLoopResult(result as unknown as AgentLoopResult)) return false;
+  if (candidate.state !== 'failed') return candidate.failure === undefined;
+  if (typeof candidate.failure !== 'object' || candidate.failure === null) return false;
+  const failure = candidate.failure as Record<string, unknown>;
+  return typeof failure.errorType === 'string'
+    && failure.errorType.length > 0
+    && typeof failure.message === 'string'
+    && (failure.stack === undefined || typeof failure.stack === 'string');
+}
+
+export function areAgentRunTerminalsEqual(left: AgentRunTerminal, right: AgentRunTerminal): boolean {
+  return left.version === right.version
+    && left.runId === right.runId
+    && left.state === right.state
+    && left.result.reason === right.result.reason
+    && left.result.error === right.result.error
+    && left.failure?.errorType === right.failure?.errorType
+    && left.failure?.message === right.failure?.message
+    && left.failure?.stack === right.failure?.stack;
+}

--- a/src/core/agent/subagentLoop.ts
+++ b/src/core/agent/subagentLoop.ts
@@ -20,12 +20,19 @@ import { TOOL_NAMES } from '../tools/toolNames';
 // sidecar process. See settingsSelectors.ts's module doc.
 import { getActiveApiKey, getActiveProvider, resolveAgentModel } from '../../utils/settingsSelectors';
 import { getSettingsReader, type SettingsReader } from './ports/settingsReader';
-import { resolveCapabilities, computeReasoningParams, isReasoningStarvation, type ModelCapabilities } from '../llm/modelCapabilities';
+import {
+  resolveCapabilities,
+  resolveEffectiveContextWindow,
+  computeReasoningParams,
+  isReasoningStarvation,
+  type ModelCapabilities,
+} from '../llm/modelCapabilities';
 import { applyDeclaredCapabilities } from '../llm/applyDeclaredCapabilities';
 import { resolveModelDeclared } from '../llm/resolveModelDeclared';
 import { getCapsPort, type CapsPort } from './ports/capsPort';
 import { getWorkspaceReader, type WorkspaceReader } from './ports/workspaceReader';
-import { prepareContextMessages } from '../context/contextManager';
+import { enforceContextBudget } from '../context/contextManager';
+import { estimateToolSchemaTokens } from '../context/tokenEstimator';
 import { compressContextIfNeeded } from '../context/contextCompressor';
 import { getMessageText } from '../context/contextUtils';
 import { withRetry } from './retry';
@@ -42,6 +49,9 @@ import type { SubagentStartEvent, SubagentEndEvent, PreToolCallEvent } from './l
 import { startSubagentSpan } from '../observability/langfuse';
 import { getI18n } from '../../i18n';
 import { matchesToolName, matchesToolPattern } from '../skill/toolFilter';
+import { createLogger } from '../logging/logger';
+
+const logger = createLogger('subagentLoop');
 
 /** Max times a subagent re-prompts after a max_tokens truncation. Mirrors the
  *  same-named limit in agentLoop (kept in sync deliberately). */
@@ -433,7 +443,11 @@ export async function runSubagentLoop(options: SubagentLoopOptions): Promise<Sub
         settings.maxOutputTokens ?? subagentCaps.maxOutputTokens,
       );
       // Apply context management to prevent subagent context overflow
-      const contextWindowSize = settings.contextWindowSize ?? subagentCaps.contextWindow;
+      const contextWindowSize = resolveEffectiveContextWindow(
+        effectiveModelId,
+        declared?.maxInputTokens ?? settings.contextWindowSize,
+        discovered?.contextWindow,
+      );
       // True output ceiling (distinct from the conservative per-turn budget below):
       // max_tokens-recovery escalation may climb toward this, never above a known limit.
       const effectiveModelCeiling = discovered?.maxOutputTokens ?? baseCaps.outputCeiling ?? subagentCaps.maxOutputTokens;
@@ -474,12 +488,24 @@ export async function runSubagentLoop(options: SubagentLoopOptions): Promise<Sub
       }
 
       // Step 2: Hard truncation as safety net
-      const preparedMessages = prepareContextMessages(
+      const toolSchemaTokens = estimateToolSchemaTokens(tools);
+      const budgetResult = enforceContextBudget(
         messagesForContext,
         systemPrompt,
         contextWindowSize,
-        maxOutputTokens
+        maxOutputTokens,
+        toolSchemaTokens,
       );
+      const preparedMessages = budgetResult.messages;
+      if (budgetResult.strategy !== 'unchanged') {
+        logger.info('Context budget gate applied', {
+          tokensBefore: budgetResult.tokensBefore,
+          tokensAfter: budgetResult.tokensAfter,
+          inputBudget: budgetResult.inputBudget,
+          safetyMarginTokens: budgetResult.safetyMarginTokens,
+          strategy: budgetResult.strategy,
+        });
+      }
 
       // Resolve apiKey + baseUrl — enterprise gateway overrides personal creds.
       const subChatCreds = resolveEffectiveLlmCreds(

--- a/src/core/agent/subagentRecovery.integration.test.ts
+++ b/src/core/agent/subagentRecovery.integration.test.ts
@@ -34,7 +34,14 @@ vi.mock('../memdir/scan', () => ({
 }));
 
 vi.mock('../context/contextManager', () => ({
-  prepareContextMessages: vi.fn((msgs: unknown) => msgs),
+  enforceContextBudget: vi.fn((msgs: unknown[]) => ({
+    messages: msgs,
+    tokensBefore: 1,
+    tokensAfter: 1,
+    inputBudget: 100000,
+    safetyMarginTokens: 1000,
+    strategy: 'unchanged',
+  })),
 }));
 vi.mock('../context/contextCompressor', () => ({
   compressContextIfNeeded: vi.fn().mockResolvedValue({ compressed: false, messages: [] }),

--- a/src/core/context/contextManager.test.ts
+++ b/src/core/context/contextManager.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import { prepareContextMessages } from './contextManager';
+import {
+  ContextBudgetError,
+  enforceContextBudget,
+  prepareContextMessages,
+} from './contextManager';
+import { estimateMessageTokens, estimateTokens } from './tokenEstimator';
 import type { Message } from '../../types';
 
+let messageSequence = 0;
 function makeMsg(role: 'user' | 'assistant', content: string): Message {
-  return { id: Math.random().toString(36), role, content, timestamp: Date.now() };
+  messageSequence += 1;
+  return { id: `message-${messageSequence}`, role, content, timestamp: 1_800_000_000_000 };
 }
 
 describe('contextManager', () => {
@@ -19,6 +26,20 @@ describe('contextManager', () => {
       const result = prepareContextMessages(messages, systemPrompt, 100000, 4000);
       expect(result).toHaveLength(2);
       expect(result).toEqual(messages);
+    });
+
+    it('reports the safe budget and leaves a safety margin', () => {
+      const result = enforceContextBudget(
+        [makeMsg('user', 'Hello')],
+        systemPrompt,
+        10_000,
+        1_000,
+      );
+
+      expect(result.strategy).toBe('unchanged');
+      expect(result.inputBudget).toBeLessThan(9_000);
+      expect(result.tokensAfter).toBeLessThanOrEqual(result.inputBudget);
+      expect(result.safetyMarginTokens).toBeGreaterThan(0);
     });
   });
 
@@ -81,39 +102,55 @@ describe('contextManager', () => {
 
       // Very tight limit
       const result = prepareContextMessages(messages, systemPrompt, 500, 100);
-      // Should at minimum have the first user message and last 2 rounds
-      expect(result.length).toBeGreaterThanOrEqual(3);
+      const safeBudget = enforceContextBudget(messages, systemPrompt, 500, 100);
+      expect(safeBudget.tokensAfter).toBeLessThanOrEqual(safeBudget.inputBudget);
       expect(result.length).toBeLessThan(messages.length);
     });
   });
 
   // ── Single round ──
   describe('single round', () => {
-    it('returns messages as-is when only 1 round', () => {
+    it('compacts an oversized assistant response instead of returning it over budget', () => {
       const messages = [
         makeMsg('user', 'Hello'),
-        makeMsg('assistant', 'Hi!'),
+        makeMsg('assistant', 'x'.repeat(20_000)),
       ];
-      // Even with very tight limit, single round is returned as-is
-      const result = prepareContextMessages(messages, systemPrompt, 50, 10);
-      expect(result).toEqual(messages);
+      const result = enforceContextBudget(messages, systemPrompt, 1_000, 200);
+
+      expect(result.strategy).toMatch(/last_round_compacted|latest_user_only/);
+      expect(result.tokensAfter).toBeLessThanOrEqual(result.inputBudget);
+      expect(result.messages[0]).toEqual(messages[0]);
+      expect(estimateMessageTokens(result.messages)).toBeLessThan(estimateMessageTokens(messages));
+    });
+
+    it('rejects a latest user input that cannot fit by itself', () => {
+      const messages = [makeMsg('user', 'x'.repeat(20_000))];
+
+      expect(() => enforceContextBudget(messages, systemPrompt, 1_000, 200))
+        .toThrowError(ContextBudgetError);
+      try {
+        enforceContextBudget(messages, systemPrompt, 1_000, 200);
+      } catch (error) {
+        expect(error).toMatchObject({ code: 'INPUT_TOO_LARGE' });
+      }
     });
   });
 
   // ── Preserves first user message ──
-  describe('first user message preservation', () => {
-    it('always includes first user message in aggressive mode', () => {
+  describe('user message preservation', () => {
+    it('prefers the latest user instruction when only one message can fit', () => {
       const messages: Message[] = [];
       messages.push(makeMsg('user', 'TASK_CONTEXT_IMPORTANT'));
       for (let i = 0; i < 10; i++) {
-        messages.push(makeMsg('assistant', `A${i} ${'x'.repeat(200)}`));
-        messages.push(makeMsg('user', `Q${i + 1}`));
+        messages.push(makeMsg('assistant', `A${i} ${'x'.repeat(2_000)}`));
+        messages.push(makeMsg('user', `Q${i + 1} ${'z'.repeat(50)}`));
       }
-      messages.push(makeMsg('assistant', 'Final'));
+      messages.push(makeMsg('assistant', `Final ${'y'.repeat(20_000)}`));
 
-      const result = prepareContextMessages(messages, systemPrompt, 500, 100);
-      const firstUser = result.find((m) => m.role === 'user');
-      expect(firstUser?.content).toContain('TASK_CONTEXT_IMPORTANT');
+      const result = enforceContextBudget(messages, systemPrompt, 500, 100);
+      const latestUser = [...result.messages].reverse().find((message) => message.role === 'user');
+      expect(latestUser?.content).toContain('Q10');
+      expect(result.tokensAfter).toBeLessThanOrEqual(result.inputBudget);
     });
   });
 
@@ -141,5 +178,100 @@ describe('contextManager', () => {
       // At least some assistant messages should be stripped
       expect(compressed?.toolCalls).toBeUndefined();
     });
+
+    it('truncates a giant latest tool result and preserves the outbound invariant', () => {
+      const messages: Message[] = [
+        makeMsg('user', 'Inspect the file'),
+        {
+          ...makeMsg('assistant', 'Reading the file'),
+          toolCallsForContext: [{
+            id: 'tool-1',
+            name: 'read_file',
+            input: { path: '/tmp/large.txt' },
+            result: 'data'.repeat(20_000),
+          }],
+        },
+      ];
+
+      const result = enforceContextBudget(messages, systemPrompt, 2_000, 400);
+      expect(result.tokensAfter).toBeLessThanOrEqual(result.inputBudget);
+      expect(result.messages[0]).toEqual(messages[0]);
+      expect(result.tokensAfter).toBeLessThan(result.tokensBefore);
+      expect(result.messages[1]?.toolCallsForContext?.[0]?.id).toBe('tool-1');
+    });
+
+    it('counts and removes rich tool-result images when the latest round is over budget', () => {
+      const resultContent = Array.from({ length: 8 }, () => ({
+        type: 'image' as const,
+        source: { type: 'base64' as const, media_type: 'image/png', data: 'image-data' },
+      }));
+      const messages: Message[] = [
+        makeMsg('user', 'Inspect the screenshots'),
+        {
+          ...makeMsg('assistant', 'Captured screenshots'),
+          toolCallsForContext: [{
+            id: 'tool-images',
+            name: 'computer_screenshot',
+            input: {},
+            result: '',
+            resultContent,
+          }],
+        },
+      ];
+
+      const result = enforceContextBudget(messages, systemPrompt, 4_000, 500);
+      expect(result.tokensBefore).toBeGreaterThan(result.inputBudget);
+      expect(result.tokensAfter).toBeLessThanOrEqual(result.inputBudget);
+      expect(result.messages[1]?.toolCallsForContext?.[0]?.resultContent)
+        .toEqual([{ type: 'text', text: '' }]);
+    });
+
+    it('includes tool schemas in the fixed context budget', () => {
+      const toolSchemaTokens = 1_000;
+      expect(() => enforceContextBudget(
+        [makeMsg('user', 'Hello')],
+        systemPrompt,
+        1_000,
+        200,
+        toolSchemaTokens,
+      )).toThrowError(expect.objectContaining({ code: 'FIXED_CONTEXT_TOO_LARGE' }));
+    });
+
+    it('does not double-count the UI and context copies of the same tool call', () => {
+      const base = makeMsg('assistant', 'Tool finished');
+      const toolCall = {
+        id: 'tool-mirrored',
+        name: 'read_file',
+        input: { path: '/tmp/file.txt' },
+        result: 'file content',
+      };
+      const withUiCopy: Message = {
+        ...base,
+        toolCalls: [toolCall],
+        toolCallsForContext: [toolCall],
+      };
+      const contextOnly: Message = {
+        ...base,
+        toolCallsForContext: [toolCall],
+      };
+
+      expect(estimateMessageTokens([withUiCopy])).toBe(estimateMessageTokens([contextOnly]));
+    });
   });
+
+  it.each([500, 1_000, 2_000, 4_000])(
+    'never returns an estimated payload above a %i-token context window',
+    (contextWindow) => {
+      const messages: Message[] = [];
+      for (let index = 0; index < 12; index++) {
+        messages.push(makeMsg('user', `Question ${index} ${'q'.repeat(120)}`));
+        messages.push(makeMsg('assistant', `Answer ${index} ${'a'.repeat(1_500)}`));
+      }
+
+      const result = enforceContextBudget(messages, systemPrompt, contextWindow, 100);
+      const independentlyEstimated = estimateTokens(systemPrompt) + estimateMessageTokens(result.messages);
+      expect(result.tokensAfter).toBeLessThanOrEqual(result.inputBudget);
+      expect(independentlyEstimated).toBeLessThanOrEqual(result.inputBudget);
+    },
+  );
 });

--- a/src/core/context/contextManager.ts
+++ b/src/core/context/contextManager.ts
@@ -3,10 +3,11 @@
  *
  * Strategy:
  * 1. Always keep system prompt
- * 2. Always keep first user message (task context)
- * 3. Keep last 4 complete conversation rounds
+ * 2. Keep the first user message while the normal compression tiers still fit
+ * 3. Keep the most recent complete conversation rounds
  * 4. Older messages: keep user messages, compress assistant to summary
- * 5. If still over limit, drop middle messages keeping first + last
+ * 5. Enforce a final hard invariant, preferring the latest user instruction
+ *    when only one message can fit safely
  */
 
 import type { Message, ToolCallForContext, ToolResultContent } from '../../types';
@@ -17,6 +18,51 @@ import { createLogger } from '../logging/logger';
 const logger = createLogger('contextManager');
 
 const ASSISTANT_SUMMARY_MAX_CHARS = 200;
+const CONTEXT_SAFETY_MARGIN_RATIO = 0.02;
+const CONTEXT_SAFETY_MARGIN_MAX_TOKENS = 4096;
+const CONTEXT_TRUNCATION_MARKER = '[Content truncated to fit the context budget]';
+
+export type ContextBudgetStrategy =
+  | 'unchanged'
+  | 'compressed_middle'
+  | 'recent_rounds'
+  | 'last_two_rounds'
+  | 'last_round_compacted'
+  | 'latest_user_only';
+
+export interface ContextBudgetResult {
+  messages: Message[];
+  tokensBefore: number;
+  tokensAfter: number;
+  inputBudget: number;
+  safetyMarginTokens: number;
+  strategy: ContextBudgetStrategy;
+}
+
+export type ContextBudgetErrorCode =
+  | 'INPUT_TOO_LARGE'
+  | 'FIXED_CONTEXT_TOO_LARGE';
+
+export class ContextBudgetError extends Error {
+  readonly code: ContextBudgetErrorCode;
+  readonly estimatedTokens: number;
+  readonly inputBudget: number;
+
+  constructor(
+    code: ContextBudgetErrorCode,
+    estimatedTokens: number,
+    inputBudget: number,
+  ) {
+    const subject = code === 'INPUT_TOO_LARGE'
+      ? 'The latest user input'
+      : 'The system prompt and tool definitions';
+    super(`${code}: ${subject} requires an estimated ${estimatedTokens} input tokens, but the safe input budget is ${inputBudget}.`);
+    this.name = 'ContextBudgetError';
+    this.code = code;
+    this.estimatedTokens = estimatedTokens;
+    this.inputBudget = inputBudget;
+  }
+}
 
 /**
  * If the first round is older than this, treat it as stale and include it
@@ -175,6 +221,137 @@ function compressAssistantMessage(msg: Message): Message {
   };
 }
 
+function calculateSafetyMargin(rawInputBudget: number, contextWindowSize: number): number {
+  if (rawInputBudget <= 0) return 0;
+  return Math.min(
+    Math.floor(rawInputBudget * 0.05),
+    Math.max(1, Math.min(
+      CONTEXT_SAFETY_MARGIN_MAX_TOKENS,
+      Math.ceil(contextWindowSize * CONTEXT_SAFETY_MARGIN_RATIO),
+    )),
+  );
+}
+
+function truncateTextToChars(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  if (maxChars <= 0) return CONTEXT_TRUNCATION_MARKER;
+  return `${text.slice(0, maxChars)}\n${CONTEXT_TRUNCATION_MARKER}`;
+}
+
+function compactHistoricalMessage(message: Message, maxCharsPerField: number): Message {
+  const content = typeof message.content === 'string'
+    ? truncateTextToChars(message.content, maxCharsPerField)
+    : [{
+        type: 'text' as const,
+        text: truncateTextToChars(getMessageText(message.content), maxCharsPerField),
+      }];
+
+  const compactInput = (input: Record<string, unknown>): Record<string, unknown> => (
+    JSON.stringify(input).length <= maxCharsPerField
+      ? input
+      : { _contextTruncated: true }
+  );
+  const compactResultContent = (contentBlocks: ToolResultContent[] | undefined): ToolResultContent[] | undefined => {
+    if (!contentBlocks) return undefined;
+    const text = contentBlocks
+      .filter((block): block is Extract<ToolResultContent, { type: 'text' }> => block.type === 'text')
+      .map((block) => block.text)
+      .join('\n');
+    return [{ type: 'text', text: truncateTextToChars(text, maxCharsPerField) }];
+  };
+
+  return {
+    ...message,
+    content,
+    thinking: undefined,
+    toolCalls: message.toolCalls?.map((toolCall) => ({
+      ...toolCall,
+      input: compactInput(toolCall.input),
+      result: toolCall.result === undefined
+        ? undefined
+        : truncateTextToChars(toolCall.result, maxCharsPerField),
+      resultContent: compactResultContent(toolCall.resultContent),
+    })),
+    toolCallsForContext: message.toolCallsForContext?.map((toolCall) => ({
+      ...toolCall,
+      input: compactInput(toolCall.input),
+      result: truncateTextToChars(toolCall.result, maxCharsPerField),
+      resultContent: compactResultContent(toolCall.resultContent),
+    })),
+  };
+}
+
+function fitLastRoundToBudget(
+  messages: Message[],
+  fixedTokens: number,
+  inputBudget: number,
+): { messages: Message[]; strategy: ContextBudgetStrategy } {
+  const rounds = identifyRounds(messages);
+  const lastRound = rounds.at(-1) ?? [];
+  const latestUser = [...messages].reverse().find((message) => message.role === 'user');
+
+  if (!latestUser) {
+    return { messages: [], strategy: 'latest_user_only' };
+  }
+
+  const latestUserTokens = fixedTokens + estimateMessageTokens([latestUser]);
+  if (latestUserTokens > inputBudget) {
+    throw new ContextBudgetError('INPUT_TOO_LARGE', latestUserTokens, inputBudget);
+  }
+
+  const compactRound = (maxCharsPerField: number): Message[] => stripOldThinking(sanitizeToolPairs(
+    lastRound.map((message) => (
+      message === latestUser
+        ? message
+        : compactHistoricalMessage(message, maxCharsPerField)
+    )),
+  ));
+
+  const maxChars = lastRound.reduce((largest, message) => {
+    const candidates = [getMessageText(message.content).length, message.thinking?.length ?? 0];
+    for (const toolCall of message.toolCalls ?? []) {
+      candidates.push(
+        JSON.stringify(toolCall.input).length,
+        toolCall.result?.length ?? 0,
+        toolCall.resultContent
+          ?.filter((block) => block.type === 'text')
+          .reduce((total, block) => total + block.text.length, 0) ?? 0,
+      );
+    }
+    for (const toolCall of message.toolCallsForContext ?? []) {
+      candidates.push(
+        JSON.stringify(toolCall.input).length,
+        toolCall.result.length,
+        toolCall.resultContent
+          ?.filter((block) => block.type === 'text')
+          .reduce((total, block) => total + block.text.length, 0) ?? 0,
+      );
+    }
+    return Math.max(largest, ...candidates);
+  }, 0);
+
+  let low = 0;
+  let high = maxChars;
+  let best: Message[] | null = null;
+  while (low <= high) {
+    const midpoint = Math.floor((low + high) / 2);
+    const candidate = compactRound(midpoint);
+    const candidateTokens = fixedTokens + estimateMessageTokens(candidate);
+    if (candidateTokens <= inputBudget) {
+      best = candidate;
+      low = midpoint + 1;
+    } else {
+      high = midpoint - 1;
+    }
+  }
+
+  if (best) {
+    return { messages: best, strategy: 'last_round_compacted' };
+  }
+
+  return { messages: [latestUser], strategy: 'latest_user_only' };
+}
+
 /**
  * Prepare messages for LLM call, fitting within context window limit
  *
@@ -182,37 +359,93 @@ function compressAssistantMessage(msg: Message): Message {
  * @param systemPrompt The system prompt text
  * @param contextWindowSize Total context window size (tokens)
  * @param reserveForOutput Tokens to reserve for model output
- * @returns Trimmed messages array
+ * @returns Trimmed messages plus the measured safe-budget result
  */
-export function prepareContextMessages(
+export function enforceContextBudget(
   messages: Message[],
   systemPrompt: string,
   contextWindowSize: number,
   reserveForOutput: number,
   toolSchemaTokens?: number
-): Message[] {
-  const maxInputTokens = contextWindowSize - reserveForOutput;
+): ContextBudgetResult {
+  const rawInputBudget = contextWindowSize - reserveForOutput;
+  const safetyMarginTokens = calculateSafetyMargin(rawInputBudget, contextWindowSize);
+  const inputBudget = Math.max(0, rawInputBudget - safetyMarginTokens);
   const systemTokens = estimateTokens(systemPrompt);
+  const fixedTokens = systemTokens + (toolSchemaTokens ?? 0);
+
+  if (fixedTokens > inputBudget) {
+    throw new ContextBudgetError('FIXED_CONTEXT_TOO_LARGE', fixedTokens, inputBudget);
+  }
 
   // Fast path: everything fits
   const messageTokens = estimateMessageTokens(messages);
-  const totalTokens = systemTokens + messageTokens + (toolSchemaTokens ?? 0);
-  if (totalTokens <= maxInputTokens) {
-    return messages;
+  const totalTokens = fixedTokens + messageTokens;
+  if (totalTokens <= inputBudget) {
+    return {
+      messages,
+      tokensBefore: totalTokens,
+      tokensAfter: totalTokens,
+      inputBudget,
+      safetyMarginTokens,
+      strategy: 'unchanged',
+    };
   }
 
-  const usagePercent = Math.round((totalTokens / maxInputTokens) * 100);
+  const usagePercent = inputBudget > 0
+    ? Math.round((totalTokens / inputBudget) * 100)
+    : 100;
   logger.info('Hard truncation needed', {
     systemTokens,
     messageTokens,
     toolSchemaTokens: toolSchemaTokens ?? 0,
     totalTokens,
-    maxInputTokens,
+    inputBudget,
+    safetyMarginTokens,
     usagePercent,
   });
 
   const rounds = identifyRounds(messages);
-  if (rounds.length <= 1) return messages; // Can't compress further
+
+  const finalize = (
+    candidate: Message[],
+    strategy: ContextBudgetStrategy,
+  ): ContextBudgetResult => {
+    const sanitized = stripOldThinking(sanitizeToolPairs(candidate));
+    const candidateTokens = fixedTokens + estimateMessageTokens(sanitized);
+    if (candidateTokens <= inputBudget) {
+      return {
+        messages: sanitized,
+        tokensBefore: totalTokens,
+        tokensAfter: candidateTokens,
+        inputBudget,
+        safetyMarginTokens,
+        strategy,
+      };
+    }
+
+    const fitted = fitLastRoundToBudget(messages, fixedTokens, inputBudget);
+    const fittedTokens = fixedTokens + estimateMessageTokens(fitted.messages);
+    logger.info('Context budget enforced', {
+      tokensBefore: totalTokens,
+      tokensAfter: fittedTokens,
+      inputBudget,
+      safetyMarginTokens,
+      strategy: fitted.strategy,
+    });
+    return {
+      messages: fitted.messages,
+      tokensBefore: totalTokens,
+      tokensAfter: fittedTokens,
+      inputBudget,
+      safetyMarginTokens,
+      strategy: fitted.strategy,
+    };
+  };
+
+  if (rounds.length <= 1) {
+    return finalize(messages, 'last_round_compacted');
+  }
 
   // Keep first round only if it's recent enough to be relevant context.
   // In long-lived IM sessions, the first round from weeks ago is stale noise.
@@ -226,7 +459,7 @@ export function prepareContextMessages(
 
   // If no middle rounds, we can only return what we have
   if (middleRounds.length === 0) {
-    return messages;
+    return finalize(messages, 'recent_rounds');
   }
 
   // Step 1: Compress middle assistant messages, keep user messages
@@ -248,8 +481,8 @@ export function prepareContextMessages(
   ];
 
   const tokens1 = systemTokens + (toolSchemaTokens ?? 0) + estimateMessageTokens(sanitizeToolPairs(result1));
-  if (tokens1 <= maxInputTokens) {
-    return stripOldThinking(sanitizeToolPairs(result1));
+  if (tokens1 <= inputBudget) {
+    return finalize(result1, 'compressed_middle');
   }
 
   // Step 2: Drop middle entirely, keep first + recent
@@ -259,8 +492,8 @@ export function prepareContextMessages(
   ];
 
   const tokens2 = systemTokens + (toolSchemaTokens ?? 0) + estimateMessageTokens(sanitizeToolPairs(result2));
-  if (tokens2 <= maxInputTokens) {
-    return stripOldThinking(sanitizeToolPairs(result2));
+  if (tokens2 <= inputBudget) {
+    return finalize(result2, 'recent_rounds');
   }
 
   // Step 3: Aggressive — keep first user message (if recent) + last 2 rounds
@@ -268,10 +501,26 @@ export function prepareContextMessages(
   if (keepFirstRound) {
     const firstUserMsg = messages.find((m) => m.role === 'user');
     if (firstUserMsg) {
-      return stripOldThinking(sanitizeToolPairs([firstUserMsg, ...lastTwoRounds.flat()]));
+      return finalize([firstUserMsg, ...lastTwoRounds.flat()], 'last_two_rounds');
     }
   }
-  return stripOldThinking(sanitizeToolPairs(lastTwoRounds.flat()));
+  return finalize(lastTwoRounds.flat(), 'last_two_rounds');
+}
+
+export function prepareContextMessages(
+  messages: Message[],
+  systemPrompt: string,
+  contextWindowSize: number,
+  reserveForOutput: number,
+  toolSchemaTokens?: number,
+): Message[] {
+  return enforceContextBudget(
+    messages,
+    systemPrompt,
+    contextWindowSize,
+    reserveForOutput,
+    toolSchemaTokens,
+  ).messages;
 }
 
 /**

--- a/src/core/context/tokenEstimator.ts
+++ b/src/core/context/tokenEstimator.ts
@@ -7,7 +7,7 @@
  * - Mixed: weighted average based on character distribution
  */
 
-import type { Message, MessageContent, ToolDefinition } from '../../types';
+import type { Message, MessageContent, ToolDefinition, ToolResultContent } from '../../types';
 import { getMessageText } from './contextUtils';
 
 // CJK Unicode ranges
@@ -81,6 +81,15 @@ export function estimateTokens(text: string): number {
 // Approximate tokens per image (Anthropic vision: ~1600 tokens per image)
 const TOKENS_PER_IMAGE = 1600;
 
+function estimateToolResultContentTokens(content: ToolResultContent[] | undefined): number {
+  if (!content) return 0;
+  return content.reduce((total, block) => (
+    block.type === 'image'
+      ? total + TOKENS_PER_IMAGE
+      : total + estimateTokens(block.text)
+  ), 0);
+}
+
 /**
  * Count image blocks in message content
  */
@@ -107,23 +116,16 @@ export function estimateMessageTokens(messages: Message[]): number {
       total += estimateTokens(msg.thinking);
     }
 
-    // Tool calls
-    if (msg.toolCalls) {
-      for (const tc of msg.toolCalls) {
+    // Match the provider normalizer: toolCallsForContext is the canonical
+    // send representation when present; toolCalls is the UI fallback. Counting
+    // both would double-charge the same tool exchange and over-truncate history.
+    const contextToolCalls = msg.toolCallsForContext ?? msg.toolCalls;
+    if (contextToolCalls) {
+      for (const tc of contextToolCalls) {
         total += estimateTokens(tc.name);
         total += estimateTokens(JSON.stringify(tc.input));
-        if (tc.result) {
-          total += estimateTokens(tc.result);
-        }
-      }
-    }
-
-    // Tool calls for context
-    if (msg.toolCallsForContext) {
-      for (const tc of msg.toolCallsForContext) {
-        total += estimateTokens(tc.name);
-        total += estimateTokens(JSON.stringify(tc.input));
-        total += estimateTokens(tc.result);
+        if (tc.result) total += estimateTokens(tc.result);
+        total += estimateToolResultContentTokens(tc.resultContent);
       }
     }
 

--- a/src/core/diagnostic/bundle.test.ts
+++ b/src/core/diagnostic/bundle.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+const diagnosticRunnerMock = vi.hoisted(() => vi.fn());
+vi.mock('./runner', () => ({ runAllChecks: diagnosticRunnerMock }));
 import { unzipSync, strFromU8 } from 'fflate';
 import { collectAndZip } from './bundle';
 import { useChatStore } from '@/stores/chatStore';
@@ -34,6 +36,7 @@ describe('collectAndZip (诊断反馈增强 L1: 二进制截图打包)', () => {
   const conv = makeConversation('conv-zzzzzzzz-9999');
 
   beforeEach(() => {
+    diagnosticRunnerMock.mockReset().mockResolvedValue([]);
     useChatStore.setState({
       conversations: { [conv.id]: conv },
       conversationIndex: { [conv.id]: makeMeta(conv.id) },
@@ -59,6 +62,10 @@ describe('collectAndZip (诊断反馈增强 L1: 二进制截图打包)', () => {
     const screenshotOut = unzipped['feedback/screenshots/01.png'];
     expect(screenshotOut).toBeInstanceOf(Uint8Array);
     expect(Array.from(screenshotOut)).toEqual(Array.from(pngBytes));
+    expect(JSON.parse(strFromU8(unzipped['manifest.json']))).toMatchObject({
+      schemaVersion: 1,
+      missingRequiredFiles: [],
+    });
   });
 
   it('uses a multi-N short id in the filename when several conversations are selected', async () => {

--- a/src/core/diagnostic/collect.test.ts
+++ b/src/core/diagnostic/collect.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+const diagnosticRunnerMock = vi.hoisted(() => vi.fn());
+vi.mock('./runner', () => ({ runAllChecks: diagnosticRunnerMock }));
+
 import {
   capDiagnosticMessages,
   DEFAULT_DIAGNOSTIC_MESSAGE_CAP,
@@ -10,6 +13,12 @@ import { useChatStore } from '@/stores/chatStore';
 import type { Conversation, Message } from '@/types';
 import type { ConversationMeta } from '@/core/session/conversationStorage';
 import { clearLogs, createLogger } from '@/core/logging/logger';
+import { useDiagnosticStore } from '@/stores/diagnosticStore';
+
+beforeEach(() => {
+  diagnosticRunnerMock.mockReset().mockResolvedValue([]);
+  useDiagnosticStore.setState({ results: {}, lastCheckedAt: null, isChecking: false });
+});
 
 function makeMessage(id: string, text: string): Message {
   return { id, role: 'user', content: text, timestamp: Date.now() };
@@ -113,6 +122,57 @@ describe('collectBundleFiles (诊断反馈增强 L1: 多选对话 / 描述 / 截
     expect(files[`conversations/${shortB}/index-entry.json`]).toBeDefined();
     // C was not selected — must not appear
     expect(files[`conversations/${shortC}/messages.jsonl`]).toBeUndefined();
+  });
+
+  it('runs a live bounded doctor and writes freshness plus a machine-readable manifest', async () => {
+    diagnosticRunnerMock.mockResolvedValue([{
+      id: 'app:version',
+      category: 'app',
+      name: 'version',
+      status: 'passed',
+      checkedAt: 100,
+      durationMs: 2,
+    }]);
+
+    const { files } = await collectBundleFiles({ includeRawText: true, conversationIds: [] });
+    const snapshot = JSON.parse(String(files['diagnostic-snapshot.json']));
+    const manifest = JSON.parse(String(files['manifest.json']));
+
+    expect(diagnosticRunnerMock).toHaveBeenCalledWith({ categoryTimeoutMs: 10_000 });
+    expect(snapshot).toMatchObject({ schemaVersion: 2, freshness: 'fresh' });
+    expect(snapshot.results[0]).toMatchObject({ id: 'app:version', freshness: 'fresh' });
+    expect(manifest).toMatchObject({
+      schemaVersion: 1,
+      diagnosticFreshness: 'fresh',
+      missingRequiredFiles: [],
+    });
+    expect(manifest.files.map((entry: { path: string }) => entry.path)).toEqual(
+      expect.arrayContaining(['manifest.json', 'README.txt', 'diagnostic-snapshot.json']),
+    );
+  });
+
+  it('marks cached fallback results stale instead of presenting them as live', async () => {
+    diagnosticRunnerMock.mockRejectedValue(new Error('runner unavailable'));
+    useDiagnosticStore.setState({
+      lastCheckedAt: 100,
+      results: {
+        'network:reachability': {
+          id: 'network:reachability',
+          category: 'network',
+          name: 'network',
+          status: 'passed',
+          checkedAt: 100,
+          durationMs: 1,
+        },
+      },
+    });
+
+    const { files } = await collectBundleFiles({ includeRawText: true, conversationIds: [] });
+    const snapshot = JSON.parse(String(files['diagnostic-snapshot.json']));
+
+    expect(snapshot.freshness).toBe('stale');
+    expect(snapshot.staleAgeMs).toBeGreaterThanOrEqual(0);
+    expect(snapshot.results[0]).toMatchObject({ freshness: 'stale' });
   });
 
   it('produces no conversations/<id>/ content when conversationIds is empty and there is no active conversation, but still writes environment files', async () => {

--- a/src/core/diagnostic/collect.ts
+++ b/src/core/diagnostic/collect.ts
@@ -26,10 +26,18 @@ import { getElectronRuntimeDiagnostics } from '@/utils/electronHost';
 import { APP_VERSION } from '@/utils/version';
 import { platform } from '@tauri-apps/plugin-os';
 import { scrubSecrets, scrubMessage } from './scrub';
-import type { CheckResult, DiagnosticSnapshot, OverallStatus } from './types';
+import { runAllChecks } from './runner';
+import { buildDiagnosticRunTimeline } from './runTimeline';
+import type {
+  CheckResult,
+  DiagnosticFreshness,
+  DiagnosticSnapshot,
+  OverallStatus,
+} from './types';
 
 const RUNTIME_LOG_LIMIT = 200;
 const DISK_LOG_TAIL_LINES = 500;
+export const EXPORT_DIAGNOSTIC_CATEGORY_TIMEOUT_MS = 10_000;
 
 /** localStorage keys for all persisted Zustand stores. Keep in sync with storeVersions.test.ts. */
 const PERSISTED_STORE_KEYS = [
@@ -173,6 +181,109 @@ function deriveOverall(results: CheckResult[]): OverallStatus {
   return 'all-passed';
 }
 
+interface SnapshotIdentity {
+  bundleId: string;
+  os: string;
+}
+
+/** Always attempt a bounded live check; cached rows are explicitly marked stale on fallback. */
+export async function collectLiveDiagnosticSnapshot(
+  identity: SnapshotIdentity,
+): Promise<DiagnosticSnapshot> {
+  const checkStartedAt = Date.now();
+  const cached = useDiagnosticStore.getState();
+  try {
+    const liveResults = await runAllChecks({
+      categoryTimeoutMs: EXPORT_DIAGNOSTIC_CATEGORY_TIMEOUT_MS,
+    });
+    const results = liveResults.map((row) => ({
+      ...row,
+      freshness: row.freshness === 'unknown' ? 'unknown' as const : 'fresh' as const,
+    }));
+    const takenAt = Date.now();
+    const freshness: DiagnosticFreshness = results.some((row) => row.freshness === 'unknown')
+      ? 'unknown'
+      : 'fresh';
+    const resultMap = Object.fromEntries(results.map((row) => [row.id, row]));
+    useDiagnosticStore.setState({ results: resultMap, lastCheckedAt: takenAt });
+    return {
+      schemaVersion: 2,
+      checkStartedAt,
+      takenAt,
+      appVersion: APP_VERSION,
+      bundleId: identity.bundleId,
+      os: identity.os,
+      overall: deriveOverall(results),
+      freshness,
+      results,
+    };
+  } catch {
+    const takenAt = Date.now();
+    const cachedResults = Object.values(cached.results);
+    const freshness: DiagnosticFreshness = cachedResults.length > 0 ? 'stale' : 'unknown';
+    const results = cachedResults.map((row) => ({ ...row, freshness }));
+    return {
+      schemaVersion: 2,
+      checkStartedAt,
+      takenAt,
+      appVersion: APP_VERSION,
+      bundleId: identity.bundleId,
+      os: identity.os,
+      overall: deriveOverall(results),
+      freshness,
+      staleAgeMs: cached.lastCheckedAt == null ? undefined : Math.max(0, takenAt - cached.lastCheckedAt),
+      results,
+    };
+  }
+}
+
+type ManifestPrivacy = 'diagnostic-metadata' | 'scrubbed-config' | 'user-content';
+
+function manifestPrivacyFor(path: string): ManifestPrivacy {
+  if (path.startsWith('conversations/') || path.startsWith('feedback/')) return 'user-content';
+  if (path.startsWith('settings/') || path.startsWith('mcp/') || path.startsWith('permissions/')) {
+    return 'scrubbed-config';
+  }
+  return 'diagnostic-metadata';
+}
+
+function contentSizeBytes(content: string | Uint8Array): number {
+  return typeof content === 'string' ? new TextEncoder().encode(content).byteLength : content.byteLength;
+}
+
+export function buildDiagnosticManifest(
+  files: Record<string, string | Uint8Array>,
+  generatedAt: number,
+  includeRawText: boolean,
+  snapshot: DiagnosticSnapshot,
+): string {
+  const requiredFiles = [
+    'meta.json',
+    'diagnostic-snapshot.json',
+    'runtime/renderer-trace.json',
+    'settings/settings.json',
+    'stores/versions.json',
+  ];
+  const entries = Object.entries(files)
+    .map(([path, content]) => ({
+      path,
+      sizeBytes: contentSizeBytes(content),
+      privacy: manifestPrivacyFor(path),
+    }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+  entries.push({ path: 'manifest.json', sizeBytes: 0, privacy: 'diagnostic-metadata' });
+  entries.sort((a, b) => a.path.localeCompare(b.path));
+  return JSON.stringify({
+    schemaVersion: 1,
+    generatedAt,
+    includeRawText,
+    diagnosticFreshness: snapshot.freshness,
+    requiredFiles,
+    missingRequiredFiles: requiredFiles.filter((path) => !Object.hasOwn(files, path)),
+    files: entries,
+  }, null, 2);
+}
+
 async function getBundleId(): Promise<string> {
   // Best-effort: derive from appDataDir path tail (com.abu.app vs com.abu.app.dev)
   try {
@@ -244,17 +355,10 @@ export async function collectBundleFiles(opts: CollectOptions): Promise<CollectR
   files['meta.json'] = JSON.stringify(meta, null, 2);
 
   // ── diagnostic-snapshot.json ────────────────────────────────────────
-  const diag = useDiagnosticStore.getState();
-  const results = Object.values(diag.results);
-  const snapshot: DiagnosticSnapshot = {
-    schemaVersion: 1,
-    takenAt: diag.lastCheckedAt ?? Date.now(),
-    appVersion: APP_VERSION,
-    bundleId: meta.bundleId,
-    os: meta.os,
-    overall: deriveOverall(results),
-    results,
-  };
+  // Never silently export a persisted historical result as if it were live.
+  // Every upload/export performs a bounded fresh run; fallback rows carry
+  // explicit stale/unknown freshness metadata.
+  const snapshot = await collectLiveDiagnosticSnapshot({ bundleId: meta.bundleId, os: meta.os });
   files['diagnostic-snapshot.json'] = JSON.stringify(snapshot, null, 2);
 
   // ── conversations/<shortId>/* ────────────────────────────────────────
@@ -523,8 +627,9 @@ export async function collectBundleFiles(opts: CollectOptions): Promise<CollectR
   // only — never prompts, message text, tool arguments, or provider bodies.
   // Tauri and tests without an Electron preload bridge simply omit the main
   // process files while retaining the renderer snapshot.
+  const rendererRuntime = getRendererRuntimeTraceSnapshot();
   files['runtime/renderer-trace.json'] = JSON.stringify(
-    scrubSecrets(getRendererRuntimeTraceSnapshot()),
+    scrubSecrets(rendererRuntime),
     null,
     2,
   );
@@ -553,6 +658,14 @@ export async function collectBundleFiles(opts: CollectOptions): Promise<CollectR
       2,
     );
   }
+  files['runtime/run-timeline.json'] = JSON.stringify(
+    scrubSecrets(buildDiagnosticRunTimeline(
+      rendererRuntime,
+      electronRuntime?.recentEventLines ?? [],
+    )),
+    null,
+    2,
+  );
 
   // ── stores/versions.json ─────────────────────────────────────────────
   // Schema versions of all persisted Zustand stores. Lets PM spot
@@ -613,9 +726,15 @@ export async function collectBundleFiles(opts: CollectOptions): Promise<CollectR
     files['schedule/summary.json'] = JSON.stringify({ error: e instanceof Error ? e.message : String(e) }, null, 2);
   }
 
-  // ── README.txt ───────────────────────────────────────────────────────
-  const fileList = Object.keys(files).sort().concat(['README.txt']);
+  // ── README.txt + manifest.json ───────────────────────────────────────
+  const fileList = Object.keys(files).sort().concat(['README.txt', 'manifest.json']).sort();
   files['README.txt'] = generateReadme(opts, fileList);
+  files['manifest.json'] = buildDiagnosticManifest(
+    files,
+    meta.generatedAt,
+    opts.includeRawText,
+    snapshot,
+  );
 
   return { files, scrubbedTextCount: scrubCount };
 }

--- a/src/core/diagnostic/runTimeline.test.ts
+++ b/src/core/diagnostic/runTimeline.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { buildDiagnosticRunTimeline } from './runTimeline';
+import type { RendererRuntimeTraceSnapshot } from '@/core/observability/runtimeTrace';
+
+function rendererSnapshot(events: RendererRuntimeTraceSnapshot['recentEvents']): RendererRuntimeTraceSnapshot {
+  return { schemaVersion: 1, takenAt: 500, recentEvents: events, activeRuns: [] };
+}
+
+describe('buildDiagnosticRunTimeline', () => {
+  it('correlates a recovered replay into one completed run', () => {
+    const timeline = buildDiagnosticRunTimeline(rendererSnapshot([
+      { schemaVersion: 1, timestamp: 100, process: 'renderer', event: 'renderer.local_message_persisted', runId: 'run-1', clientMessageId: 'msg-1' },
+      { schemaVersion: 1, timestamp: 110, process: 'renderer', event: 'renderer.agent_start_ack_missing', runId: 'run-1' },
+      { schemaVersion: 1, timestamp: 120, process: 'renderer', event: 'renderer.agent_run_transport_replayed', runId: 'run-1', replayCount: 1 },
+      { schemaVersion: 1, timestamp: 130, process: 'renderer', event: 'renderer.first_frame_applied', runId: 'run-1' },
+      { schemaVersion: 1, timestamp: 150, process: 'renderer', event: 'renderer.agent_run_completed', runId: 'run-1' },
+    ]), [], 600);
+
+    expect(timeline).toMatchObject({ schemaVersion: 1, runCount: 1, rootCauseCounts: { start_ack: 1 } });
+    expect(timeline.runs[0]).toMatchObject({
+      runId: 'run-1',
+      clientMessageId: 'msg-1',
+      terminalOutcome: 'completed',
+      rootCause: 'start_ack',
+      replayCount: 1,
+      committed: true,
+      finishedAt: 150,
+    });
+  });
+
+  it('classifies a post-commit sidecar close as transport failure', () => {
+    const mainLines = [
+      JSON.stringify({ schemaVersion: 1, timestamp: 200, process: 'sidecar', event: 'sidecar.agent_delta_emitted', runId: 'run-2' }),
+      JSON.stringify({ schemaVersion: 1, timestamp: 220, process: 'main', event: 'main.rpc_orphaned_on_sidecar_close', runId: 'run-2' }),
+      JSON.stringify({ schemaVersion: 1, timestamp: 230, process: 'renderer', event: 'renderer.agent_run_failed', runId: 'run-2', stage: 'failed_after_commit' }),
+    ];
+
+    const timeline = buildDiagnosticRunTimeline(rendererSnapshot([]), mainLines, 600);
+
+    expect(timeline.runs[0]).toMatchObject({
+      terminalOutcome: 'failed',
+      rootCause: 'sidecar_transport',
+      committed: true,
+    });
+  });
+
+  it.each([
+    ['completed', 'completed', 'none'],
+    ['error', 'failed', 'runtime_failure'],
+    ['aborted', 'interrupted', 'user_stopped'],
+  ] as const)('uses sidecar outcome %s when the renderer terminal trace is missing', (sidecarOutcome, terminalOutcome, rootCause) => {
+    const timeline = buildDiagnosticRunTimeline(rendererSnapshot([]), [
+      JSON.stringify({ schemaVersion: 1, timestamp: 100, process: 'sidecar', event: 'sidecar.agent_loop_started', runId: 'run-3' }),
+      JSON.stringify({ schemaVersion: 1, timestamp: 160, process: 'sidecar', event: 'sidecar.agent_run_completed', runId: 'run-3', outcome: sidecarOutcome }),
+    ], 600);
+
+    expect(timeline.runs[0]).toMatchObject({
+      terminalOutcome,
+      rootCause,
+      finishedAt: 160,
+    });
+  });
+
+  it('counts malformed or non-correlatable main events without leaking them into runs', () => {
+    const timeline = buildDiagnosticRunTimeline(rendererSnapshot([]), [
+      '{broken',
+      JSON.stringify({ timestamp: 1, process: 'main', event: 'main.sidecar_closed' }),
+    ], 600);
+
+    expect(timeline.runCount).toBe(0);
+    expect(timeline.uncorrelatedEventCount).toBe(2);
+  });
+});

--- a/src/core/diagnostic/runTimeline.ts
+++ b/src/core/diagnostic/runTimeline.ts
@@ -1,0 +1,187 @@
+import type { RendererRuntimeTraceSnapshot, RuntimeTraceEvent } from '@/core/observability/runtimeTrace';
+
+export type RunTerminalOutcome = 'completed' | 'failed' | 'interrupted' | 'running' | 'unknown';
+export type RunRootCause =
+  | 'none'
+  | 'context_budget'
+  | 'sidecar_transport'
+  | 'bridge_delivery'
+  | 'start_ack'
+  | 'user_stopped'
+  | 'runtime_failure'
+  | 'unknown';
+
+export interface RunTimelineEvent {
+  timestamp: number;
+  process: 'renderer' | 'main' | 'sidecar';
+  event: string;
+  runId: string;
+  clientMessageId?: string;
+  stage?: string;
+  outcome?: string;
+  errorType?: string;
+  durationMs?: number;
+  replayCount?: number;
+}
+
+export interface RunTimelineSummary {
+  runId: string;
+  clientMessageId?: string;
+  startedAt: number;
+  finishedAt?: number;
+  terminalOutcome: RunTerminalOutcome;
+  rootCause: RunRootCause;
+  replayCount: number;
+  committed: boolean;
+  events: RunTimelineEvent[];
+}
+
+export interface DiagnosticRunTimeline {
+  schemaVersion: 1;
+  takenAt: number;
+  runCount: number;
+  uncorrelatedEventCount: number;
+  rootCauseCounts: Partial<Record<RunRootCause, number>>;
+  runs: RunTimelineSummary[];
+}
+
+const VALID_PROCESS = new Set(['renderer', 'main', 'sidecar']);
+const SAFE_STRING_KEYS = ['clientMessageId', 'stage', 'outcome', 'errorType'] as const;
+const SAFE_NUMBER_KEYS = ['durationMs', 'replayCount'] as const;
+
+function normalizeEvent(raw: unknown): RunTimelineEvent | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const value = raw as Record<string, unknown>;
+  if (
+    typeof value.timestamp !== 'number'
+    || !Number.isFinite(value.timestamp)
+    || typeof value.event !== 'string'
+    || !/^[a-z][a-z0-9_.-]{0,79}$/.test(value.event)
+    || typeof value.process !== 'string'
+    || !VALID_PROCESS.has(value.process)
+    || typeof value.runId !== 'string'
+    || value.runId.length === 0
+  ) return null;
+  const event: RunTimelineEvent = {
+    timestamp: Math.max(0, Math.round(value.timestamp)),
+    process: value.process as RunTimelineEvent['process'],
+    event: value.event,
+    runId: value.runId.slice(0, 160),
+  };
+  for (const key of SAFE_STRING_KEYS) {
+    if (typeof value[key] === 'string') event[key] = value[key].slice(0, 160);
+  }
+  for (const key of SAFE_NUMBER_KEYS) {
+    if (typeof value[key] === 'number' && Number.isFinite(value[key])) {
+      event[key] = Math.max(0, Math.round(value[key]));
+    }
+  }
+  return event;
+}
+
+function parseMainEventLines(lines: string[]): { events: RunTimelineEvent[]; uncorrelated: number } {
+  const events: RunTimelineEvent[] = [];
+  let uncorrelated = 0;
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      const normalized = normalizeEvent(parsed);
+      if (normalized) events.push(normalized);
+      else uncorrelated += 1;
+    } catch {
+      uncorrelated += 1;
+    }
+  }
+  return { events, uncorrelated };
+}
+
+function classifyOutcome(events: RunTimelineEvent[]): RunTerminalOutcome {
+  if (events.some((event) => event.event === 'renderer.agent_run_aborted')) return 'interrupted';
+  if (events.some((event) => event.event === 'renderer.agent_run_failed' || event.event === 'sidecar.agent_run_failed')) return 'failed';
+  if (events.some((event) => event.event === 'renderer.agent_run_completed')) return 'completed';
+  const sidecarTerminal = [...events].reverse().find((event) => event.event === 'sidecar.agent_run_completed');
+  if (sidecarTerminal?.outcome === 'aborted') return 'interrupted';
+  if (sidecarTerminal?.outcome === 'error') return 'failed';
+  if (sidecarTerminal?.outcome) return 'completed';
+  if (events.some((event) => event.event === 'sidecar.agent_loop_started')) return 'running';
+  return 'unknown';
+}
+
+function classifyRootCause(events: RunTimelineEvent[], outcome: RunTerminalOutcome): RunRootCause {
+  if (outcome === 'interrupted') return 'user_stopped';
+  if (events.some((event) => event.errorType?.includes('contextbudget'))) return 'context_budget';
+  if (events.some((event) => (
+    event.event === 'main.rpc_orphaned_on_sidecar_close'
+    || event.event === 'main.sidecar_closed'
+    || event.stage === 'failed_after_commit'
+  ))) return 'sidecar_transport';
+  if (events.some((event) => event.event === 'main.renderer_bridge_ack_timeout')) return 'bridge_delivery';
+  if (events.some((event) => event.event === 'renderer.agent_start_ack_missing')) return 'start_ack';
+  if (outcome === 'failed') return 'runtime_failure';
+  if (outcome === 'completed') return 'none';
+  return 'unknown';
+}
+
+export function buildDiagnosticRunTimeline(
+  renderer: RendererRuntimeTraceSnapshot,
+  mainEventLines: string[] = [],
+  takenAt = Date.now(),
+): DiagnosticRunTimeline {
+  const parsedMain = parseMainEventLines(mainEventLines);
+  const rendererEvents = renderer.recentEvents
+    .map((event: RuntimeTraceEvent) => normalizeEvent(event))
+    .filter((event): event is RunTimelineEvent => event !== null);
+  const deduped = new Map<string, RunTimelineEvent>();
+  for (const event of [...parsedMain.events, ...rendererEvents]) {
+    const key = `${event.timestamp}:${event.process}:${event.event}:${event.runId}:${event.stage ?? ''}`;
+    deduped.set(key, event);
+  }
+  const byRun = new Map<string, RunTimelineEvent[]>();
+  for (const event of deduped.values()) {
+    const runEvents = byRun.get(event.runId) ?? [];
+    runEvents.push(event);
+    byRun.set(event.runId, runEvents);
+  }
+  const runs = Array.from(byRun, ([runId, events]) => {
+    events.sort((a, b) => a.timestamp - b.timestamp);
+    const terminalOutcome = classifyOutcome(events);
+    let finished: RunTimelineEvent | undefined;
+    for (let i = events.length - 1; i >= 0; i -= 1) {
+      const event = events[i];
+      if (
+        event.event === 'renderer.agent_run_completed'
+        || event.event === 'sidecar.agent_run_completed'
+        || event.event === 'renderer.agent_run_failed'
+        || event.event === 'renderer.agent_run_aborted'
+      ) {
+        finished = event;
+        break;
+      }
+    }
+    return {
+      runId,
+      clientMessageId: events.find((event) => event.clientMessageId)?.clientMessageId,
+      startedAt: events[0].timestamp,
+      ...(finished ? { finishedAt: finished.timestamp } : {}),
+      terminalOutcome,
+      rootCause: classifyRootCause(events, terminalOutcome),
+      replayCount: Math.max(0, ...events.map((event) => event.replayCount ?? 0)),
+      committed: events.some((event) => (
+        event.event === 'renderer.first_frame_applied'
+        || event.event === 'renderer.agent_delta_received'
+        || event.event === 'sidecar.agent_delta_emitted'
+      )),
+      events,
+    } satisfies RunTimelineSummary;
+  }).sort((a, b) => b.startedAt - a.startedAt);
+  const rootCauseCounts: Partial<Record<RunRootCause, number>> = {};
+  for (const run of runs) rootCauseCounts[run.rootCause] = (rootCauseCounts[run.rootCause] ?? 0) + 1;
+  return {
+    schemaVersion: 1,
+    takenAt,
+    runCount: runs.length,
+    uncorrelatedEventCount: parsedMain.uncorrelated,
+    rootCauseCounts,
+    runs,
+  };
+}

--- a/src/core/diagnostic/runner.test.ts
+++ b/src/core/diagnostic/runner.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CheckCategory, CheckResult } from './types';
+
+const mocks = vi.hoisted(() => ({
+  ai: vi.fn(),
+  permissions: vi.fn(),
+  mcp: vi.fn(),
+  skills: vi.fn(),
+  network: vi.fn(),
+  app: vi.fn(),
+}));
+
+vi.mock('./checks/aiServices', () => ({ runAIServicesChecks: mocks.ai }));
+vi.mock('./checks/permissions', () => ({ runPermissionsChecks: mocks.permissions }));
+vi.mock('./checks/mcp', () => ({ runMcpChecks: mocks.mcp }));
+vi.mock('./checks/skills', () => ({ runSkillsChecks: mocks.skills }));
+vi.mock('./checks/network', () => ({ runNetworkChecks: mocks.network }));
+vi.mock('./checks/app', () => ({ runAppChecks: mocks.app }));
+
+import { runAllChecks, runCategoryChecks } from './runner';
+
+function passed(category: CheckCategory): CheckResult[] {
+  return [{
+    id: `${category}:ok`,
+    category,
+    name: 'ok',
+    status: 'passed',
+    checkedAt: 1,
+    durationMs: 1,
+  }];
+}
+
+describe('diagnostic runner deadlines', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.ai.mockReset().mockResolvedValue(passed('ai-services'));
+    mocks.permissions.mockReset().mockResolvedValue(passed('permissions'));
+    mocks.mcp.mockReset().mockResolvedValue(passed('mcp'));
+    mocks.skills.mockReset().mockResolvedValue(passed('skills'));
+    mocks.network.mockReset().mockResolvedValue(passed('network'));
+    mocks.app.mockReset().mockResolvedValue(passed('app'));
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  it('bounds a hung category without blocking healthy categories', async () => {
+    mocks.network.mockReturnValue(new Promise(() => {}));
+
+    const pending = runAllChecks({ categoryTimeoutMs: 50 });
+    await vi.advanceTimersByTimeAsync(50);
+    const results = await pending;
+
+    expect(results).toHaveLength(6);
+    expect(results.find((row) => row.category === 'network')).toMatchObject({
+      id: 'network:runner-timeout',
+      status: 'warning',
+      freshness: 'unknown',
+      durationMs: 50,
+    });
+    expect(results.filter((row) => row.status === 'passed')).toHaveLength(5);
+  });
+
+  it('applies the same deadline to a single-category rerun', async () => {
+    mocks.ai.mockReturnValue(new Promise(() => {}));
+
+    const pending = runCategoryChecks('ai-services', { categoryTimeoutMs: 25 });
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expect(pending).resolves.toEqual([
+      expect.objectContaining({
+        id: 'ai-services:runner-timeout',
+        status: 'warning',
+        freshness: 'unknown',
+      }),
+    ]);
+  });
+});

--- a/src/core/diagnostic/runner.ts
+++ b/src/core/diagnostic/runner.ts
@@ -23,6 +23,13 @@ interface CategoryRunner {
   run: () => CheckResult[] | Promise<CheckResult[]>;
 }
 
+export interface RunChecksOptions {
+  /** Per-category deadline. Categories run in parallel, so this also bounds the full run. */
+  categoryTimeoutMs?: number;
+}
+
+export const DEFAULT_CATEGORY_TIMEOUT_MS = 12_000;
+
 const RUNNERS: CategoryRunner[] = [
   { category: 'ai-services', run: runAIServicesChecks },
   { category: 'permissions', run: runPermissionsChecks },
@@ -43,11 +50,39 @@ function categoryErrorRow(category: CheckCategory, err: unknown): CheckResult {
     errorDetail: err instanceof Error ? err.stack ?? err.message : String(err),
     checkedAt: Date.now(),
     durationMs: 0,
+    freshness: 'unknown',
   };
 }
 
-export async function runAllChecks(): Promise<CheckResult[]> {
-  const settled = await Promise.allSettled(RUNNERS.map((r) => Promise.resolve(r.run())));
+function categoryTimeoutRow(category: CheckCategory, timeoutMs: number): CheckResult {
+  const t = getI18n();
+  return {
+    id: `${category}:runner-timeout`,
+    category,
+    name: t.diagnostic.checkTimedOut,
+    status: 'warning',
+    errorMessage: `${t.diagnostic.checkTimedOut} (${timeoutMs}ms)`,
+    checkedAt: Date.now(),
+    durationMs: timeoutMs,
+    freshness: 'unknown',
+  };
+}
+
+async function runWithDeadline(runner: CategoryRunner, timeoutMs: number): Promise<CheckResult[]> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<CheckResult[]>((resolve) => {
+    timeoutId = setTimeout(() => resolve([categoryTimeoutRow(runner.category, timeoutMs)]), timeoutMs);
+  });
+  try {
+    return await Promise.race([Promise.resolve().then(runner.run), timeout]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
+export async function runAllChecks(options: RunChecksOptions = {}): Promise<CheckResult[]> {
+  const timeoutMs = Math.max(1, options.categoryTimeoutMs ?? DEFAULT_CATEGORY_TIMEOUT_MS);
+  const settled = await Promise.allSettled(RUNNERS.map((r) => runWithDeadline(r, timeoutMs)));
   const out: CheckResult[] = [];
   for (let i = 0; i < settled.length; i++) {
     const s = settled[i];
@@ -60,11 +95,15 @@ export async function runAllChecks(): Promise<CheckResult[]> {
   return out;
 }
 
-export async function runCategoryChecks(category: CheckCategory): Promise<CheckResult[]> {
+export async function runCategoryChecks(
+  category: CheckCategory,
+  options: RunChecksOptions = {},
+): Promise<CheckResult[]> {
   const runner = RUNNERS.find((r) => r.category === category);
   if (!runner) return [];
   try {
-    return await Promise.resolve(runner.run());
+    const timeoutMs = Math.max(1, options.categoryTimeoutMs ?? DEFAULT_CATEGORY_TIMEOUT_MS);
+    return await runWithDeadline(runner, timeoutMs);
   } catch (e) {
     return [categoryErrorRow(category, e)];
   }

--- a/src/core/diagnostic/types.ts
+++ b/src/core/diagnostic/types.ts
@@ -27,6 +27,8 @@ export type CheckStatus =
   /** Currently running. */
   | 'checking';
 
+export type DiagnosticFreshness = 'fresh' | 'stale' | 'unknown';
+
 export interface SuggestedAction {
   /**
    * `open-settings` — deep-link into a system-settings tab.
@@ -59,6 +61,8 @@ export interface CheckResult {
   checkedAt: number;
   /** Wall time spent on this check in ms. */
   durationMs: number;
+  /** Whether this row was measured now, reused from cache, or could not be measured. */
+  freshness?: DiagnosticFreshness;
 }
 
 /** A `CheckResult` instance still in-flight (status === 'checking'). */
@@ -71,11 +75,15 @@ export type OverallStatus = 'all-passed' | 'has-warnings' | 'has-failures' | 'ch
 
 /** Snapshot embedded inside the diagnostic-bundle zip. */
 export interface DiagnosticSnapshot {
-  schemaVersion: 1;
+  schemaVersion: 2;
+  checkStartedAt: number;
   takenAt: number;
   appVersion: string;
   bundleId: string;
   os: string;
   overall: OverallStatus;
+  freshness: DiagnosticFreshness;
+  /** Present when cached results had to be reused. */
+  staleAgeMs?: number;
   results: CheckResult[];
 }

--- a/src/core/observability/runtimeTrace.ts
+++ b/src/core/observability/runtimeTrace.ts
@@ -5,6 +5,7 @@ const MAX_STRING_CHARS = 160;
 
 export interface RuntimeTraceAttributes {
   runId?: string;
+  clientMessageId?: string;
   rpcId?: string;
   method?: string;
   stage?: string;
@@ -20,6 +21,8 @@ export interface RuntimeTraceAttributes {
   executionPath?: string;
   firstFrameMs?: number;
   bridgeLatencyMs?: number;
+  acceptedAt?: number;
+  replayCount?: number;
 }
 
 export interface RuntimeTraceEvent extends RuntimeTraceAttributes {
@@ -54,6 +57,7 @@ const activeRuns = new Map<string, ActiveRuntimeRun>();
 
 const SAFE_ATTRIBUTE_KEYS = new Set<keyof RuntimeTraceAttributes>([
   'runId',
+  'clientMessageId',
   'rpcId',
   'method',
   'stage',
@@ -69,6 +73,8 @@ const SAFE_ATTRIBUTE_KEYS = new Set<keyof RuntimeTraceAttributes>([
   'executionPath',
   'firstFrameMs',
   'bridgeLatencyMs',
+  'acceptedAt',
+  'replayCount',
 ]);
 
 const SECRET_PATTERNS: RegExp[] = [

--- a/src/core/session/conversationStorage.ts
+++ b/src/core/session/conversationStorage.ts
@@ -263,6 +263,7 @@ export async function flushWrites(): Promise<void> {
 // ════════════════════════════════════════════════════════════
 
 const writtenIds = new Set<string>();
+const writingIds = new Map<string, Promise<void>>();
 
 /**
  * Clear the dedup cache. Call when loading messages from disk
@@ -597,19 +598,29 @@ export async function appendMessage(
   message: Message,
 ): Promise<void> {
   if (writtenIds.has(message.id)) return; // dedup
-  writtenIds.add(message.id);
+  const inFlight = writingIds.get(message.id);
+  if (inFlight) return inFlight;
 
-  await ensureBase();
-  const line = JSON.stringify(stripForDisk(message)) + '\n';
-  await enqueueWrite(messagesPath(convId), line);
+  const write = (async () => {
+    await ensureBase();
+    const line = JSON.stringify(stripForDisk(message)) + '\n';
+    await enqueueWrite(messagesPath(convId), line);
 
-  // Write-through the catalog AFTER the JSONL write is queued. Fire-and-
-  // forget (fix #9): the catalog bump is best-effort (IPC + SQLite +
-  // fs::metadata on every append) and already swallows its own errors, so
-  // there is nothing for a caller to await or react to. JSONL success above
-  // is the hard requirement; catalog drift is repaired by startup reconcile,
-  // which does not depend on append ordering.
-  void catalogBumpCount(convId, 1, message.timestamp ?? Date.now(), message.id);
+    // Only claim the id after the append has actually succeeded. Marking it
+    // before I/O made a transient disk failure permanently suppress retry and
+    // allowed Reliable Run to execute without a durable user message.
+    writtenIds.add(message.id);
+
+    // The catalog is a rebuildable projection; JSONL success above is the
+    // hard requirement and the catalog bump remains best-effort.
+    void catalogBumpCount(convId, 1, message.timestamp ?? Date.now(), message.id);
+  })();
+  writingIds.set(message.id, write);
+  try {
+    await write;
+  } finally {
+    if (writingIds.get(message.id) === write) writingIds.delete(message.id);
+  }
 }
 
 /**

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -241,6 +241,13 @@ const enUS: TranslationDict = {
     collapseSources: 'Collapse',
     userMessageShowMore: 'Show more',
     userMessageCollapse: 'Collapse',
+    runPending: 'Sending…',
+    runAccepted: 'Accepted, starting…',
+    runRunning: 'Running…',
+    runFailed: 'Send failed',
+    runInterrupted: 'Stopped',
+    runRecoveredAfterRestart: 'The task did not finish before the app restarted. Please retry.',
+    runRetry: 'Retry',
     noModelConfigured: 'Set up a model',
     scrollToBottom: 'Scroll to bottom',
     compressingContext: 'Compacting long conversation…',
@@ -370,9 +377,14 @@ const enUS: TranslationDict = {
     skillMissingTools: 'This skill needs some tools that aren\'t available right now: {missing}. Check whether the related MCP servers are connected.',
     gatewayUnreachable: 'Cannot reach the enterprise AI gateway. Check your network connection, or contact your administrator.\n\nThe client will not fall back to a personal API key (to prevent budget bypass).',
     sidecarInterrupted: 'The background service was interrupted and is recovering automatically. Please resend your request in a moment.',
+    messageSaveFailed: 'The message could not be saved to disk, so Abu did not start the task. Check disk access and retry.',
+    attachmentDuringRun: 'Wait for the current task to finish before sending an image. Your draft is still here.',
+    conversationBusy: 'This conversation already has a running task. Wait for it to finish before starting another.',
     visionUnsupported: 'The current model may not support image/vision input. Try removing the image or switching to a vision-capable model (e.g. Claude, GPT-4o).',
     ollamaForbidden: 'Ollama returned 403 Forbidden (CORS origin restriction). Set the environment variable `OLLAMA_ORIGINS=*` and restart Ollama, e.g. `OLLAMA_ORIGINS=* ollama serve`',
     compactingInlineNotice: '\n*Context is getting long, optimizing context...*',
+    contextInputTooLarge: 'This message is too large for the current model context. Shorten the message or attachments, or switch to a model with a larger context window.',
+    contextFixedTooLarge: 'The current system instructions and tool definitions exceed this model’s safe context budget. Disable some tools or switch to a model with a larger context window.',
     notificationTaskFallback: 'Task',
     outputLimitError:
       '\n\n**Error:** The model hit the output token limit {limit} times in a row without finishing. Suggestions:\n' +
@@ -982,6 +994,7 @@ const enUS: TranslationDict = {
     appUpdateAvailable: 'Update available: v{version}',
     appCheckFailed: 'Update check failed',
     checkInternalError: 'Check internal error',
+    checkTimedOut: 'Check timed out; result is unknown',
     detailShow: 'Show details',
     detailHide: 'Hide details',
     errMap: {
@@ -1049,7 +1062,7 @@ const enUS: TranslationDict = {
     screenshotTooMany: 'Up to 5 screenshots allowed',
     screenshotTooLarge: 'Total screenshot size exceeds 5MB — not added',
     screenshotRemoveAria: 'Remove screenshot',
-    uploadAutoIncludedHint: 'Automatically included: environment self-check · logs · error snapshots',
+    uploadAutoIncludedHint: 'Rechecked at submission and automatically included: manifest · environment self-check · logs · error snapshots',
   },
 
   toolbox: {

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -241,6 +241,13 @@ const zhCN: TranslationDict = {
     collapseSources: '收起',
     userMessageShowMore: '显示更多',
     userMessageCollapse: '收起',
+    runPending: '正在发送…',
+    runAccepted: '已接收，正在启动…',
+    runRunning: '运行中…',
+    runFailed: '发送失败',
+    runInterrupted: '已停止',
+    runRecoveredAfterRestart: '应用重启前任务未完成，请重试。',
+    runRetry: '重试',
     noModelConfigured: '请配置模型',
     scrollToBottom: '回到底部',
     compressingContext: '正在压缩长对话上下文…',
@@ -370,9 +377,14 @@ const zhCN: TranslationDict = {
     skillMissingTools: '这个技能需要一些工具但当前不可用哦：{missing}。检查一下相关 MCP 服务器是否已连接～',
     gatewayUnreachable: '无法连接企业 AI 网关。请检查网络连接，或联系管理员。\n\n客户端不会回退到个人 API key（防止预算绕过）。',
     sidecarInterrupted: '后台服务意外中断，正在自动恢复。请稍后重新发送刚才的请求。',
+    messageSaveFailed: '消息未能写入磁盘，阿布没有启动任务。请检查磁盘权限后重试。',
+    attachmentDuringRun: '请等待当前任务结束后再发送图片，草稿已为你保留。',
+    conversationBusy: '当前会话已有任务在运行，请等待结束后再启动新任务。',
     visionUnsupported: '当前模型可能不支持图片/视觉输入，请尝试移除图片或切换到支持视觉的模型（如 Claude、GPT-4o）。',
     ollamaForbidden: 'Ollama 返回了 403 Forbidden（CORS 来源限制）。请设置环境变量 `OLLAMA_ORIGINS=*` 后重启 Ollama，例如：`OLLAMA_ORIGINS=* ollama serve`',
     compactingInlineNotice: '\n*上下文过长，正在优化上下文...*',
+    contextInputTooLarge: '这条消息超过了当前模型的上下文容量。请缩短消息或附件，或者切换到上下文更大的模型。',
+    contextFixedTooLarge: '当前系统指令和工具定义超过了模型的安全上下文预算。请停用部分工具，或者切换到上下文更大的模型。',
     notificationTaskFallback: '任务',
     outputLimitError:
       '\n\n**Error:** 模型连续 {limit} 次输出达到 token 上限仍未完成。建议：\n' +
@@ -982,6 +994,7 @@ const zhCN: TranslationDict = {
     appUpdateAvailable: '有新版本 v{version}',
     appCheckFailed: '无法检查更新',
     checkInternalError: '检查内部错误',
+    checkTimedOut: '检查超时，结果未知',
     detailShow: '展开详情',
     detailHide: '收起详情',
     errMap: {
@@ -1049,7 +1062,7 @@ const zhCN: TranslationDict = {
     screenshotTooMany: '最多添加 5 张截图',
     screenshotTooLarge: '截图总大小超过 5MB，未添加',
     screenshotRemoveAria: '删除截图',
-    uploadAutoIncludedHint: '已自动附带：环境自检 · 日志 · 报错快照',
+    uploadAutoIncludedHint: '提交时会实时重检，并自动附带：诊断清单 · 环境自检 · 日志 · 报错快照',
   },
 
   toolbox: {

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -272,6 +272,13 @@ export interface TranslationDict {
     collapseSources: string;
     userMessageShowMore: string;
     userMessageCollapse: string;
+    runPending: string;
+    runAccepted: string;
+    runRunning: string;
+    runFailed: string;
+    runInterrupted: string;
+    runRecoveredAfterRestart: string;
+    runRetry: string;
     noModelConfigured: string;
     scrollToBottom: string;
     compressingContext: string;
@@ -367,12 +374,19 @@ export interface TranslationDict {
     gatewayUnreachable: string;
     /** Sidecar process exited mid-task and automatic recovery has started. */
     sidecarInterrupted: string;
+    messageSaveFailed: string;
+    attachmentDuringRun: string;
+    conversationBusy: string;
     /** Model likely doesn't support image/vision input. */
     visionUnsupported: string;
     /** Ollama returned 403 Forbidden (CORS origin restriction). */
     ollamaForbidden: string;
     /** Streamed-inline notice while compacting an oversized context (includes markdown). */
     compactingInlineNotice: string;
+    /** Latest user message cannot fit within the model's safe context budget. */
+    contextInputTooLarge: string;
+    /** System prompt and tool definitions leave no safe room for user input. */
+    contextFixedTooLarge: string;
     /** Conversation-title fallback used in task notifications. */
     notificationTaskFallback: string;
     /** Error after repeated output-token-limit hits (multi-line). {limit} */
@@ -1096,6 +1110,7 @@ export interface TranslationDict {
     appCheckFailed: string;
     // Internal
     checkInternalError: string;
+    checkTimedOut: string;
     // Detail toggle on failed items
     detailShow: string;
     detailHide: string;

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -467,6 +467,45 @@ describe('chatStore', () => {
       expect(conv.messages[0].content).toBe('Hello');
     });
 
+    it('persists Reliable Run Protocol lifecycle and route metadata on the existing user message', async () => {
+      const id = useChatStore.getState().createConversation();
+      const message = {
+        id: 'client-msg-1',
+        role: 'user',
+        content: '/writer draft',
+        timestamp: Date.now(),
+        runId: 'run-1',
+        clientMessageId: 'client-msg-1',
+        runState: 'pending',
+      } as const;
+      useChatStore.getState().addMessage(id, message);
+      vi.mocked(exists).mockResolvedValue(true);
+      vi.mocked(readTextFile).mockResolvedValue(`${JSON.stringify(message)}\n`);
+
+      try {
+        useChatStore.getState().updateUserMessageRun(id, 'client-msg-1', {
+          state: 'accepted',
+          content: 'draft',
+          skill: { name: 'writer', description: 'Write documents' },
+        });
+        await waitForConversationPersistence(id);
+
+        expect(useChatStore.getState().conversations[id].messages[0]).toMatchObject({
+          id: 'client-msg-1',
+          content: 'draft',
+          runState: 'accepted',
+          runId: 'run-1',
+          clientMessageId: 'client-msg-1',
+          skill: { name: 'writer' },
+        });
+      } finally {
+        vi.mocked(exists).mockReset();
+        vi.mocked(exists).mockResolvedValue(false);
+        vi.mocked(readTextFile).mockReset();
+        vi.mocked(readTextFile).mockResolvedValue('');
+      }
+    });
+
     it('exposes a durability barrier for the asynchronous JSONL append', async () => {
       let releaseAppend!: () => void;
       const appendPending = new Promise<void>((resolve) => {
@@ -500,6 +539,20 @@ describe('chatStore', () => {
       } finally {
         vi.mocked(invoke).mockReset();
       }
+    });
+
+    it('rejects the durability barrier when every append path fails', async () => {
+      vi.mocked(invoke).mockRejectedValue(new Error('disk unavailable'));
+      const id = useChatStore.getState().createConversation();
+      useChatStore.getState().addMessage(id, {
+        id: `barrier-failure-${Date.now()}`,
+        role: 'user',
+        content: 'must not execute',
+        timestamp: Date.now(),
+      });
+
+      await expect(waitForConversationPersistence(id)).rejects.toThrow('disk unavailable');
+      vi.mocked(invoke).mockReset();
     });
 
     it('auto-titles from first user message', () => {
@@ -1677,6 +1730,24 @@ describe('chatStore', () => {
   });
 
   describe('sandbox recovery restart sanitization', () => {
+    it.each(['pending', 'accepted', 'running'] as const)(
+      'turns a persisted %s user run into an explicit retryable failure',
+      (runState) => {
+        const [message] = sanitizeLoadedMessages([{
+          id: 'msg-running-before-restart',
+          role: 'user',
+          content: 'continue the task',
+          timestamp: Date.now(),
+          runId: 'run-before-restart',
+          runState,
+        }]);
+
+        expect(message.runState).toBe('failed');
+        expect(message.runError).toBeTruthy();
+        expect(message.runId).toBe('run-before-restart');
+      },
+    );
+
     it.each(['pending', 'enqueued'] as const)(
       'turns interrupted %s recovery into a retryable failed state',
       (action) => {

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -27,10 +27,21 @@ function generateId(): string {
   return Date.now().toString(36) + Math.random().toString(36).substring(2, 8);
 }
 
+const ACTIVE_RUN_STATES = new Set<Message['runState']>(['pending', 'accepted', 'running']);
+
+function recoverInterruptedUserRun(msg: Message): Message {
+  if (msg.role !== 'user' || !ACTIVE_RUN_STATES.has(msg.runState)) return msg;
+  return {
+    ...msg,
+    runState: 'failed',
+    runError: getI18n().chat.runRecoveredAfterRestart,
+  };
+}
+
 /** Extra safety net for messages coming in via import — ensures no streaming
  * flag survives even if the source bundle was built by a broken exporter. */
 export function sanitizeImportedMessage(msg: Message): Message {
-  return {
+  return recoverInterruptedUserRun({
     ...msg,
     isStreaming: false,
     toolCalls: msg.toolCalls?.map((tc) => {
@@ -41,7 +52,7 @@ export function sanitizeImportedMessage(msg: Message): Message {
       } = tc;
       return { ...safeToolCall, isExecuting: false };
     }),
-  };
+  });
 }
 
 /** Strip ghost assistant messages and clear stale isStreaming flags after loading from disk.
@@ -64,11 +75,11 @@ export function sanitizeLoadedMessages(messages: Message[]): Message[] {
             : tc.sandboxRecoveryAction,
         };
       });
-      return {
+      return recoverInterruptedUserRun({
         ...msg,
         isStreaming: false,
         toolCalls,
-      };
+      });
     })
     .filter(msg => {
       if (msg.role !== 'assistant') return true;
@@ -171,20 +182,40 @@ const abortControllers: Map<string, AbortController> = new Map();
 // otherwise the UI can show a completed assistant turn while its fire-and-
 // forget JSONL append/replace is still in flight. Keep the promises grouped
 // by conversation so the dispatch bridge can await only the run it owns.
-const pendingConversationPersistence = new Map<string, Promise<void>>();
+interface ConversationPersistenceState {
+  tail: Promise<void>;
+  firstError?: unknown;
+}
+
+const pendingConversationPersistence = new Map<string, ConversationPersistenceState>();
 
 function trackConversationPersistence(
   convId: string,
   operation: () => Promise<unknown>,
 ): void {
-  const previous = pendingConversationPersistence.get(convId) ?? Promise.resolve();
-  const tracked = previous
+  const state = pendingConversationPersistence.get(convId) ?? {
+    tail: Promise.resolve(),
+  };
+  const tracked = state.tail
+    // A failed write must not permanently poison the serial queue: later
+    // mutations still get a chance to repair disk state. The first error is
+    // retained separately and surfaced by the durability barrier below.
+    .catch(() => undefined)
     .then(operation)
     .then(() => undefined)
-    .catch(() => undefined);
-  pendingConversationPersistence.set(convId, tracked);
-  void tracked.finally(() => {
-    if (pendingConversationPersistence.get(convId) === tracked) {
+    .catch((error: unknown) => {
+      state.firstError ??= error;
+      throw error;
+    });
+  state.tail = tracked;
+  pendingConversationPersistence.set(convId, state);
+  // Attach a rejection handler immediately so fire-and-forget store actions
+  // never produce an unhandled rejection. The error remains in `state` until
+  // an explicit barrier consumes it.
+  void tracked.catch(() => undefined).finally(() => {
+    if (pendingConversationPersistence.get(convId) === state
+      && state.tail === tracked
+      && state.firstError === undefined) {
       pendingConversationPersistence.delete(convId);
     }
   });
@@ -198,10 +229,19 @@ function trackConversationPersistence(
  */
 export async function waitForConversationPersistence(convId: string): Promise<void> {
   while (true) {
-    const pending = pendingConversationPersistence.get(convId);
-    if (!pending) return;
-    await pending;
-    if (pendingConversationPersistence.get(convId) === pending) return;
+    const state = pendingConversationPersistence.get(convId);
+    if (!state) return;
+    const pending = state.tail;
+    try {
+      await pending;
+    } catch {
+      // `firstError` below is the authoritative failure. Keep looping if a
+      // newer queued mutation appeared while this snapshot was in flight.
+    }
+    if (pendingConversationPersistence.get(convId) !== state || state.tail !== pending) continue;
+    pendingConversationPersistence.delete(convId);
+    if (state.firstError !== undefined) throw state.firstError;
+    return;
   }
 }
 
@@ -441,6 +481,17 @@ interface ChatActions {
 
   // New message operations
   editMessage: (convId: string, messageId: string, newContent: string) => void;
+  updateUserMessageRun: (
+    convId: string,
+    messageId: string,
+    patch: {
+      state: NonNullable<Message['runState']>;
+      error?: string;
+      content?: Message['content'];
+      skill?: Message['skill'];
+      delegateAgent?: Message['delegateAgent'];
+    },
+  ) => void;
   deleteMessage: (convId: string, messageId: string, opts?: { skipCatalogBump?: boolean }) => void;
   deleteMessagesFrom: (convId: string, messageId: string) => void;
   deleteLoopMessages: (convId: string, loopId: string) => void;
@@ -1175,6 +1226,34 @@ export const useChatStore = create<ChatStore>()(
       },
 
       // New message operations
+      updateUserMessageRun: (convId, messageId, patch) => {
+        let updatedMessage: Message | undefined;
+        set((state) => {
+          const conv = state.conversations[convId];
+          const message = conv?.messages.find((candidate) => candidate.id === messageId);
+          if (!conv || !message || message.role !== 'user') return;
+
+          message.runState = patch.state;
+          if (patch.error) message.runError = patch.error;
+          else delete message.runError;
+          if ('content' in patch && patch.content !== undefined) message.content = patch.content;
+          if ('skill' in patch) message.skill = patch.skill;
+          if ('delegateAgent' in patch) message.delegateAgent = patch.delegateAgent;
+          conv.updatedAt = Date.now();
+          conv.contextCache = undefined;
+          updatedMessage = { ...message };
+        });
+
+        if (!updatedMessage) return;
+        const messageToPersist = updatedMessage;
+        trackConversationPersistence(
+          convId,
+          () => import('../core/session/conversationStorage').then(({ replaceMessageByIdStrict }) =>
+            replaceMessageByIdStrict(convId, messageToPersist),
+          ),
+        );
+      },
+
       editMessage: (convId, messageId, newContent) => {
         set((state) => {
           const msg = state.conversations[convId]?.messages.find((m) => m.id === messageId);
@@ -1890,11 +1969,17 @@ export const useChatStore = create<ChatStore>()(
         if (!get().conversationIndex[convId]) return;
 
         try {
-          const { loadMessages } = await import('../core/session/conversationStorage');
-          const messages = sanitizeLoadedMessages(await loadMessages(convId));
+          const { loadMessages, replaceMessageById } = await import('../core/session/conversationStorage');
+          const loadedMessages = await loadMessages(convId);
+          const messages = sanitizeLoadedMessages(loadedMessages);
           const meta = get().conversationIndex[convId];
           if (!meta) return;
 
+          const recoveredMessages = messages.filter((message, index) => (
+            message.role === 'user'
+            && message.runState === 'failed'
+            && ACTIVE_RUN_STATES.has(loadedMessages[index]?.runState)
+          ));
           set((state) => {
             state.conversations[convId] = {
               id: meta.id,
@@ -1914,6 +1999,15 @@ export const useChatStore = create<ChatStore>()(
               importedFrom: meta.importedFrom,
             };
           });
+
+          // Recovery persistence is best-effort. The sanitized in-memory
+          // conversation must remain available even if a disk replacement
+          // fails (for example, a transient permission or I/O error). A
+          // failed repair must never fall through to the outer load catch
+          // and replace a successfully-read conversation with an empty one.
+          await Promise.allSettled(
+            recoveredMessages.map((message) => replaceMessageById(convId, message)),
+          );
         } catch {
           // Load failed — create an empty conversation so the chat view still
           // renders (instead of falling through to the welcome page)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -245,6 +245,17 @@ export interface Message {
   isStreaming?: boolean;
   /** Persisted terminal reason for an assistant turn that the user stopped. */
   stopReason?: 'user';
+  /**
+   * Durable shell-owned lifecycle for a user message dispatched to the
+   * sidecar. The message is appended before any asynchronous preparation so
+   * it can never disappear when the sidecar handshake stalls or fails.
+   */
+  runState?: 'pending' | 'accepted' | 'running' | 'completed' | 'failed' | 'interrupted';
+  /** Stable correlation ids for Reliable Run Protocol V1. */
+  runId?: string;
+  clientMessageId?: string;
+  /** User-facing detail retained when dispatch reaches a failed terminal. */
+  runError?: string;
   toolCalls?: ToolCall[];
   // Extended thinking content
   thinking?: string;

--- a/tests/e2e/diagnostic-export.spec.ts
+++ b/tests/e2e/diagnostic-export.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * Offline diagnostic export through the real Electron renderer/main bridge.
+ * The isolated E2E app-data root also owns Electron's Downloads directory, so
+ * this journey cannot leave a bundle in the developer's real home directory.
+ */
+import { expect, test } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { strFromU8, unzipSync } from 'fflate';
+import type { ElectronApplication, Page } from 'playwright';
+import {
+  closeAbuElectron,
+  createElectronDataRoot,
+  launchAbuElectron,
+  removeElectronDataRoot,
+  type ElectronDataRoot,
+} from './electronHelpers';
+
+const READY_TIMEOUT = 45_000;
+const CHAT_PLACEHOLDER = '想让阿布帮你做点什么？';
+
+async function waitForApp(page: Page): Promise<void> {
+  await page.waitForLoadState('domcontentloaded');
+  await expect(page.getByPlaceholder(CHAT_PLACEHOLDER)).toBeVisible({ timeout: READY_TIMEOUT });
+}
+
+async function dismissFirstRunOverlays(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const raw = window.localStorage.getItem('abu-settings');
+    if (!raw) throw new Error('abu-settings was not initialized before E2E configuration');
+    const persisted = JSON.parse(raw) as { state: Record<string, unknown>; version: number };
+    Object.assign(persisted.state, {
+      guideShown: true,
+      guideOpen: false,
+      hasAcknowledgedDisclaimer: true,
+      hasRunSensitiveAudit_v015: true,
+    });
+    window.localStorage.setItem('abu-settings', JSON.stringify(persisted));
+  });
+  await page.reload();
+  await waitForApp(page);
+}
+
+let app: ElectronApplication | undefined;
+let dataRoot: ElectronDataRoot | undefined;
+
+test.describe.serial('Electron diagnostic export', () => {
+  test.afterEach(async () => {
+    if (app) {
+      await closeAbuElectron(app);
+      app = undefined;
+    }
+    if (dataRoot) {
+      removeElectronDataRoot(dataRoot);
+      dataRoot = undefined;
+    }
+  });
+
+  test('rechecks live state and exports a manifest plus run timeline', async () => {
+    dataRoot = createElectronDataRoot();
+    const launched = await launchAbuElectron(dataRoot);
+    app = launched.app;
+    const page = await app.firstWindow({ timeout: READY_TIMEOUT });
+    await waitForApp(page);
+    await dismissFirstRunOverlays(page);
+
+    await page.getByRole('button', { name: /^(我|Me)$/ }).first().click();
+    await page.getByRole('menuitem', { name: /^(设置|Settings)$/ }).click();
+    await page.getByRole('button', { name: /^(反馈|Feedback)$/ }).click();
+
+    await expect(page.getByText(/提交时会实时重检|Rechecked at submission/)).toBeVisible();
+    await page.getByRole('button', { name: /导出离线诊断包|Save offline bundle/ }).click();
+    await expect(page.getByText(/已导出诊断包|Bundle exported/)).toBeVisible({ timeout: READY_TIMEOUT });
+
+    await page.getByRole('button', { name: /查看包内清单|View contents/ }).click();
+    await expect(page.getByText('manifest.json', { exact: true })).toBeVisible();
+    await expect(page.getByText('diagnostic-snapshot.json', { exact: true })).toBeVisible();
+    await expect(page.getByText('runtime/run-timeline.json', { exact: true })).toBeVisible();
+
+    const exportDir = path.join(dataRoot.appDataDir, 'Downloads', 'Abu-Diagnostic');
+    await expect.poll(() => {
+      try {
+        return fs.readdirSync(exportDir).filter((name) => name.endsWith('.zip')).length;
+      } catch {
+        return 0;
+      }
+    }, { timeout: READY_TIMEOUT }).toBe(1);
+
+    const bundleName = fs.readdirSync(exportDir).find((name) => name.endsWith('.zip'));
+    expect(bundleName).toBeTruthy();
+    const archive = unzipSync(new Uint8Array(fs.readFileSync(path.join(exportDir, bundleName!))));
+    const manifest = JSON.parse(strFromU8(archive['manifest.json'])) as {
+      schemaVersion?: unknown;
+      missingRequiredFiles?: unknown;
+    };
+    const snapshot = JSON.parse(strFromU8(archive['diagnostic-snapshot.json'])) as {
+      schemaVersion?: unknown;
+      checkStartedAt?: unknown;
+      freshness?: unknown;
+    };
+    const timeline = JSON.parse(strFromU8(archive['runtime/run-timeline.json'])) as {
+      schemaVersion?: unknown;
+      runs?: unknown;
+    };
+
+    expect(manifest).toMatchObject({ schemaVersion: 1, missingRequiredFiles: [] });
+    expect(snapshot.schemaVersion).toBe(2);
+    expect(snapshot.checkStartedAt).toEqual(expect.any(Number));
+    expect(['fresh', 'unknown']).toContain(snapshot.freshness);
+    expect(timeline.schemaVersion).toBe(1);
+    expect(Array.isArray(timeline.runs)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What changed

- Make every agent turn durable before execution and terminal settlement.
- Add a bounded agent.start handshake, idempotent run-state lookup, sidecar recovery, and deterministic Stop finalization.
- Enforce one live owner per conversation across sidecar, in-process, image, IM, trigger, and scheduler paths.
- Improve context budgeting, bundled Windows Python launcher parsing, and diagnostic manifests/run timelines.

## Why

Users reported conversations that could stall, lose their final lifecycle state, or be difficult to diagnose across renderer, Electron, sidecar, and provider boundaries. This makes those boundaries explicit and recoverable.

## Validation

- npm run verify: 349 files / 4788 tests passed
- Electron E2E: 5/5 passed (restart, Stop, abrupt termination, sidecar crash recovery, diagnostic export)
- Build, sidecar build, Electron dev preflight, and independent quality review passed
- Windows host tests: 22 passed