### PR TITLE
fix(release): publish updater blockmaps

### DIFF
--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -79,8 +79,9 @@ switch the Tauri `latest.json` last.
 
 ## 5. Post-release
 
-- [ ] Confirm the GitHub Release contains the two DMGs and Windows setup EXE,
-      with matching update metadata and blockmaps.
+- [ ] Confirm the GitHub Release contains the two DMGs and Windows setup EXE.
+- [ ] Confirm all three public Electron feeds reference the release version and
+      each feed artifact plus its external `.blockmap` returns HTTP 200.
 - [ ] Real-machine smoke the published build (especially Windows / a machine without Node).
 - [ ] Keep v0.33.0 artifacts and the pre-release root `latest.json` available
       throughout the v0.34 transition window.

--- a/scripts/electron-release-workflow.test.mjs
+++ b/scripts/electron-release-workflow.test.mjs
@@ -626,6 +626,7 @@ test('release publishes only after all Electron targets and switches root pointe
   assert.match(immutableStep.run, /X-Oss-Forbid-Overwrite:true/);
   assert.match(immutableStep.run, /200\)[\s\S]*cmp "release-stage\/\$local" "\$downloaded"/);
   assert.match(immutableStep.run, /404\)[\s\S]*ossutil cp/);
+  assert.match(immutableStep.run, /done < release-stage\/content-map\.tsv/);
 
   const releaseSource = fs.readFileSync(
     path.join(root, '.github', 'workflows', 'release.yml'),

--- a/scripts/stage-electron-transition-release.mjs
+++ b/scripts/stage-electron-transition-release.mjs
@@ -85,14 +85,18 @@ function validateUpdaterFeed({ sourceDir, metadataName, version, requiredExtensi
     copied.push(filename);
 
     const blockmap = `${source}.blockmap`;
-    if (entry.blockMapSize !== undefined) {
-      if (!fs.existsSync(blockmap)) throw new Error(`missing blockmap for ${filename}`);
-      if (Number(entry.blockMapSize) !== fs.statSync(blockmap).size) {
-        throw new Error(`${metadataName} blockmap size mismatch for ${filename}`);
-      }
-      copy(blockmap, path.join(destination, `${filename}.blockmap`));
-      copied.push(`${filename}.blockmap`);
+    const hasBlockmap = fs.existsSync(blockmap);
+    if (!hasBlockmap) {
+      throw new Error(`missing blockmap for ${filename}`);
     }
+    if (
+      entry.blockMapSize !== undefined &&
+      Number(entry.blockMapSize) !== fs.statSync(blockmap).size
+    ) {
+      throw new Error(`${metadataName} blockmap size mismatch for ${filename}`);
+    }
+    copy(blockmap, path.join(destination, `${filename}.blockmap`));
+    copied.push(`${filename}.blockmap`);
   }
   copy(metadataPath, path.join(destination, metadataName));
   return { metadata, copied };

--- a/scripts/stage-electron-transition-release.test.mjs
+++ b/scripts/stage-electron-transition-release.test.mjs
@@ -36,6 +36,13 @@ function writeFeed(directory, metadataName, version, artifactName) {
   );
 }
 
+function omitBlockMapSize(directory, metadataName) {
+  const metadataPath = path.join(directory, metadataName);
+  const metadata = YAML.parse(fs.readFileSync(metadataPath, 'utf8'));
+  for (const entry of metadata.files) delete entry.blockMapSize;
+  fs.writeFileSync(metadataPath, YAML.stringify(metadata));
+}
+
 function fixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'abu-release-stage-test-'));
   const input = path.join(root, 'input');
@@ -108,6 +115,68 @@ test('stages all three transition platforms and three isolated updater feeds', (
       /electron\/win-x64\/Abu-0\.34\.0-windows-x64-setup\.exe/
     );
     assert.equal(result.checksums.every((entry) => entry.sha256.length === 64), true);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('stages existing external blockmaps when feed entries omit blockMapSize', () => {
+  const fx = fixture();
+  const output = path.join(fx.root, 'output');
+  try {
+    omitBlockMapSize(path.join(fx.input, 'mac-arm64'), 'latest-mac.yml');
+    omitBlockMapSize(path.join(fx.input, 'mac-x64'), 'latest-mac.yml');
+    omitBlockMapSize(path.join(fx.input, 'windows-x64'), 'latest.yml');
+
+    stageRelease({
+      input: fx.input,
+      output,
+      version: 'v0.34.0',
+      repo: 'PM-Shawn/Abu-Cowork',
+      releaseBaseUrl: 'https://example.invalid/releases/v0.34.0',
+      changelogEn: fx.changelogEn,
+      changelogZh: fx.changelogZh,
+    });
+
+    for (const relative of [
+      'feeds/mac-arm64/Abu-0.34.0-arm64.zip.blockmap',
+      'feeds/mac-x64/Abu-0.34.0-x64.zip.blockmap',
+      'feeds/win-x64/Abu-0.34.0-windows-x64-setup.exe.blockmap',
+    ]) {
+      assert.equal(fs.existsSync(path.join(output, relative)), true, relative);
+    }
+    const contentMap = fs.readFileSync(path.join(output, 'content-map.tsv'), 'utf8');
+    assert.match(contentMap, /electron\/mac-arm64\/Abu-0\.34\.0-arm64\.zip\.blockmap/);
+    assert.match(contentMap, /electron\/mac-x64\/Abu-0\.34\.0-x64\.zip\.blockmap/);
+    assert.match(
+      contentMap,
+      /electron\/win-x64\/Abu-0\.34\.0-windows-x64-setup\.exe\.blockmap/,
+    );
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('rejects a feed whose external blockmap metadata and file are both absent', () => {
+  const fx = fixture();
+  try {
+    const arm = path.join(fx.input, 'mac-arm64');
+    omitBlockMapSize(arm, 'latest-mac.yml');
+    fs.rmSync(path.join(arm, 'Abu-0.34.0-arm64.zip.blockmap'));
+
+    assert.throws(
+      () =>
+        stageRelease({
+          input: fx.input,
+          output: path.join(fx.root, 'output'),
+          version: 'v0.34.0',
+          repo: 'PM-Shawn/Abu-Cowork',
+          releaseBaseUrl: 'https://example.invalid/releases/v0.34.0',
+          changelogEn: fx.changelogEn,
+          changelogZh: fx.changelogZh,
+        }),
+      /missing blockmap for Abu-0\.34\.0-arm64\.zip/,
+    );
   } finally {
     fs.rmSync(fx.root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What changed

- stage each updater artifact's sibling external blockmap even when electron-builder omits `blockMapSize`
- fail release staging when a referenced updater artifact has no blockmap
- cover the three feed channels, immutable content-map upload, and public HTTP acceptance checklist

## Root cause

Electron-builder 26 writes external blockmap files without adding `blockMapSize` to current feed entries. Release staging treated that optional metadata field as the signal to copy the sibling file, so the full artifacts were published but all differential-update blockmaps were omitted.

## Validation

- `npm run build`
- `npm run verify` (4801 tests)
- `npm run test:electron:release-stage`
- `npm run test:electron:release-workflow`
- `npm run parity:check`
- `bash scripts/enterprise-leak-guard.sh`
- `npm run electron:dev:check`
- two independent `codex review --uncommitted` passes; one P2 was fixed, final pass found no correctness regression

Closes #182