### PR TITLE
docs: place language switch below README covers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
-**English** | [中文](README.zh-CN.md)
-
 <img src="website/assets/readme-cover.en.jpg" alt="Abu — Your AI Desktop Office Assistant" width="100%" />
+
+**English** | [中文](README.zh-CN.md)
 
 # Abu
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,8 +1,8 @@
 <div align="center">
 
-[English](README.md) | **中文**
-
 <img src="website/assets/readme-cover.zh-CN.jpg" alt="Abu — 你的 AI 桌面办公搭子" width="100%" />
+
+[English](README.md) | **中文**
 
 # Abu (阿布)
 


### PR DESCRIPTION
## What changed

- Move the English/Chinese language switch below the README cover image.
- Apply the same visual order to both English and Simplified Chinese README files.

## Why

The cover should be the repository README first visual. Placing the language switch above it interrupts the brand presentation and creates an unnecessary navigation row before the hero image.

## Validation

- npm run build
- npm run lint
- git diff --check