### PR TITLE
fix(chat): make Stop and queued follow-ups deterministic

### DIFF
--- a/sidecar/src/main.ts
+++ b/sidecar/src/main.ts
@@ -56,15 +56,11 @@
  *   - `agent.abort` → P1-3B-3A: abort one in-flight `agent.run` call by
  *     runId (idempotent, unknown runId silent no-op, same discipline)
  *   - `agent.enqueueInput` → P1-3B-3B, extended by P1-3B-4: `{runId, message
- *     | userMessage, queueId?, isSystem?}` — either (a) the shell
- *     dispatcher's concurrency guard staging a message into an
- *     already-running conversation's run instead of starting a second
- *     agent.run (`userMessage`, no `queueId` — no shell-queue chip to
- *     correlate), or (b) the shell's queued-input forwarder relaying a NEW
- *     entry added to the shell's `userInputQueue` (chip strip) for a
- *     conversation with an active sidecar run (`message` + `queueId`,
- *     id-preserved so `input.consumed` can clear the exact chip once this
- *     run's loop consumes it). Unknown runId silent drop.
+ *     | userMessage, queueId?, isSystem?}` — the shell's queue forwarder
+ *     relays internal system wake-ups into an active run (`message` +
+ *     `queueId`, id-preserved for `input.consumed`). The `userMessage` shape
+ *     remains accepted for backward compatibility, but new user follow-ups
+ *     stay shell-side and start independent runs. Unknown runId silent drop.
  *   - `state.convPatch` → P1-3B-3A: `{runId, patch}` — scalar-field patch
  *     (workspacePath/title/activeSkills/model) applied to that run's
  *     conversation read-mirror. Unknown runId silent drop.
@@ -83,10 +79,8 @@
  *   - `input.consumed` → P1-3B-4: `{ runId, queueIds }` — the sidecar's
  *     `userInputQueue` shim (see shims/userInputQueueRun.ts) sends this
  *     after `agentLoop.ts` drains or clears queued inputs, naming exactly
- *     the ids it consumed. `agentLoopRunner.ts`'s handler removes the same
- *     ids from the shell's `userInputQueue` — clearing the `QueuedMessages
- *     Strip` chip only once the loop actually consumed the message (not a
- *     flash-then-clear). Unknown runId silent drop.
+ *     the ids it consumed. `agentLoopRunner.ts` removes the same system ids
+ *     from the shell queue. Unknown runId silent drop.
  * Reverse requests sidecar→shell (see rpcClient.ts, subagentRunner.ts):
  *   - `tool.invoke` → `{ runId, toolName, input, context }`, response = the
  *     tool's `ToolResult`

--- a/sidecar/src/shims/userInputQueueRun.test.ts
+++ b/sidecar/src/shims/userInputQueueRun.test.ts
@@ -15,7 +15,9 @@ import {
   getQueuedInputs,
   removeQueuedInput,
   hasQueuedInputs,
+  hasSystemQueuedInputs,
   drainQueuedInputs,
+  drainSystemQueuedInputs,
   clearInputQueue,
 } from './userInputQueueRun';
 
@@ -95,6 +97,24 @@ describe('userInputQueueRun shim', () => {
 
       expect(drained.map((qi) => qi.text)).toEqual(['one']);
       expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('drainSystemQueuedInputs — selective consumed-notify', () => {
+    it('notifies only system ids and leaves user follow-ups queued', () => {
+      const spy = vi.spyOn(rpcClient, 'sendNotification').mockImplementation(() => {});
+      enqueueUserInputWithId(CONV, 'user-1', 'later');
+      enqueueUserInputWithId(CONV, 'system-1', 'background result', true);
+
+      const drained = agentRunContext.run(
+        makeAgentCtx({ runId: 'run-42', conversationId: CONV }),
+        () => drainSystemQueuedInputs(CONV),
+      );
+
+      expect(drained.map((item) => item.id)).toEqual(['system-1']);
+      expect(hasSystemQueuedInputs(CONV)).toBe(false);
+      expect(getQueuedInputs(CONV).map((item) => item.id)).toEqual(['user-1']);
+      expect(spy).toHaveBeenCalledWith('input.consumed', { runId: 'run-42', queueIds: ['system-1'] });
     });
   });
 

--- a/sidecar/src/shims/userInputQueueRun.ts
+++ b/sidecar/src/shims/userInputQueueRun.ts
@@ -7,11 +7,9 @@
  * bundled into the sidecar as a plain module, giving the sidecar its OWN
  * separate module instance (a fresh, empty `inputQueues` Map) disconnected
  * from the shell's. `agentLoop.ts` (which now runs INSIDE the sidecar for a
- * sidecar-dispatched run) calls `drainQueuedInputs`/`hasQueuedInputs`/
- * `clearInputQueue` against THAT instance, never the shell's — so a message
- * the UI staged via the shell's `enqueueUserInput` (which drives the
- * `QueuedMessagesStrip` chip) was never seen by the sidecar-run loop: the
- * chip never cleared, the message never ran.
+ * sidecar-dispatched run) calls the queue APIs against THAT instance, never
+ * the shell's — so an internal wake-up staged shell-side was previously never
+ * seen by the sidecar loop.
  *
  * The fix keeps the shell's `userInputQueue` as the single UI source of
  * truth (the chip). This shim does NOT reimplement the queue — it wraps the
@@ -20,22 +18,20 @@
  * side effect: after the loop drains/clears queued entries from the
  * sidecar's own (real, unchanged) queue instance, notify the shell via
  * `input.consumed { runId, queueIds }` so `agentLoopRunner.ts`'s handler can
- * `removeQueuedInput` the SAME ids from the shell's queue — clearing the
- * chip exactly when the loop actually consumes it (lingers until consumed,
- * matching in-process; never a flash-then-clear).
+ * `removeQueuedInput` the same system ids from the shell's queue.
  *
  * The other half of the bridge — NEW entries reaching the sidecar's queue in
  * the first place — is NOT this shim's job:
- *   - Leftover-at-dispatch: `agentLoopHost.ts`'s `handleAgentRun` seeds this
+ *   - System wake-up at dispatch: `agentLoopHost.ts` seeds this
  *     module (via `enqueueUserInputWithId`, id-preserving) from the
  *     `agent.run` params' `queuedInputs` snapshot, BEFORE the loop starts —
- *     so `agentLoop.ts`'s turn-1 `drainQueuedInputs` (agentLoop.ts:990)
- *     picks it up.
- *   - Mid-run add: `agentLoopHost.ts`'s `handleAgentEnqueueInput` (the
+ *     so `agentLoop.ts`'s selective system drain picks it up.
+ *   - Mid-run system add: `agentLoopHost.ts`'s `handleAgentEnqueueInput` (the
  *     `agent.enqueueInput` notification handler) calls
  *     `enqueueUserInputWithId` directly when the shell's forwarder
  *     (`agentLoopRunner.ts`) observes a new shell-queue entry for a
- *     conversation with an active sidecar `RunSession`.
+ *     conversation with an active sidecar `RunSession`. User follow-ups are
+ *     never forwarded; the shell starts them as independent runs.
  *
  * ── runId resolution for the consumed-notify ─────────────────────────────
  * `drainQueuedInputs`/`clearInputQueue` take a `conversationId`, not a
@@ -57,8 +53,13 @@ import {
   getQueuedInputs as realGetQueuedInputs,
   removeQueuedInput as realRemoveQueuedInput,
   drainQueuedInputs as realDrainQueuedInputs,
+  drainSystemQueuedInputs as realDrainSystemQueuedInputs,
   hasQueuedInputs as realHasQueuedInputs,
+  hasSystemQueuedInputs as realHasSystemQueuedInputs,
   getQueuedInputCount as realGetQueuedInputCount,
+  isUserInputQueuePaused as realIsUserInputQueuePaused,
+  pauseUserInputQueue as realPauseUserInputQueue,
+  resumeUserInputQueue as realResumeUserInputQueue,
   clearInputQueue as realClearInputQueue,
   subscribeToInputQueue as realSubscribeToInputQueue,
   getInputQueueSnapshot as realGetInputQueueSnapshot,
@@ -78,7 +79,11 @@ export const enqueueUserInputWithId = realEnqueueUserInputWithId;
 export const getQueuedInputs = realGetQueuedInputs;
 export const removeQueuedInput = realRemoveQueuedInput;
 export const hasQueuedInputs = realHasQueuedInputs;
+export const hasSystemQueuedInputs = realHasSystemQueuedInputs;
 export const getQueuedInputCount = realGetQueuedInputCount;
+export const isUserInputQueuePaused = realIsUserInputQueuePaused;
+export const pauseUserInputQueue = realPauseUserInputQueue;
+export const resumeUserInputQueue = realResumeUserInputQueue;
 export const subscribeToInputQueue = realSubscribeToInputQueue;
 export const getInputQueueSnapshot = realGetInputQueueSnapshot;
 
@@ -92,6 +97,13 @@ function notifyConsumed(queueIds: string[]): void {
 /** Real drain — then notify the shell of exactly the ids this call drained. */
 export function drainQueuedInputs(conversationId: string): QueuedInput[] {
   const items = realDrainQueuedInputs(conversationId);
+  notifyConsumed(items.map((qi) => qi.id));
+  return items;
+}
+
+/** Selective real drain used by the active loop; user follow-ups stay shell-side. */
+export function drainSystemQueuedInputs(conversationId: string): QueuedInput[] {
+  const items = realDrainSystemQueuedInputs(conversationId);
   notifyConsumed(items.map((qi) => qi.id));
   return items;
 }

--- a/src/__tests__/agentPipeline.integration.test.ts
+++ b/src/__tests__/agentPipeline.integration.test.ts
@@ -181,9 +181,12 @@ vi.mock('../core/agent/permissionBridge', () => ({
 
 vi.mock('../core/agent/userInputQueue', () => ({
   drainQueuedInputs: vi.fn().mockReturnValue([]),
+  drainSystemQueuedInputs: vi.fn().mockReturnValue([]),
   clearInputQueue: vi.fn(),
   hasQueuedInputs: vi.fn().mockReturnValue(false),
+  hasSystemQueuedInputs: vi.fn().mockReturnValue(false),
   enqueueUserInput: vi.fn(),
+  pauseUserInputQueue: vi.fn(),
 }));
 
 vi.mock('../core/agent/executionSnapshot', () => ({
@@ -613,11 +616,11 @@ describe('Agent Pipeline Integration', () => {
       expect(execs.every((e) => e.plannedSteps.length === 0)).toBe(true);
     });
 
-    it('drained queued messages surface as user bubbles at consumption time', async () => {
-      const { drainQueuedInputs } = await import('../core/agent/userInputQueue');
+    it('drained system wake-ups remain hidden user-context messages', async () => {
+      const { drainSystemQueuedInputs } = await import('../core/agent/userInputQueue');
       const convId = useChatStore.getState().createConversation();
-      vi.mocked(drainQueuedInputs).mockReturnValueOnce([
-        { id: 'q1', text: '数完说你好', timestamp: 123 },
+      vi.mocked(drainSystemQueuedInputs).mockReturnValueOnce([
+        { id: 'q1', text: '后台任务完成', timestamp: 123, isSystem: true },
       ]);
       mockClaudeChat.mockImplementation(
         async (_m: unknown, _o: unknown, onEvent: (e: StreamEvent) => void) => {
@@ -629,9 +632,9 @@ describe('Agent Pipeline Integration', () => {
       await runAgentLoop(convId, '从1数到3');
 
       const conv = useChatStore.getState().conversations[convId];
-      const queuedMsg = conv.messages.find((m) => m.role === 'user' && m.content === '数完说你好');
+      const queuedMsg = conv.messages.find((m) => m.role === 'user' && m.content === '后台任务完成');
       expect(queuedMsg).toBeDefined();
-      expect(queuedMsg?.isSystem).toBeFalsy();
+      expect(queuedMsg?.isSystem).toBe(true);
     });
 
     it('keeps an aborted turn that already streamed partial text', async () => {
@@ -684,13 +687,13 @@ describe('Agent Pipeline Integration', () => {
       expect(useChatStore.getState().conversations[convId].activeSkills).toEqual([]);
     });
 
-    it('resets the no-progress counter when a queued-input override rescues the loop (review finding [5])', async () => {
+    it('resets the no-progress counter when a system wake-up rescues the loop (review finding [5])', async () => {
       // Without the reset, a mid-stream user rescue buys only ONE more turn before
       // the (still-3) counter trips. With it, the full 3-turn tolerance is restored:
       // turns 1-3 trip the guard, the rescue at turn 3 resets it, turns 4-6 trip it
       // again → stop at turn 6 (calls===6). Without the reset it would stop at turn 4.
-      const { hasQueuedInputs } = await import('../core/agent/userInputQueue');
-      vi.mocked(hasQueuedInputs).mockReturnValueOnce(true); // rescue exactly once (turn 3)
+      const { hasSystemQueuedInputs } = await import('../core/agent/userInputQueue');
+      vi.mocked(hasSystemQueuedInputs).mockReturnValueOnce(true); // rescue exactly once (turn 3)
 
       let calls = 0;
       mockClaudeChat.mockImplementation(
@@ -708,17 +711,8 @@ describe('Agent Pipeline Integration', () => {
       expect(calls).toBe(6);
     });
 
-    it('surfaces staged queue messages as user bubbles when the loop aborts (F5)', async () => {
-      // Regression: the abort path called clearInputQueue directly, silently
-      // destroying messages the user staged mid-loop. They must land in the
-      // transcript instead — the aborted loop can't answer them, but the text
-      // has to stay visible.
-      const { drainQueuedInputs } = await import('../core/agent/userInputQueue');
-      // Drain is called at the top of each loop iteration AND (now) in the
-      // abort path: 1st call = loop top (empty), 2nd call = abort drain (item).
-      vi.mocked(drainQueuedInputs)
-        .mockReturnValueOnce([])
-        .mockReturnValueOnce([{ id: 'q9', text: '别丢了我', timestamp: 1 }]);
+    it('pauses staged user follow-ups instead of attaching them to the aborted run', async () => {
+      const { pauseUserInputQueue, drainSystemQueuedInputs } = await import('../core/agent/userInputQueue');
       const convId = useChatStore.getState().createConversation();
       mockClaudeChat.mockImplementation(async () => {
         const err = new Error('Aborted');
@@ -729,9 +723,11 @@ describe('Agent Pipeline Integration', () => {
       const result = await runAgentLoop(convId, 'abort with staged input');
 
       expect(result.reason).toBe('aborted');
-      const conv = useChatStore.getState().conversations[convId];
-      const staged = conv.messages.find((m) => m.role === 'user' && m.content === '别丢了我');
-      expect(staged).toBeDefined();
+      expect(pauseUserInputQueue).toHaveBeenCalledWith(convId);
+      expect(drainSystemQueuedInputs).toHaveBeenCalledWith(convId);
+      expect(useChatStore.getState().conversations[convId].messages).not.toContainEqual(
+        expect.objectContaining({ role: 'user', content: '别丢了我' }),
+      );
     });
 
     it('rejects an image-only send during a running in-process loop instead of starting a second stream (F6)', async () => {

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -34,40 +34,8 @@ import { cn } from '@/lib/utils';
 import { isMacOS } from '@/utils/platform';
 import { Input } from '@/components/ui/input';
 import UsageChip from './UsageChip';
-
-/**
- * Groups messages by loopId for rendering.
- * Messages with the same loopId are grouped together and rendered as one visual block.
- * Messages without loopId (legacy) are each treated as their own group.
- */
-function groupMessagesByLoop(messages: Message[]): Message[][] {
-  const groups: Message[][] = [];
-  let currentGroup: Message[] = [];
-  let currentLoopId: string | undefined | null = null;
-
-  for (const msg of messages) {
-    const msgLoopId = msg.loopId;
-
-    // If loopId changes, or message has no loopId (undefined !== undefined should start new group)
-    if (!msgLoopId || msgLoopId !== currentLoopId) {
-      if (currentGroup.length > 0) {
-        groups.push(currentGroup);
-      }
-      currentGroup = [msg];
-      currentLoopId = msgLoopId;
-    } else {
-      // Same loopId - add to current group
-      currentGroup.push(msg);
-    }
-  }
-
-  // Don't forget the last group
-  if (currentGroup.length > 0) {
-    groups.push(currentGroup);
-  }
-
-  return groups;
-}
+import { shouldShowTypingIndicator } from './typingIndicator';
+import { groupMessagesByLoop } from './messageGrouping';
 
 /**
  * Context passed to the Virtuoso `Footer` component (the streaming typing
@@ -116,15 +84,18 @@ const VirtuosoTypingFooter: NonNullable<Components<Message[], MessageListContext
 }) => {
   if (!context?.showTypingIndicator) return null;
   return (
-    <div className="flex items-center gap-3 pl-9 py-1">
-      <div className="flex items-center gap-1">
+    <div className="flex items-center gap-3 py-1">
+      <div className="w-7 h-7 rounded-full overflow-hidden shrink-0">
+        <img src={abuAvatar} alt="Abu" className="w-full h-full object-cover" />
+      </div>
+      <div className="flex items-center gap-1.5 py-2">
+        <span className="text-minor text-[var(--abu-text-muted)]">
+          {context.retryingLabel ?? context.thinkingLabel}
+        </span>
         <span className="typing-dot w-1.5 h-1.5 rounded-full bg-[var(--abu-clay-60)]" />
         <span className="typing-dot w-1.5 h-1.5 rounded-full bg-[var(--abu-clay-60)]" />
         <span className="typing-dot w-1.5 h-1.5 rounded-full bg-[var(--abu-clay-60)]" />
       </div>
-      <span className="text-body text-[var(--abu-text-tertiary)]">
-        {context.retryingLabel ?? context.thinkingLabel}
-      </span>
     </div>
   );
 };
@@ -709,9 +680,10 @@ export default function ChatView() {
             // srcdoc reload + in-widget JS state reset that a bare unmount causes.
             increaseViewportBy={{ top: 900, bottom: 900 }}
             context={{
-              // Typing indicator - brief flash before assistant message is created
-              showTypingIndicator:
-                activeConv?.status === 'running' && messages.every((m) => m.role === 'user'),
+              // Covers the gap before the next assistant placeholder is created.
+              // This occurs both on a normal send and when a staged queue item
+              // is consumed after earlier assistant turns already exist.
+              showTypingIndicator: shouldShowTypingIndicator(activeConv?.status, visibleMessages),
               retryingLabel: retryInfo
                 ? format(t.chat.retrying, { attempt: retryInfo.attempt, max: retryInfo.maxAttempts })
                 : null,

--- a/src/components/chat/MessageBubble.test.tsx
+++ b/src/components/chat/MessageBubble.test.tsx
@@ -1,0 +1,76 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { initLanguage } from '@/i18n';
+import { useChatStore } from '@/stores/chatStore';
+import type { Conversation, Message } from '@/types';
+import MessageBubble from './MessageBubble';
+
+vi.mock('./MarkdownRenderer', () => ({
+  default: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+vi.mock('./ToolCallsGroup', () => ({
+  default: () => null,
+  InlineToolResultImages: () => null,
+}));
+
+vi.mock('@/core/agent/agentLoopRunner', () => ({
+  runAgentLoopDispatched: vi.fn(),
+}));
+
+const baseMessage: Message = {
+  id: 'message-1',
+  role: 'user',
+  content: '看看我桌面上有什么',
+  timestamp: 0,
+};
+
+function setConversation(message: Message, status: Conversation['status']): void {
+  const conversation: Conversation = {
+    id: 'conversation-1',
+    title: 'test',
+    messages: [message],
+    createdAt: 0,
+    updatedAt: 0,
+    status,
+  };
+  useChatStore.setState({
+    activeConversationId: conversation.id,
+    conversations: { [conversation.id]: conversation },
+  });
+}
+
+describe('MessageBubble user run status', () => {
+  beforeEach(() => {
+    initLanguage('en-US');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it.each(['pending', 'accepted', 'running', 'recovering', 'interrupted'] as const)(
+    'hides the internal %s lifecycle state',
+    (runState) => {
+      const message = { ...baseMessage, runState };
+      setConversation(message, runState === 'interrupted' ? 'idle' : 'running');
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText(baseMessage.content as string)).toBeInTheDocument();
+      expect(screen.queryByText(/Sending|Accepted|Running|Recovering|Stopped/)).not.toBeInTheDocument();
+    },
+  );
+
+  it('keeps an actionable failure and retry control visible', () => {
+    const message = { ...baseMessage, runState: 'failed' as const, runError: 'network unavailable' };
+    setConversation(message, 'idle');
+
+    render(<MessageBubble message={message} />);
+
+    expect(screen.getByText('Send failed')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+});

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -430,6 +430,7 @@ export default function MessageBubble({
   const [isTextExpanded, setIsTextExpanded] = useState(false);
   const activeConv = useActiveConversation();
   const isConvRunning = activeConv?.status === 'running';
+  const hasRunFailure = message.runState === 'failed' || message.runState === 'connection-failed';
 
   const textContent = getTextContent(message.content);
   const imageBlocks = getImageBlocks(message.content);
@@ -642,29 +643,16 @@ export default function MessageBubble({
                   })()}
                 </div>
               )}
-              {message.runState && message.runState !== 'completed' && (
-                <div
-                  className={cn(
-                    'flex items-center gap-1.5 text-caption',
-                    message.runState === 'failed' || message.runState === 'connection-failed'
-                      ? 'text-[var(--abu-danger)]'
-                      : 'text-[var(--abu-text-muted)]',
-                  )}
-                  title={message.runError}
-                >
-                  {(message.runState === 'pending' || message.runState === 'accepted' || message.runState === 'running' || message.runState === 'recovering') && (
-                    <RefreshCw className="h-3 w-3 animate-spin" />
-                  )}
+              {/* Reliable-run progress is internal. The assistant activity row already
+                  communicates that work is in progress; only actionable failures belong
+                  under the user's message. */}
+              {hasRunFailure && (
+                <div className="flex items-center gap-1.5 text-caption text-[var(--abu-danger)]" title={message.runError}>
                   <span>
-                    {message.runState === 'pending' && t.chat.runPending}
-                    {message.runState === 'accepted' && t.chat.runAccepted}
-                    {message.runState === 'running' && t.chat.runRunning}
-                    {message.runState === 'recovering' && t.chat.runRecovering}
                     {message.runState === 'failed' && t.chat.runFailed}
                     {message.runState === 'connection-failed' && t.chat.runConnectionFailed}
-                    {message.runState === 'interrupted' && t.chat.runInterrupted}
                   </span>
-                  {(message.runState === 'failed' || message.runState === 'connection-failed') && !isConvRunning && (
+                  {!isConvRunning && (
                     <Button variant="ghost" size="xs" onClick={handleRunRetry}>
                       <RefreshCw className="h-3 w-3" />
                       {t.chat.runRetry}

--- a/src/components/chat/MessageGroup.segments.test.ts
+++ b/src/components/chat/MessageGroup.segments.test.ts
@@ -3,7 +3,13 @@
  * that interleaves text, tool-step, and mid-loop user-bubble segments.
  */
 import { describe, it, expect } from 'vitest';
-import { buildRenderSegments, computeWorkProcessFold, streamingTurnHasRenderableContent } from './MessageGroup';
+import {
+  buildRenderSegments,
+  computeWorkProcessFold,
+  hasPersistedStopState,
+  streamingTurnHasRenderableContent,
+  stripLegacyStopMarker,
+} from './MessageGroup';
 import type { Message } from '@/types';
 import type { ExecutionStep } from '@/types/execution';
 
@@ -243,6 +249,22 @@ describe('buildRenderSegments', () => {
     expect(stepSegs).toHaveLength(1);
     expect(stepSegs[0].executionSteps.map((s) => s.id)).toEqual(['thinking-a1', 'real-tool']);
     expect(stepSegs[0].executionSteps.some((s) => s.id === 'ghost')).toBe(false);
+  });
+});
+
+describe('persisted stop terminal', () => {
+  it('uses the user reliable-run terminal even when no assistant message exists', () => {
+    expect(hasPersistedStopState([{
+      ...makeUser('u1', 'stop before first token'),
+      runState: 'interrupted',
+      runEndedAt: 2_000,
+    }])).toBe(true);
+  });
+
+  it('keeps compatibility with assistant stopReason and legacy markers', () => {
+    expect(hasPersistedStopState([{ ...makeAssistant('a1', ''), stopReason: 'user' }])).toBe(true);
+    expect(hasPersistedStopState([makeAssistant('a2', 'partial\n\n*[已停止]*')])).toBe(true);
+    expect(stripLegacyStopMarker('partial\n\n*[已停止]*')).toBe('partial');
   });
 });
 

--- a/src/components/chat/MessageGroup.status.test.tsx
+++ b/src/components/chat/MessageGroup.status.test.tsx
@@ -1,0 +1,47 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { initLanguage } from '@/i18n';
+import { useChatStore } from '@/stores/chatStore';
+import type { Conversation, Message } from '@/types';
+import MessageGroup from './MessageGroup';
+
+describe('MessageGroup stopped terminal', () => {
+  beforeEach(() => {
+    initLanguage('en-US');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders a persisted stopped status when the first-token placeholder was deleted', () => {
+    const userMessage: Message = {
+      id: 'user-stopped',
+      role: 'user',
+      content: 'inspect my desktop',
+      timestamp: 1_000,
+      loopId: 'loop-stopped',
+      runState: 'interrupted',
+      runEndedAt: 3_000,
+    };
+    const conversation: Conversation = {
+      id: 'conversation-stopped',
+      title: 'Stopped task',
+      messages: [userMessage],
+      createdAt: 1_000,
+      updatedAt: 3_000,
+      status: 'idle',
+    };
+    useChatStore.setState({
+      activeConversationId: conversation.id,
+      conversations: { [conversation.id]: conversation },
+      agentStatus: 'idle',
+    });
+
+    render(<MessageGroup messages={[userMessage]} isLastGroup />);
+
+    expect(screen.getByText('You stopped after 2s')).toBeInTheDocument();
+  });
+});

--- a/src/components/chat/MessageGroup.tsx
+++ b/src/components/chat/MessageGroup.tsx
@@ -137,6 +137,25 @@ function stripMarkdownImages(text: string): string {
   return text.replace(/!\[[^\]]*\]\([^)]+\)\n?/g, '').trim();
 }
 
+const LEGACY_STOP_MARKER = /\s*\*\[已停止\]\*\s*$/;
+
+/** Backward compatibility for transcripts written before runState terminals. */
+// eslint-disable-next-line react-refresh/only-export-components
+export function hasPersistedStopState(messages: Message[]): boolean {
+  return messages.some((message) =>
+    (message.role === 'user' && message.runState === 'interrupted')
+    || (message.role === 'assistant' && message.stopReason === 'user')
+    || (message.role === 'assistant'
+      && typeof message.content === 'string'
+      && LEGACY_STOP_MARKER.test(message.content)),
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function stripLegacyStopMarker(text: string): string {
+  return text.replace(LEGACY_STOP_MARKER, '').trimEnd();
+}
+
 // --- Render segment types ---
 
 type RenderSegment =
@@ -353,10 +372,11 @@ export default function MessageGroup({ messages, isLastGroup: isLastGroupProp = 
   // Check if THIS execution is active (not global status)
   const isThisExecutionActive = execution?.status === 'running';
 
-  // Execution status is live-only; message.stopReason is persisted so a
-  // stopped tool-only turn keeps the same terminal after app restart.
+  // Reliable-run state on the user message is the canonical persisted
+  // terminal. Assistant stopReason and the old markdown marker remain only as
+  // compatibility fallbacks for transcripts written before that protocol.
   const isStopped = execution?.status === 'cancelled'
-    || assistantMsgs.some((message) => message.stopReason === 'user');
+    || hasPersistedStopState(messages);
 
   // Check if any message is still streaming
   const isStreaming = assistantMsgs.some((m) => m.isStreaming);
@@ -564,7 +584,7 @@ export default function MessageGroup({ messages, isLastGroup: isLastGroupProp = 
   // the execution's start/end timing; fall back to message timestamps when the
   // execution has been evicted (older groups). Aborted = execution cancelled.
   const workStart = execution?.startTime ?? userMsg?.timestamp ?? assistantMsgs[0]?.timestamp;
-  const workEnd = execution?.endTime ?? lastAssistantMsg?.timestamp;
+  const workEnd = execution?.endTime ?? userMsg?.runEndedAt ?? lastAssistantMsg?.timestamp;
   const workSpanMs = workStart != null && workEnd != null ? Math.max(0, workEnd - workStart) : 0;
   // The message-timestamp span under-counts (the last message's own thinking/
   // generation isn't captured — its timestamp is set at creation — and the live
@@ -575,8 +595,11 @@ export default function MessageGroup({ messages, isLastGroup: isLastGroupProp = 
     assistantMsgs.reduce((a, m) => a + (m.thinkingDuration ?? 0), 0) +
     activeExecSteps.filter((s) => s.type !== 'thinking').reduce((a, s) => a + (s.duration ?? 0), 0);
   const workDurationMs = Math.max(workSpanMs, workStepsSec * 1000);
-  const workLabel = execution?.status === 'cancelled'
+  const stoppedLabel = workDurationMs > 0
     ? format(t.chat.stoppedAfter, { duration: formatWorkDuration(workDurationMs) })
+    : t.chat.runInterrupted;
+  const workLabel = isStopped
+    ? stoppedLabel
     : format(t.chat.workedFor, { duration: formatWorkDuration(workDurationMs) });
 
   // Per-segment render callback — extracted from the map so it can be reused
@@ -607,6 +630,9 @@ export default function MessageGroup({ messages, isLastGroup: isLastGroupProp = 
       let cleanedText = allMdImages.length > 0 ? stripMarkdownImages(seg.text) : seg.text;
       if (searchResults.length > 0 && cleanedText) {
         cleanedText = stripSourcesBlock(cleanedText);
+      }
+      if (isStopped) {
+        cleanedText = stripLegacyStopMarker(cleanedText);
       }
       const showCursor = seg.isLastTurn && seg.message.isStreaming && !!cleanedText;
 
@@ -749,7 +775,7 @@ export default function MessageGroup({ messages, isLastGroup: isLastGroupProp = 
       {userMsg && <MessageErrorBoundary><MessageBubble message={userMsg} /></MessageErrorBoundary>}
 
       {/* Multiple assistant messages grouped with single avatar */}
-      {assistantMsgs.length > 0 && (
+      {(assistantMsgs.length > 0 || isStopped) && (
         <div className="flex gap-3 w-full overflow-hidden group">
           {/* ABU Avatar - only shown once for the group */}
           <div className="shrink-0 mt-0.5">
@@ -760,6 +786,15 @@ export default function MessageGroup({ messages, isLastGroup: isLastGroupProp = 
 
           {/* Content area */}
           <div className="flex-1 min-w-0 overflow-hidden">
+            {/* A stopped run is a turn terminal, not assistant-authored text.
+                Render it even when Stop arrived before the first model token
+                and the empty assistant placeholder was durably deleted. */}
+            {isStopped && workFoldEnd == null && (
+              <div className="text-body text-[var(--abu-text-muted)] mb-2">
+                {stoppedLabel}
+              </div>
+            )}
+
             {/* Typing dots — shown while the current turn is streaming but has not
                 yet emitted any renderable content. Tracks the streaming message
                 itself, so a plan card from an earlier turn in the same group does

--- a/src/components/chat/QueuedMessagesStrip.test.tsx
+++ b/src/components/chat/QueuedMessagesStrip.test.tsx
@@ -1,8 +1,8 @@
 /// <reference types="@testing-library/jest-dom" />
 /**
- * Codex-style staging strip: queued mid-task messages render as light-gray
- * pills at the composer's top-right edge, each cancellable — they are NOT
- * transcript bubbles until the loop consumes them.
+ * Queued follow-ups render as light-gray pills at the composer's top-right
+ * edge, each cancellable. They are not transcript turns until the current
+ * task has reached a terminal state.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
@@ -12,7 +12,14 @@ import {
   enqueueUserInput,
   clearInputQueue,
   getQueuedInputs,
+  pauseUserInputQueue,
 } from '@/core/agent/userInputQueue';
+
+const runAgentLoopDispatchedMock = vi.fn().mockResolvedValue({ reason: 'completed' });
+
+vi.mock('@/core/agent/agentLoopRunner', () => ({
+  runAgentLoopDispatched: (...args: unknown[]) => runAgentLoopDispatchedMock(...args),
+}));
 
 vi.mock('@/i18n', () => ({
   useI18n: () => ({
@@ -20,6 +27,8 @@ vi.mock('@/i18n', () => ({
       queueStrip: {
         queuedHint: '已排队',
         cancel: '取消排队',
+        paused: '当前回复已停止，队列已暂停',
+        resume: '继续队列',
       },
     },
   }),
@@ -28,7 +37,10 @@ vi.mock('@/i18n', () => ({
 const CONV = 'conv-strip';
 
 describe('QueuedMessagesStrip', () => {
-  beforeEach(() => clearInputQueue(CONV));
+  beforeEach(() => {
+    clearInputQueue(CONV);
+    runAgentLoopDispatchedMock.mockClear();
+  });
   afterEach(() => {
     cleanup();
     clearInputQueue(CONV);
@@ -53,7 +65,7 @@ describe('QueuedMessagesStrip', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('the × cancels a queued message before consumption', async () => {
+  it('the × cancels a queued message before handoff', async () => {
     const user = userEvent.setup();
     enqueueUserInput(CONV, '取消我');
     render(<QueuedMessagesStrip conversationId={CONV} />);
@@ -62,5 +74,38 @@ describe('QueuedMessagesStrip', () => {
 
     expect(screen.queryByText('取消我')).not.toBeInTheDocument();
     expect(getQueuedInputs(CONV)).toHaveLength(0);
+  });
+
+  it('shows a paused terminal after Stop and resumes the oldest item as a new run', async () => {
+    const user = userEvent.setup();
+    enqueueUserInput(CONV, '第一条');
+    enqueueUserInput(CONV, '第二条');
+    pauseUserInputQueue(CONV);
+    render(<QueuedMessagesStrip conversationId={CONV} />);
+
+    expect(screen.getByText('当前回复已停止，队列已暂停')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: '继续队列' }));
+
+    await vi.waitFor(() => {
+      expect(runAgentLoopDispatchedMock).toHaveBeenCalledWith(CONV, '第一条');
+    });
+    expect(getQueuedInputs(CONV).map((item) => item.text)).toEqual(['第二条']);
+    expect(screen.getByText('当前回复已停止，队列已暂停')).toBeInTheDocument();
+  });
+
+  it('re-pauses the remaining queue when resume fails during startup', async () => {
+    const user = userEvent.setup();
+    runAgentLoopDispatchedMock.mockRejectedValueOnce(new Error('startup failed'));
+    enqueueUserInput(CONV, '第一条');
+    enqueueUserInput(CONV, '第二条');
+    pauseUserInputQueue(CONV);
+    render(<QueuedMessagesStrip conversationId={CONV} />);
+
+    await user.click(screen.getByRole('button', { name: '继续队列' }));
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('当前回复已停止，队列已暂停')).toBeInTheDocument();
+    });
+    expect(getQueuedInputs(CONV).map((item) => item.text)).toEqual(['第二条']);
   });
 });

--- a/src/components/chat/QueuedMessagesStrip.tsx
+++ b/src/components/chat/QueuedMessagesStrip.tsx
@@ -1,26 +1,51 @@
-import { useSyncExternalStore } from 'react';
+import { useState, useSyncExternalStore } from 'react';
 import { CornerDownRight, X } from 'lucide-react';
 import {
+  dequeueNextUserInput,
   subscribeToInputQueue,
   getQueuedInputs,
+  isUserInputQueuePaused,
+  pauseUserInputQueue,
   removeQueuedInput,
+  resumeUserInputQueue,
 } from '@/core/agent/userInputQueue';
+import { runAgentLoopDispatched } from '@/core/agent/agentLoopRunner';
 import { useI18n } from '@/i18n';
+import { Button } from '@/components/ui/button';
 
 /**
- * Codex-style staging strip for mid-task messages: queued inputs sit at the
- * composer's top-right edge as light-gray cancellable pills. They become
- * transcript bubbles only when the running loop drains them (agentLoop's
- * drainQueuedInputs block) — until then the × removes them without a trace.
+ * Staging strip for follow-up messages: queued inputs sit at the composer's
+ * top-right edge as light-gray cancellable pills. After the current task
+ * finishes, each becomes an independent transcript turn; until then the ×
+ * removes it without a trace.
  */
 export default function QueuedMessagesStrip({ conversationId }: { conversationId: string }) {
   const { t } = useI18n();
+  const [isResuming, setIsResuming] = useState(false);
   const items = useSyncExternalStore(
     subscribeToInputQueue,
     () => getQueuedInputs(conversationId),
   );
   const visible = items.filter((qi) => !qi.isSystem);
   if (visible.length === 0) return null;
+  const isPaused = isUserInputQueuePaused(conversationId);
+
+  const handleResume = async () => {
+    if (!isPaused || isResuming) return;
+    setIsResuming(true);
+    resumeUserInputQueue(conversationId);
+    const next = dequeueNextUserInput(conversationId);
+    try {
+      if (next) await runAgentLoopDispatched(conversationId, next.text);
+    } catch {
+      pauseUserInputQueue(conversationId);
+    } finally {
+      if (getQueuedInputs(conversationId).some((item) => !item.isSystem)) {
+        pauseUserInputQueue(conversationId);
+      }
+      setIsResuming(false);
+    }
+  };
 
   return (
     <div className="flex flex-col items-end gap-1">
@@ -42,6 +67,14 @@ export default function QueuedMessagesStrip({ conversationId }: { conversationId
           </button>
         </div>
       ))}
+      {isPaused && (
+        <div className="flex items-center gap-2 text-caption text-[var(--abu-text-muted)]">
+          <span>{t.queueStrip.paused}</span>
+          <Button variant="ghost" size="xs" disabled={isResuming} onClick={handleResume}>
+            {t.queueStrip.resume}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/chat/messageGrouping.test.ts
+++ b/src/components/chat/messageGrouping.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import type { Message } from '@/types';
+import { groupMessagesByLoop } from './messageGrouping';
+
+function message(id: string, role: Message['role'], loopId?: string): Message {
+  return { id, role, loopId, content: id, timestamp: 0 };
+}
+
+describe('groupMessagesByLoop', () => {
+  it('keeps a normal user and its assistant turns in one loop group', () => {
+    const messages = [
+      message('user-1', 'user', 'loop-1'),
+      message('assistant-1', 'assistant', 'loop-1'),
+      message('assistant-2', 'assistant', 'loop-1'),
+    ];
+
+    expect(groupMessagesByLoop(messages).map((group) => group.map((item) => item.id)))
+      .toEqual([['user-1', 'assistant-1', 'assistant-2']]);
+  });
+
+  it('splits an older same-loop queued user message so it remains visible', () => {
+    const messages = [
+      message('user-1', 'user', 'loop-1'),
+      message('assistant-1', 'assistant', 'loop-1'),
+      message('queued-user', 'user', 'loop-1'),
+      message('assistant-2', 'assistant', 'loop-1'),
+    ];
+
+    expect(groupMessagesByLoop(messages).map((group) => group.map((item) => item.id)))
+      .toEqual([
+        ['user-1', 'assistant-1'],
+        ['queued-user', 'assistant-2'],
+      ]);
+  });
+
+  it('keeps legacy messages without loopIds as separate groups', () => {
+    expect(groupMessagesByLoop([
+      message('legacy-user', 'user'),
+      message('legacy-assistant', 'assistant'),
+    ])).toHaveLength(2);
+  });
+});

--- a/src/components/chat/messageGrouping.ts
+++ b/src/components/chat/messageGrouping.ts
@@ -1,0 +1,30 @@
+import type { Message } from '@/types';
+
+/**
+ * Group one agent run into a visual block, while treating every user message
+ * as a hard boundary. The latter is a compatibility guard for transcripts
+ * written by older queue behavior that injected a follow-up into the current
+ * loopId: no persisted user message may disappear merely because the loopId
+ * was reused.
+ */
+export function groupMessagesByLoop(messages: Message[]): Message[][] {
+  const groups: Message[][] = [];
+  let currentGroup: Message[] = [];
+  let currentLoopId: string | undefined | null = null;
+
+  for (const message of messages) {
+    const loopChanged = !message.loopId || message.loopId !== currentLoopId;
+    const startsAnotherUserTurn = message.role === 'user' && currentGroup.length > 0;
+
+    if (loopChanged || startsAnotherUserTurn) {
+      if (currentGroup.length > 0) groups.push(currentGroup);
+      currentGroup = [message];
+      currentLoopId = message.loopId;
+    } else {
+      currentGroup.push(message);
+    }
+  }
+
+  if (currentGroup.length > 0) groups.push(currentGroup);
+  return groups;
+}

--- a/src/components/chat/typingIndicator.test.ts
+++ b/src/components/chat/typingIndicator.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import type { Message } from '@/types';
+import { shouldShowTypingIndicator } from './typingIndicator';
+
+function message(id: string, role: Message['role']): Message {
+  return { id, role, content: id, timestamp: 0 };
+}
+
+describe('shouldShowTypingIndicator', () => {
+  it('shows for the first user message of a running conversation', () => {
+    expect(shouldShowTypingIndicator('running', [message('user-1', 'user')])).toBe(true);
+  });
+
+  it('shows when a queued user message starts after existing assistant history', () => {
+    expect(shouldShowTypingIndicator('running', [
+      message('user-1', 'user'),
+      message('assistant-1', 'assistant'),
+      message('queued-user', 'user'),
+    ])).toBe(true);
+  });
+
+  it('hides as soon as the streaming assistant placeholder exists', () => {
+    expect(shouldShowTypingIndicator('running', [
+      message('queued-user', 'user'),
+      { ...message('assistant-2', 'assistant'), isStreaming: true },
+    ])).toBe(false);
+  });
+
+  it('does not show for an idle conversation ending in a user message', () => {
+    expect(shouldShowTypingIndicator('idle', [message('user-1', 'user')])).toBe(false);
+  });
+});

--- a/src/components/chat/typingIndicator.ts
+++ b/src/components/chat/typingIndicator.ts
@@ -1,0 +1,12 @@
+import type { Conversation, Message } from '@/types';
+
+/**
+ * Show the assistant placeholder while a live turn has accepted the latest
+ * user message but has not appended its streaming assistant message yet.
+ */
+export function shouldShowTypingIndicator(
+  status: Conversation['status'] | undefined,
+  visibleMessages: Message[],
+): boolean {
+  return status === 'running' && visibleMessages.at(-1)?.role === 'user';
+}

--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -52,7 +52,12 @@ import { runSubagent } from './subagentRunner';
 import type { SubagentProgressEvent } from './subagentLoop';
 import { createSubagentController } from './subagentAbort';
 import { allToolsUnparseable, MAX_NO_PROGRESS_TURNS, resolveMaxTurns, escalateMaxOutputTokens, shouldContinueTruncatedToolCalls } from './loopGuards';
-import { drainQueuedInputs, clearInputQueue, enqueueUserInput } from './userInputQueue';
+import {
+  drainSystemQueuedInputs,
+  enqueueUserInput,
+  hasSystemQueuedInputs,
+  pauseUserInputQueue,
+} from './userInputQueue';
 import { snapshotExecutionSteps } from './executionSnapshot';
 import { emitHook } from './lifecycleHooks';
 import { getI18n, format } from '../../i18n';
@@ -69,7 +74,6 @@ import { rehydrateForSend, type ImageBase64Cache } from '../llm/imageRehydration
 import { TOOL_NAMES, isDisplayHiddenStepBackedTool } from '../tools/toolNames';
 import { prefetchTools } from '../tools/toolPrefetch';
 import { classifyTools, buildDeferredToolsSummary } from '../tools/toolSearch';
-import { hasQueuedInputs } from './userInputQueue';
 import { resolveEffectiveLlmCreds, EnterpriseLlmUnavailableError } from '../enterprise/llm-resolver';
 import { createLogger } from '../logging/logger';
 import { reportError } from '@/utils/consoleError';
@@ -536,9 +540,9 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
             error: 'A restricted recovery run cannot join an existing agent loop',
           };
         }
-        // Codex-style staging: the message lives in the cancellable queue strip
-        // above the composer and becomes a transcript bubble only when the
-        // running loop drains it (see the drainQueuedInputs block below).
+        // The message lives in the cancellable queue strip until the current
+        // run reaches a terminal state. The shell dispatcher then starts it as
+        // an independent run with its own loopId.
         enqueueUserInput(conversationId, userMessage);
         return { reason: 'enqueued' };
       }
@@ -1052,11 +1056,10 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       });
     }).catch(() => {});
 
-    // Check for mid-task user input. Queued messages are staged OUTSIDE the
-    // transcript (cancellable strip above the composer) and become chat
-    // messages only here, at consumption time — tagged with THIS loop's id so
-    // they group with the turn that actually reads them.
-    const queuedInputs = drainQueuedInputs(conversationId);
+    // Only internal system wake-ups may join the current run. User-authored
+    // follow-ups stay in the shell queue until this run terminates, then start
+    // as independent runs with new loopIds (agentLoopRunner.ts).
+    const queuedInputs = drainSystemQueuedInputs(conversationId);
     for (const qi of queuedInputs) {
       chatDelta.addMessage(conversationId, {
         id: generateId(),
@@ -2078,15 +2081,13 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         consecutiveNoProgress = 0;
       }
 
-      // If the user enqueued additional input mid-stream (handled by ChatInput when
-      // a message is sent while a turn is still running), and the current turn ended
-      // with plain text rather than tool_use, run another turn so the LLM actually
-      // responds to that follow-up. Without this, mid-stream user messages get added
-      // to the conversation but never receive a reply.
+      // Internal wake-ups (for example background-agent results) still belong
+      // to this task and need another model turn when the current turn ended in
+      // plain text. User-authored follow-ups are deliberately excluded here.
       if (
         !continueLoop
         && !awaitingUserRecovery
-        && hasQueuedInputs(conversationId)
+        && hasSystemQueuedInputs(conversationId)
         && !abortController.signal.aborted
       ) {
         // Flush any buffered tokens and finalize the previous assistant message
@@ -2250,20 +2251,11 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
 
         // Clear loop context and any pending confirmation/permission dialogs
         clearLoopContext(loopId);
-        // Surface staged (non-system) queue messages as transcript user bubbles
-        // before clearing — the aborted loop can't answer them, but the text
-        // must remain visible instead of being silently destroyed.
-        for (const qi of drainQueuedInputs(conversationId)) {
-          if (qi.isSystem) continue;
-          chatDelta.addMessage(conversationId, {
-            id: generateId(),
-            role: 'user',
-            content: qi.text,
-            timestamp: qi.timestamp,
-            loopId,
-          });
-        }
-        clearInputQueue(conversationId);
+        // Stop pauses staged user follow-ups instead of turning them into
+        // transcript bubbles owned by the aborted run. Internal system wake-ups
+        // are discarded because their parent task no longer exists.
+        pauseUserInputQueue(conversationId);
+        drainSystemQueuedInputs(conversationId);
         drainConfirmationQueue();
         drainFilePermissionQueue();
         drainWorkspaceRequest();
@@ -2304,6 +2296,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
             const { isMessageWrittenToDisk } = await import('../session/conversationStorage');
             chatDelta.deleteMessage(conversationId, assistantMsgId, {
               skipCatalogBump: !(await isMessageWrittenToDisk(assistantMsgId)),
+              persist: true,
             });
           }
         }

--- a/src/core/agent/agentLoopRunner.test.ts
+++ b/src/core/agent/agentLoopRunner.test.ts
@@ -224,7 +224,9 @@ vi.mock('../enterprise/llm-resolver', () => ({
 const enqueueUserInputMock = vi.fn();
 const getQueuedInputsMock = vi.fn().mockReturnValue([]);
 const removeQueuedInputMock = vi.fn();
-const drainQueuedInputsMock = vi.fn().mockReturnValue([]);
+const drainSystemQueuedInputsMock = vi.fn().mockReturnValue([]);
+const pauseUserInputQueueMock = vi.fn();
+const dequeueNextUserInputMock = vi.fn().mockReturnValue(undefined);
 let capturedQueueCb: (() => void) | undefined;
 const queueUnsubMock = vi.fn();
 const subscribeToInputQueueMock = vi.fn((cb: () => void) => {
@@ -235,7 +237,9 @@ vi.mock('./userInputQueue', () => ({
   enqueueUserInput: (...a: unknown[]) => enqueueUserInputMock(...a),
   getQueuedInputs: (...a: unknown[]) => getQueuedInputsMock(...a),
   removeQueuedInput: (...a: unknown[]) => removeQueuedInputMock(...a),
-  drainQueuedInputs: (...a: unknown[]) => drainQueuedInputsMock(...a),
+  drainSystemQueuedInputs: (...a: unknown[]) => drainSystemQueuedInputsMock(...a),
+  pauseUserInputQueue: (...a: unknown[]) => pauseUserInputQueueMock(...a),
+  dequeueNextUserInput: (...a: unknown[]) => dequeueNextUserInputMock(...a),
   subscribeToInputQueue: (...a: [() => void]) => subscribeToInputQueueMock(...a),
 }));
 
@@ -546,8 +550,11 @@ describe('agentLoopRunner', () => {
     getQueuedInputsMock.mockReset();
     getQueuedInputsMock.mockReturnValue([]);
     removeQueuedInputMock.mockReset();
-    drainQueuedInputsMock.mockReset();
-    drainQueuedInputsMock.mockReturnValue([]);
+    drainSystemQueuedInputsMock.mockReset();
+    drainSystemQueuedInputsMock.mockReturnValue([]);
+    pauseUserInputQueueMock.mockReset();
+    dequeueNextUserInputMock.mockReset();
+    dequeueNextUserInputMock.mockReturnValue(undefined);
     subscribeToInputQueueMock.mockClear();
     queueUnsubMock.mockReset();
     capturedQueueCb = undefined;
@@ -1181,7 +1188,7 @@ describe('agentLoopRunner', () => {
   // ── Queued-input forwarder + input.consumed handler (P1-3B-4) ──────────
 
   describe('queued-input forwarder', () => {
-    it('forwards a new shell-queue entry to the matching active sidecar RunSession via agent.enqueueInput, id-preserved', async () => {
+    it('does not forward a user follow-up into the active sidecar run', async () => {
       const { registerRunSession } = await importFresh();
       registerRunSession('run-1', makeSession({ conversationId: 'conv-1' }));
       notifySidecar.mockClear();
@@ -1189,7 +1196,7 @@ describe('agentLoopRunner', () => {
       getQueuedInputsMock.mockReturnValue([{ id: 'q1', text: 'more', timestamp: 1 }]);
       capturedQueueCb?.();
 
-      expect(notifySidecar).toHaveBeenCalledWith('agent.enqueueInput', { runId: 'run-1', message: 'more', queueId: 'q1' });
+      expect(notifySidecar).not.toHaveBeenCalledWith('agent.enqueueInput', expect.anything());
     });
 
     it('threads the isSystem flag through when forwarding', async () => {
@@ -1206,7 +1213,7 @@ describe('agentLoopRunner', () => {
       const { registerRunSession } = await importFresh();
       registerRunSession('run-1', makeSession({ conversationId: 'conv-1' }));
 
-      getQueuedInputsMock.mockReturnValue([{ id: 'q1', text: 'more', timestamp: 1 }]);
+      getQueuedInputsMock.mockReturnValue([{ id: 'q1', text: 'system result', timestamp: 1, isSystem: true }]);
       capturedQueueCb?.();
       capturedQueueCb?.(); // entry still sitting in the (unmutated — chip lingers) shell queue
 
@@ -1240,7 +1247,7 @@ describe('agentLoopRunner', () => {
       const session = { ...makeSession({ conversationId: 'conv-1' }), forwardedQueueIds: new Set(['leftover-1']) };
       registerRunSession('run-1', session);
 
-      getQueuedInputsMock.mockReturnValue([{ id: 'leftover-1', text: 'already seeded', timestamp: 1 }]);
+      getQueuedInputsMock.mockReturnValue([{ id: 'leftover-1', text: 'already seeded', timestamp: 1, isSystem: true }]);
       capturedQueueCb?.();
 
       expect(notifySidecar).not.toHaveBeenCalledWith('agent.enqueueInput', expect.anything());
@@ -1250,7 +1257,7 @@ describe('agentLoopRunner', () => {
       const { registerRunSession } = await importFresh();
       const session = { ...makeSession({ conversationId: 'conv-1' }), abortRequested: true };
       registerRunSession('run-1', session);
-      getQueuedInputsMock.mockReturnValue([{ id: 'q-after-stop', text: 'must stay local', timestamp: 1 }]);
+      getQueuedInputsMock.mockReturnValue([{ id: 'q-after-stop', text: 'must stay local', timestamp: 1, isSystem: true }]);
 
       capturedQueueCb?.();
 
@@ -1921,6 +1928,58 @@ describe('agentLoopRunner', () => {
       expect(result).toEqual({ reason: 'completed' });
     });
 
+    it('starts queued user follow-ups FIFO as independent runs with fresh loopIds', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      sidecarRequestMock.mockResolvedValue({ reason: 'completed' });
+      dequeueNextUserInputMock
+        .mockReturnValueOnce({ id: 'q1', text: 'first follow-up', timestamp: 1 })
+        .mockReturnValueOnce({ id: 'q2', text: 'second follow-up', timestamp: 2 })
+        .mockReturnValue(undefined);
+
+      const result = await runAgentLoopDispatched('conv-1', 'original task');
+
+      expect(result).toEqual({ reason: 'completed' });
+      expect(sidecarRequestMock).toHaveBeenCalledTimes(3);
+      const payloads = sidecarRequestMock.mock.calls.map((call) => call[1] as {
+        runId: string;
+        conversationId: string;
+        userMessage: string;
+      });
+      expect(payloads.map((payload) => payload.userMessage)).toEqual([
+        'original task',
+        'first follow-up',
+        'second follow-up',
+      ]);
+      expect(new Set(payloads.map((payload) => payload.runId)).size).toBe(3);
+      expect(chatStoreAddMessageMock.mock.calls.map((call) => call[1])).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ content: 'original task', loopId: payloads[0].runId }),
+          expect.objectContaining({ content: 'first follow-up', loopId: payloads[1].runId }),
+          expect.objectContaining({ content: 'second follow-up', loopId: payloads[2].runId }),
+        ]),
+      );
+    });
+
+    it('does not fan out the remaining queue after a handed-off run fails', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      sidecarRequestMock
+        .mockResolvedValueOnce({ reason: 'completed' })
+        .mockResolvedValueOnce({ reason: 'error', error: 'provider unavailable' });
+      dequeueNextUserInputMock
+        .mockReturnValueOnce({ id: 'q1', text: 'first follow-up', timestamp: 1 })
+        .mockReturnValueOnce({ id: 'q2', text: 'must remain queued', timestamp: 2 });
+      getQueuedInputsMock.mockReturnValue([
+        { id: 'q2', text: 'must remain queued', timestamp: 2 },
+      ]);
+
+      await expect(runAgentLoopDispatched('conv-1', 'original task'))
+        .resolves.toEqual({ reason: 'completed' });
+
+      expect(sidecarRequestMock).toHaveBeenCalledTimes(2);
+      expect(dequeueNextUserInputMock).toHaveBeenCalledTimes(1);
+      expect(pauseUserInputQueueMock).toHaveBeenCalledWith('conv-1');
+    });
+
     it('persists the user message before the bounded start handshake', async () => {
       const { runAgentLoopDispatched } = await importFresh();
       sidecarRequestMock.mockResolvedValue({ reason: 'completed' });
@@ -2327,7 +2386,7 @@ describe('agentLoopRunner', () => {
       );
     });
 
-    it('buildAgentRunParams includes a queuedInputs snapshot of the shell queue at dispatch time (P1-3B-4, wire-safe shape)', async () => {
+    it('buildAgentRunParams includes only system wake-ups from the shell queue at dispatch time', async () => {
       const { runAgentLoopDispatched } = await importFresh();
       getQueuedInputsMock.mockReturnValue([
         { id: 'q1', text: 'leftover 1', timestamp: 111 },
@@ -2338,9 +2397,9 @@ describe('agentLoopRunner', () => {
       await runAgentLoopDispatched('conv-1', 'hello');
 
       const params = sidecarRequestMock.mock.calls[0][1] as { queuedInputs: unknown };
-      // Projected to id/text/isSystem — the shell-local `timestamp` is dropped (see AgentRunParams.queuedInputs's doc).
+      // User follow-ups remain shell-side; the system entry is projected to
+      // id/text/isSystem and the shell-local timestamp is dropped.
       expect(params.queuedInputs).toEqual([
-        { id: 'q1', text: 'leftover 1' },
         { id: 'q2', text: 'leftover 2', isSystem: true },
       ]);
     });
@@ -2358,7 +2417,7 @@ describe('agentLoopRunner', () => {
 
     it('pre-seeds the new RunSession.forwardedQueueIds from the queuedInputs snapshot, so the live forwarder never re-sends a dispatch-time leftover', async () => {
       const { runAgentLoopDispatched, getRunSession } = await importFresh();
-      getQueuedInputsMock.mockReturnValue([{ id: 'leftover-1', text: 'already seeded', timestamp: 1 }]);
+      getQueuedInputsMock.mockReturnValue([{ id: 'leftover-1', text: 'already seeded', timestamp: 1, isSystem: true }]);
       const d = deferred<unknown>();
       sidecarRequestMock.mockReturnValue(d.promise);
 
@@ -2413,8 +2472,7 @@ describe('agentLoopRunner', () => {
         status: 'running',
         messages: [{ id: 'ghost-1', role: 'assistant', content: '', timestamp: 1, isStreaming: true }],
       });
-      drainQueuedInputsMock.mockReturnValue([
-        { id: 'queued-1', text: 'keep this follow-up', timestamp: 2 },
+      drainSystemQueuedInputsMock.mockReturnValue([
         { id: 'system-1', text: 'hidden control input', timestamp: 3, isSystem: true },
       ]);
       shellController.abort();
@@ -2430,15 +2488,13 @@ describe('agentLoopRunner', () => {
       );
       expect(chatDeltaCancelStreamingMock).toHaveBeenCalledWith('conv-1', { fromSidecarFrame: true });
       expect(chatDeltaDeactivateSkillsMock).toHaveBeenCalledWith('conv-1');
-      expect(chatDeltaDeleteMessageMock).toHaveBeenCalledWith('conv-1', 'ghost-1', { skipCatalogBump: false });
-      expect(chatDeltaAddMessageMock).toHaveBeenCalledWith('conv-1', expect.objectContaining({
-        id: 'abort-queued-queued-1',
-        role: 'user',
-        content: 'keep this follow-up',
-      }));
-      expect(chatDeltaAddMessageMock).not.toHaveBeenCalledWith('conv-1', expect.objectContaining({
-        content: 'hidden control input',
-      }));
+      expect(chatDeltaDeleteMessageMock).toHaveBeenCalledWith('conv-1', 'ghost-1', {
+        skipCatalogBump: false,
+        persist: true,
+      });
+      expect(pauseUserInputQueueMock).toHaveBeenCalledWith('conv-1');
+      expect(drainSystemQueuedInputsMock).toHaveBeenCalledWith('conv-1');
+      expect(chatDeltaAddMessageMock).not.toHaveBeenCalled();
       expect(chatDeltaSetAgentStatusMock).toHaveBeenCalledWith('idle');
       expect(chatDeltaSetConversationStatusMock).toHaveBeenCalledWith('conv-1', 'idle');
       expect(cancelExecutionMock).toHaveBeenCalledWith(expect.any(String));
@@ -2913,14 +2969,15 @@ describe('agentLoopRunner', () => {
         expect(sidecarRequestMock).not.toHaveBeenCalled();
       });
 
-      it('stages the message into an existing sidecar RunSession via agent.enqueueInput instead of dispatching a second agent.run', async () => {
+      it('stages the message in the shell queue instead of injecting it into an existing sidecar run', async () => {
         const { runAgentLoopDispatched, registerRunSession } = await importFresh();
         registerRunSession('run-existing', makeSession({ conversationId: 'conv-1' }));
 
         const result = await runAgentLoopDispatched('conv-1', 'more instructions');
 
         expect(result).toEqual({ reason: 'enqueued' });
-        expect(notifySidecar).toHaveBeenCalledWith('agent.enqueueInput', { runId: 'run-existing', userMessage: 'more instructions' });
+        expect(enqueueUserInputMock).toHaveBeenCalledWith('conv-1', 'more instructions');
+        expect(notifySidecar).not.toHaveBeenCalledWith('agent.enqueueInput', expect.anything());
         expect(sidecarRequestMock).not.toHaveBeenCalled();
       });
 

--- a/src/core/agent/agentLoopRunner.ts
+++ b/src/core/agent/agentLoopRunner.ts
@@ -98,7 +98,15 @@ import type { ConversationMeta } from '../session/conversationStorage';
 import { resolveEntryModel } from './resolveEntryModel';
 import { getActiveApiKey, getActiveProvider } from '../../utils/settingsSelectors';
 import { resolveEffectiveLlmCreds } from '../enterprise/llm-resolver';
-import { enqueueUserInput, getQueuedInputs, subscribeToInputQueue, removeQueuedInput, drainQueuedInputs } from './userInputQueue';
+import {
+  dequeueNextUserInput,
+  drainSystemQueuedInputs,
+  enqueueUserInput,
+  getQueuedInputs,
+  pauseUserInputQueue,
+  removeQueuedInput,
+  subscribeToInputQueue,
+} from './userInputQueue';
 import { registerSidecarRunPredicate } from './sidecarRunPredicate';
 import { bindWorkspaceFromWrite } from './defaultWorkspace';
 import { snapshotBeforeAiEdit } from '../../utils/aiEditSnapshots';
@@ -180,8 +188,8 @@ export interface RunSession {
    *  settle avoids leaking a dangling `abort` handler. */
   onShellAbort?: () => void;
   /**
-   * P1-3B-4 — ids of shell `userInputQueue` entries already forwarded to
-   * this run's sidecar-side queue (via `agent.enqueueInput`), so
+   * P1-3B-4 — ids of shell SYSTEM queue entries already forwarded to this
+   * run's sidecar-side queue (via `agent.enqueueInput`), so
    * `forwardQueuedInputsForActiveSessions` (below) forwards each entry
    * EXACTLY ONCE per run — otherwise every `subscribeToInputQueue` change
    * notification would re-scan the whole (unmutated, still-lingering-for-
@@ -558,6 +566,7 @@ async function finalizeAbortedRun(session: RunSession, source: 'ack' | 'watchdog
             const { isMessageWrittenToDisk } = await import('../session/conversationStorage');
             chatDelta.deleteMessage(session.conversationId, streamingAssistant.id, {
               skipCatalogBump: !isMessageWrittenToDisk(streamingAssistant.id),
+              persist: true,
             });
           }
         }
@@ -568,20 +577,12 @@ async function finalizeAbortedRun(session: RunSession, source: 'ack' | 'watchdog
         });
       }
 
-      // Preserve user-visible queued follow-ups before clearing the queue,
-      // matching agentLoop.ts's normal abort catch. System entries remain
-      // hidden because they are internal wake-up/control messages.
+      // Preserve staged user follow-ups as paused queue chips. They must not
+      // become transcript turns owned by this aborted run or execute until the
+      // user explicitly resumes. Internal wake-ups can be discarded.
       try {
-        for (const queued of drainQueuedInputs(session.conversationId)) {
-          if (queued.isSystem) continue;
-          chatDelta.addMessage(session.conversationId, {
-            id: `abort-queued-${queued.id}`,
-            role: 'user',
-            content: queued.text,
-            timestamp: queued.timestamp,
-            loopId: session.loopId,
-          });
-        }
+        pauseUserInputQueue(session.conversationId);
+        drainSystemQueuedInputs(session.conversationId);
       } catch (err) {
         logger.warn('abort queued-input cleanup failed; continuing terminal finalization', {
           runId: session.runId,
@@ -926,7 +927,6 @@ async function handleMainLoopToolInvoke(rawParams: unknown): Promise<unknown> {
   if (!params || typeof params.runId !== 'string' || typeof params.toolName !== 'string') {
     throw new SidecarRequestError(-32602, 'Invalid tool.invoke params: runId and toolName must be strings');
   }
-
   const session = sessions.get(params.runId);
   if (!session) {
     throw new SidecarRequestError(-32000, `Unknown agent-loop runId: ${params.runId}`);
@@ -1370,7 +1370,7 @@ function pushExecPatchesForActiveSessions(): void {
 }
 
 /**
- * Queued-input forwarder — P1-3B-4, closes the mid-task-queue sidecar gap
+ * System-input forwarder — relays internal wake-ups into an active sidecar run.
  * (see this module's header comment / P1-3B-4-QUEUEINPUT-FIX-REPORT.md).
  * The shell's `userInputQueue` stays the single UI source of truth (the
  * `QueuedMessagesStrip` chip) — this forwarder relays each NEW entry to the
@@ -1381,6 +1381,10 @@ function pushExecPatchesForActiveSessions(): void {
  * unrelated queue mutation (e.g. a different conversation's chip) would
  * re-scan this conversation's still-lingering (not-yet-consumed) entries and
  * re-send them.
+ *
+ * User-authored queue entries are deliberately NOT forwarded. They remain as
+ * cancellable chips until the current run terminates, then the dispatcher
+ * starts them as independent runs with fresh loopIds.
  *
  * Deliberately does NOT touch the shell queue itself (no `removeQueuedInput`
  * here) — the chip must linger until the sidecar loop actually CONSUMES the
@@ -1408,6 +1412,7 @@ function forwardQueuedInputsForActiveSessions(): void {
 
     session.forwardedQueueIds ??= new Set();
     for (const qi of queued) {
+      if (!qi.isSystem) continue;
       if (session.forwardedQueueIds.has(qi.id)) continue;
       session.forwardedQueueIds.add(qi.id);
       notifySidecar('agent.enqueueInput', {
@@ -1565,14 +1570,13 @@ interface AgentRunParams {
   planMode?: 'off' | 'planning' | 'approved';
   locale: string;
   /**
-   * P1-3B-4 — a snapshot of the shell's `userInputQueue` for this
+   * P1-3B-4 — a snapshot of the shell's SYSTEM queue entries for this
    * conversation, taken at dispatch time (see `buildAgentRunParams` below).
    * `agentLoopHost.ts`'s `handleAgentRun` seeds its own (real, but
    * previously-disconnected) `userInputQueue` instance from this,
-   * id-preserved, so a message already staged in the shell queue BEFORE
-   * this run was dispatched is picked up by `agentLoop.ts`'s turn-1
-   * `drainQueuedInputs` — the "leftover flushes on the next run" parity the
-   * in-process path already has.
+   * id-preserved, so an internal wake-up staged before dispatch is picked up
+   * by `agentLoop.ts`'s turn-1 selective system drain. User follow-ups never
+   * cross this boundary; the shell starts them as independent runs.
    */
   queuedInputs?: { id: string; text: string; isSystem?: boolean }[];
 }
@@ -1908,11 +1912,9 @@ async function buildAgentRunParams(
     throw new Error(`buildAgentRunParams: conversation "${conversationId}" disappeared before dispatch`);
   }
 
-  // P1-3B-4 — snapshot the shell's userInputQueue for this conversation at
-  // dispatch time (projected to the wire-safe shape — id/text/isSystem,
-  // dropping the shell-local `timestamp`). See AgentRunParams.queuedInputs's
-  // doc above for why this exists.
-  const queuedInputs = getQueuedInputs(conversationId).map((qi) => ({
+  // Snapshot only internal system wake-ups for this conversation at dispatch
+  // time. User follow-ups remain shell-side until the current run terminates.
+  const queuedInputs = getQueuedInputs(conversationId).filter((qi) => qi.isSystem).map((qi) => ({
     id: qi.id,
     text: qi.text,
     ...(qi.isSystem ? { isSystem: qi.isSystem } : {}),
@@ -2011,7 +2013,7 @@ async function buildAgentRunParams(
  * `EnterpriseLlmUnavailableError`, or a missing conversation record) is
  * ALSO pre-commit by construction — same in-process fallback.
  */
-export async function runAgentLoopDispatched(
+async function runSingleAgentLoopDispatched(
   conversationId: string,
   userMessage: string,
   options?: AgentLoopOptions,
@@ -2041,7 +2043,7 @@ export async function runAgentLoopDispatched(
             error: 'A restricted recovery run cannot join an existing agent loop',
           };
         }
-        notifySidecar('agent.enqueueInput', { runId: runningSession.runId, userMessage });
+        enqueueUserInput(conversationId, userMessage);
         return { reason: 'enqueued' };
       }
     }
@@ -2587,4 +2589,43 @@ export async function runAgentLoopDispatched(
       abortRegistry.clearAbortController(conversationId);
     }
   }
+}
+
+/**
+ * Dispatch one user turn, then hand staged user follow-ups off one-by-one after
+ * each completed run. Each follow-up re-enters the full dispatcher and therefore
+ * receives a fresh runId/loopId instead of being injected into the previous task.
+ *
+ * The original caller still receives the result of its own turn. A concurrent
+ * sender receives `{ reason: 'enqueued' }` immediately; the owner of the active
+ * run performs the FIFO handoff once its session has been fully unregistered.
+ */
+export async function runAgentLoopDispatched(
+  conversationId: string,
+  userMessage: string,
+  options?: AgentLoopOptions,
+): Promise<AgentLoopResult> {
+  const initialResult = await runSingleAgentLoopDispatched(conversationId, userMessage, options);
+  let previousResult = initialResult;
+
+  while (
+    previousResult.reason === 'completed'
+    || previousResult.reason === 'max_turns'
+    || previousResult.reason === 'no_progress'
+  ) {
+    const queuedInput = dequeueNextUserInput(conversationId);
+    if (!queuedInput) break;
+    previousResult = await runSingleAgentLoopDispatched(conversationId, queuedInput.text);
+  }
+
+  if (
+    (previousResult.reason === 'aborted'
+      || previousResult.reason === 'error'
+      || previousResult.reason === 'awaiting_user')
+    && getQueuedInputs(conversationId).some((queued) => !queued.isSystem)
+  ) {
+    pauseUserInputQueue(conversationId);
+  }
+
+  return initialResult;
 }

--- a/src/core/agent/frameApplier.test.ts
+++ b/src/core/agent/frameApplier.test.ts
@@ -91,7 +91,8 @@ describe('applyDeltaFrames', () => {
       });
       await applyDeltaFrames([{ p: 'chat', m: 'cancelStreaming', a: [convId] }]);
       const msg = useChatStore.getState().conversations[convId].messages[0];
-      expect(msg.content).toBe('部分输出\n\n*[已停止]*');
+      expect(msg.content).toBe('部分输出');
+      expect(msg.stopReason).toBe('user');
       expect(msg.isStreaming).toBe(false);
     });
   });

--- a/src/core/agent/ports/chatDelta.test.ts
+++ b/src/core/agent/ports/chatDelta.test.ts
@@ -75,14 +75,17 @@ describe('createInProcessChatDelta', () => {
     expect(useChatStore.getState().agentStatus).toBe('idle');
   });
 
-  it('cancelStreaming() forwards and appends the stop marker', () => {
+  it('cancelStreaming() forwards and records the stop terminal without changing content', () => {
     const delta = createInProcessChatDelta();
     const id = useChatStore.getState().createConversation();
     useChatStore.getState().addMessage(id, {
       id: 'a1', role: 'assistant', content: '部分', timestamp: Date.now(), isStreaming: true,
     });
     delta.cancelStreaming(id);
-    expect(useChatStore.getState().conversations[id].messages[0].content).toContain('已停止');
+    expect(useChatStore.getState().conversations[id].messages[0]).toMatchObject({
+      content: '部分',
+      stopReason: 'user',
+    });
   });
 
   it('deactivateSkills() forwards to deactivateConversationSkills', () => {

--- a/src/core/agent/ports/chatDelta.ts
+++ b/src/core/agent/ports/chatDelta.ts
@@ -86,7 +86,7 @@ export interface ChatDelta {
   /** Mirrors chatStore's `addMessage`. */
   addMessage(convId: string, message: Message): void;
   /** Mirrors chatStore's `deleteMessage`. */
-  deleteMessage(convId: string, messageId: string, opts?: { skipCatalogBump?: boolean }): void;
+  deleteMessage(convId: string, messageId: string, opts?: { skipCatalogBump?: boolean; persist?: boolean }): void;
   /** Mirrors chatStore's `updateToolCall`. */
   updateToolCall(
     convId: string,

--- a/src/core/agent/userInputQueue.test.ts
+++ b/src/core/agent/userInputQueue.test.ts
@@ -1,16 +1,22 @@
 /**
- * Queue staging semantics (Codex-style): queued messages live OUTSIDE the
- * transcript in a cancellable staging area and only become chat messages
- * when the running loop drains them.
+ * Queue staging semantics: user follow-ups live outside the transcript in a
+ * cancellable staging area until the current task finishes; system wake-ups
+ * may be consumed inside the current loop.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   enqueueUserInput,
   enqueueUserInputWithId,
+  dequeueNextUserInput,
   drainQueuedInputs,
+  drainSystemQueuedInputs,
   clearInputQueue,
   getQueuedInputs,
+  hasSystemQueuedInputs,
+  isUserInputQueuePaused,
+  pauseUserInputQueue,
   removeQueuedInput,
+  resumeUserInputQueue,
 } from './userInputQueue';
 
 const CONV = 'conv-queue-test';
@@ -45,6 +51,54 @@ describe('userInputQueue staging', () => {
     removeQueuedInput(CONV, target.id);
     expect(getQueuedInputs(CONV).map((i) => i.text)).toEqual(['keep']);
     expect(drainQueuedInputs(CONV).map((i) => i.text)).toEqual(['keep']);
+  });
+
+  it('drains only system wake-ups while preserving user follow-ups in FIFO order', () => {
+    enqueueUserInputWithId(CONV, 'user-1', 'first user');
+    enqueueUserInputWithId(CONV, 'system-1', 'background result', true);
+    enqueueUserInputWithId(CONV, 'user-2', 'second user');
+
+    expect(hasSystemQueuedInputs(CONV)).toBe(true);
+    expect(drainSystemQueuedInputs(CONV).map((item) => item.id)).toEqual(['system-1']);
+    expect(hasSystemQueuedInputs(CONV)).toBe(false);
+    expect(getQueuedInputs(CONV).map((item) => item.id)).toEqual(['user-1', 'user-2']);
+  });
+
+  it('dequeues user follow-ups one at a time without consuming system entries', () => {
+    enqueueUserInputWithId(CONV, 'system-1', 'background result', true);
+    enqueueUserInputWithId(CONV, 'user-1', 'first user');
+    enqueueUserInputWithId(CONV, 'user-2', 'second user');
+
+    expect(dequeueNextUserInput(CONV)?.id).toBe('user-1');
+    expect(getQueuedInputs(CONV).map((item) => item.id)).toEqual(['system-1', 'user-2']);
+    expect(dequeueNextUserInput(CONV)?.id).toBe('user-2');
+    expect(dequeueNextUserInput(CONV)).toBeUndefined();
+    expect(getQueuedInputs(CONV).map((item) => item.id)).toEqual(['system-1']);
+  });
+
+  it('blocks FIFO handoff while paused and resumes without losing order', () => {
+    enqueueUserInputWithId(CONV, 'user-1', 'first user');
+    enqueueUserInputWithId(CONV, 'user-2', 'second user');
+
+    pauseUserInputQueue(CONV);
+
+    expect(isUserInputQueuePaused(CONV)).toBe(true);
+    expect(dequeueNextUserInput(CONV)).toBeUndefined();
+    expect(getQueuedInputs(CONV).map((item) => item.id)).toEqual(['user-1', 'user-2']);
+
+    resumeUserInputQueue(CONV);
+    expect(isUserInputQueuePaused(CONV)).toBe(false);
+    expect(dequeueNextUserInput(CONV)?.id).toBe('user-1');
+    expect(dequeueNextUserInput(CONV)?.id).toBe('user-2');
+  });
+
+  it('clears the paused state after the last user item is cancelled', () => {
+    enqueueUserInputWithId(CONV, 'user-1', 'only user');
+    pauseUserInputQueue(CONV);
+
+    removeQueuedInput(CONV, 'user-1');
+
+    expect(isUserInputQueuePaused(CONV)).toBe(false);
   });
 
   describe('enqueueUserInputWithId (P1-3B-4)', () => {

--- a/src/core/agent/userInputQueue.ts
+++ b/src/core/agent/userInputQueue.ts
@@ -1,9 +1,9 @@
 /**
- * User Input Queue — mid-task user message injection
+ * User Input Queue — staged follow-ups and internal loop wake-ups
  *
- * Allows users to send additional instructions while the agent loop is running.
- * The agent checks this queue at the start of each loop iteration and incorporates
- * new messages into the conversation context.
+ * User-authored entries wait for the current run to finish and are then started
+ * as independent runs. System entries (for example background-agent results)
+ * may still be consumed by the current loop at its next iteration.
  */
 
 /** Queued user input entry */
@@ -19,6 +19,7 @@ export interface QueuedInput {
 // change so getQueuedInputs() snapshots stay referentially stable for
 // useSyncExternalStore.
 const inputQueues = new Map<string, QueuedInput[]>();
+const pausedUserQueues = new Set<string>();
 
 const EMPTY_QUEUE: readonly QueuedInput[] = [];
 
@@ -30,8 +31,7 @@ function notifyListeners() {
 }
 
 /**
- * Enqueue a user message for a running conversation.
- * The agent loop will pick this up at the next iteration.
+ * Enqueue a staged message for a running conversation.
  */
 export function enqueueUserInput(conversationId: string, text: string, isSystem?: boolean): void {
   if (!text.trim()) return;
@@ -92,6 +92,7 @@ export function removeQueuedInput(conversationId: string, id: string): void {
   if (next.length === queue.length) return;
   if (next.length === 0) inputQueues.delete(conversationId);
   else inputQueues.set(conversationId, next);
+  if (!next.some((qi) => !qi.isSystem)) pausedUserQueues.delete(conversationId);
   notifyListeners();
 }
 
@@ -105,8 +106,72 @@ export function drainQueuedInputs(conversationId: string): QueuedInput[] {
 
   const items = [...queue];
   inputQueues.delete(conversationId);
+  pausedUserQueues.delete(conversationId);
   notifyListeners();
   return items;
+}
+
+/**
+ * Drain only system-authored entries, preserving user follow-ups and their FIFO
+ * order. The active agent loop uses this selective drain so a queued user turn
+ * can never be folded into the current run.
+ */
+export function drainSystemQueuedInputs(conversationId: string): QueuedInput[] {
+  const queue = inputQueues.get(conversationId);
+  if (!queue || queue.length === 0) return [];
+
+  const systemInputs = queue.filter((qi) => qi.isSystem);
+  if (systemInputs.length === 0) return [];
+
+  const userInputs = queue.filter((qi) => !qi.isSystem);
+  if (userInputs.length === 0) inputQueues.delete(conversationId);
+  else inputQueues.set(conversationId, userInputs);
+  notifyListeners();
+  return systemInputs;
+}
+
+/**
+ * Remove and return the oldest user-authored follow-up while leaving system
+ * entries untouched. The shell dispatcher calls this only after the previous
+ * run has reached a terminal state, then starts the returned item as a new run.
+ */
+export function dequeueNextUserInput(conversationId: string): QueuedInput | undefined {
+  if (pausedUserQueues.has(conversationId)) return undefined;
+  const queue = inputQueues.get(conversationId);
+  if (!queue || queue.length === 0) return undefined;
+
+  const index = queue.findIndex((qi) => !qi.isSystem);
+  if (index < 0) return undefined;
+
+  const item = queue[index];
+  const next = [...queue.slice(0, index), ...queue.slice(index + 1)];
+  if (next.length === 0) inputQueues.delete(conversationId);
+  else inputQueues.set(conversationId, next);
+  notifyListeners();
+  return item;
+}
+
+/** Pause user-authored follow-ups after the active run is interrupted. */
+export function pauseUserInputQueue(conversationId: string): void {
+  const queue = inputQueues.get(conversationId);
+  if (!queue?.some((qi) => !qi.isSystem) || pausedUserQueues.has(conversationId)) return;
+  pausedUserQueues.add(conversationId);
+  // Replace the snapshot so useSyncExternalStore subscribers observe the
+  // pause-state change even though the queue items themselves are unchanged.
+  inputQueues.set(conversationId, [...queue]);
+  notifyListeners();
+}
+
+/** Resume a queue explicitly; the caller owns dispatching its first item. */
+export function resumeUserInputQueue(conversationId: string): void {
+  if (!pausedUserQueues.delete(conversationId)) return;
+  const queue = inputQueues.get(conversationId);
+  if (queue) inputQueues.set(conversationId, [...queue]);
+  notifyListeners();
+}
+
+export function isUserInputQueuePaused(conversationId: string): boolean {
+  return pausedUserQueues.has(conversationId);
 }
 
 /**
@@ -115,6 +180,11 @@ export function drainQueuedInputs(conversationId: string): QueuedInput[] {
 export function hasQueuedInputs(conversationId: string): boolean {
   const queue = inputQueues.get(conversationId);
   return !!queue && queue.length > 0;
+}
+
+/** Check whether the active loop has an internal wake-up waiting. */
+export function hasSystemQueuedInputs(conversationId: string): boolean {
+  return (inputQueues.get(conversationId) ?? EMPTY_QUEUE).some((qi) => qi.isSystem);
 }
 
 /**
@@ -129,6 +199,7 @@ export function getQueuedInputCount(conversationId: string): number {
  */
 export function clearInputQueue(conversationId: string): void {
   inputQueues.delete(conversationId);
+  pausedUserQueues.delete(conversationId);
   notifyListeners();
 }
 

--- a/src/core/im/channelRouter.test.ts
+++ b/src/core/im/channelRouter.test.ts
@@ -203,6 +203,7 @@ describe('IMChannelRouter', () => {
       if (mockConversations[convId]) {
         mockConversations[convId].messages.push({ role: 'assistant', content: 'AI reply' });
       }
+      return { reason: 'completed' };
     });
 
     await getInternal().processMessage(message, channel, 'safe_tools');
@@ -250,6 +251,7 @@ describe('IMChannelRouter', () => {
       if (mockConversations[convId]) {
         mockConversations[convId].messages.push({ role: 'assistant', content: 'ok' });
       }
+      return { reason: 'completed' };
     });
     mockSetChannelStatus.mockClear();
 
@@ -304,7 +306,7 @@ describe('handleMessage dedup', () => {
 
     // Agent loop is a noop — we only care whether processMessage was reached
     mockRunAgentLoop.mockReset();
-    mockRunAgentLoop.mockResolvedValue(undefined);
+    mockRunAgentLoop.mockResolvedValue({ reason: 'completed' });
     mockSendThinking.mockReset();
     mockSendThinking.mockResolvedValue({ platform: 'dingtalk', supportsUpdate: false, replyContext: {} });
     mockSendFinal.mockReset();

--- a/src/core/session/conversationStorage.test.ts
+++ b/src/core/session/conversationStorage.test.ts
@@ -143,6 +143,23 @@ describe('conversationStorage', () => {
     });
   });
 
+  describe('deleteMessageById', () => {
+    it('durably removes only the targeted JSONL row and releases its dedup id', async () => {
+      await storage.appendMessage('conv-delete-one', makeMsg({ id: 'keep', content: 'keep me' }));
+      await storage.appendMessage('conv-delete-one', makeMsg({ id: 'ghost', role: 'assistant', content: '' }));
+
+      await expect(storage.deleteMessageById('conv-delete-one', 'ghost')).resolves.toBe(true);
+
+      const loaded = await storage.loadMessages('conv-delete-one');
+      expect(loaded.map((message) => message.id)).toEqual(['keep']);
+      expect(storage.isMessageWrittenToDisk('ghost')).toBe(false);
+    });
+
+    it('treats an id that never reached disk as an idempotent no-op', async () => {
+      await expect(storage.deleteMessageById('conv-missing', 'never-written')).resolves.toBe(false);
+    });
+  });
+
   describe('appendToFile · native append (Part B1)', () => {
     it('uses the native append_file_text command and skips the atomic-write fallback when it succeeds', async () => {
       const calls: Array<{ cmd: string; args?: Record<string, unknown> }> = [];

--- a/src/core/session/conversationStorage.ts
+++ b/src/core/session/conversationStorage.ts
@@ -624,6 +624,64 @@ export async function appendMessage(
 }
 
 /**
+ * Durably remove one message row from a conversation JSONL file.
+ *
+ * The operation shares the per-file mutex with append/replace, so a ghost
+ * placeholder queued for append immediately before Stop is either deleted
+ * after that append lands or the append failure is surfaced by the caller's
+ * persistence barrier. A missing row is a valid no-op only when this process
+ * has never observed the id as persisted.
+ */
+export async function deleteMessageById(
+  convId: string,
+  messageId: string,
+): Promise<boolean> {
+  await ensureBase();
+  const path = messagesPath(convId);
+  if (!(await exists(path))) {
+    if (writtenIds.has(messageId)) {
+      throw new Error(`Conversation messages file does not exist for persisted message "${messageId}"`);
+    }
+    return false;
+  }
+
+  return withFileLock(path, async () => {
+    const raw = await readTextFile(path);
+    const lines = raw.trimEnd().split('\n');
+    const kept: string[] = [];
+    let removed = false;
+
+    for (const line of lines) {
+      if (!line.includes(`"${messageId}"`)) {
+        if (line) kept.push(line);
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(line) as Message;
+        if (parsed.id === messageId) {
+          removed = true;
+          continue;
+        }
+      } catch {
+        // Preserve corrupt/non-matching lines; loadMessages already skips them.
+      }
+      if (line) kept.push(line);
+    }
+
+    if (!removed) {
+      if (writtenIds.has(messageId)) {
+        throw new Error(`Message "${messageId}" was not found in conversation "${convId}"`);
+      }
+      return false;
+    }
+
+    await atomicWrite(path, kept.length > 0 ? `${kept.join('\n')}\n` : '');
+    writtenIds.delete(messageId);
+    return true;
+  });
+}
+
+/**
  * Replace a message in the JSONL file by its id.
  * Unlike updateLastMessage, this scans for the matching id, so it correctly
  * updates intermediate-turn messages even after later turns have appended new

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -2106,6 +2106,8 @@ const enUS: TranslationDict = {
   queueStrip: {
     queuedHint: 'Queued · read next turn',
     cancel: 'Cancel queued message',
+    paused: 'Queue paused because you stopped the response',
+    resume: 'Resume queue',
   },
 
   reference: {

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -2107,6 +2107,8 @@ const zhCN: TranslationDict = {
   queueStrip: {
     queuedHint: '已排队 · 阿布会在下轮读取',
     cancel: '取消排队',
+    paused: '当前回复已停止，队列已暂停',
+    resume: '继续队列',
   },
 
   reference: {

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -2258,6 +2258,10 @@ export interface TranslationDict {
     queuedHint: string;
     /** aria-label / tooltip of the cancel button */
     cancel: string;
+    /** Explains why queued messages did not auto-run after Stop. */
+    paused: string;
+    /** Resumes the paused FIFO queue. */
+    resume: string;
   };
 
   reference: {

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -506,6 +506,60 @@ describe('chatStore', () => {
       }
     });
 
+    it('persists a terminal timestamp with the interrupted reliable-run state', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-08-13T06:30:00.000Z'));
+      const id = 'conv-interrupted-terminal';
+      const message = {
+        id: 'client-msg-stopped',
+        role: 'user',
+        content: 'inspect my desktop',
+        timestamp: 1_000,
+        runState: 'running',
+      } as const;
+      useChatStore.setState({
+        conversations: {
+          [id]: {
+            id,
+            title: 'Stopped task',
+            messages: [message],
+            createdAt: 1_000,
+            updatedAt: 1_000,
+            status: 'running',
+          },
+        },
+        conversationIndex: {
+          [id]: {
+            id,
+            title: 'Stopped task',
+            createdAt: 1_000,
+            updatedAt: 1_000,
+            messageCount: 1,
+          },
+        },
+      });
+      vi.mocked(exists).mockResolvedValue(true);
+      vi.mocked(readTextFile).mockResolvedValue(`${JSON.stringify(message)}\n`);
+      vi.mocked(invoke).mockResolvedValue(undefined);
+
+      try {
+        useChatStore.getState().updateUserMessageRun(id, message.id, { state: 'interrupted' });
+        await waitForConversationPersistence(id);
+
+        expect(useChatStore.getState().conversations[id].messages[0]).toMatchObject({
+          runState: 'interrupted',
+          runEndedAt: new Date('2026-08-13T06:30:00.000Z').getTime(),
+        });
+      } finally {
+        vi.useRealTimers();
+        vi.mocked(exists).mockReset();
+        vi.mocked(exists).mockResolvedValue(false);
+        vi.mocked(readTextFile).mockReset();
+        vi.mocked(readTextFile).mockResolvedValue('');
+        vi.mocked(invoke).mockReset();
+      }
+    });
+
     it('exposes a durability barrier for the asynchronous JSONL append', async () => {
       let releaseAppend!: () => void;
       const appendPending = new Promise<void>((resolve) => {
@@ -904,10 +958,7 @@ describe('chatStore', () => {
       vi.mocked(invoke).mockReset();
     });
 
-    it('persists the stop-marker mutation to disk so reload matches the live view', async () => {
-      // Regression: cancelStreaming appended "*[已停止]*" and cancelled tool
-      // calls in memory only — the JSONL row on disk kept the pre-stop
-      // snapshot, so the same turn reloaded as a blank/stale bubble.
+    it('persists the assistant stop terminal to disk so reload matches the live view', async () => {
       const id = useChatStore.getState().createConversation();
       useChatStore.getState().addMessage(id, {
         id: 'a1', role: 'assistant', content: '部分输出', timestamp: Date.now(), isStreaming: true,
@@ -916,10 +967,10 @@ describe('chatStore', () => {
       useChatStore.getState().cancelStreaming(id);
 
       const live = useChatStore.getState().conversations[id].messages[0];
-      expect(live.content).toContain('已停止');
+      expect(live.content).toBe('部分输出');
       expect(live.stopReason).toBe('user');
       await vi.waitFor(() => {
-        expect(written.some((c) => c.includes('已停止'))).toBe(true);
+        expect(written.some((c) => c.includes('"stopReason":"user"'))).toBe(true);
       });
     });
 
@@ -936,9 +987,10 @@ describe('chatStore', () => {
       useChatStore.getState().cancelStreaming(id);
 
       const live = useChatStore.getState().conversations[id].messages[0];
-      expect(live.content).toBe('前段后段\n\n*[已停止]*');
+      expect(live.content).toBe('前段后段');
+      expect(live.stopReason).toBe('user');
       await vi.waitFor(() => {
-        expect(written.some((c) => c.includes('后段') && c.includes('已停止'))).toBe(true);
+        expect(written.some((c) => c.includes('后段') && c.includes('"stopReason":"user"'))).toBe(true);
       });
     });
 
@@ -1045,7 +1097,8 @@ describe('chatStore', () => {
       useChatStore.getState().cancelStreaming(id, { fromSidecarFrame: true });
 
       const live = useChatStore.getState().conversations[id].messages[0];
-      expect(live.content).toBe('部分输出\n\n*[已停止]*');
+      expect(live.content).toBe('部分输出');
+      expect(live.stopReason).toBe('user');
       expect(live.isStreaming).toBe(false);
       expect(useChatStore.getState().agentStatus).toBe('idle');
     });
@@ -1061,7 +1114,8 @@ describe('chatStore', () => {
       useChatStore.getState().cancelStreaming(id);
 
       const live = useChatStore.getState().conversations[id].messages[0];
-      expect(live.content).toBe('部分输出\n\n*[已停止]*');
+      expect(live.content).toBe('部分输出');
+      expect(live.stopReason).toBe('user');
       expect(live.isStreaming).toBe(false);
       expect(useChatStore.getState().agentStatus).toBe('idle');
     });
@@ -1255,6 +1309,61 @@ describe('chatStore', () => {
       await waitForConversationPersistence(id);
       const bump = vi.mocked(invoke).mock.calls.find((c) => c[0] === 'catalog_bump_count');
       expect(bump).toBeUndefined();
+    });
+
+    it('durably removes a zero-output placeholder when persist is true', async () => {
+      const id = 'conv-durable-ghost';
+      const user = { id: 'u1', role: 'user' as const, content: 'hello', timestamp: 1 };
+      const ghost = { id: 'a1', role: 'assistant' as const, content: '', timestamp: 2, isStreaming: true };
+      const messageWrites: string[] = [];
+      useChatStore.setState({
+        conversations: {
+          [id]: {
+            id,
+            title: 'Ghost cleanup',
+            messages: [user, ghost],
+            createdAt: 1,
+            updatedAt: 2,
+            status: 'running',
+          },
+        },
+        conversationIndex: {
+          [id]: {
+            id,
+            title: 'Ghost cleanup',
+            createdAt: 1,
+            updatedAt: 2,
+            messageCount: 2,
+          },
+        },
+      });
+      vi.mocked(exists).mockResolvedValue(true);
+      vi.mocked(readTextFile).mockImplementation(async (path) =>
+        String(path).endsWith('messages.jsonl')
+          ? `${JSON.stringify(user)}\n${JSON.stringify(ghost)}\n`
+          : '');
+      vi.mocked(invoke).mockImplementation(async (command, args) => {
+        const payload = args as { path?: string; content?: string } | undefined;
+        if (command === 'atomic_write_text' && payload?.path?.endsWith('messages.jsonl')) {
+          messageWrites.push(payload.content ?? '');
+        }
+        return undefined;
+      });
+
+      try {
+        useChatStore.getState().deleteMessage(id, ghost.id, { persist: true });
+        await waitForConversationPersistence(id);
+
+        expect(useChatStore.getState().conversations[id].messages.map((message) => message.id)).toEqual(['u1']);
+        expect(messageWrites.at(-1)).toContain('"id":"u1"');
+        expect(messageWrites.at(-1)).not.toContain('"id":"a1"');
+      } finally {
+        vi.mocked(exists).mockReset();
+        vi.mocked(exists).mockResolvedValue(false);
+        vi.mocked(readTextFile).mockReset();
+        vi.mocked(readTextFile).mockResolvedValue('');
+        vi.mocked(invoke).mockReset();
+      }
     });
   });
 

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -28,6 +28,12 @@ function generateId(): string {
 }
 
 const ACTIVE_RUN_STATES = new Set<Message['runState']>(['pending', 'accepted', 'running', 'recovering']);
+const TERMINAL_RUN_STATES = new Set<Message['runState']>([
+  'completed',
+  'failed',
+  'connection-failed',
+  'interrupted',
+]);
 
 function recoverInterruptedUserRun(msg: Message): Message {
   if (msg.role !== 'user' || !ACTIVE_RUN_STATES.has(msg.runState)) return msg;
@@ -492,7 +498,7 @@ interface ChatActions {
       delegateAgent?: Message['delegateAgent'];
     },
   ) => void;
-  deleteMessage: (convId: string, messageId: string, opts?: { skipCatalogBump?: boolean }) => void;
+  deleteMessage: (convId: string, messageId: string, opts?: { skipCatalogBump?: boolean; persist?: boolean }) => void;
   deleteMessagesFrom: (convId: string, messageId: string) => void;
   deleteLoopMessages: (convId: string, loopId: string) => void;
   updateMessageThinking: (convId: string, thinking: string, msgId?: string) => void;
@@ -1234,6 +1240,11 @@ export const useChatStore = create<ChatStore>()(
           if (!conv || !message || message.role !== 'user') return;
 
           message.runState = patch.state;
+          if (TERMINAL_RUN_STATES.has(patch.state)) {
+            message.runEndedAt ??= Date.now();
+          } else {
+            delete message.runEndedAt;
+          }
           if (patch.error) message.runError = patch.error;
           else delete message.runError;
           if ('content' in patch && patch.content !== undefined) message.content = patch.content;
@@ -1277,6 +1288,7 @@ export const useChatStore = create<ChatStore>()(
 
       deleteMessage: (convId, messageId, opts) => {
         let removedCount = 0;
+        let metaToPersist: ConversationMeta | undefined;
         set((state) => {
           const conv = state.conversations[convId];
           if (conv) {
@@ -1285,8 +1297,30 @@ export const useChatStore = create<ChatStore>()(
             removedCount = before - conv.messages.length;
             conv.updatedAt = Date.now();
             conv.contextCache = undefined;  // Invalidate compression cache
+            const meta = state.conversationIndex[convId];
+            if (meta && removedCount > 0) {
+              meta.messageCount = conv.messages.length;
+              meta.updatedAt = conv.updatedAt;
+              metaToPersist = { ...meta };
+            }
           }
         });
+        if (opts?.persist && removedCount > 0) {
+          const finalMeta = metaToPersist;
+          trackConversationPersistence(
+            convId,
+            () => import('../core/session/conversationStorage').then(async ({
+              catalogReindexConversation,
+              deleteMessageById,
+              updateIndexEntry,
+            }) => {
+              await deleteMessageById(convId, messageId);
+              if (finalMeta) await updateIndexEntry(finalMeta);
+              await catalogReindexConversation(convId);
+            }),
+          );
+          return;
+        }
         // See bumpCatalogAfterDelete's doc comment for why this is an
         // intentionally approximate, self-healing display-level nudge.
         // `skipCatalogBump` (code-review fix #8): the agentLoop ghost-message
@@ -1552,19 +1586,12 @@ export const useChatStore = create<ChatStore>()(
                 || !!lastMsg.thinking?.trim()
                 || !!lastMsg.toolCalls?.length
                 || !!lastMsg.toolCallsForContext?.length;
-              // Persist the user-stop terminal independently of the cosmetic
-              // markdown marker. Tool-only turns have no assistant text to
-              // append that marker to, but still need to reopen as "Stopped"
-              // rather than being inferred as successfully completed.
+              // Persist a compatibility stop terminal on assistant activity.
+              // The canonical run terminal now lives on the user message's
+              // `runState`; this field keeps older transcripts and tool-only
+              // turns readable without injecting presentation text into content.
               if (hasVisibleActivity && lastMsg.stopReason !== 'user') {
                 lastMsg.stopReason = 'user';
-                mutated = true;
-              }
-              // Append cancellation notice — only when real streamed content
-              // exists, so an untouched placeholder never becomes a
-              // "*[已停止]*"-only bubble.
-              if (typeof lastMsg.content === 'string' && lastMsg.content.trim().length > 0) {
-                lastMsg.content += '\n\n*[已停止]*';
                 mutated = true;
               }
             }
@@ -1598,7 +1625,7 @@ export const useChatStore = create<ChatStore>()(
           state.thinkingStartTime = null;
         });
 
-        // Persist the stop mutation (marker + cancelled tool calls) — without
+        // Persist the stop mutation (terminal + cancelled tool calls) — without
         // this the live view shows "已停止" while reload shows the pre-stop
         // JSONL snapshot (often a blank bubble).
         if (cancelledMsgId) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -251,6 +251,8 @@ export interface Message {
    * it can never disappear when the sidecar handshake stalls or fails.
    */
   runState?: 'pending' | 'accepted' | 'running' | 'recovering' | 'completed' | 'failed' | 'connection-failed' | 'interrupted';
+  /** Persisted wall-clock terminal time for reliable-run status and duration UI. */
+  runEndedAt?: number;
   /** Stable correlation ids for Reliable Run Protocol V1. */
   runId?: string;
   clientMessageId?: string;


### PR DESCRIPTION
## Summary

- keep queued user follow-ups out of the active run and execute them FIFO as independent turns
- pause queued follow-ups after Stop until the user explicitly resumes the queue
- persist interrupted turn state and render a lightweight stopped result without ghost assistant messages
- restore the thinking indicator during queue handoff and keep message grouping aligned with turn boundaries

## Root cause

The queue refactor allowed user follow-ups to enter the active agent loop and reused transient renderer state as the source of truth. That made queue handoff race with terminal events: a queued message could start before the previous run finished, disappear during reconciliation, or leave an empty stopped turn after reload.

## Validation

- `npm run verify` — 354 files / 4,830 tests passed; coverage gates passed
- `npm run build:sidecar`
- `npm run build`
- `npm run electron:dev:check`
- `npm run build:electron:renderer`
- real Electron smoke: queue during an active tool run, Stop, paused queue, Resume queue, Stop again, reload and reopen conversation; both stopped turns and queued user messages persisted correctly
- pre-commit ESLint and related Vitest checks passed
