### PR TITLE
fix(ci): preserve Windows installed smoke failures

### DIFF
--- a/scripts/electron-release-workflow.test.mjs
+++ b/scripts/electron-release-workflow.test.mjs
@@ -500,6 +500,17 @@ test('Electron build uses native runners for all three release targets', () => {
   assert.match(installedSmoke, /TotalSeconds -ge 3/);
   assert.match(installedSmoke, /activeUninstallerPids=/);
   assert.match(installedSmoke, /Test-Path \$installedExe\.FullName/);
+  assert.match(installedSmoke, /\$primaryFailure = \$_/);
+  assert.match(installedSmoke, /\$cleanupFailure = \$_/);
+  assert.match(
+    installedSmoke,
+    /Installed smoke failed:/
+  );
+  assert.match(installedSmoke, /cleanup\/rollback also failed:/);
+  assert.match(
+    installedSmoke,
+    /if \(-not \$uninstaller -and \$installedExe -and \(Test-Path \$installedExe\.DirectoryName\)\)/
+  );
   assert.match(
     installedSmoke,
     /Expected a recovery copy of the preexisting Electron conflict/

--- a/scripts/electron-windows-installed-smoke.ps1
+++ b/scripts/electron-windows-installed-smoke.ps1
@@ -45,6 +45,8 @@ $tauriLegacyUninstallKey = `
   "Registry::HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Uninstall\Abu"
 $tauriTransitionHiddenMarker = "AbuElectronTransitionHidden"
 $createdLegacyUninstallFixture = $false
+$primaryFailure = $null
+$cleanupFailure = $null
 
 try {
   if ($expectMigration) {
@@ -287,11 +289,26 @@ try {
   }
 
 }
+catch {
+  # Cleanup must not replace the actual installed-app failure. Preserve both so
+  # a broken launch/migration and a broken rollback path remain independently
+  # actionable in CI instead of whichever exception happened last winning.
+  $primaryFailure = $_
+}
 finally {
+  try {
   foreach ($process in $installedProcesses) {
     if (-not $process.HasExited) {
       Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
     }
+  }
+  # A failure before the happy-path lookup must still uninstall the candidate
+  # and restore the legacy entry. Resolve the uninstaller again from the
+  # installed executable instead of skipping rollback with a null variable.
+  if (-not $uninstaller -and $installedExe -and (Test-Path $installedExe.DirectoryName)) {
+    $uninstaller = Get-ChildItem -Path $installedExe.DirectoryName `
+      -Filter "Uninstall*.exe" -File -ErrorAction SilentlyContinue |
+      Select-Object -First 1
   }
   if ($uninstaller -and (Test-Path $uninstaller.FullName)) {
     # Do not start the uninstaller while an Electron process is still winding
@@ -469,6 +486,21 @@ finally {
   Remove-Item Env:ABU_E2E_MIGRATION_DIAGNOSTICS_PATH -ErrorAction SilentlyContinue
   Remove-Item Env:ABU_PACKAGED_E2E -ErrorAction SilentlyContinue
   Remove-Item $migrationDiagnostics -Force -ErrorAction SilentlyContinue
+  }
+  catch {
+    $cleanupFailure = $_
+  }
+}
+
+if ($primaryFailure -and $cleanupFailure) {
+  throw "Installed smoke failed: $($primaryFailure.Exception.Message); " +
+    "cleanup/rollback also failed: $($cleanupFailure.Exception.Message)"
+}
+if ($primaryFailure) {
+  throw $primaryFailure
+}
+if ($cleanupFailure) {
+  throw $cleanupFailure
 }
 
 Write-Host "[windows-installed-smoke] PASS"


### PR DESCRIPTION
## Context

`v0.38.0-rc.1` failed twice in Windows installed acceptance. The rerun reached the installed application but its cleanup exception replaced the original failure because the happy-path uninstaller lookup had not run.

## Change

- preserve the primary installed-app failure separately from cleanup/rollback failures
- rediscover the installed NSIS uninstaller during cleanup when the happy path exits early
- report both failures if both occur, so the next RC identifies the actual product/startup failure without leaving the legacy Tauri entry hidden
- add release-workflow contract assertions for this behavior

## Validation

- `npm run test:electron:release-workflow` — 25/25
- `git diff --check`

This does not weaken or skip Windows installed acceptance. A new RC is required after merge; the failed `v0.38.0-rc.1` tag will not be reused.
