### PR TITLE
fix: keep model provider credentials atomic

### DIFF
--- a/sidecar/src/shims/subagentRunnerRun.ts
+++ b/sidecar/src/shims/subagentRunnerRun.ts
@@ -26,9 +26,10 @@
  * `settingsReader` is the one exception — `AgentRunContext` deliberately has
  * no `settingsReader` field (see `agentRunContext.ts`'s own doc: settings
  * live in the sidecar-GLOBAL `settingsMirror.ts`, not per-run) — so this
- * uses `getSettingsMirrorReader()` directly, the SAME shared mirror
- * `agentLoopHost.ts` wires into the top-level `AgentLoopOptions.settingsReader`
- * for the parent run itself.
+ * uses the caller's frozen `settingsReader` when present. The main loop
+ * passes its entry provider/model snapshot so a nested agent cannot drift to
+ * a later global selection. Only legacy callers fall back to the shared
+ * mirror.
  *
  * ── `runSubagentLoop` called DIRECTLY, in-process — no reverse RPC ───────
  * We're already inside the sidecar process; there is no shell round trip to
@@ -80,7 +81,7 @@ export async function runSubagent(options: SubagentLoopOptions): Promise<Subagen
 
   const fullOptions: SubagentLoopOptions = {
     ...options,
-    settingsReader: getSettingsMirrorReader(),
+    settingsReader: options.settingsReader ?? getSettingsMirrorReader(),
     toolInvoker: ctx.toolInvoker,
     capsPort: ctx.capsPort,
     workspaceReader: ctx.workspaceReader,

--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -625,6 +625,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
     settings.activeModel;
   const settingsForModel: typeof settings =
     baseModel === settings.activeModel ? settings : { ...settings, activeModel: baseModel };
+  const entrySettingsReader: SettingsReader = { getSnapshot: () => settingsForModel };
 
   // Generate a unique loopId for this agent loop - all messages in this loop share it.
   // Shell dispatch (P1-3B-3B) can override via options.loopId — see that
@@ -702,7 +703,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
     conversationId,
     userMessage,
     options?.imContext,
-    { settings, settingsForModel },
+    { settingsForModel },
     abortController.signal,
   );
   options?.runtimeEvent?.('agent_route_selected', {
@@ -757,7 +758,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
   // entryOrchestration.ts's precomputeOrchestration and the shell
   // dispatcher's buildAgentRunParams — single source, see that module's
   // doc); setActiveModel's side effect stays uniquely here.
-  const { effectiveModelId, entryModelDeclared } = resolveEntryModel(route, settings, settingsForModel);
+  const { effectiveModelId, entryModelDeclared } = resolveEntryModel(route, settingsForModel);
   // Set active model for per-model token calibration
   setActiveModel(effectiveModelId);
 
@@ -908,6 +909,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         onProgress,
         imContext: options?.imContext,
         parentConversationId: conversationId,
+        settingsReader: entrySettingsReader,
       });
 
       // runSubagentLoop RETURNS a (partial/cancelled) SubagentResult on abort
@@ -2037,6 +2039,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
           continueLoop,
           contextUsagePercent: usagePercent,
           toolInvoker,
+          settingsReader: entrySettingsReader,
         });
         if (batchResult.requiresUserRecovery) {
           awaitingUserRecovery = true;

--- a/src/core/agent/agentLoopRunner.test.ts
+++ b/src/core/agent/agentLoopRunner.test.ts
@@ -2380,6 +2380,52 @@ describe('agentLoopRunner', () => {
       expect(params.options.allowedTools).toEqual(['read_*']);
     });
 
+    it('keeps the entry provider, model, and credentials atomic when the conversation model changes during persistence', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      const p1Model = { providerId: 'p1', modelId: 'model-a' };
+      const p2Model = { providerId: 'p2', modelId: 'model-b' };
+      getSettingsSnapshotMock.mockReturnValue({
+        agentMaxTurns: 200,
+        activeModel: p1Model,
+        providers: [
+          { id: 'p1', name: 'P1', apiFormat: 'anthropic', enabled: true, apiKey: 'p1-key', baseUrl: 'https://p1.test', models: [{ id: 'model-a', name: 'Model A' }] },
+          { id: 'p2', name: 'P2', apiFormat: 'openai-compatible', enabled: true, apiKey: 'p2-key', baseUrl: 'https://p2.test', models: [{ id: 'model-b', name: 'Model B' }] },
+        ],
+      });
+      let conversation = { id: 'conv-1', title: 't', messages: [], status: 'idle' } as Record<string, unknown>;
+      getConversationMock.mockImplementation(() => conversation);
+      let persistenceCount = 0;
+      waitForConversationPersistenceMock.mockImplementation(async () => {
+        persistenceCount += 1;
+        if (persistenceCount === 2) conversation = { ...conversation, model: p2Model };
+      });
+      resolveEffectiveLlmCredsMock.mockImplementation((apiKey: string, baseUrl: string | undefined) => ({
+        apiKey,
+        baseUrl,
+        forceOpenAiCompatible: false,
+      }));
+      sidecarRequestMock.mockResolvedValue({ reason: 'completed' });
+
+      await runAgentLoopDispatched('conv-1', 'hello');
+
+      const params = sidecarRequestMock.mock.calls[0][1] as {
+        conversationSnapshot: { model?: unknown };
+        settingsSnapshot: { activeModel: unknown };
+        resolvedCreds: { apiKey: string; baseUrl?: string };
+      };
+      expect(params.conversationSnapshot.model).toEqual(p1Model);
+      expect(params.settingsSnapshot.activeModel).toEqual(p1Model);
+      expect(params.resolvedCreds).toEqual({
+        apiKey: 'p1-key',
+        baseUrl: 'https://p1.test',
+        forceOpenAiCompatible: false,
+      });
+      const installedContext = setLoopContextMock.mock.calls.at(-1)?.[1] as {
+        settingsReader?: { getSnapshot: () => { activeModel: unknown } };
+      };
+      expect(installedContext.settingsReader?.getSnapshot().activeModel).toEqual(p1Model);
+    });
+
     it('creates the task controller before prompt preprocessing and stops without dispatching when it is aborted there', async () => {
       const { runAgentLoopDispatched } = await importFresh();
       const controller = new AbortController();

--- a/src/core/agent/agentLoopRunner.ts
+++ b/src/core/agent/agentLoopRunner.ts
@@ -48,7 +48,7 @@ import { getScratchpadPort } from './ports/scratchpadPort';
 import { getCapsPort } from './ports/capsPort';
 import { getAbortRegistry } from './ports/abortRegistry';
 import { getToolInvoker } from './ports/toolInvoker';
-import { getSettingsReader } from './ports/settingsReader';
+import { getSettingsReader, type SettingsReader } from './ports/settingsReader';
 import { toSerializableTool } from './subagentRunner';
 import { registerToolInvokeSource, ensureToolInvokeRouterRegistered } from './toolInvokeRouter';
 import { ensureHookBridgeRegistered, registerHookSignalSource } from './hookBridge';
@@ -154,6 +154,8 @@ export interface AgentLoopRunOptions {
   requestFilePermission?: FilePermissionCallback;
   blockedTools?: string[];
   allowedTools?: string[];
+  /** Frozen provider/model snapshot inherited by nested shell-side agents. */
+  settingsReader?: SettingsReader;
 }
 
 export interface RunSession {
@@ -1540,6 +1542,7 @@ export function installShellLoopContext(runId: string, session: RunSession): voi
     eventRouter,
     loopId: session.loopId,
     conversationId: session.conversationId,
+    settingsReader: session.options.settingsReader,
     toolCallToStepId: session.toolCallToStepId,
     blockedTools: session.options.blockedTools,
     allowedTools: session.options.allowedTools,
@@ -1867,7 +1870,7 @@ async function buildAgentRunParams(
   }
   const indexEntrySnapshot = getConversationReader().getIndexEntry(conversationId);
 
-  const { settings, settingsForModel } = resolveEntrySettings(conversationId);
+  const { settingsForModel } = resolveEntrySettings(conversationId);
 
   // Single source with runAgentLoop's own entry derivation AND
   // entryOrchestration.ts's precomputeOrchestration — see
@@ -1877,10 +1880,10 @@ async function buildAgentRunParams(
     conversationId,
     userMessage,
     options?.imContext,
-    { settings, settingsForModel },
+    { settingsForModel },
     abortSignal,
   );
-  const { effectiveModelId, provider } = resolveEntryModel(orchestration.route, settings, settingsForModel);
+  const { effectiveModelId, provider } = resolveEntryModel(orchestration.route, settingsForModel);
 
   // May throw (EnterpriseLlmUnavailableError) — propagates to the caller,
   // see this function's doc.
@@ -1964,9 +1967,15 @@ async function buildAgentRunParams(
       prePersistedUserMessageId: clientMessageId,
     },
     orchestration,
-    conversationSnapshot: conversationSnapshot as Conversation,
+    // Freeze the entry provider/model onto the wire snapshot. A model switch
+    // while message persistence is in flight belongs to the next run and must
+    // not be combined with this run's already-resolved credentials.
+    conversationSnapshot: {
+      ...conversationSnapshot,
+      model: settingsForModel.activeModel,
+    } as Conversation,
     indexEntrySnapshot: indexEntrySnapshot as ConversationMeta | undefined,
-    settingsSnapshot: settings,
+    settingsSnapshot: settingsForModel,
     capsSnapshot,
     resolvedCreds,
     toolList,
@@ -2243,6 +2252,7 @@ async function runSingleAgentLoopDispatched(
       requestFilePermission: options?.filePermissionCallback,
       blockedTools: options?.blockedTools,
       allowedTools: options?.allowedTools,
+      settingsReader: { getSnapshot: () => params.settingsSnapshot },
     },
     shellAbortController,
     transportAbortController: new AbortController(),

--- a/src/core/agent/entryOrchestration.ts
+++ b/src/core/agent/entryOrchestration.ts
@@ -77,12 +77,9 @@ export interface PrecomputedOrchestration {
 }
 
 /**
- * `entry.settings` / `entry.settingsForModel` are the loop's OWN
- * already-resolved locals (see `runAgentLoop`'s `settings`/`settingsForModel`
- * — the latter is the per-conversation-pinned-model overlay on top of the
- * former; `resolveAgentModel` deliberately reads the RAW `settings`, not
- * `settingsForModel`, mirroring the original call site exactly). Accepting
- * both as params (rather than re-deriving `settingsForModel` from a fresh
+ * `entry.settingsForModel` is the loop's OWN already-resolved
+ * per-conversation-pinned-model overlay. Accepting it as a param (rather than
+ * re-deriving it from a fresh
  * conversation read) avoids duplicating the model-pin derivation logic
  * (`pinnedConv?.model ?? indexEntry?.model ?? settings.activeModel`) a
  * second time — "keep the signature small and derive internally what you
@@ -93,7 +90,7 @@ export async function precomputeOrchestration(
   conversationId: string,
   userMessage: string,
   imContext: IMContext | undefined,
-  entry: { settings: SettingsState; settingsForModel: SettingsState },
+  entry: { settingsForModel: SettingsState },
   abortSignal?: AbortSignal,
 ): Promise<PrecomputedOrchestration> {
   const route = routeInput(userMessage);
@@ -115,7 +112,7 @@ export async function precomputeOrchestration(
   // formula itself — only the `setActiveModel` side effect stays
   // uniquely in the loop), and the shell dispatcher's `buildAgentRunParams`
   // is a third caller of the same helper — see resolveEntryModel.ts's doc.
-  const { entryModelDeclared } = resolveEntryModel(route, entry.settings, entry.settingsForModel);
+  const { entryModelDeclared } = resolveEntryModel(route, entry.settingsForModel);
 
   const systemPromptSections = await buildSystemPromptSections(
     route,

--- a/src/core/agent/permissionBridge.ts
+++ b/src/core/agent/permissionBridge.ts
@@ -18,6 +18,7 @@ import { usePermissionStore } from '../../stores/permissionStore';
 import type { PermissionDuration } from '../../stores/permissionStore';
 import { authorizeWorkspace } from '../tools/pathSafety';
 import type { EventRouter } from './eventRouter';
+import type { SettingsReader } from './ports/settingsReader';
 import * as approvalBridge from './ports/approvalBridge';
 
 // The file-permission queue's dequeue-time re-check ("another tool call may
@@ -38,6 +39,9 @@ export interface LoopContext {
   eventRouter: EventRouter;
   loopId: string;
   conversationId: string;
+  /** Frozen provider/model snapshot owned by this parent run. Nested agents
+   * must inherit it instead of consulting the mutable global selection. */
+  settingsReader?: SettingsReader;
   toolCallToStepId: Map<string, string>;
   /** Execution denylist inherited by tools that may create nested work. */
   blockedTools?: string[];

--- a/src/core/agent/resolveEntryModel.test.ts
+++ b/src/core/agent/resolveEntryModel.test.ts
@@ -41,23 +41,43 @@ function makeRoute(overrides: Partial<RouteResult> = {}): RouteResult {
 
 describe('resolveEntryModel', () => {
   it('uses settingsForModel.activeModel.modelId for a general route', () => {
-    const settings = makeSettings();
     const settingsForModel = makeSettings({ activeModel: { providerId: 'p1', modelId: 'model-b' } });
-    const { effectiveModelId, provider } = resolveEntryModel(makeRoute({ type: 'general' }), settings, settingsForModel);
+    const { effectiveModelId, provider } = resolveEntryModel(makeRoute({ type: 'general' }), settingsForModel);
     expect(effectiveModelId).toBe('model-b');
     expect(provider?.id).toBe('p1');
   });
 
-  it("an 'agent' route with a compatible definition.model overrides the effective model, resolved against the RAW settings (not settingsForModel)", () => {
-    const settings = makeSettings({ activeModel: { providerId: 'p1', modelId: 'model-a' } });
+  it("an 'agent' route with a definition.model offered by the active provider overrides the effective model", () => {
     const settingsForModel = makeSettings({ activeModel: { providerId: 'p1', modelId: 'model-b' } });
     const { effectiveModelId } = resolveEntryModel(
       makeRoute({ type: 'agent', definition: { model: 'model-a' } as never }),
-      settings,
       settingsForModel,
     );
-    // resolveAgentModel searches `settings.providers` (RAW) for a provider
-    // with this model enabled — 'model-a' is enabled there, so it wins.
+    expect(effectiveModelId).toBe('model-a');
+  });
+
+  it("an 'agent' route cannot borrow a model from a different provider", () => {
+    const settings = makeSettings({
+      activeModel: { providerId: 'p1', modelId: 'model-a' },
+      providers: [
+        ...makeSettings().providers,
+        {
+          id: 'p2',
+          name: 'P2',
+          apiFormat: 'openai-compatible',
+          enabled: true,
+          apiKey: 'sk-2',
+          models: [{ id: 'other-provider-model', name: 'Other Provider Model' }],
+        },
+      ],
+    });
+
+    const { effectiveModelId, provider } = resolveEntryModel(
+      makeRoute({ type: 'agent', definition: { model: 'other-provider-model' } as never }),
+      settings,
+    );
+
+    expect(provider?.id).toBe('p1');
     expect(effectiveModelId).toBe('model-a');
   });
 
@@ -66,27 +86,25 @@ describe('resolveEntryModel', () => {
     const { effectiveModelId } = resolveEntryModel(
       makeRoute({ type: 'agent', definition: { model: 'nonexistent-model' } as never }),
       settings,
-      settings,
     );
     expect(effectiveModelId).toBe('model-a');
   });
 
   it('derives entryModelDeclared from the resolved (provider, modelId) pair — a model-level declaredCapabilities override wins', () => {
-    const settings = makeSettings();
     const settingsForModel = makeSettings({ activeModel: { providerId: 'p1', modelId: 'model-b' } });
-    const { entryModelDeclared } = resolveEntryModel(makeRoute(), settings, settingsForModel);
+    const { entryModelDeclared } = resolveEntryModel(makeRoute(), settingsForModel);
     expect(entryModelDeclared?.supportsTools).toBe(false);
   });
 
   it('entryModelDeclared is undefined when neither provider nor model declares anything', () => {
     const settings = makeSettings();
-    const { entryModelDeclared } = resolveEntryModel(makeRoute(), settings, settings);
+    const { entryModelDeclared } = resolveEntryModel(makeRoute(), settings);
     expect(entryModelDeclared).toBeUndefined();
   });
 
   it('provider is undefined when settingsForModel.activeModel.providerId matches no configured provider', () => {
     const settings = makeSettings({ activeModel: { providerId: 'missing-provider', modelId: 'x' } });
-    const { provider, entryModelDeclared } = resolveEntryModel(makeRoute(), settings, settings);
+    const { provider, entryModelDeclared } = resolveEntryModel(makeRoute(), settings);
     expect(provider).toBeUndefined();
     expect(entryModelDeclared).toBeUndefined();
   });

--- a/src/core/agent/resolveEntryModel.ts
+++ b/src/core/agent/resolveEntryModel.ts
@@ -29,20 +29,18 @@ export interface ResolvedEntryModel {
 }
 
 /**
- * `settings` / `settingsForModel` mirror `runAgentLoop`'s own locals — the
- * latter is the per-conversation-pinned-model overlay on top of the former.
- * `resolveAgentModel` deliberately reads the RAW `settings`, not
- * `settingsForModel` (mirrors the original call site exactly — see
- * `entryOrchestration.ts`'s doc for why).
+ * `settingsForModel` is `runAgentLoop`'s per-conversation-pinned-model
+ * overlay. Provider identity, credentials and any agent model override must
+ * all resolve from this same snapshot; consulting the raw global selection
+ * would let a later switch in another conversation bleed into this run.
  */
 export function resolveEntryModel(
   route: Pick<RouteResult, 'type' | 'definition'>,
-  settings: SettingsState,
   settingsForModel: SettingsState,
 ): ResolvedEntryModel {
   let effectiveModelId = getEffectiveModel(settingsForModel);
   if (route.type === 'agent' && route.definition?.model) {
-    effectiveModelId = resolveAgentModel(route.definition.model, settings);
+    effectiveModelId = resolveAgentModel(route.definition.model, settingsForModel);
   }
   const provider = getActiveProvider(settingsForModel);
   const entryModelDeclared = resolveModelDeclared(provider, effectiveModelId);

--- a/src/core/agent/subagentRunner.test.ts
+++ b/src/core/agent/subagentRunner.test.ts
@@ -191,6 +191,57 @@ describe('subagentRunner', () => {
       expect(result.tokenUsage).toEqual({ input: 10, output: 20 });
     });
 
+    it('uses the parent run settings snapshot for both subagent credentials and sidecar model selection', async () => {
+      getSidecarStatus.mockReturnValue('running');
+      sidecarRequestMock.mockResolvedValue({
+        text: 'sidecar result',
+        toolCallCount: 0,
+        turnCount: 1,
+        tokenUsage: { input: 1, output: 1 },
+        duration: 1,
+      });
+      const parentSettings = {
+        activeModel: { providerId: 'parent-provider', modelId: 'parent-model' },
+        providers: [{ id: 'parent-provider', apiKey: 'parent-key', baseUrl: 'https://parent.test' }],
+      };
+      const parentReader = { getSnapshot: () => parentSettings };
+      getActiveApiKeyMock.mockImplementation((settings: unknown) => {
+        expect(settings).toBe(parentSettings);
+        return 'parent-key';
+      });
+      getActiveProviderMock.mockImplementation((settings: unknown) => {
+        expect(settings).toBe(parentSettings);
+        return { id: 'parent-provider', baseUrl: 'https://parent.test', apiFormat: 'openai-compatible' };
+      });
+      resolveEffectiveLlmCredsMock.mockImplementation((apiKey: string, baseUrl: string | undefined) => ({
+        apiKey,
+        baseUrl,
+        forceOpenAiCompatible: false,
+      }));
+      const { getSubagentRunInheritance, runSubagent } = await importFresh();
+
+      expect(getSubagentRunInheritance({
+        conversationId: 'conv-parent',
+        settingsReader: parentReader as never,
+      })).toEqual({
+        parentConversationId: 'conv-parent',
+        settingsReader: parentReader,
+      });
+
+      await runSubagent({ agent, task: 'do the thing', settingsReader: parentReader as never });
+
+      const params = sidecarRequestMock.mock.calls[0][1] as {
+        settingsSnapshot: unknown;
+        resolvedCreds: unknown;
+      };
+      expect(params.settingsSnapshot).toBe(parentSettings);
+      expect(params.resolvedCreds).toEqual({
+        apiKey: 'parent-key',
+        baseUrl: 'https://parent.test',
+        forceOpenAiCompatible: false,
+      });
+    });
+
     it('falls back to runSubagentLoop when the dispatch-time projection fails (e.g. resolveEffectiveLlmCreds throws) — session never registered, sidecar never touched', async () => {
       getSidecarStatus.mockReturnValue('running');
       resolveEffectiveLlmCredsMock.mockImplementation(() => { throw new Error('EnterpriseLlmUnavailableError'); });

--- a/src/core/agent/subagentRunner.ts
+++ b/src/core/agent/subagentRunner.ts
@@ -76,8 +76,20 @@ import { runSubagentLoop, SubagentResult, type SubagentLoopOptions, type Subagen
 import { registerToolInvokeSource, ensureToolInvokeRouterRegistered } from './toolInvokeRouter';
 import { ensureHookBridgeRegistered, registerHookSignalSource } from './hookBridge';
 import { createLogger } from '../logging/logger';
+import type { LoopContext } from './permissionBridge';
 
 const logger = createLogger('subagent-transport');
+
+/** Security boundary for tool-triggered nesting: inherit the parent run's
+ * frozen provider/model snapshot and conversation identity as one unit. */
+export function getSubagentRunInheritance(
+  loopContext: Pick<LoopContext, 'conversationId' | 'settingsReader'> | null | undefined,
+): Pick<SubagentLoopOptions, 'parentConversationId' | 'settingsReader'> {
+  return {
+    parentConversationId: loopContext?.conversationId,
+    settingsReader: loopContext?.settingsReader,
+  };
+}
 import { getToolInvoker } from './ports/toolInvoker';
 import { getSettingsReader } from './ports/settingsReader';
 import { getWorkspaceReader } from './ports/workspaceReader';

--- a/src/core/agent/toolExecutor.test.ts
+++ b/src/core/agent/toolExecutor.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   executeAnyTool: vi.fn(),
   emitHook: vi.fn(),
   route: vi.fn(),
+  setLoopContext: vi.fn(),
 }));
 
 vi.mock('./ports/chatDelta', () => ({
@@ -51,7 +52,7 @@ vi.mock('./computerUseStatus', () => ({
 }));
 
 vi.mock('./permissionBridge', () => ({
-  setLoopContext: vi.fn(),
+  setLoopContext: (...args: unknown[]) => mocks.setLoopContext(...args),
   clearLoopContext: vi.fn(),
 }));
 
@@ -112,6 +113,7 @@ function makeParams(
     filePermCb: async () => true,
     toolContext: {} as ToolExecutionContext,
     toolInvoker: invoker,
+    settingsReader: { getSnapshot: () => ({}) as never },
     continueLoop: true,
   };
 }
@@ -151,6 +153,21 @@ describe('executeToolBatch · hard run restrictions', () => {
         error: true,
       }],
     });
+  });
+
+  it('installs the frozen parent settings reader for nested delegate tools', async () => {
+    const executeAnyTool = vi.fn().mockResolvedValue('ok');
+    const params = makeParams(makeToolCall('delegate_to_agent'), makeInvoker(executeAnyTool));
+
+    await executeToolBatch(params);
+
+    expect(mocks.setLoopContext).toHaveBeenCalledWith(
+      'loop-1',
+      expect.objectContaining({
+        conversationId: 'conv-1',
+        settingsReader: params.settingsReader,
+      }),
+    );
   });
 
   it('fails closed before invoking a tool outside the per-run whitelist', async () => {

--- a/src/core/agent/toolExecutor.ts
+++ b/src/core/agent/toolExecutor.ts
@@ -17,6 +17,7 @@ import type {
 } from '../../types';
 import type { ConfirmationInfo } from '../tools/commandSafety';
 import type { FilePermissionCallback, ToolInvoker } from './ports/toolInvoker';
+import type { SettingsReader } from './ports/settingsReader';
 import { processToolResult } from '../session/sessionMemory';
 import { evaluatePlanGate, getPlanMode } from './planMode';
 import { emitHook } from './lifecycleHooks';
@@ -84,6 +85,8 @@ export interface ToolBatchParams {
   /** ToolInvoker port instance, resolved once by the caller (agentLoop.ts)
    *  and threaded in — same discipline as the other resolve-once locals. */
   toolInvoker: ToolInvoker;
+  /** Frozen provider/model snapshot for nested delegate tools. */
+  settingsReader: SettingsReader;
   /** Whether the loop will continue (tool_use stop reason) */
   continueLoop: boolean;
   /** Current context window usage (0-100). Scales tool result truncation under pressure. */
@@ -135,6 +138,7 @@ export async function executeToolBatch(params: ToolBatchParams): Promise<ToolBat
     continueLoop,
     contextUsagePercent,
     toolInvoker,
+    settingsReader,
   } = params;
 
   const chatDelta = getChatDelta();
@@ -155,6 +159,7 @@ export async function executeToolBatch(params: ToolBatchParams): Promise<ToolBat
     eventRouter,
     loopId,
     conversationId,
+    settingsReader,
     toolCallToStepId,
     blockedTools: params.blockedTools,
     allowedTools: params.allowedTools,

--- a/src/core/tools/definitions/agentTools.ts
+++ b/src/core/tools/definitions/agentTools.ts
@@ -4,7 +4,7 @@ import { skillLoader } from '../../skill/loader';
 import { agentRegistry } from '../../agent/registry';
 import { getCurrentLoopContext, getLoopContext, requestWorkspace } from '../../agent/permissionBridge';
 import { extractParentConversationSummary } from '../../agent/subagentLoop';
-import { runSubagent } from '../../agent/subagentRunner';
+import { getSubagentRunInheritance, runSubagent } from '../../agent/subagentRunner';
 import type { SubagentProgressEvent } from '../../agent/subagentLoop';
 import { createSubagentController } from '../../agent/subagentAbort';
 import { useChatStore } from '../../../stores/chatStore';
@@ -313,6 +313,7 @@ export const delegateToAgentTool: ToolDefinition = {
         commandConfirmCallback: loopCtx?.commandConfirmCallback,
         filePermissionCallback: loopCtx?.filePermissionCallback,
         allowedTools: loopCtx?.allowedTools,
+        ...getSubagentRunInheritance(loopCtx),
         onProgress,
       });
 

--- a/src/core/tools/definitions/orchestrationTools.ts
+++ b/src/core/tools/definitions/orchestrationTools.ts
@@ -11,7 +11,7 @@
 import type { ToolDefinition, ToolExecutionContext, SubagentDefinition } from '../../../types';
 import { TOOL_NAMES } from '../toolNames';
 import { agentRegistry } from '../../agent/registry';
-import { runSubagent } from '../../agent/subagentRunner';
+import { getSubagentRunInheritance, runSubagent } from '../../agent/subagentRunner';
 import { getSettingsReader } from '../../agent/ports/settingsReader';
 import { getCurrentLoopContext, getLoopContext } from '../../agent/permissionBridge';
 import { extractParentConversationSummary } from '../../agent/subagentLoop';
@@ -392,6 +392,7 @@ export const runAgentBatchTool: ToolDefinition = {
             commandConfirmCallback: loopCtx?.commandConfirmCallback,
             filePermissionCallback: loopCtx?.filePermissionCallback,
             allowedTools: loopCtx?.allowedTools,
+            ...getSubagentRunInheritance(loopCtx),
             onProgress: (event) => {
               try {
                 const store = useBatchProgressStore.getState();

--- a/src/utils/settingsSelectors.test.ts
+++ b/src/utils/settingsSelectors.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import type { SettingsState } from '@/stores/settingsStore';
+import { resolveAgentModel } from './settingsSelectors';
+
+function makeSettings({
+  activeProviderId = 'deepseek',
+  activeModelId = 'deepseek-v4-flash',
+}: {
+  activeProviderId?: string;
+  activeModelId?: string;
+} = {}): SettingsState {
+  return {
+    activeModel: { providerId: activeProviderId, modelId: activeModelId },
+    providers: [
+      {
+        id: 'deepseek',
+        name: 'DeepSeek',
+        source: 'builtin',
+        apiFormat: 'openai-compatible',
+        enabled: true,
+        apiKey: 'deepseek-key',
+        models: [
+          { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash' },
+          { id: 'shared-model', name: 'Shared Model' },
+        ],
+      },
+      {
+        id: 'zmodel',
+        name: 'ZModel',
+        source: 'custom',
+        apiFormat: 'openai-compatible',
+        enabled: true,
+        apiKey: 'zmodel-key',
+        models: [
+          { id: 'glm-5.2', name: 'GLM 5.2' },
+          { id: 'shared-model', name: 'Shared Model' },
+        ],
+      },
+    ],
+  } as unknown as SettingsState;
+}
+
+describe('resolveAgentModel', () => {
+  it('uses an agent override offered by the active provider', () => {
+    const settings = makeSettings({ activeModelId: 'deepseek-v4-flash' });
+
+    expect(resolveAgentModel('shared-model', settings)).toBe('shared-model');
+  });
+
+  it('does not combine the active provider with an override from another provider', () => {
+    const settings = makeSettings();
+
+    expect(resolveAgentModel('glm-5.2', settings)).toBe('deepseek-v4-flash');
+  });
+
+  it('inherits the active model for inherit and missing overrides', () => {
+    const settings = makeSettings();
+
+    expect(resolveAgentModel('inherit', settings)).toBe('deepseek-v4-flash');
+    expect(resolveAgentModel('missing-model', settings)).toBe('deepseek-v4-flash');
+  });
+});

--- a/src/utils/settingsSelectors.ts
+++ b/src/utils/settingsSelectors.ts
@@ -51,11 +51,22 @@ export function getActiveApiKey(state: SettingsState): string {
 export function resolveAgentModel(agentModel: string | undefined, state: SettingsState): string {
   const globalModel = state.activeModel.modelId;
   if (!agentModel || agentModel === 'inherit') return globalModel;
-  // Search across enabled providers
-  for (const p of state.providers) {
-    if (p.enabled && p.models.some(m => m.id === agentModel)) return agentModel;
+
+  // A model id cannot be detached from the provider whose base URL/API key
+  // will execute it. Accepting an override merely because another enabled
+  // provider exposes the same id creates an invalid mixed pair such as
+  // DeepSeek credentials + a GLM model. Agent definitions currently carry
+  // only a model id (no provider id), so the only unambiguous override is one
+  // offered by the active provider itself.
+  const activeProvider = getActiveProvider(state);
+  if (
+    activeProvider?.enabled
+    && activeProvider.models.some((model) => model.id === agentModel)
+  ) {
+    return agentModel;
   }
-  // Incompatible → fall back to global
+
+  // Incompatible with the active provider -> inherit its selected model.
   return globalModel;
 }
 


### PR DESCRIPTION
## Summary
- bind agent model overrides to the active provider instead of borrowing model IDs across providers
- freeze provider/model/credential snapshots across dispatch races and pinned conversations
- inherit the parent snapshot across direct, tool-triggered, batch, and sidecar-nested subagents

## Verification
- npm run verify (362 files, 4960 tests)
- npm run electron:test
- npm run test:e2e:electron (15 passed)
- npm run electron:dev:check
- enterprise leak guard
- independent security review: P0/P1/P2 = 0, COMMIT_SAFE yes