### PR TITLE
docs: announce DeepSeek Harness integration roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Tell Abu what you need — it reads files, runs commands, writes docs, and build
 
 </div>
 
+> 🚧 **Multi-Harness integration in progress:** Abu is evolving toward pluggable agent runtimes, with [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) among the first integration targets. Stable releases currently use Abu's native harness.
+
 ---
 
 ## Why Abu?

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,6 +18,8 @@
 
 </div>
 
+> 🚧 **多 Harness 改造进行中**：Abu 正在演进为可插拔的 Agent Runtime，并把 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 作为首批适配目标。当前稳定版仍使用 Abu 原生 Harness。
+
 ---
 
 ## 为什么选择 Abu？


### PR DESCRIPTION
## What changed

- Added a prominent bilingual README notice for Abu's multi-Harness roadmap.
- Named DeepSeek Harness as one of the first integration targets.
- Clarified that stable releases still use Abu's native Harness.

## Why

Make the direction publicly visible while the integration architecture and development plan are being evaluated, without implying that the integration has already shipped or that there is an official partnership.

## Impact

Documentation only. No runtime behavior changes.

## Checks

- `git diff --check`
- Verified matching Chinese and English notices and the official DeepSeek Harness link.
