### PR TITLE
fix: stop completed Tauri localStorage migration from re-running every launch

### DIFF
--- a/electron/tauriHost.cjs
+++ b/electron/tauriHost.cjs
@@ -958,6 +958,13 @@ function registerTauriHost(app, options = {}) {
       console.log(
         `[tauriLocalStorageMigration] ${localStorageMigration.status}; ${itemCount} item(s)`
       );
+      if (localStorageMigration.sourceChangedSinceMigration === true) {
+        // Completed migrations are never silently re-applied (see
+        // prepareTauriLocalStorageMigration); surface the drift for support.
+        console.log(
+          '[tauriLocalStorageMigration] legacy source changed after completed migration; not re-importing'
+        );
+      }
       if (migrationArmed && localStorageMigration.status === 'error') {
         setMigrationStartupBlock(localStorageMigration.reason);
       }

--- a/electron/tauriLocalStorageMigration.cjs
+++ b/electron/tauriLocalStorageMigration.cjs
@@ -376,8 +376,23 @@ function prepareTauriLocalStorageMigration(options) {
   const scan = findStorageDatabases(storageRoot, platform);
   if (scan.incomplete) return { status: 'error', reason: 'storage-scan-incomplete' };
   const sourceFingerprint = storageStateFingerprint(scan.paths, platform);
-  if (hasValidSentinel(electronDir, sourceFingerprint)) {
-    return { status: 'skipped', reason: 'already-migrated', sourceFingerprint };
+  // A `complete` sentinel at the current MIGRATION_VERSION permanently ends
+  // the migration — fingerprint drift must NOT re-arm it. The fingerprint
+  // hashes file metadata (size/mtime) of live databases, and merely READING
+  // those databases mutates their sidecar files (SQLite WAL `-shm` on macOS,
+  // LevelDB LOCK/LOG on Windows), so requiring fingerprint equality here made
+  // every completed migration invalid again by the next launch and re-imported
+  // the stale Tauri snapshot with `source-wins` on every boot, wiping current
+  // renderer stores. The fingerprint is still recorded for diagnostics; a
+  // post-completion source change is reported via `sourceChangedSinceMigration`
+  // for the host to log, never silently re-applied.
+  if (hasValidSentinel(electronDir)) {
+    return {
+      status: 'skipped',
+      reason: 'already-migrated',
+      sourceFingerprint,
+      sourceChangedSinceMigration: !hasValidSentinel(electronDir, sourceFingerprint),
+    };
   }
 
   let selected = { items: [], rejectedKeys: [], allowedCount: 0 };

--- a/electron/tauriTransition.test.cjs
+++ b/electron/tauriTransition.test.cjs
@@ -449,3 +449,109 @@ test('source-wins acknowledgement backs up replaced Electron localStorage', () =
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+test('a completed sentinel skips migration even when the source fingerprint drifts', () => {
+  // Regression: the fingerprint hashes file metadata of live databases, and
+  // merely reading them mutates sidecar files (SQLite WAL -shm / LevelDB
+  // LOCK+LOG). Binding sentinel validity to fingerprint equality re-armed the
+  // migration on every launch and re-imported the stale Tauri snapshot with
+  // source-wins, wiping current renderer stores each boot.
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'abu-transition-drift-'));
+  const electronDir = path.join(root, 'electron');
+  const storageRoot = path.join(root, 'webkit');
+  const dbDir = path.join(storageRoot, 'LocalStorage');
+  try {
+    fs.mkdirSync(dbDir, { recursive: true });
+    fs.writeFileSync(path.join(dbDir, 'localstorage.sqlite3'), 'fixture-bytes');
+    const plan = {
+      status: 'pending',
+      expectedKeys: ['abu-settings'],
+      rejectedKeys: [],
+      electronDir,
+      sourceDatabase: 'LocalStorage/localstorage.sqlite3',
+      sourceFingerprint: 'stale-fingerprint-from-before-the-read',
+      secretMigrationFailed: false,
+    };
+    const complete = finalizeTauriLocalStorageMigration(plan, {
+      imported: ['abu-settings'],
+      overwritten: [],
+      skippedExisting: [],
+      failed: [],
+      previous: [],
+    });
+    assert.deepEqual(complete, { ok: true, retry: false });
+
+    const second = prepareTauriLocalStorageMigration({
+      electronDir,
+      storageRoot,
+      platform: 'darwin',
+    });
+    assert.equal(second.status, 'skipped');
+    assert.equal(second.reason, 'already-migrated');
+    assert.equal(second.sourceChangedSinceMigration, true);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('an old-version sentinel still re-arms the migration', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'abu-transition-oldver-'));
+  const electronDir = path.join(root, 'electron');
+  try {
+    fs.mkdirSync(electronDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(electronDir, SENTINEL_FILENAME),
+      JSON.stringify({
+        version: 1,
+        migratedAt: '2026-01-01T00:00:00.000Z',
+        status: 'complete',
+        sourceDatabase: null,
+        sourceFingerprint: 'v1-fingerprint',
+        imported: [],
+        skippedExisting: [],
+      })
+    );
+    const plan = prepareTauriLocalStorageMigration({
+      electronDir,
+      storageRoot: path.join(root, 'missing-webkit'),
+      platform: 'darwin',
+    });
+    assert.equal(plan.status, 'pending');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a removed legacy source completes as a no-op and stays skipped', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'abu-transition-nosource-'));
+  const electronDir = path.join(root, 'electron');
+  const storageRoot = path.join(root, 'missing-webkit');
+  try {
+    const first = prepareTauriLocalStorageMigration({
+      electronDir,
+      storageRoot,
+      platform: 'darwin',
+    });
+    assert.equal(first.status, 'pending');
+    assert.deepEqual(first.items, []);
+
+    const complete = finalizeTauriLocalStorageMigration(first, {
+      imported: [],
+      overwritten: [],
+      skippedExisting: [],
+      failed: [],
+      previous: [],
+    });
+    assert.deepEqual(complete, { ok: true, retry: false });
+
+    const second = prepareTauriLocalStorageMigration({
+      electronDir,
+      storageRoot,
+      platform: 'darwin',
+    });
+    assert.equal(second.status, 'skipped');
+    assert.equal(second.sourceChangedSinceMigration, false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -1008,3 +1008,45 @@ describe('secret write-through failure fallback', () => {
     });
   });
 });
+
+describe('failedSecretKeys clearing (decrypt-failed banner)', () => {
+  const invokeMock = vi.mocked(invoke);
+
+  beforeEach(() => {
+    invokeMock.mockReset();
+    useSettingsStore.setState({
+      providers: [makeProvider({ id: 'p1' })],
+      activeModel: { providerId: 'p1', modelId: 'm1' },
+      failedSecretKeys: ['provider:p1'],
+    });
+  });
+
+  it('clears the marker once updateProvider successfully re-writes the key', async () => {
+    invokeMock.mockResolvedValue(null);
+
+    useSettingsStore.getState().updateProvider('p1', { apiKey: 'sk-new' });
+
+    await vi.waitFor(() => {
+      expect(useSettingsStore.getState().failedSecretKeys).not.toContain('provider:p1');
+    });
+  });
+
+  it('keeps the marker when the secret write fails', async () => {
+    invokeMock.mockRejectedValue(new Error('encrypted store unavailable'));
+
+    useSettingsStore.getState().updateProvider('p1', { apiKey: 'sk-new' });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(useSettingsStore.getState().failedSecretKeys).toContain('provider:p1');
+  });
+
+  it('clears the marker when the provider is removed', async () => {
+    invokeMock.mockResolvedValue(null);
+
+    useSettingsStore.getState().removeProvider('p1');
+
+    await vi.waitFor(() => {
+      expect(useSettingsStore.getState().failedSecretKeys).not.toContain('provider:p1');
+    });
+  });
+});

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -54,6 +54,27 @@ function fafSecret(promise: Promise<void>, label: string): void {
   });
 }
 
+/**
+ * Fire-and-forget secret write that also clears the key's decrypt-failed
+ * marker once the write round-trips. Without this, `failedSecretKeys` (set
+ * once by `bootstrapSecrets` at launch) kept the "re-enter your key" banner
+ * up for the whole session even after the user successfully re-entered the
+ * key — making the fix look like it didn't take until the next restart.
+ */
+function fafSecretWrite(key: string, promise: Promise<void>, label: string): void {
+  fafSecret(
+    promise.then(() => {
+      const { failedSecretKeys } = useSettingsStore.getState();
+      if (failedSecretKeys.includes(key)) {
+        useSettingsStore.setState({
+          failedSecretKeys: failedSecretKeys.filter((k) => k !== key),
+        });
+      }
+    }),
+    label,
+  );
+}
+
 function syncComputerUseGate(enabled: boolean): void {
   if (!hasElectronCommandHost()) return;
   void invoke('computer_use_set_enabled', { enabled }).catch((err) => {
@@ -641,7 +662,7 @@ export const useSettingsStore = create<SettingsStore>()(
           return update;
         });
         // Mirror apiKey to encrypted secret store.
-        fafSecret(writeSecretOrDelete(SECRET_KEYS.provider(id), cleanApiKey), `addProvider(${id})`);
+        fafSecretWrite(SECRET_KEYS.provider(id), writeSecretOrDelete(SECRET_KEYS.provider(id), cleanApiKey), `addProvider(${id})`);
         return id;
       },
 
@@ -656,7 +677,8 @@ export const useSettingsStore = create<SettingsStore>()(
         // Only touch the secret store when apiKey is actually being updated;
         // other patches (enabled flag, status, model list) must not clobber it.
         if (Object.prototype.hasOwnProperty.call(patch, 'apiKey')) {
-          fafSecret(
+          fafSecretWrite(
+            SECRET_KEYS.provider(id),
             writeSecretOrDelete(SECRET_KEYS.provider(id), cleanPatch.apiKey ?? ''),
             `updateProvider(${id})`,
           );
@@ -682,7 +704,7 @@ export const useSettingsStore = create<SettingsStore>()(
           }
           return update;
         });
-        fafSecret(deleteSecret(SECRET_KEYS.provider(id)), `removeProvider(${id})`);
+        fafSecretWrite(SECRET_KEYS.provider(id), deleteSecret(SECRET_KEYS.provider(id)), `removeProvider(${id})`);
       },
 
       toggleProvider: (id) => set((s) => ({
@@ -769,7 +791,8 @@ export const useSettingsStore = create<SettingsStore>()(
         set((s) => ({
           auxiliaryServices: { ...s.auxiliaryServices, webSearch: cleaned },
         }));
-        fafSecret(
+        fafSecretWrite(
+          SECRET_KEYS.auxWebSearch,
           writeSecretOrDelete(SECRET_KEYS.auxWebSearch, cleaned?.apiKey ?? ''),
           'setAuxiliaryWebSearch',
         );
@@ -789,7 +812,7 @@ export const useSettingsStore = create<SettingsStore>()(
           const defaultId = s.imageGeneration.defaultId ?? id;
           return { imageGeneration: { backends, defaultId } };
         });
-        fafSecret(writeSecretOrDelete(SECRET_KEYS.imageGenBackend(id), cleanApiKey), `addImageGenBackend(${id})`);
+        fafSecretWrite(SECRET_KEYS.imageGenBackend(id), writeSecretOrDelete(SECRET_KEYS.imageGenBackend(id), cleanApiKey), `addImageGenBackend(${id})`);
         return id;
       },
 
@@ -804,7 +827,8 @@ export const useSettingsStore = create<SettingsStore>()(
           },
         }));
         if (Object.prototype.hasOwnProperty.call(patch, 'apiKey')) {
-          fafSecret(
+          fafSecretWrite(
+            SECRET_KEYS.imageGenBackend(id),
             writeSecretOrDelete(SECRET_KEYS.imageGenBackend(id), cleanPatch.apiKey ?? ''),
             `updateImageGenBackend(${id})`,
           );
@@ -819,7 +843,7 @@ export const useSettingsStore = create<SettingsStore>()(
             : s.imageGeneration.defaultId;
           return { imageGeneration: { backends, defaultId } };
         });
-        fafSecret(deleteSecret(SECRET_KEYS.imageGenBackend(id)), `removeImageGenBackend(${id})`);
+        fafSecretWrite(SECRET_KEYS.imageGenBackend(id), deleteSecret(SECRET_KEYS.imageGenBackend(id)), `removeImageGenBackend(${id})`);
       },
 
       setDefaultImageBackend: (id) => set((s) => ({


### PR DESCRIPTION
## Root cause

`prepareTauriLocalStorageMigration` treated a completed sentinel as valid only when the recorded `sourceFingerprint` equaled the current one. The fingerprint hashes file metadata (size/mtime) of the live legacy databases — and merely **reading** them mutates their sidecar files (SQLite WAL `-shm` on macOS, LevelDB LOCK/LOG on Windows). So every completed migration was invalid again by the next launch, and the migration re-imported the stale Tauri snapshot with `source-wins` **on every boot**, overwriting 13 renderer stores (`abu-settings`, `abu-chat`, …). User-visible symptom: deleted providers resurrected after every restart; any settings change silently rolled back.

Verified on a real machine: sentinel `migratedAt` advanced on every launch, and the legacy `-shm` mtime matched the sentinel timestamp to the second.

## Fix

- A `complete` sentinel at the current `MIGRATION_VERSION` now **permanently** ends the migration. Fingerprint drift no longer re-arms it; it is surfaced as `sourceChangedSinceMigration` and logged by the host, never silently re-applied. Old-version sentinels still re-arm the v2 upgrade path. Same code path fixes macOS and Windows.
- Bonus P0 in the same incident: `failedSecretKeys` (the "re-enter your key" banner) was only written at launch by `bootstrapSecrets`; a successful re-entry never cleared it in-session. New `fafSecretWrite` clears the marker once the secret write/delete round-trips; all 7 keyed call sites migrated. Failed writes keep the marker and the plaintext-fallback behavior.

## Tests

- `tauriTransition.test.cjs` +3 regressions: fingerprint drift → skipped; v1 sentinel → still migrates; removed legacy source → no-op then permanently skipped (14/14 pass)
- `settingsStore.test.ts` +3: banner cleared on successful save / kept on failure / cleared on provider removal (71/71 pass)
- `npm run verify` exit 0; real Electron shell boot with `ABU_MIGRATE_FROM_TAURI=dry` exercises the prepare path

🤖 Generated with [Claude Code](https://claude.com/claude-code)