### PR TITLE
fix(harness): 六处信任与正确性修复（浏览器审批门 / 自建能力审核 / 意图落盘 / 输入不丢 / 遥测可关 / 日志可追）

### DIFF
--- a/sidecar/src/agentLoopHost.ts
+++ b/sidecar/src/agentLoopHost.ts
@@ -719,6 +719,7 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
   });
   traceSidecarRuntimeEvent('sidecar.agent_loop_started', {
     runId,
+    conversationId,
     stage: 'agent_loop_running',
     durationMs: Date.now() - startedAt,
   });
@@ -742,7 +743,10 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
       // correctly without threading a second id back across the wire.
       loopId: runId,
       runtimeEvent: (event, attributes) => {
-        traceSidecarRuntimeEvent(`sidecar.${event}`, attributes);
+        // Stamp the conversation so loop-emitted sidecar events join the same
+        // run timeline as the renderer/main planes during diagnosis; an
+        // explicit conversationId from the loop still wins.
+        traceSidecarRuntimeEvent(`sidecar.${event}`, { conversationId, ...attributes });
       },
     };
     const result: AgentLoopResult = await agentRunContext.run(runCtx, () =>
@@ -750,6 +754,7 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
     );
     traceSidecarRuntimeEvent('sidecar.agent_run_completed', {
       runId,
+      conversationId,
       stage: 'completed',
       outcome: result.reason,
       durationMs: Date.now() - startedAt,
@@ -765,6 +770,7 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
   } catch (error) {
     traceSidecarRuntimeEvent('sidecar.agent_run_failed', {
       runId,
+      conversationId,
       stage: 'failed',
       outcome: 'error',
       errorType: sidecarRuntimeErrorType(error),

--- a/src/__tests__/agentPipeline.integration.test.ts
+++ b/src/__tests__/agentPipeline.integration.test.ts
@@ -424,6 +424,38 @@ describe('Agent Pipeline Integration', () => {
     expect(userMsg?.loopId).toBe(errorMsg?.loopId);
   });
 
+  it('keeps the user message when routing fails before the loop starts', async () => {
+    // Regression: routing produces the cleanInput the user message is built
+    // from, so it runs BEFORE that message is persisted. A throw there escaped
+    // as an unhandled rejection and the typed input vanished with no trace —
+    // the composer had already cleared.
+    const orchestration = await import('../core/agent/entryOrchestration');
+    const spy = vi
+      .spyOn(orchestration, 'precomputeOrchestration')
+      .mockRejectedValue(new Error('skill index unavailable'));
+
+    try {
+      const convId = useChatStore.getState().createConversation();
+      const result = await runAgentLoop(convId, 'route me somewhere');
+
+      expect(result.reason).toBe('error');
+
+      const conv = useChatStore.getState().conversations[convId];
+      const userMsg = conv.messages.find((m) => m.role === 'user');
+      expect(userMsg?.content).toBe('route me somewhere');
+
+      const errorMsg = conv.messages.find(
+        (m) => m.role === 'assistant'
+          && typeof m.content === 'string'
+          && m.content.includes('skill index unavailable'),
+      );
+      expect(errorMsg).toBeDefined();
+      expect(userMsg?.loopId).toBe(errorMsg?.loopId);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it('shows an actionable local error and skips the provider when the latest input is too large', async () => {
     vi.mocked(contextManagerModule.enforceContextBudget).mockImplementationOnce(() => {
       throw new contextManagerModule.ContextBudgetError('INPUT_TOO_LARGE', 20_000, 10_000);

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -85,7 +85,16 @@ export function shouldShowWorkspaceContextBar(
 
 interface ChatInputProps {
   variant: 'welcome' | 'chat';
-  onSend: (message: string, images?: ImageAttachment[], workspacePath?: string | null) => void;
+  /**
+   * Deliver the composed message. Resolving to `false` means the send was not
+   * accepted (no API key, conversation busy) and the composer restores the
+   * draft it optimistically cleared.
+   */
+  onSend: (
+    message: string,
+    images?: ImageAttachment[],
+    workspacePath?: string | null,
+  ) => void | Promise<boolean | void>;
   disabled?: boolean;
   /** Custom placeholder from scenario guide (welcome variant only) */
   scenarioPlaceholder?: string | null;
@@ -665,6 +674,26 @@ export default function ChatInput({ variant, onSend, disabled, scenarioPlacehold
     if (textareaRef.current) textareaRef.current.style.height = 'auto';
   };
 
+  /**
+   * Put a cleared draft back after a send that was not accepted.
+   *
+   * The composer clears optimistically so typing stays responsive, but the
+   * dispatch result only arrives later — without this, a rejected send (no API
+   * key configured, conversation busy) left the user staring at an empty box
+   * with their text gone.
+   */
+  const restoreInput = (draft: ComposerDraft) => {
+    currentDraftRef.current = draft;
+    setText(draft.text);
+    setImages(draft.images);
+    setFiles(draft.files);
+    setReferences(draft.references);
+    setSelectedSkill(draft.selectedSkill);
+    setSelectedAgent(draft.selectedAgent);
+    writeComposerDraft(draftKey, draft);
+    textareaRef.current?.focus();
+  };
+
   const handleSend = () => {
     const trimmed = text.trim();
     if ((!trimmed && !selectedSkill && !selectedAgent && images.length === 0 && files.length === 0 && references.length === 0) || disabled) return;
@@ -704,8 +733,29 @@ export default function ChatInput({ variant, onSend, disabled, scenarioPlacehold
       return;
     }
 
-    onSend(message, images.length > 0 ? images : undefined, isWelcome ? localWorkspace : undefined);
+    // Snapshot before the optimistic clear so a rejected send can hand the
+    // draft back instead of losing it.
+    const sentDraft: ComposerDraft = {
+      text,
+      images: [...images],
+      files: [...files],
+      references: [...references],
+      selectedSkill,
+      selectedAgent,
+    };
+    const sendResult = onSend(
+      message,
+      images.length > 0 ? images : undefined,
+      isWelcome ? localWorkspace : undefined,
+    );
     resetInput();
+    if (sendResult && typeof sendResult.then === 'function') {
+      void sendResult.then(
+        (accepted) => { if (accepted === false) restoreInput(sentDraft); },
+        // A send that throws definitely did not take the message.
+        () => restoreInput(sentDraft),
+      );
+    }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -682,7 +682,13 @@ export default function ChatInput({ variant, onSend, disabled, scenarioPlacehold
    * key configured, conversation busy) left the user staring at an empty box
    * with their text gone.
    */
-  const restoreInput = (draft: ComposerDraft) => {
+  const restoreInput = (draft: ComposerDraft, sentDraftKey: string) => {
+    // The rejection arrives asynchronously, so the user may have switched
+    // conversations in the meantime. Putting the text back on screen then would
+    // show conversation A's message inside conversation B. Persist it under the
+    // key it was typed for and leave the visible composer alone.
+    writeComposerDraft(sentDraftKey, draft);
+    if (sentDraftKey !== draftKey) return;
     currentDraftRef.current = draft;
     setText(draft.text);
     setImages(draft.images);
@@ -690,7 +696,6 @@ export default function ChatInput({ variant, onSend, disabled, scenarioPlacehold
     setReferences(draft.references);
     setSelectedSkill(draft.selectedSkill);
     setSelectedAgent(draft.selectedAgent);
-    writeComposerDraft(draftKey, draft);
     textareaRef.current?.focus();
   };
 
@@ -750,10 +755,11 @@ export default function ChatInput({ variant, onSend, disabled, scenarioPlacehold
     );
     resetInput();
     if (sendResult && typeof sendResult.then === 'function') {
+      const sentDraftKey = draftKey;
       void sendResult.then(
-        (accepted) => { if (accepted === false) restoreInput(sentDraft); },
+        (accepted) => { if (accepted === false) restoreInput(sentDraft, sentDraftKey); },
         // A send that throws definitely did not take the message.
-        () => restoreInput(sentDraft),
+        () => restoreInput(sentDraft, sentDraftKey),
       );
     }
   };

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -356,11 +356,13 @@ export default function ChatView() {
   }, [pendingSearchJump, activeConvId, messageCount, updatePinned]);
 
   const handleSend = async (text: string, images?: ImageAttachment[], workspacePath?: string | null) => {
-    // Block sending if API key is not configured (Ollama doesn't need one)
+    // Block sending if API key is not configured (Ollama doesn't need one).
+    // Returning false hands the text back to the composer — opening settings
+    // used to swallow whatever the user had typed.
     const currentState = useSettingsStore.getState();
     if (!isEnterprise && providerRequiresApiKey(currentState) && !getActiveApiKey(currentState)?.trim()) {
       currentState.openSystemSettings('ai-services');
-      return;
+      return false;
     }
 
     let convId = activeConv?.id;
@@ -389,7 +391,18 @@ export default function ChatView() {
     // freshly-appended item on its own next render, so this doesn't need to
     // wait for a DOM mutation callback the way the old MutationObserver did.
     scrollToLatest('auto');
-    await runAgentLoopDispatched(convId, text, { images });
+    const dispatch = await runAgentLoopDispatched(convId, text, { images });
+    // A rejected dispatch (conversation busy, attachment mid-run) used to be
+    // discarded here: the composer had already cleared, so the text and any
+    // images simply vanished with no feedback. Surface it and hand the draft
+    // back instead.
+    if (dispatch?.reason === 'error') {
+      useToastStore.getState().addToast({
+        type: 'error',
+        title: dispatch.error || t.chat.conversationBusy,
+      });
+      return false;
+    }
   };
 
 

--- a/src/components/common/CommandConfirmDialog.tsx
+++ b/src/components/common/CommandConfirmDialog.tsx
@@ -8,6 +8,8 @@ export interface CommandConfirmRequest {
   command: string;
   level: DangerLevel;
   reason: string;
+  /** Selects the wording — see ConfirmationInfo.kind. */
+  kind?: 'command' | 'browser' | 'self-extension';
 }
 
 interface CommandConfirmDialogProps {
@@ -91,10 +93,18 @@ export default function CommandConfirmDialog({
             </div>
             <div className="flex-1 min-w-0">
               <h2 className="text-h-md font-semibold text-[var(--abu-text-primary)]">
-                {t.commandConfirm[config.titleKey]}
+                {request.kind === 'browser'
+                  ? t.commandConfirm.browserTitle
+                  : request.kind === 'self-extension'
+                    ? t.commandConfirm.selfExtensionTitle
+                    : t.commandConfirm[config.titleKey]}
               </h2>
               <p className="text-body text-[var(--abu-text-tertiary)] mt-0.5">
-                {t.commandConfirm[config.descKey]}
+                {request.kind === 'browser'
+                  ? t.commandConfirm.browserDescription
+                  : request.kind === 'self-extension'
+                    ? t.commandConfirm.selfExtensionDescription
+                    : t.commandConfirm[config.descKey]}
               </p>
             </div>
           </div>

--- a/src/components/settings/sections/DiagnosticSection.tsx
+++ b/src/components/settings/sections/DiagnosticSection.tsx
@@ -73,21 +73,6 @@ export default function DiagnosticSection() {
     <div className="space-y-6 max-w-3xl">
       <SettingsSectionHeader title={t.diagnostic.title} description={t.diagnostic.desc} />
 
-      {/* Anonymous reporting opt-out — personal installs previously had no way
-          to turn reporting off (only a build-time constant and, for enterprise,
-          a server-side flag). */}
-      <div className="flex items-center justify-between p-4 rounded-xl border border-[var(--abu-border)] bg-[var(--abu-bg-muted)]">
-        <div className="flex-1 mr-4">
-          <p className="text-body text-[var(--abu-text-primary)]">{t.diagnostic.telemetryOptOut}</p>
-          <p className="text-minor text-[var(--abu-text-muted)] mt-0.5">{t.diagnostic.telemetryOptOutDesc}</p>
-        </div>
-        <Toggle
-          checked={!telemetryOptOut}
-          onChange={() => setTelemetryOptOut(!telemetryOptOut)}
-          size="lg"
-        />
-      </div>
-
       {/* Banner */}
       <DiagnosticBanner />
 
@@ -102,6 +87,23 @@ export default function DiagnosticSection() {
             results={grouped[cat]}
           />
         ))}
+      </div>
+
+      {/* Anonymous reporting opt-out. Sits at the bottom with the other
+          send-data affordances: most people never touch it, so it should not
+          outrank the diagnostic results this page exists to show. Personal
+          installs previously had no way to turn reporting off at all — only a
+          build-time constant and, for enterprise, a server-side flag. */}
+      <div className="pt-2 border-t border-[var(--abu-border)] flex items-center justify-between gap-4">
+        <div className="flex-1">
+          <p className="text-minor text-[var(--abu-text-primary)]">{t.diagnostic.telemetryOptOut}</p>
+          <p className="text-minor text-[var(--abu-text-muted)] mt-0.5">{t.diagnostic.telemetryOptOutDesc}</p>
+        </div>
+        <Toggle
+          checked={!telemetryOptOut}
+          onChange={() => setTelemetryOptOut(!telemetryOptOut)}
+          size="sm"
+        />
       </div>
 
       {/* Feedback navigation prompt */}

--- a/src/components/settings/sections/DiagnosticSection.tsx
+++ b/src/components/settings/sections/DiagnosticSection.tsx
@@ -8,6 +8,7 @@ import type { CheckCategory, CheckResult } from '@/core/diagnostic/types';
 import DiagnosticBanner from './diagnostic/DiagnosticBanner';
 import DiagnosticCategory from './diagnostic/DiagnosticCategory';
 import SettingsSectionHeader from '@/components/settings/SettingsSectionHeader';
+import { Toggle } from '@/components/ui/toggle';
 
 const CATEGORY_ICON = {
   'ai-services': Bot,
@@ -26,6 +27,8 @@ export default function DiagnosticSection() {
   const runAll = useDiagnosticStore((s) => s.runAll);
   const refreshApp = useDiagnosticStore((s) => s.refreshApp);
   const setActiveSystemTab = useSettingsStore((s) => s.setActiveSystemTab);
+  const telemetryOptOut = useSettingsStore((s) => s.telemetryOptOut);
+  const setTelemetryOptOut = useSettingsStore((s) => s.setTelemetryOptOut);
 
   // First visit (no cached results): run the full suite. Otherwise the panel
   // renders the persisted snapshot instantly, but that snapshot can be stale —
@@ -69,6 +72,21 @@ export default function DiagnosticSection() {
   return (
     <div className="space-y-6 max-w-3xl">
       <SettingsSectionHeader title={t.diagnostic.title} description={t.diagnostic.desc} />
+
+      {/* Anonymous reporting opt-out — personal installs previously had no way
+          to turn reporting off (only a build-time constant and, for enterprise,
+          a server-side flag). */}
+      <div className="flex items-center justify-between p-4 rounded-xl border border-[var(--abu-border)] bg-[var(--abu-bg-muted)]">
+        <div className="flex-1 mr-4">
+          <p className="text-body text-[var(--abu-text-primary)]">{t.diagnostic.telemetryOptOut}</p>
+          <p className="text-minor text-[var(--abu-text-muted)] mt-0.5">{t.diagnostic.telemetryOptOutDesc}</p>
+        </div>
+        <Toggle
+          checked={!telemetryOptOut}
+          onChange={() => setTelemetryOptOut(!telemetryOptOut)}
+          size="lg"
+        />
+      </div>
 
       {/* Banner */}
       <DiagnosticBanner />

--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -2021,6 +2021,22 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         const confirmCb = options?.commandConfirmCallback ?? requestCommandConfirmation;
         const filePermCb = options?.filePermissionCallback ?? requestFilePermission;
 
+        // Move the crash checkpoint from "waiting on the model" to "running
+        // tools" before any side effect starts, so recovery can tell which of
+        // the two a crash interrupted. App.tsx already renders the
+        // 'tool_executing' wording; until now nothing ever wrote that status.
+        import('../session/checkpoint').then(({ writeCheckpoint }) => {
+          writeCheckpoint({
+            conversationId,
+            loopId,
+            turnCount,
+            lastMessageId: assistantMsgId,
+            status: 'tool_executing',
+            currentTool: collectedToolCalls.map((tc) => tc.name).join(', '),
+            timestamp: Date.now(),
+          });
+        }).catch(() => {});
+
         const batchResult = await executeToolBatch({
           collectedToolCalls,
           toolCallToStepId,

--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -697,15 +697,47 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
   // never take a static import of entryOrchestration.ts (it drags the full
   // orchestrator graph); see that module's doc comment for the sidecar-bundle
   // reasoning and entryOrchestrationRun.ts's throwing shim.
-  const { route, systemPromptSections } = options?.orchestration ?? await (
-    await import('./entryOrchestration')
-  ).precomputeOrchestration(
-    conversationId,
-    userMessage,
-    options?.imContext,
-    { settingsForModel },
-    abortController.signal,
-  );
+  let orchestration: Awaited<ReturnType<
+    typeof import('./entryOrchestration').precomputeOrchestration
+  >>;
+  try {
+    orchestration = options?.orchestration ?? await (
+      await import('./entryOrchestration')
+    ).precomputeOrchestration(
+      conversationId,
+      userMessage,
+      options?.imContext,
+      { settingsForModel },
+      abortController.signal,
+    );
+  } catch (error) {
+    // Routing runs BEFORE the user message is persisted (it produces the
+    // cleanInput the message is built from), so a failure here used to escape
+    // as an unhandled rejection with the user's input never reaching the
+    // transcript — it just disappeared. Persist the raw input and explain,
+    // same shape as the missing-API-key path above.
+    if (!options?.prePersistedUserMessageId) {
+      const userContent = await buildUserMessageContent(conversationId, userMessage, options?.images);
+      chatDelta.addMessage(conversationId, {
+        id: generateId(),
+        role: 'user',
+        content: userContent,
+        timestamp: Date.now(),
+        loopId,
+      });
+    }
+    const detail = error instanceof Error ? error.message : String(error);
+    chatDelta.addMessage(conversationId, {
+      id: generateId(),
+      role: 'assistant',
+      content: `**Error:** ${detail}`,
+      timestamp: Date.now(),
+      loopId,
+    });
+    logger.error('orchestration failed before the loop started', { conversationId, error: detail });
+    return { reason: 'error', error: detail };
+  }
+  const { route, systemPromptSections } = orchestration;
   options?.runtimeEvent?.('agent_route_selected', {
     conversationId,
     loopId,

--- a/src/core/agent/agentLoopRunner.ts
+++ b/src/core/agent/agentLoopRunner.ts
@@ -2104,7 +2104,7 @@ async function runSingleAgentLoopDispatched(
   const clientMessageId = `msg-${runId}`;
   logger.debug('agent-loop path selected', { path: 'sidecar', runId, conversationId });
   const runtimeStartedAt = Date.now();
-  startRuntimeRun(runId, 'sidecar', 'local_message_persisting');
+  startRuntimeRun(runId, 'sidecar', 'local_message_persisting', conversationId);
 
   const abortRegistry = getAbortRegistry();
   abortRegistry.clearAbortController(conversationId);

--- a/src/core/observability/runtimeTrace.test.ts
+++ b/src/core/observability/runtimeTrace.test.ts
@@ -124,4 +124,40 @@ describe('renderer runtime trace', () => {
     });
     expect(getRendererRuntimeTraceSnapshot().recentEvents[0]).not.toHaveProperty('toolNames');
   });
+
+  describe('conversation join', () => {
+    it('stamps the run conversationId onto later events that only carry a runId', () => {
+      startRuntimeRun('run-join', 'sidecar', 'local_message_persisting', 'conversation-join');
+
+      traceRuntimeEvent('renderer.first_frame_applied', { runId: 'run-join' });
+
+      expect(getRendererRuntimeTraceSnapshot().recentEvents[0]).toMatchObject({
+        runId: 'run-join',
+        conversationId: 'conversation-join',
+      });
+      expect(recordElectronRuntimeEventMock).toHaveBeenCalledWith(
+        expect.objectContaining({ conversationId: 'conversation-join' }),
+      );
+    });
+
+    it('keeps an explicit conversationId and never invents one for unknown runs', () => {
+      startRuntimeRun('run-join', 'sidecar', 'stage', 'conversation-join');
+
+      traceRuntimeEvent('renderer.explicit', { runId: 'run-join', conversationId: 'conversation-explicit' });
+      traceRuntimeEvent('renderer.unknown_run', { runId: 'run-absent' });
+
+      const [explicit, unknown] = getRendererRuntimeTraceSnapshot().recentEvents;
+      expect(explicit).toMatchObject({ conversationId: 'conversation-explicit' });
+      expect(unknown).not.toHaveProperty('conversationId');
+    });
+
+    it('stops stamping once the run is finished', () => {
+      startRuntimeRun('run-join', 'sidecar', 'stage', 'conversation-join');
+      finishRuntimeRun('run-join');
+
+      traceRuntimeEvent('renderer.after_finish', { runId: 'run-join' });
+
+      expect(getRendererRuntimeTraceSnapshot().recentEvents[0]).not.toHaveProperty('conversationId');
+    });
+  });
 });

--- a/src/core/observability/runtimeTrace.ts
+++ b/src/core/observability/runtimeTrace.ts
@@ -66,6 +66,8 @@ interface ActiveRuntimeRun {
   stage: string;
   startedAt: number;
   updatedAt: number;
+  /** Set at run start so every later event carrying this runId can be joined to its conversation. */
+  conversationId?: string;
 }
 
 export interface RendererRuntimeTraceSnapshot {
@@ -173,24 +175,43 @@ export function runtimeErrorType(error: unknown): string {
   return raw.toLowerCase().replace(/[^a-z0-9_.-]+/g, '_').slice(0, 80) || 'unknown';
 }
 
+/**
+ * Attach the run's conversationId to events that carry a runId but no explicit
+ * conversationId. Without this the run timeline cannot be joined to the session
+ * ledger during diagnosis — most emit sites know their runId but not the
+ * conversation, so the join is resolved centrally from the run registry rather
+ * than threaded through every call site. An explicit conversationId always wins.
+ */
+function withRunConversation(attributes: RuntimeTraceAttributes): RuntimeTraceAttributes {
+  if (attributes.conversationId !== undefined || attributes.runId === undefined) return attributes;
+  const conversationId = activeRuns.get(attributes.runId)?.conversationId;
+  return conversationId === undefined ? attributes : { ...attributes, conversationId };
+}
+
 export function traceRuntimeEvent(eventName: string, attributes: RuntimeTraceAttributes = {}): void {
   const event = sanitizeEventName(eventName);
   if (!event || !event.startsWith('renderer.')) return;
+  const safeAttributes = sanitizeAttributes(withRunConversation(attributes));
   const entry: RuntimeTraceEvent = {
     schemaVersion: 1,
     timestamp: Date.now(),
     process: 'renderer',
     event,
-    ...sanitizeAttributes(attributes),
+    ...safeAttributes,
   };
   recentEvents.push(entry);
   if (recentEvents.length > MAX_EVENTS) recentEvents.shift();
-  recordElectronRuntimeEvent({ event, ...sanitizeAttributes(attributes) });
+  recordElectronRuntimeEvent({ event, ...safeAttributes });
 }
 
-export function startRuntimeRun(runId: string, executionPath: string, stage: string): void {
+export function startRuntimeRun(
+  runId: string,
+  executionPath: string,
+  stage: string,
+  conversationId?: string,
+): void {
   const now = Date.now();
-  activeRuns.set(runId, { runId, executionPath, stage, startedAt: now, updatedAt: now });
+  activeRuns.set(runId, { runId, executionPath, stage, startedAt: now, updatedAt: now, conversationId });
 }
 
 export function markRuntimeRunStage(runId: string, stage: string): void {

--- a/src/core/permissions/browserToolPolicy.test.ts
+++ b/src/core/permissions/browserToolPolicy.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   __resetBrowserGrantsForTests,
+  BROWSER_GRANT_TTL_MS,
   classifyBrowserTool,
   grantBrowserAutomation,
   hasBrowserGrant,
@@ -56,6 +57,27 @@ describe('browser tool policy', () => {
       grantBrowserAutomation('conv-1');
       revokeBrowserGrant('conv-1');
       expect(hasBrowserGrant('conv-1')).toBe(false);
+    });
+  });
+  describe('grant expiry', () => {
+    // Without a TTL the approval would be strictly weaker than the Computer Use
+    // task grant it mirrors: one approval would cover the conversation for as
+    // long as the app stayed open, including after the user tightened the
+    // permission mode expecting to be asked again.
+    it('stops covering the conversation once the TTL elapses', () => {
+      const start = 1_000_000;
+      grantBrowserAutomation('conv-1', start);
+
+      expect(hasBrowserGrant('conv-1', start + BROWSER_GRANT_TTL_MS - 1)).toBe(true);
+      expect(hasBrowserGrant('conv-1', start + BROWSER_GRANT_TTL_MS)).toBe(false);
+    });
+
+    it('re-approving extends the window from the new approval', () => {
+      const start = 1_000_000;
+      grantBrowserAutomation('conv-1', start);
+      grantBrowserAutomation('conv-1', start + BROWSER_GRANT_TTL_MS + 5);
+
+      expect(hasBrowserGrant('conv-1', start + BROWSER_GRANT_TTL_MS + 6)).toBe(true);
     });
   });
 });

--- a/src/core/permissions/browserToolPolicy.test.ts
+++ b/src/core/permissions/browserToolPolicy.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  __resetBrowserGrantsForTests,
+  classifyBrowserTool,
+  grantBrowserAutomation,
+  hasBrowserGrant,
+  revokeBrowserGrant,
+} from './browserToolPolicy';
+
+describe('browser tool policy', () => {
+  beforeEach(() => {
+    __resetBrowserGrantsForTests();
+  });
+
+  describe('classifyBrowserTool', () => {
+    it('classifies actions that act inside the logged-in session as state-changing', () => {
+      for (const tool of ['click', 'fill', 'select', 'keyboard', 'execute_js', 'navigate']) {
+        expect(classifyBrowserTool(`abu-browser__${tool}`)).toBe('state-changing');
+        expect(classifyBrowserTool(`abu-browser-bridge__${tool}`)).toBe('state-changing');
+      }
+    });
+
+    it('leaves observation tools ungated', () => {
+      for (const tool of ['snapshot', 'get_tabs', 'extract_text', 'extract_table', 'screenshot', 'scroll']) {
+        expect(classifyBrowserTool(`abu-browser__${tool}`)).toBe('read-only');
+      }
+    });
+
+    it('ignores non-browser tools so other MCP servers keep their current behavior', () => {
+      expect(classifyBrowserTool('some-server__click')).toBeNull();
+      expect(classifyBrowserTool('run_command')).toBeNull();
+      expect(classifyBrowserTool('read_file')).toBeNull();
+    });
+
+    it('does not let a server name ending in the browser name slip through', () => {
+      expect(classifyBrowserTool('evil-abu-browser__click')).toBeNull();
+    });
+  });
+
+  describe('per-conversation grant', () => {
+    it('starts ungranted and grants only the conversation that approved', () => {
+      expect(hasBrowserGrant('conv-1')).toBe(false);
+
+      grantBrowserAutomation('conv-1');
+
+      expect(hasBrowserGrant('conv-1')).toBe(true);
+      expect(hasBrowserGrant('conv-2')).toBe(false);
+    });
+
+    it('treats a missing conversation id as ungranted and ignores granting it', () => {
+      grantBrowserAutomation(undefined);
+      expect(hasBrowserGrant(undefined)).toBe(false);
+    });
+
+    it('drops the grant when revoked', () => {
+      grantBrowserAutomation('conv-1');
+      revokeBrowserGrant('conv-1');
+      expect(hasBrowserGrant('conv-1')).toBe(false);
+    });
+  });
+});

--- a/src/core/permissions/browserToolPolicy.ts
+++ b/src/core/permissions/browserToolPolicy.ts
@@ -47,22 +47,45 @@ export function classifyBrowserTool(namespacedName: string): BrowserToolConseque
 }
 
 /**
- * Conversations that already approved browser automation.
+ * How long one approval covers the rest of the task.
  *
- * Scoped per conversation and kept in memory on purpose, mirroring Computer
- * Use's task grant: the user approves once for the task at hand, and the grant
- * dies with the app rather than silently outliving the session that earned it.
+ * Same 30 minutes Computer Use gives a task grant. An approval that never
+ * expires would be strictly weaker than the model it mirrors: the user would
+ * approve once and the conversation would keep acting in their browser for as
+ * long as the app stays open, including after they tightened the permission
+ * mode expecting to be asked again.
  */
-const grantedConversations = new Set<string>();
+export const BROWSER_GRANT_TTL_MS = 30 * 60 * 1000;
 
-export function hasBrowserGrant(conversationId: string | undefined): boolean {
-  return conversationId !== undefined && grantedConversations.has(conversationId);
+/**
+ * Conversations that already approved browser automation, with the moment the
+ * approval was given. Kept in memory on purpose — the grant dies with the app
+ * rather than silently outliving the session that earned it.
+ */
+const grantedConversations = new Map<string, number>();
+
+export function hasBrowserGrant(
+  conversationId: string | undefined,
+  now: number = Date.now(),
+): boolean {
+  if (conversationId === undefined) return false;
+  const grantedAt = grantedConversations.get(conversationId);
+  if (grantedAt === undefined) return false;
+  if (now - grantedAt >= BROWSER_GRANT_TTL_MS) {
+    grantedConversations.delete(conversationId);
+    return false;
+  }
+  return true;
 }
 
-export function grantBrowserAutomation(conversationId: string | undefined): void {
-  if (conversationId !== undefined) grantedConversations.add(conversationId);
+export function grantBrowserAutomation(
+  conversationId: string | undefined,
+  now: number = Date.now(),
+): void {
+  if (conversationId !== undefined) grantedConversations.set(conversationId, now);
 }
 
+/** Drop a grant early — used when the conversation's permission posture changes. */
 export function revokeBrowserGrant(conversationId: string): void {
   grantedConversations.delete(conversationId);
 }

--- a/src/core/permissions/browserToolPolicy.ts
+++ b/src/core/permissions/browserToolPolicy.ts
@@ -1,0 +1,72 @@
+/**
+ * Browser-automation consequence classification.
+ *
+ * Computer Use already treats browsers as `approval-required` (see
+ * `computerUsePolicy.json`): driving Safari/Chrome asks the user in every
+ * permission mode, because a click in a logged-in session can submit, pay, or
+ * delete. The browser-automation tools reach the *same* logged-in sessions
+ * through a different mechanism (the `abu-browser` runtime and the Chrome
+ * extension bridge), so the gate has to follow the consequence, not the
+ * mechanism — otherwise the cheaper path is also the ungated one.
+ *
+ * Only page-state-changing actions are gated. Reading the page (snapshot,
+ * extract, screenshot) stays free: it is what the agent does constantly while
+ * browsing, and gating it would train users to click through prompts.
+ */
+
+/** Built-in browser runtime + Chrome extension bridge — both expose the same tool set. */
+const BROWSER_SERVER_NAMES = new Set(['abu-browser', 'abu-browser-bridge']);
+
+/**
+ * Actions that change page state or run code in the page's origin.
+ * `navigate` is included because it drives the session somewhere new (and GET
+ * endpoints can act); `keyboard` because Enter submits.
+ */
+const STATE_CHANGING_TOOLS = new Set([
+  'click',
+  'fill',
+  'select',
+  'keyboard',
+  'execute_js',
+  'navigate',
+]);
+
+export type BrowserToolConsequence = 'read-only' | 'state-changing';
+
+/**
+ * Classify a namespaced MCP tool name (`server__tool`).
+ * Returns null when the tool is not a browser-automation tool.
+ */
+export function classifyBrowserTool(namespacedName: string): BrowserToolConsequence | null {
+  const separator = namespacedName.indexOf('__');
+  if (separator === -1) return null;
+  const serverName = namespacedName.slice(0, separator);
+  if (!BROWSER_SERVER_NAMES.has(serverName)) return null;
+  const toolName = namespacedName.slice(separator + 2);
+  return STATE_CHANGING_TOOLS.has(toolName) ? 'state-changing' : 'read-only';
+}
+
+/**
+ * Conversations that already approved browser automation.
+ *
+ * Scoped per conversation and kept in memory on purpose, mirroring Computer
+ * Use's task grant: the user approves once for the task at hand, and the grant
+ * dies with the app rather than silently outliving the session that earned it.
+ */
+const grantedConversations = new Set<string>();
+
+export function hasBrowserGrant(conversationId: string | undefined): boolean {
+  return conversationId !== undefined && grantedConversations.has(conversationId);
+}
+
+export function grantBrowserAutomation(conversationId: string | undefined): void {
+  if (conversationId !== undefined) grantedConversations.add(conversationId);
+}
+
+export function revokeBrowserGrant(conversationId: string): void {
+  grantedConversations.delete(conversationId);
+}
+
+export function __resetBrowserGrantsForTests(): void {
+  grantedConversations.clear();
+}

--- a/src/core/permissions/permissionMode.ts
+++ b/src/core/permissions/permissionMode.ts
@@ -57,8 +57,35 @@ export interface PermissionStrategy {
   /** Decide gating for file tools (read_file, write_file, edit_file, etc.). */
   decideFileAccess(capability: 'read' | 'write', needsPermission: boolean): PermissionDecision;
 
-  /** Decide gating for MCP/other tools. */
-  decideOtherTool(): PermissionDecision;
+  /**
+   * Decide gating for MCP/other tools.
+   *
+   * @param consequence - 'state-changing' for actions that act on the user's
+   *   behalf inside a live session (browser click/fill/execute_js); 'read-only'
+   *   for observation. Omitted for tools with no consequence classification,
+   *   which stay ungated as before.
+   * @param alreadyGranted - the user already approved this class for the
+   *   current conversation, so the remaining actions of the task run freely
+   *   (same shape as Computer Use's per-task grant).
+   */
+  decideOtherTool(
+    consequence?: 'read-only' | 'state-changing',
+    alreadyGranted?: boolean,
+  ): PermissionDecision;
+}
+
+/**
+ * Shared gate for consequence-classified non-command tools.
+ * Mirrors `computerUsePolicy.modePolicy`'s `approval-required` row, which asks
+ * in every mode — the browser is the same high-consequence surface whether it
+ * is driven by Computer Use or by the automation tools.
+ */
+function decideConsequentialTool(
+  consequence?: 'read-only' | 'state-changing',
+  alreadyGranted?: boolean,
+): PermissionDecision {
+  if (consequence !== 'state-changing') return 'allow';
+  return alreadyGranted ? 'allow' : 'confirm';
 }
 
 /** Whether a command's content classification counts as an escalation. */
@@ -79,8 +106,8 @@ const standardStrategy: PermissionStrategy = {
     // needsPermission === true means the path isn't in an authorized working dir yet.
     return needsPermission ? 'confirm' : 'allow';
   },
-  decideOtherTool() {
-    return 'allow';
+  decideOtherTool(consequence, alreadyGranted) {
+    return decideConsequentialTool(consequence, alreadyGranted);
   },
 };
 
@@ -93,8 +120,8 @@ const smartStrategy: PermissionStrategy = {
   decideFileAccess(_capability, needsPermission) {
     return needsPermission ? 'review' : 'allow';
   },
-  decideOtherTool() {
-    return 'allow';
+  decideOtherTool(consequence, alreadyGranted) {
+    return decideConsequentialTool(consequence, alreadyGranted);
   },
 };
 
@@ -106,8 +133,10 @@ const autonomousStrategy: PermissionStrategy = {
   decideFileAccess() {
     return 'allow';
   },
-  decideOtherTool() {
-    return 'allow';
+  // Even here the browser stays gated: `computerUsePolicy.modePolicy` keeps
+  // `approval-required` at 'confirm' in autonomous for exactly this surface.
+  decideOtherTool(consequence, alreadyGranted) {
+    return decideConsequentialTool(consequence, alreadyGranted);
   },
 };
 

--- a/src/core/permissions/selfExtensionPolicy.ts
+++ b/src/core/permissions/selfExtensionPolicy.ts
@@ -1,0 +1,56 @@
+/**
+ * Self-extension consequence classification.
+ *
+ * Abu lets the agent grow its own capabilities — create subagents, install MCP
+ * servers, rewrite its persona. That is a real product strength, but all three
+ * write durable state that shapes every later turn, and the model can be
+ * steered by whatever it just read (a web page, a document, a tool result).
+ * Without a gate, one injected instruction buys a persistent foothold: an MCP
+ * server that spawns processes, a subagent with an attacker-authored system
+ * prompt, or a rewritten persona that survives into every future conversation.
+ *
+ * Skills already got this treatment (draft queue + content guard + audited
+ * history). These three took the same kind of write with none of it.
+ *
+ * Unlike browser automation there is no per-conversation grant: these are rare,
+ * deliberate acts, so each one is worth its own confirmation.
+ */
+
+import { TOOL_NAMES } from '../tools/toolNames';
+
+/** manage_mcp_server actions that add a server (and therefore spawn processes or reach a URL). */
+const MCP_INSTALLING_ACTIONS = new Set(['install', 'add_custom', 'ensure']);
+
+export interface SelfExtensionAction {
+  /** Short, human-readable description of what is about to be written. */
+  summary: string;
+}
+
+/**
+ * Classify a tool call that would extend the agent's own capabilities.
+ * Returns null when the call does not write durable capability state.
+ */
+export function classifySelfExtension(
+  name: string,
+  input: Record<string, unknown>,
+): SelfExtensionAction | null {
+  if (name === TOOL_NAMES.SAVE_AGENT) {
+    const agentName = typeof input.name === 'string' ? input.name : '';
+    return { summary: agentName ? `save_agent: ${agentName}` : 'save_agent' };
+  }
+
+  if (name === TOOL_NAMES.UPDATE_SOUL) {
+    return { summary: 'update_soul' };
+  }
+
+  if (name === TOOL_NAMES.MANAGE_MCP_SERVER) {
+    const action = typeof input.action === 'string' ? input.action : '';
+    if (!MCP_INSTALLING_ACTIONS.has(action)) return null;
+    const target = typeof input.name === 'string' && input.name
+      ? input.name
+      : typeof input.query === 'string' ? input.query : '';
+    return { summary: target ? `manage_mcp_server (${action}): ${target}` : `manage_mcp_server (${action})` };
+  }
+
+  return null;
+}

--- a/src/core/tools/commandSafety.ts
+++ b/src/core/tools/commandSafety.ts
@@ -21,6 +21,14 @@ export interface ConfirmationInfo {
   command: string;
   level: DangerLevel;
   reason: string;
+  /**
+   * What the user is being asked to approve. The dialog's wording follows this:
+   * a shell command, a browser action, and a new long-lived capability are not
+   * the same decision, and describing all three as "命令" leaves the user
+   * unable to judge what they are agreeing to. Defaults to 'command' so every
+   * existing caller keeps its current wording.
+   */
+  kind?: 'command' | 'browser' | 'self-extension';
 }
 
 /**

--- a/src/core/tools/registry.permissionMode.test.ts
+++ b/src/core/tools/registry.permissionMode.test.ts
@@ -128,3 +128,76 @@ describe('browser automation approval gate', () => {
     expect(decision.decision).toBe('deny');
   });
 });
+
+// ── Self-extension gate ──
+// Creating a subagent, installing an MCP server, or rewriting the persona all
+// write durable state that shapes every later turn. Each is confirmed on its
+// own — unlike browser automation there is no per-conversation grant.
+describe('self-extension approval gate', () => {
+  beforeEach(() => {
+    useChatStore.setState({ conversations: {}, conversationIndex: {}, activeConversationId: null });
+    useSettingsStore.setState({ permissionMode: 'standard' });
+  });
+
+  const collectingConfirm = (asked: string[]) =>
+    (async (info: { command: string }) => { asked.push(info.command); return true; }) as never;
+
+  it('asks before saving an agent, and names it', async () => {
+    const asked: string[] = [];
+    const decision = await checkToolApproval(
+      'save_agent', { name: 'helper', systemPrompt: 'do things' },
+      { conversationId: 'conv-1' } as never, collectingConfirm(asked),
+    );
+
+    expect(decision.decision).toBe('allow');
+    expect(asked).toHaveLength(1);
+    expect(asked[0]).toContain('helper');
+  });
+
+  it('asks before rewriting the persona', async () => {
+    const asked: string[] = [];
+    await checkToolApproval(
+      'update_soul', { content: 'new persona' }, { conversationId: 'conv-1' } as never, collectingConfirm(asked),
+    );
+    expect(asked).toHaveLength(1);
+  });
+
+  it('asks for every install — approving one does not grant the next', async () => {
+    const asked: string[] = [];
+    const confirm = collectingConfirm(asked);
+
+    await checkToolApproval('manage_mcp_server', { action: 'install', name: 'a' }, { conversationId: 'conv-1' } as never, confirm);
+    await checkToolApproval('manage_mcp_server', { action: 'add_custom', name: 'b' }, { conversationId: 'conv-1' } as never, confirm);
+
+    expect(asked).toHaveLength(2);
+  });
+
+  it('leaves read-only MCP actions alone', async () => {
+    const asked: string[] = [];
+    const decision = await checkToolApproval(
+      'manage_mcp_server', { action: 'search', query: 'github' },
+      { conversationId: 'conv-1' } as never, collectingConfirm(asked),
+    );
+
+    expect(decision.decision).toBe('allow');
+    expect(asked).toHaveLength(0);
+  });
+
+  it('denies when the user declines the install', async () => {
+    const decision = await checkToolApproval(
+      'manage_mcp_server', { action: 'install', name: 'sketchy' },
+      { conversationId: 'conv-1' } as never, (async () => false) as never,
+    );
+    expect(decision.decision).toBe('deny');
+  });
+
+  it('fails closed with no confirmation channel, in every permission mode', async () => {
+    for (const mode of ['standard', 'smart', 'autonomous'] as const) {
+      useSettingsStore.setState({ permissionMode: mode });
+      const decision = await checkToolApproval(
+        'save_agent', { name: 'x' }, { conversationId: 'conv-1' } as never, undefined,
+      );
+      expect(decision.decision).toBe('deny');
+    }
+  });
+});

--- a/src/core/tools/registry.permissionMode.test.ts
+++ b/src/core/tools/registry.permissionMode.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { useChatStore } from '../../stores/chatStore';
 import { useSettingsStore } from '../../stores/settingsStore';
 import type { PermissionMode } from '../permissions/permissionMode';
+import { __resetBrowserGrantsForTests } from '../permissions/browserToolPolicy';
+import { checkToolApproval } from './registry';
 
 // Test the conversation-level permission mode resolution formula used in registry.ts.
 // We test the logic in isolation via store state rather than calling executeTool directly
@@ -47,5 +49,82 @@ describe('permission mode resolution', () => {
     useChatStore.getState().setConversationPermissionMode(id, 'autonomous');
     useChatStore.getState().setConversationPermissionMode(id, undefined);
     expect(resolvePermissionMode(id)).toBe('smart');
+  });
+});
+
+// ── Browser automation gate (end-to-end through checkToolApproval) ──
+// Browser tools reach the user's logged-in sessions, the same consequence
+// Computer Use already gates for browser apps. These pin the gate itself, not
+// just the classifier, because the failure mode being fixed was a policy that
+// existed but was never wired into the approval chain.
+describe('browser automation approval gate', () => {
+  beforeEach(() => {
+    useChatStore.setState({ conversations: {}, conversationIndex: {}, activeConversationId: null });
+    useSettingsStore.setState({ permissionMode: 'standard' });
+    __resetBrowserGrantsForTests();
+  });
+
+  it('asks before a state-changing browser action, then not again in the same conversation', async () => {
+    const asked: string[] = [];
+    const confirm = async (info: { command: string }) => { asked.push(info.command); return true; };
+
+    const first = await checkToolApproval(
+      'abu-browser__click', { ref: 'e1' }, { conversationId: 'conv-1' } as never, confirm as never,
+    );
+    const second = await checkToolApproval(
+      'abu-browser__fill', { ref: 'e2', value: 'x' }, { conversationId: 'conv-1' } as never, confirm as never,
+    );
+
+    expect(first.decision).toBe('allow');
+    expect(second.decision).toBe('allow');
+    expect(asked).toHaveLength(1);
+    expect(asked[0]).toContain('abu-browser__click');
+  });
+
+  it('denies the action when the user declines', async () => {
+    const decision = await checkToolApproval(
+      'abu-browser__execute_js', { code: 'fetch("/transfer")' },
+      { conversationId: 'conv-1' } as never, (async () => false) as never,
+    );
+    expect(decision.decision).toBe('deny');
+  });
+
+  it('keeps asking in another conversation — the grant does not leak', async () => {
+    const asked: string[] = [];
+    const confirm = async (info: { command: string }) => { asked.push(info.command); return true; };
+
+    await checkToolApproval('abu-browser__click', {}, { conversationId: 'conv-1' } as never, confirm as never);
+    await checkToolApproval('abu-browser__click', {}, { conversationId: 'conv-2' } as never, confirm as never);
+
+    expect(asked).toHaveLength(2);
+  });
+
+  it('never asks for read-only browser tools', async () => {
+    const asked: string[] = [];
+    const confirm = async (info: { command: string }) => { asked.push(info.command); return true; };
+
+    const decision = await checkToolApproval(
+      'abu-browser__snapshot', { tabId: 1 }, { conversationId: 'conv-1' } as never, confirm as never,
+    );
+
+    expect(decision.decision).toBe('allow');
+    expect(asked).toHaveLength(0);
+  });
+
+  it('still asks in autonomous mode — this surface is approval-required in every mode', async () => {
+    useSettingsStore.setState({ permissionMode: 'autonomous' });
+    const asked: string[] = [];
+    const confirm = async (info: { command: string }) => { asked.push(info.command); return true; };
+
+    await checkToolApproval('abu-browser__click', {}, { conversationId: 'conv-1' } as never, confirm as never);
+
+    expect(asked).toHaveLength(1);
+  });
+
+  it('fails closed when there is no confirmation channel (headless/background run)', async () => {
+    const decision = await checkToolApproval(
+      'abu-browser__click', {}, { conversationId: 'conv-1' } as never, undefined,
+    );
+    expect(decision.decision).toBe('deny');
   });
 });

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -8,6 +8,7 @@ import { getSettingsReader } from '../agent/ports/settingsReader';
 import { useChatStore } from '../../stores/chatStore';
 import { getPermissionStrategy } from '../permissions/permissionMode';
 import { classifyBrowserTool, grantBrowserAutomation, hasBrowserGrant } from '../permissions/browserToolPolicy';
+import { classifySelfExtension } from '../permissions/selfExtensionPolicy';
 import { analyzeCommandBoundary, type CmdBoundary } from '../permissions/commandBoundary';
 import { reviewAction } from '../safety/reviewer';
 import { getLoopContext } from '../agent/permissionBridge';
@@ -441,6 +442,32 @@ export async function checkToolApproval(
           return { decision: 'deny', reason: t.commandConfirm.userCancelled };
         }
         grantBrowserAutomation(toolContext?.conversationId);
+      }
+    }
+  }
+
+  // Self-extension: creating a subagent, installing an MCP server, or
+  // rewriting the persona all write durable state that shapes every later
+  // turn. Skills already require a draft + content scan + audited history;
+  // these took the same kind of write with no gate at all, so a single
+  // injected instruction could buy a persistent foothold. No per-conversation
+  // grant here — these are rare, deliberate acts, each worth its own ask.
+  {
+    const selfExtension = classifySelfExtension(name, input);
+    if (selfExtension) {
+      const decision = strategy.decideOtherTool('state-changing', false);
+      if (decision !== 'allow') {
+        if (!onRequireConfirmation) {
+          return { decision: 'deny', reason: `Error: ${t.commandConfirm.selfExtensionDenied}` };
+        }
+        const confirmed = await onRequireConfirmation({
+          command: selfExtension.summary,
+          level: 'warn',
+          reason: t.commandConfirm.selfExtensionReason,
+        });
+        if (!confirmed) {
+          return { decision: 'deny', reason: t.commandConfirm.userCancelled };
+        }
       }
     }
   }

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -7,6 +7,7 @@ import { truncateToolResult } from '../context/truncation';
 import { getSettingsReader } from '../agent/ports/settingsReader';
 import { useChatStore } from '../../stores/chatStore';
 import { getPermissionStrategy } from '../permissions/permissionMode';
+import { classifyBrowserTool, grantBrowserAutomation, hasBrowserGrant } from '../permissions/browserToolPolicy';
 import { analyzeCommandBoundary, type CmdBoundary } from '../permissions/commandBoundary';
 import { reviewAction } from '../safety/reviewer';
 import { getLoopContext } from '../agent/permissionBridge';
@@ -411,6 +412,35 @@ export async function checkToolApproval(
           // Hard blocked — always enforced regardless of permission mode
           return { decision: 'deny', reason: `Error: ${pathCheck.reason}` };
         }
+      }
+    }
+  }
+
+  // Browser automation acts inside the user's live, logged-in sessions — the
+  // same consequence Computer Use already gates for browser apps. Gate the
+  // state-changing subset here so the cheaper mechanism is not the ungated one.
+  // Approval is per conversation (like Computer Use's per-task grant): the user
+  // approves once for the task, not once per click.
+  {
+    const consequence = classifyBrowserTool(name);
+    if (consequence === 'state-changing') {
+      const granted = hasBrowserGrant(toolContext?.conversationId);
+      const decision = strategy.decideOtherTool(consequence, granted);
+      if (decision !== 'allow') {
+        if (!onRequireConfirmation) {
+          // No confirmation channel (headless/background run) — fail closed
+          // rather than silently acting in the user's session.
+          return { decision: 'deny', reason: `Error: ${t.commandConfirm.browserDenied}` };
+        }
+        const confirmed = await onRequireConfirmation({
+          command: `${t.commandConfirm.browserAction}: ${name}`,
+          level: 'warn',
+          reason: t.commandConfirm.browserReason,
+        });
+        if (!confirmed) {
+          return { decision: 'deny', reason: t.commandConfirm.userCancelled };
+        }
+        grantBrowserAutomation(toolContext?.conversationId);
       }
     }
   }

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -437,6 +437,7 @@ export async function checkToolApproval(
           command: `${t.commandConfirm.browserAction}: ${name}`,
           level: 'warn',
           reason: t.commandConfirm.browserReason,
+          kind: 'browser',
         });
         if (!confirmed) {
           return { decision: 'deny', reason: t.commandConfirm.userCancelled };
@@ -464,6 +465,7 @@ export async function checkToolApproval(
           command: selfExtension.summary,
           level: 'warn',
           reason: t.commandConfirm.selfExtensionReason,
+          kind: 'self-extension',
         });
         if (!confirmed) {
           return { decision: 'deny', reason: t.commandConfirm.userCancelled };

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -2139,6 +2139,9 @@ const enUS: TranslationDict = {
     blocked: 'This command has been blocked for security reasons',
     userCancelled: '[User cancelled this operation]',
     aiDenied: 'Blocked by AI review',
+    browserAction: 'Browser action',
+    browserReason: 'This acts inside your logged-in browser (it may submit forms, click buttons, or run scripts). Once allowed, later browser actions in this conversation will not ask again.',
+    browserDenied: 'Browser actions need confirmation, but no confirmation channel is available',
   },
 
   toolErrors: {

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -2142,6 +2142,8 @@ const enUS: TranslationDict = {
     browserAction: 'Browser action',
     browserReason: 'This acts inside your logged-in browser (it may submit forms, click buttons, or run scripts). Once allowed, later browser actions in this conversation will not ask again.',
     browserDenied: 'Browser actions need confirmation, but no confirmation channel is available',
+    selfExtensionReason: 'This adds or rewrites a long-lived capability (subagent / MCP server / persona) that shapes every later conversation.',
+    selfExtensionDenied: 'Adding a capability needs confirmation, but no confirmation channel is available',
   },
 
   toolErrors: {

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -2146,6 +2146,10 @@ const enUS: TranslationDict = {
     browserDenied: 'Browser actions need confirmation, but no confirmation channel is available',
     selfExtensionReason: 'This adds or rewrites a long-lived capability (subagent / MCP server / persona) that shapes every later conversation.',
     selfExtensionDenied: 'Adding a capability needs confirmation, but no confirmation channel is available',
+    browserTitle: 'Confirm browser action',
+    browserDescription: 'Abu wants to run this action inside your logged-in browser:',
+    selfExtensionTitle: 'Confirm new capability',
+    selfExtensionDescription: 'Abu wants to add or rewrite one of its own long-lived capabilities:',
   },
 
   toolErrors: {

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -960,6 +960,8 @@ const enUS: TranslationDict = {
   },
 
   diagnostic: {
+    telemetryOptOut: 'Send anonymous usage and error reports',
+    telemetryOptOutDesc: 'Helps diagnose crashes and failures. Turn this off and Abu stops sending any usage, error, or diagnostic data.',
     title: 'Diagnostic',
     desc: 'Check Abu\'s health. Export a diagnostic bundle when reporting issues.',
     bannerAllPassed: 'All systems healthy',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -2147,6 +2147,10 @@ const zhCN: TranslationDict = {
     browserDenied: '浏览器操作需要确认，但当前没有可用的确认入口',
     selfExtensionReason: '将为阿布新增或改写一项长期能力（子代理 / MCP 服务 / 人格设定），它会影响之后的每一次对话。',
     selfExtensionDenied: '新增能力需要确认，但当前没有可用的确认入口',
+    browserTitle: '浏览器操作确认',
+    browserDescription: '阿布要在你已登录的浏览器里执行下面这个操作：',
+    selfExtensionTitle: '新增能力确认',
+    selfExtensionDescription: '阿布要为自己新增或改写一项长期能力：',
   },
 
   toolErrors: {

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -2140,6 +2140,9 @@ const zhCN: TranslationDict = {
     blocked: '此命令因安全原因被阻止执行',
     userCancelled: '[用户取消了此操作]',
     aiDenied: 'AI 审核已拒绝此操作',
+    browserAction: '浏览器操作',
+    browserReason: '将在你已登录的浏览器里执行操作（可能提交表单、点击按钮或运行脚本）。允许后，本次对话内的后续浏览器操作不再询问。',
+    browserDenied: '浏览器操作需要确认，但当前没有可用的确认入口',
   },
 
   toolErrors: {

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -2143,6 +2143,8 @@ const zhCN: TranslationDict = {
     browserAction: '浏览器操作',
     browserReason: '将在你已登录的浏览器里执行操作（可能提交表单、点击按钮或运行脚本）。允许后，本次对话内的后续浏览器操作不再询问。',
     browserDenied: '浏览器操作需要确认，但当前没有可用的确认入口',
+    selfExtensionReason: '将为阿布新增或改写一项长期能力（子代理 / MCP 服务 / 人格设定），它会影响之后的每一次对话。',
+    selfExtensionDenied: '新增能力需要确认，但当前没有可用的确认入口',
   },
 
   toolErrors: {

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -960,6 +960,8 @@ const zhCN: TranslationDict = {
   },
 
   diagnostic: {
+    telemetryOptOut: '发送匿名使用与错误报告',
+    telemetryOptOutDesc: '帮助定位崩溃与故障。关闭后阿布不再向服务端发送任何使用、错误或诊断数据。',
     title: '诊断',
     desc: '检查 Abu 的运行状态。出问题时也可以导出诊断包发给我们。',
     bannerAllPassed: '一切正常',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1067,6 +1067,8 @@ export interface TranslationDict {
 
   // Diagnostic
   diagnostic: {
+    telemetryOptOut: string;
+    telemetryOptOutDesc: string;
     title: string;
     desc: string;
     // Banner

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -2297,6 +2297,10 @@ export interface TranslationDict {
     browserDenied: string;
     selfExtensionReason: string;
     selfExtensionDenied: string;
+    browserTitle: string;
+    browserDescription: string;
+    selfExtensionTitle: string;
+    selfExtensionDescription: string;
   };
 
   // Tool error messages (used in core/tools/registry.ts)

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -2293,6 +2293,8 @@ export interface TranslationDict {
     browserAction: string;
     browserReason: string;
     browserDenied: string;
+    selfExtensionReason: string;
+    selfExtensionDenied: string;
   };
 
   // Tool error messages (used in core/tools/registry.ts)

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -2290,6 +2290,9 @@ export interface TranslationDict {
     blocked: string;
     userCancelled: string;
     aiDenied: string;
+    browserAction: string;
+    browserReason: string;
+    browserDenied: string;
   };
 
   // Tool error messages (used in core/tools/registry.ts)

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -1047,6 +1047,65 @@ describe('chatStore', () => {
     });
   });
 
+  // ── setMessageToolCalls — intent durability ──
+  describe('setMessageToolCalls persistence', () => {
+    // Same fs simulation as the cancelStreaming block above: assert at the
+    // atomic_write_text layer, because the store reaches conversationStorage
+    // through a dynamic import that a module-level vi.mock cannot intercept.
+    let written: string[];
+
+    beforeEach(() => {
+      written = [];
+      vi.mocked(exists).mockResolvedValue(true);
+      vi.mocked(readTextFile).mockImplementation(async () =>
+        JSON.stringify({ id: 'a1', role: 'assistant', content: '', timestamp: 1 }) + '\n');
+      vi.mocked(invoke).mockImplementation(async (cmd: string, args?: unknown) => {
+        const a = args as { path?: string; content?: string } | undefined;
+        if (cmd === 'atomic_write_text' && a?.path?.endsWith('messages.jsonl')) {
+          written.push(a.content ?? '');
+        }
+        return undefined;
+      });
+    });
+
+    afterEach(() => {
+      vi.mocked(exists).mockReset();
+      vi.mocked(readTextFile).mockReset();
+      vi.mocked(invoke).mockReset();
+    });
+
+    it('persists pending tool calls before the tools run', async () => {
+      // Regression: this action clears isStreaming, which switches off the
+      // streaming snapshot loop — so without an explicit write the intent
+      // reached disk only after the batch finished. A crash in between
+      // replayed as "never called", and retrying re-ran the side effect.
+      const id = useChatStore.getState().createConversation();
+      useChatStore.getState().addMessage(id, {
+        id: 'a1', role: 'assistant', content: '', timestamp: Date.now(), isStreaming: true,
+      });
+
+      useChatStore.getState().setMessageToolCalls(id, 'a1', [
+        { id: 'tc1', name: 'run_command', input: { command: 'rm -rf tmp' }, status: 'pending' },
+      ]);
+
+      expect(useChatStore.getState().conversations[id].messages[0].isStreaming).toBe(false);
+      await vi.waitFor(() => {
+        expect(written.some((c) => c.includes('"tc1"') && c.includes('run_command'))).toBe(true);
+      });
+    });
+
+    it('leaves no write when the target message is gone', async () => {
+      const id = useChatStore.getState().createConversation();
+
+      useChatStore.getState().setMessageToolCalls(id, 'missing', [
+        { id: 'tc1', name: 'run_command', input: {}, status: 'pending' },
+      ]);
+
+      await new Promise((r) => setTimeout(r, 30));
+      expect(written).toHaveLength(0);
+    });
+  });
+
   // ── cancelStreaming — sidecar run authority (P1-3c-1) ──
   // docs/2026-07-21-phase1-p3c-conversation-authority-design.md §3: while a
   // sidecar-hosted run owns a conversation, the sidecar is the run's SINGLE

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1411,6 +1411,20 @@ export const useChatStore = create<ChatStore>()(
             msg.isStreaming = false;
           }
         });
+        // Persist the *intent* immediately, for the same reason updateToolCall
+        // persists the result: this call clears isStreaming, which switches off
+        // the streaming snapshot loop, so without an explicit write the pending
+        // tool calls would not reach disk until the batch finishes. A crash
+        // between here and that point would replay as "the model never called
+        // anything" even though a side effect (rm, write_file, an API call) had
+        // already run — the recovery path could not tell "not started" from
+        // "started, unrecorded", and a retry would execute it twice.
+        const updatedMsg = get().conversations[convId]?.messages.find((m) => m.id === messageId);
+        if (updatedMsg) {
+          import('../core/session/conversationStorage').then(({ replaceMessageById }) => {
+            replaceMessageById(convId, updatedMsg).catch(() => {});
+          });
+        }
       },
 
       updateMessageUsage: (convId, usage, msgId) => {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -232,6 +232,10 @@ export interface SettingsState {
    *  Do NOT add to partialize. */
   guideOpen: boolean;
   behaviorSensorEnabled: boolean;
+  /** User opted out of anonymous usage/error reporting. Personal mode had no
+   *  way to turn reporting off; enterprise deployments already honour the
+   *  server-side telemetryEnabled flag. */
+  telemetryOptOut: boolean;
   computerUseEnabled: boolean;
   preventSleep: boolean;
   allowSkillCommands: boolean;
@@ -394,6 +398,7 @@ interface SettingsActions {
   openGuide: () => void;
   closeGuide: () => void;
   setBehaviorSensorEnabled: (enabled: boolean) => void;
+  setTelemetryOptOut: (optOut: boolean) => void;
   setComputerUseEnabled: (enabled: boolean) => void;
   setPreventSleep: (enabled: boolean) => void;
   setSoulInitialized: (initialized: boolean) => void;
@@ -628,6 +633,7 @@ export const useSettingsStore = create<SettingsStore>()(
       guideShown: false,
       guideOpen: false,
       behaviorSensorEnabled: false,
+      telemetryOptOut: false,
       computerUseEnabled: false,
       preventSleep: false,
       allowSkillCommands: true,
@@ -974,6 +980,7 @@ export const useSettingsStore = create<SettingsStore>()(
       // Closing the guide also marks it as shown so first-launch auto-open never re-triggers.
       closeGuide: () => set({ guideOpen: false, guideShown: true }),
       setBehaviorSensorEnabled: (behaviorSensorEnabled) => set({ behaviorSensorEnabled }),
+      setTelemetryOptOut: (telemetryOptOut) => set({ telemetryOptOut }),
       setComputerUseEnabled: (computerUseEnabled) => {
         set({ computerUseEnabled });
         syncComputerUseGate(computerUseEnabled);
@@ -1033,7 +1040,7 @@ export const useSettingsStore = create<SettingsStore>()(
     }),
     {
       name: 'abu-settings',
-      version: 42,
+      version: 43,
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
 
@@ -1051,6 +1058,13 @@ export const useSettingsStore = create<SettingsStore>()(
         // ════════════════════════════════════════════════
         if (version < 42) {
           state.theme = 'light';
+        }
+
+        if (version < 43) {
+          // New opt-out defaults to "still reporting" so upgrading does not
+          // silently change what an existing install already does; the point of
+          // this version is that the switch now exists at all.
+          if (state.telemetryOptOut === undefined) state.telemetryOptOut = false;
         }
 
         // NOTE: the V41 "imageGeneration independent config (C-a)" step lives at
@@ -1852,6 +1866,7 @@ export const useSettingsStore = create<SettingsStore>()(
         userAvatar: state.userAvatar,
         guideShown: state.guideShown,
         behaviorSensorEnabled: state.behaviorSensorEnabled,
+        telemetryOptOut: state.telemetryOptOut,
         computerUseEnabled: state.computerUseEnabled,
         preventSleep: state.preventSleep,
         allowSkillCommands: state.allowSkillCommands,

--- a/src/stores/storeVersions.test.ts
+++ b/src/stores/storeVersions.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 // All persisted stores must be registered here.
 // When adding a new persist store, add it to this list — otherwise this test fails.
 const PERSISTED_STORES = [
-  { key: 'abu-settings', minVersion: 42 },
+  { key: 'abu-settings', minVersion: 43 },
   { key: 'abu-chat', minVersion: 7 },
   { key: 'abu-scratchpad-store', minVersion: 1 },
   { key: 'abu-permissions', minVersion: 1 },

--- a/src/utils/consoleTelemetryTarget.test.ts
+++ b/src/utils/consoleTelemetryTarget.test.ts
@@ -23,6 +23,7 @@ vi.mock('@/stores/enterpriseStore', () => ({
 // ─── Import after mocks ───────────────────────────────────────────────────────
 
 import { getTelemetryTarget } from './consoleTelemetryTarget'
+import { useSettingsStore } from '@/stores/settingsStore'
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -153,5 +154,36 @@ describe('getTelemetryTarget', () => {
       expect(target.enabled).toBe(true)
       expect(target.baseUrl).toBe('https://console-test.local')
     })
+  })
+})
+
+// ─── User opt-out (personal mode had no way to say no) ───────────────────────
+
+describe('user telemetry opt-out', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ telemetryOptOut: false })
+  })
+
+  it('reports by default, matching the pre-existing behaviour', () => {
+    mockGetState.mockReturnValue({ mode: { kind: 'personal' } })
+    expect(getTelemetryTarget().enabled).toBe(true)
+  })
+
+  it('stops reporting in personal mode once the user opts out', () => {
+    mockGetState.mockReturnValue({ mode: { kind: 'personal' } })
+    useSettingsStore.setState({ telemetryOptOut: true })
+
+    const target = getTelemetryTarget()
+    expect(target.enabled).toBe(false)
+    expect(target.baseUrl).toBe('')
+  })
+
+  it('overrides an enterprise config that still has telemetry enabled', () => {
+    mockGetState.mockReturnValue({
+      mode: { kind: 'enterprise', binding: { serverUrl: SERVER_URL }, config: CONFIG_ENABLED },
+    })
+    useSettingsStore.setState({ telemetryOptOut: true })
+
+    expect(getTelemetryTarget().enabled).toBe(false)
   })
 })

--- a/src/utils/consoleTelemetryTarget.ts
+++ b/src/utils/consoleTelemetryTarget.ts
@@ -14,6 +14,7 @@
 // This is intentionally a function (not a module-level const) so it reflects
 // the live store state at the time of each telemetry call.
 import { useEnterpriseStore } from '@/stores/enterpriseStore'
+import { useSettingsStore } from '@/stores/settingsStore'
 
 const CONSOLE_URL = import.meta.env?.VITE_CONSOLE_URL as string | undefined
 
@@ -23,6 +24,12 @@ export interface TelemetryTarget {
 }
 
 export function getTelemetryTarget(): TelemetryTarget {
+  // The user's own opt-out comes first, in every mode. Enterprise deployments
+  // could already switch reporting off from the server, but a personal install
+  // had no way to say no at all — the only inputs were a build-time constant
+  // and the enterprise config.
+  if (useSettingsStore.getState().telemetryOptOut) return { baseUrl: '', enabled: false }
+
   const mode = useEnterpriseStore.getState().mode
 
   // Enterprise (connected) with a fully-fetched config snapshot


### PR DESCRIPTION
## 这批解决什么

对照 DeepSeek Harness 做了一轮 firsthand 盘点后，挑出**六处真会咬到用户的 harness 债**修掉。取舍原则是「按产品 ROI 取，不照框架完整性补」——事实账本重写、契约 codegen、统一 Job 注册表那类框架级大件明确没做。

## 改了什么

| commit | 用户能感觉到的变化 |
|---|---|
| `gate state-changing browser automation` | 模型要在你已登录的浏览器里点提交/填表单/跑 JS，先问你 |
| `confirm before the agent extends itself` | 模型给自己装 MCP、建 subagent、改人格，每次都要你点头 |
| `record tool-call intent before the tools run` | 崩溃后不再把「已经删了文件」显示成「没执行」 |
| `stop silently dropping the user's input` | 打了一大段话不会再无声蒸发 |
| `let users turn off anonymous reporting` | 个人版终于能关闭匿名上报 |
| `join runtime trace events to their conversation` | 排障能靠数据定位，不必复现 |
| `address review findings on the new gates` | 自审修复：弹窗措辞、授权 TTL、草稿回填串会话 |
| `move the reporting toggle out of the page's top slot` | 真机验收反馈：开关不再压过诊断结果 |

## 为什么这么设计

- **浏览器门按后果而非机制**：`computerUsePolicy.json` 早已把浏览器列为 `approval-required`（三档模式都 confirm），但同样后果的动作走浏览器自动化工具却零门——更便宜的路径同时是没有门的那条。新门复用同一条 `approval-required` 规则，并对齐 CU 的按任务授权（30 分钟 TTL）。
- **自建能力不做授权缓存**：低频高后果，每次单独确认。技能侧早有草稿+扫描+审计，这三条通道此前什么都没有。
- **接通了 `decideOtherTool`**：该钩子此前定义了却无任何调用点。

## 验收

- `npm run verify` **exit=0**（364 files / 5015 tests，净增 28 条回归测试），已 rebase 到最新 `dev` 后重跑。
- **真机 Electron 验收**：浏览器审批门（弹窗与文案确认）、被拒输入回填、遥测开关位置——均已在真实壳内走通。
- 工具意图落盘 / 自建能力审核门 / 日志贯穿：测试覆盖，无独立 UI 路径，未单独真机走查。

## 待决策（未处理，留给产品判断）

定时任务与触发器使用 `autoDenyConfirmation`，因此**无人值守场景下浏览器操作与自建能力现在会被拒绝**。安全上说得通（没人看着时不该在登录态里操作），但属于既有自动化的行为回退——是否给无人值守留豁免口子，需要产品侧拍板。

## 风险

- 权限类改动，建议合并前再看一眼 `checkToolApproval` 的两处新分支。
- store 版本 42 → 43（`telemetryOptOut`），带迁移，默认值保持现状（仍上报），升级不改变既有安装行为。
