### PR TITLE
fix(agent-loop): stop double-rendering failed-run errors, clarify insufficient-balance copy

### DIFF
--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -2476,6 +2476,10 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       const isOllamaForbidden = errorCode === 'authentication'
         && err instanceof LLMError && err.statusCode === 403
         && /^forbidden\s*$/i.test(err.message.trim());
+      // Provider-returned balance/resource-package exhaustion (e.g. Zhipu GLM
+      // answers HTTP 429 with this Chinese text). Replace the raw provider
+      // string with actionable copy; `result.error` keeps the original.
+      const isInsufficientBalanceError = /余额不足|无可用资源包/.test(errorMessage);
       const isEnterpriseGatewayUnavailable = err instanceof EnterpriseLlmUnavailableError;
       const isContextBudgetError = err instanceof ContextBudgetError;
       let displayError = isEnterpriseGatewayUnavailable
@@ -2488,6 +2492,8 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         ? getI18n().chat.visionUnsupported
         : isOllamaForbidden
         ? getI18n().chat.ollamaForbidden
+        : isInsufficientBalanceError
+        ? getI18n().chat.insufficientBalance
         : formatLlmDisplayError(err, errorMessage, getI18n().chat.errorEmptyBody);
       if (errorCode === 'not_found') {
         displayError += `\n\n${getI18n().chat.errorNotFoundHint}`;

--- a/src/core/agent/agentLoopRunner.test.ts
+++ b/src/core/agent/agentLoopRunner.test.ts
@@ -2279,6 +2279,35 @@ describe('agentLoopRunner', () => {
       expect(chatDeltaSetConversationStatusMock).toHaveBeenCalledWith('conv-1', 'error');
     });
 
+    it('skips re-appending the error text when agentLoop already rendered it (errorType: agent_loop_error)', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      sidecarRequestMock.mockImplementation((_method: string, _params: unknown, _timeout: number, signal?: AbortSignal) => (
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+        })
+      ));
+
+      const running = runAgentLoopDispatched('conv-1', 'hello');
+      await waitForCall(sidecarRequestMock);
+      const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
+      const terminalHandler = handlerFor(onSidecarNotification, 'agent.terminal');
+      terminalHandler({
+        version: 1,
+        runId,
+        state: 'failed',
+        result: { reason: 'error', error: '余额不足或无可用资源包，请充值。' },
+        failure: { errorType: 'agent_loop_error', message: '余额不足或无可用资源包，请充值。' },
+      });
+
+      await expect(running).resolves.toEqual({ reason: 'error', error: '余额不足或无可用资源包，请充值。' });
+      expect(runAgentLoopMock).not.toHaveBeenCalled();
+      // agentLoop's own catch branch already appended the display error inside
+      // the sidecar — the shell must not render it a second time.
+      expect(chatDeltaAppendTextMock).not.toHaveBeenCalled();
+      expect(chatDeltaFinishStreamingMock).toHaveBeenCalledTimes(1);
+      expect(chatDeltaSetConversationStatusMock).toHaveBeenCalledWith('conv-1', 'error');
+    });
+
     it('does not settle a failed terminal until its failed lifecycle is durable', async () => {
       const { runAgentLoopDispatched } = await importFresh();
       const failurePersistence = deferred<void>();

--- a/src/core/agent/agentLoopRunner.ts
+++ b/src/core/agent/agentLoopRunner.ts
@@ -494,10 +494,18 @@ async function settleRunPersistence(session: RunSession): Promise<void> {
   await waitForConversationPersistence(session.conversationId);
 }
 
+/**
+ * `skipErrorAppend` is for the case where the sidecar-hosted agent loop already
+ * rendered the error text itself (agentLoop.ts's own catch branch appends the
+ * display error and finishes streaming before returning a failed result).
+ * Appending here again would render the same provider error twice in the
+ * bubble. Everything else in the terminal contract still runs.
+ */
 async function finalizeFailedRun(
   session: RunSession,
   displayMessage: string,
   state: 'failed' | 'connection-failed' = 'failed',
+  skipErrorAppend = false,
 ): Promise<void> {
   if (session.failureFinalizationPromise) return session.failureFinalizationPromise;
 
@@ -507,7 +515,9 @@ async function finalizeFailedRun(
     await (session.frameApplyTail ?? Promise.resolve());
     try {
       const chatDelta = getChatDelta();
-      chatDelta.appendText(session.conversationId, `\n\n**Error:** ${displayMessage}`);
+      if (!skipErrorAppend) {
+        chatDelta.appendText(session.conversationId, `\n\n**Error:** ${displayMessage}`);
+      }
       chatDelta.finishStreaming(session.conversationId);
       chatDelta.setAgentStatus('idle');
       chatDelta.setConversationStatus(session.conversationId, 'error');
@@ -2339,7 +2349,14 @@ async function runSingleAgentLoopDispatched(
         errorType: terminal.failure?.errorType,
         durationMs: Date.now() - runtimeStartedAt,
       });
-      await finalizeFailedRun(session, displayMessage);
+      // `agent_loop_error` is the default errorType stamped by
+      // createAgentRunTerminal when the sidecar's agentLoop returned a failed
+      // result through its own catch branch — which already appended the error
+      // text and finished streaming. Any other errorType comes from a sidecar
+      // crash / uncaught throw, where nothing rendered and this append is the
+      // only chance to surface the failure.
+      const alreadyRenderedBySidecar = terminal.failure?.errorType === 'agent_loop_error';
+      await finalizeFailedRun(session, displayMessage, 'failed', alreadyRenderedBySidecar);
       return { reason: 'error', error: realMessage };
     }
 

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -385,6 +385,7 @@ const enUS: TranslationDict = {
     conversationBusy: 'This conversation already has a running task. Wait for it to finish before starting another.',
     visionUnsupported: 'The current model may not support image/vision input. Try removing the image or switching to a vision-capable model (e.g. Claude, GPT-4o).',
     ollamaForbidden: 'Ollama returned 403 Forbidden (CORS origin restriction). Set the environment variable `OLLAMA_ORIGINS=*` and restart Ollama, e.g. `OLLAMA_ORIGINS=* ollama serve`',
+    insufficientBalance: "Insufficient balance or no available resource package. Please recharge on the corresponding model provider's platform.",
     compactingInlineNotice: '\n*Context is getting long, optimizing context...*',
     contextInputTooLarge: 'This message is too large for the current model context. Shorten the message or attachments, or switch to a model with a larger context window.',
     contextFixedTooLarge: 'The current system instructions and tool definitions exceed this model’s safe context budget. Disable some tools or switch to a model with a larger context window.',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -385,6 +385,7 @@ const zhCN: TranslationDict = {
     conversationBusy: '当前会话已有任务在运行，请等待结束后再启动新任务。',
     visionUnsupported: '当前模型可能不支持图片/视觉输入，请尝试移除图片或切换到支持视觉的模型（如 Claude、GPT-4o）。',
     ollamaForbidden: 'Ollama 返回了 403 Forbidden（CORS 来源限制）。请设置环境变量 `OLLAMA_ORIGINS=*` 后重启 Ollama，例如：`OLLAMA_ORIGINS=* ollama serve`',
+    insufficientBalance: '余额不足或无可用资源包，请到对应模型平台充值。',
     compactingInlineNotice: '\n*上下文过长，正在优化上下文...*',
     contextInputTooLarge: '这条消息超过了当前模型的上下文容量。请缩短消息或附件，或者切换到上下文更大的模型。',
     contextFixedTooLarge: '当前系统指令和工具定义超过了模型的安全上下文预算。请停用部分工具，或者切换到上下文更大的模型。',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -385,6 +385,8 @@ export interface TranslationDict {
     visionUnsupported: string;
     /** Ollama returned 403 Forbidden (CORS origin restriction). */
     ollamaForbidden: string;
+    /** Provider account balance/resource-package exhausted. */
+    insufficientBalance: string;
     /** Streamed-inline notice while compacting an oversized context (includes markdown). */
     compactingInlineNotice: string;
     /** Latest user message cannot fit within the model's safe context budget. */


### PR DESCRIPTION
## Summary
- Diagnostic bundles from users on 0.38.0 showed a provider balance-exhaustion error rendered **twice** in the chat bubble. Root cause: `agentLoop.ts`'s own catch branch already streams + finishes the error text, but `settleFromTerminal` unconditionally appended the same text again via `finalizeFailedRun`. Now skipped when `terminal.failure?.errorType === 'agent_loop_error'` (sidecar already rendered it); the genuine sidecar-crash path (different errorType, nothing rendered yet) still appends as before.
- Replaced the raw provider text for balance/resource-package exhaustion (observed verbatim from Zhipu GLM: `余额不足或无可用资源包,请充值。`) with actionable copy pointing users to the model provider's platform, in both locales (`chat.insufficientBalance`).

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npx vitest run src/core/agent/agentLoopRunner.test.ts` — 172 passed, incl. new regression case; existing `provider_error` case (still-must-append branch) untouched and passing
- [x] Mutation check: reverting the `alreadyRenderedBySidecar` gate to hardcoded `false` fails exactly the new assertion, confirming it's load-bearing
- [x] `npm run verify` — exit 0 (363 test files / 4986 tests, coverage gates met)
- [ ] Not verified in a real Electron shell — this specific error requires an actually-exhausted provider account balance, which isn't reproducible in dev; verification relies on the targeted unit tests above (the established method for this code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)