### PR TITLE
fix(ci): harden two flaky release gates (happy-dom WeakRef GC + empty capture thumbnail)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "abu",
-  "version": "0.38.1",
+  "version": "0.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "abu",
-      "version": "0.38.1",
+      "version": "0.39.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.95.2",
@@ -89,7 +89,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.6.0",
-        "happy-dom": "^20.9.0",
+        "happy-dom": "20.11.2",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.8",
         "shadcn": "^4.7.0",
@@ -4818,9 +4818,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4838,9 +4835,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4858,9 +4852,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4878,9 +4869,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4898,9 +4886,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4918,9 +4903,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5199,9 +5181,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5219,9 +5198,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5239,9 +5215,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5259,9 +5232,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5515,9 +5485,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -5535,9 +5502,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -5555,9 +5519,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -5575,9 +5536,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -5595,9 +5553,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -7611,6 +7566,19 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmmirror.com/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/builder-util": {
       "version": "26.15.3",
@@ -11055,18 +11023,19 @@
       "license": "MIT"
     },
     "node_modules/happy-dom": {
-      "version": "20.9.0",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
-      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "version": "20.11.2",
+      "resolved": "https://registry.npmmirror.com/happy-dom/-/happy-dom-20.11.2.tgz",
+      "integrity": "sha512-7MB+bJLkxu3SowAfBJbjW+c55kNz5tkR45gu2qzrxznezhLeN5YIlJbwUgSzlGc+qWoZ8Ykg71H5ezz69xixrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
         "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
         "entities": "^7.0.1",
         "whatwg-mimetype": "^3.0.0",
-        "ws": "^8.18.3"
+        "ws": "^8.21.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.6.0",
-    "happy-dom": "^20.9.0",
+    "happy-dom": "20.11.2",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.8",
     "shadcn": "^4.7.0",

--- a/scripts/electron-packaged-smoke.mjs
+++ b/scripts/electron-packaged-smoke.mjs
@@ -1554,12 +1554,19 @@ async function inspectPackagedBrowserView(app, tabId, screenshotData) {
             sources[displayIndex] ??
             sources[0];
           if (compositeSource) {
-            // TCC status alone is not proof that desktopCapturer produced an
-            // authoritative screen image. Only make composition mandatory
-            // after Electron returns a concrete source, matching Windows.
-            windowCompositeTrusted = true;
             compositeSourceId = `${compositeSource.id}:${compositeSource.display_id}`;
             const sourceSize = compositeSource.thumbnail.getSize();
+            // TCC status alone is not proof that desktopCapturer produced an
+            // authoritative screen image. Only make composition mandatory
+            // after Electron returns a concrete source WITH a non-empty
+            // thumbnail — contended runners intermittently hand back a
+            // source whose image is 0x0, which is no evidence either way
+            // (observed failing v0.39.0: trusted=true + composite=null while
+            // the view's own draw evidence was all green).
+            if (sourceSize.width <= 0 || sourceSize.height <= 0) {
+              compositeError = 'desktop source returned an empty thumbnail';
+            } else {
+            windowCompositeTrusted = true;
             const scaleX = sourceSize.width / display.bounds.width;
             const scaleY = sourceSize.height / display.bounds.height;
             const x = Math.max(
@@ -1585,6 +1592,7 @@ async function inspectPackagedBrowserView(app, tabId, screenshotData) {
                 windowCompositePng = cropped.toPNG().toString('base64');
               }
             }
+            }
           } else {
             compositeError = 'screen capture was granted but returned no desktop source';
           }
@@ -1600,12 +1608,18 @@ async function inspectPackagedBrowserView(app, tabId, screenshotData) {
           });
           const compositeSource = sources.find((source) => source.id === mediaSourceId);
           if (compositeSource) {
+            compositeSourceId = `${compositeSource.id}:${compositeSource.display_id}`;
+            const sourceSize = compositeSource.thumbnail.getSize();
             // GitHub's non-interactive Windows runner can expose no capturable
             // top-level windows. Treat composition as authoritative only when
-            // Electron actually returned this window as a desktop source.
-            windowCompositeTrusted = true;
-            compositeSourceId = `${compositeSource.id}:${compositeSource.display_id}`;
-            windowComposite = analyze(compositeSource.thumbnail);
+            // Electron actually returned this window as a desktop source with
+            // a non-empty thumbnail (same empty-image guard as macOS).
+            if (sourceSize.width <= 0 || sourceSize.height <= 0) {
+              compositeError = 'desktop source returned an empty thumbnail';
+            } else {
+              windowCompositeTrusted = true;
+              windowComposite = analyze(compositeSource.thumbnail);
+            }
           }
         }
       } catch (error) {

--- a/src/components/panel/workspace/TerminalTab.test.tsx
+++ b/src/components/panel/workspace/TerminalTab.test.tsx
@@ -105,25 +105,21 @@ describe('TerminalTab theming', () => {
     const spawnCallsBefore = invoke.mock.calls.filter(([cmd]) => cmd === 'pty_spawn').length;
     const killCallsBefore = invoke.mock.calls.filter(([cmd]) => cmd === 'pty_kill').length;
 
-    act(() => {
+    // Deterministic, not clock-based: the MutationObserver callback
+    // (useEffectiveThemeIsDark) is delivered on the task queue and the theme
+    // repaint runs in a React effect — one awaited macrotask turn inside act()
+    // covers both, regardless of how slow the runner is. The previous
+    // real-time waitFor (even at 12s) still lost this race once on a
+    // contended Windows runner; event ordering cannot.
+    await act(async () => {
       document.documentElement.classList.add('dark');
+      await new Promise((resolve) => setTimeout(resolve, 0));
     });
-
-    // The MutationObserver callback (useEffectiveThemeIsDark) fires off a
-    // microtask checkpoint, not synchronously — under CI resource contention
-    // (observed on Windows runners) it can take a couple of seconds, so this
-    // needs real headroom. Vitest's per-test timeout defaults to 5s and is
-    // deliberately not raised project-wide (vitest.config.ts), so a waitFor
-    // timeout anywhere near that just loses the race against the *outer*
-    // test timeout before it ever gets to report its own diff — hence the
-    // explicit, larger `it(...)` timeout below alongside this one.
-    await waitFor(() => {
-      expect(terminalInstances[0].options.theme).toEqual({
-        background: DARK_VARS['--abu-bg-base'],
-        foreground: DARK_VARS['--abu-text-primary'],
-        cursor: DARK_VARS['--abu-clay'],
-      });
-    }, { timeout: 12000 });
+    expect(terminalInstances[0].options.theme).toEqual({
+      background: DARK_VARS['--abu-bg-base'],
+      foreground: DARK_VARS['--abu-text-primary'],
+      cursor: DARK_VARS['--abu-clay'],
+    });
 
     // Still the same single terminal instance — no dispose/recreate cycle.
     expect(terminalInstances).toHaveLength(1);
@@ -131,5 +127,5 @@ describe('TerminalTab theming', () => {
     const killCallsAfter = invoke.mock.calls.filter(([cmd]) => cmd === 'pty_kill').length;
     expect(spawnCallsAfter).toBe(spawnCallsBefore);
     expect(killCallsAfter).toBe(killCallsBefore);
-  }, 15000);
+  });
 });


### PR DESCRIPTION
Both v0.39.0 release runs were blocked by infra flakes; this PR root-causes and fixes both instead of relying on reruns.

## 1. TerminalTab theme-toggle test — happy-dom drops MutationObserver callbacks after GC

happy-dom 20.9.0 keeps the mutation delivery callback **only behind a WeakRef**:

```js
// MutationObserverListener.js (20.9.0)
callback: new WeakRef((record) => this.report(record))   // no strong ref anywhere
```

The arrow is collectible from birth; after the first GC, `deref()` returns undefined and every subsequent mutation is silently dropped — the observer looks alive but never fires. This is why the test failed after a 12s real-clock wait on Windows CI and ~10% of clean local runs (3/30), and why no timeout could fix it.

**Fix**: upgrade to happy-dom 20.11.2 (exact), where the arrow is stored in a `#listenerCallback` field on the strongly-referenced listener. **40/40 local runs green after** (vs 3/30 failures before). This de-flakes every MutationObserver-dependent test in the suite, not just this one. The test is also rewritten from the 12s waitFor to a deterministic event-ordering flush inside `act()`.

## 2. Packaged-smoke composite check — empty capture thumbnail treated as authoritative

On the v0.39.0 stable run (mac x64), `desktopCapturer` returned a screen source whose thumbnail was 0×0. The check set `windowCompositeTrusted = true` on source existence alone, then hard-failed on the null composite that empty image could never produce — while the view's own draw evidence was all green (`drawn:true`, 446k fixture pixels; same SHA had passed this exact platform in the RC run two hours earlier).

**Fix**: an empty thumbnail is no evidence either way — both macOS and Windows branches now record `compositeError: 'desktop source returned an empty thumbnail'` and stay untrusted, falling back to the mandatory view-draw evidence per the check's own documented philosophy ("system composition is an additive check").

## Verification

- `npm run verify` exit 0 with the happy-dom upgrade (full suite + coverage)
- TerminalTab test: 40 consecutive clean runs, 0 failures
- `node --check` on the smoke script

🤖 Generated with [Claude Code](https://claude.com/claude-code)