### PR TITLE
chore(deps): patch mermaid/dompurify/hono advisories

### DIFF
--- a/abu-browser-bridge/package-lock.json
+++ b/abu-browser-bridge/package-lock.json
@@ -611,9 +611,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
+      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "langfuse": "^3.38.20",
         "linkedom": "^0.18.13",
         "lucide-react": "^0.575.0",
-        "mermaid": "^11.15.0",
+        "mermaid": "^11.16.1",
         "node-pty": "^1.1.0",
         "pptx-preview": "^1.0.7",
         "pptxgenjs": "^4.0.1",
@@ -2632,12 +2632,12 @@
       "license": "MIT"
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
-      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
       "license": "MIT",
       "dependencies": {
-        "@chevrotain/types": "~11.1.1"
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -8450,9 +8450,9 @@
       "license": "MIT"
     },
     "node_modules/cytoscape": {
-      "version": "3.33.1",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
-      "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+      "version": "3.34.1",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.1.tgz",
+      "integrity": "sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -9391,9 +9391,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -11215,9 +11215,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/hono": {
-      "version": "4.12.33",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.33.tgz",
-      "integrity": "sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
+      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -12026,9 +12026,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.40",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.40.tgz",
-      "integrity": "sha512-1DJcK/L05k1Y9Gf7wMcyuqFOL6BiY3vY0CFcAM/LPRN04NALxcl6u7lOWNsp3f/bCHWxigzQl6FbR95XJ4R84Q==",
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -13213,26 +13213,26 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.15.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
-      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
       "license": "MIT",
       "dependencies": {
-        "@braintree/sanitize-url": "^7.1.1",
+        "@braintree/sanitize-url": "^7.1.2",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.1.1",
+        "@mermaid-js/parser": "^1.2.0",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.1",
+        "cytoscape": "^3.33.3",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.19",
-        "dompurify": "^3.3.1",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
         "es-toolkit": "^1.45.1",
-        "katex": "^0.16.25",
+        "katex": "^0.16.45",
         "khroma": "^2.1.0",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "langfuse": "^3.38.20",
     "linkedom": "^0.18.13",
     "lucide-react": "^0.575.0",
-    "mermaid": "^11.15.0",
+    "mermaid": "^11.16.1",
     "node-pty": "^1.1.0",
     "pptx-preview": "^1.0.7",
     "pptxgenjs": "^4.0.1",


### PR DESCRIPTION
Clears **10 open Dependabot advisories** that Dependabot's own PRs structurally cannot land (see below). Lockfile-only apart from a single version string — **no source changes**.

## What moves

| Package | From → To | Why |
|---|---|---|
| `mermaid` | 11.15.0 → 11.16.1 | **Reachable.** 4 medium + 1 low: radar / XY-chart DoS, architecture-diagram + config-API prototype pollution, sibling-scope CSS injection |
| `dompurify` | 3.4.12 → 3.4.13 | Transitive via mermaid `^3.3.1`. IN_PLACE hook removal leaves an escapable detached subtree |
| `hono` (root + `abu-browser-bridge`) | 4.12.33 / 4.12.27 → 4.13.3 | Transitive via `@modelcontextprotocol/sdk` `^4.11.4`. Alert-surface cleanup only — see reachability note |
| `@mermaid-js/parser`, `cytoscape`, `katex` | carried by mermaid | — |

## Reachability

**mermaid is the one group that genuinely matters.** `src/components/chat/MermaidBlock.tsx` renders model-authored and user-pasted mermaid source — untrusted input by definition — so the DoS and prototype-pollution paths are live.

**hono is not reachable.** The advisories all sit in hono's *server middleware* (CORS ReDoS, language-middleware DoS, `memo()` SSR bleed, proxy-helper header leak). We instantiate none of it: MCP uses Client-side HTTP transports (`src/core/mcp/client.ts`) plus `StdioServerTransport`, and `abu-browser-bridge`'s 127.0.0.1 listener is plain `node:http` (`wsServer.ts:60`). Bumped to clear the alert surface, not to fix an exploitable path.

## Why this isn't just merging Dependabot's PRs

Dependabot **security** updates ignore `target-branch:` and always open against the default branch (`main`). `.github/workflows/branch-policy.yml` → `main-pr-source` rejects any PR into `main` whose head isn't `dev`. So #154 / #163 / #162 / #164 fail CI by construction and can never merge. Doing the bump on `dev` instead; **those four PRs can be closed once this lands.**

Note `dompurify` needed an explicit update — mermaid's `^3.3.1` already accepts 3.4.12, so npm won't pull 3.4.13 on its own when bumping mermaid alone.

## Verification

- `npm run verify` → **exit 0** (374 test files / 5245 tests, coverage gate held)
- **23 diagram types** rendered in headless Chromium under `MermaidBlock`'s exact `initialize()` config (`securityLevel: 'strict'`, base theme), 11.15.0 vs 11.16.1 side by side: **23/23 render on both, 0 regressions**
- **7 re-rendered inside the real Electron shell over CDP**, loading the production mermaid chunk out of `dist-electron-spike/` so the lazy `import('mermaid')` path is actually exercised. All 7 correct, brand theme intact, screenshot-verified — no repeat of the v0.27.0 mermaid black-box bug (that one was Tauri-era `tauri.conf.json` `style-src`; the Electron chat window declares no CSP)

## Deliberately out of scope

- `image-size` 1.2.1 — **2× HIGH**, via `pptxgenjs`. No patched release exists upstream; needs a separate call (input allowlist on the pptx export path, or wait for upstream)
- `esbuild` in `abu-chrome-extension` (#65) — advisory only affects `esbuild serve`; that package runs `node build.js` and never serves. Not applicable, PR can be closed
- `serde_with` / `cmov` in `src-tauri/` — frozen compatibility path, `dependabot.yml` already stopped scanning Cargo

🤖 Generated with [Claude Code](https://claude.com/claude-code)