### PR TITLE
feat(session): append-only message ledger — stages 1+2 (fold + revision appends)

### DIFF
--- a/electron/catalogDb.cjs
+++ b/electron/catalogDb.cjs
@@ -49,6 +49,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { DatabaseSync } = require('node:sqlite');
 const { abuAppDataDir } = require('./appEnv.cjs');
+const { foldMessageLog } = require('./messageLedgerFold.cjs');
 
 /** Sentinel returned when `cmd` isn't a catalog command. */
 const CATALOG_MISS = Symbol('catalog-dispatch-miss');
@@ -409,11 +410,14 @@ function deriveTitle(text) {
 
 /** Read-only scan of one conversation's messages.jsonl. Returns `null` if the
  * file doesn't exist (mirrors `scan_conversation_file`'s `Ok(None)`). Never
- * mutates `jsonlPath`. Id-dedup keeps the LAST occurrence, with all id-less
- * messages collapsing onto ONE shared key (JS `Map` supports `undefined` as a
- * real, single, colliding key — exactly the semantics `dedupMessagesById()`
- * in conversationStorage.ts relies on, and what the Rust port explicitly
- * mirrors via `Option<String>`). */
+ * mutates `jsonlPath`.
+ *
+ * The JSONL→messages projection is delegated to `foldMessageLog` in
+ * `./messageLedgerFold.cjs`, which is pinned by fixture replay to the
+ * renderer's `src/core/session/messageLedger.ts`. That shared fold is what
+ * guarantees the catalog counts, `last_message_id` and FTS body describe
+ * exactly the conversation the UI shows — previously the two sides only
+ * promised each other so in a comment. */
 function scanConversationFile(jsonlPath) {
   let stat;
   try {
@@ -425,26 +429,7 @@ function scanConversationFile(jsonlPath) {
   const sourceMtime = Math.floor(stat.mtimeMs);
 
   const raw = fs.readFileSync(jsonlPath, 'utf8');
-  const parsed = [];
-  let corruptLines = 0;
-  for (const line of raw.split('\n')) {
-    if (line.trim() === '') continue;
-    try {
-      parsed.push(JSON.parse(line));
-    } catch {
-      corruptLines++;
-    }
-  }
-
-  const lastIndex = new Map();
-  parsed.forEach((v, i) => {
-    const key = typeof v.id === 'string' ? v.id : undefined;
-    lastIndex.set(key, i);
-  });
-  const deduped = parsed.filter((v, i) => {
-    const key = typeof v.id === 'string' ? v.id : undefined;
-    return lastIndex.get(key) === i;
-  });
+  const { messages: deduped, corruptCount: corruptLines } = foldMessageLog(raw.split('\n'));
 
   const messageCount = deduped.length;
   const lastIdRaw = deduped.length ? deduped[deduped.length - 1].id : undefined;

--- a/electron/messageLedgerFold.cjs
+++ b/electron/messageLedgerFold.cjs
@@ -1,0 +1,94 @@
+/**
+ * Electron-main port of the message-ledger fold.
+ *
+ * Source of truth for the semantics: `src/core/session/messageLedger.ts` (see
+ * its module doc for the full spec — plan `docs/abu-message-ledger-plan.md`
+ * §3.1/§3.3). The renderer module cannot be required from the main process
+ * (ESM + TS + the `src/` boundary rule), so this is a hand port pinned to the
+ * original by a shared fixture replay:
+ *
+ *   src/core/session/__fixtures__/messageLedgerFold.fixtures.json
+ *
+ * `electron/messageLedgerFold.contract.test.ts` replays those fixtures through
+ * BOTH implementations and asserts identical output, so the two can never
+ * drift silently. Keep this file dependency-free (no node:sqlite, no Electron)
+ * so that contract test stays cheap.
+ */
+
+'use strict';
+
+const LEDGER_KIND_PUT = 'msg.put';
+
+/**
+ * Replay an append-only message log into its current projection.
+ *
+ * @param {readonly string[]} lines
+ * @returns {{ messages: object[], corruptCount: number, totalLines: number }}
+ */
+function foldMessageLog(lines) {
+  /** @type {object[]} */
+  const state = [];
+  let index = new Map();
+  let corruptCount = 0;
+  let totalLines = 0;
+
+  const reindex = () => {
+    index = new Map();
+    for (let i = 0; i < state.length; i++) index.set(state[i].id, i);
+  };
+
+  for (const rawLine of lines) {
+    if (rawLine.trim() === '') continue;
+    totalLines++;
+
+    let parsed;
+    try {
+      parsed = JSON.parse(rawLine);
+    } catch {
+      corruptCount++;
+      continue;
+    }
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      corruptCount++;
+      continue;
+    }
+    const kind = typeof parsed.lk === 'string' ? parsed.lk : LEDGER_KIND_PUT;
+
+    if (kind === LEDGER_KIND_PUT) {
+      // Key is `parsed.id` verbatim, so every id-less line collapses onto one
+      // shared `undefined` key — matching the TS port and the pre-ledger dedup.
+      const at = index.get(parsed.id);
+      if (at === undefined) {
+        state.push(parsed);
+        index.set(parsed.id, state.length - 1);
+      } else {
+        // In place, NOT move-to-end — a revision must not reorder the log.
+        state[at] = parsed;
+      }
+    } else if (kind === 'msg.tomb') {
+      if (typeof parsed.target !== 'string') continue;
+      const at = index.get(parsed.target);
+      if (at === undefined) continue;
+      state.splice(at, 1);
+      reindex();
+    } else if (kind === 'msg.truncate') {
+      if (typeof parsed.from !== 'string') continue;
+      const at = index.get(parsed.from);
+      if (at === undefined) continue;
+      state.length = at;
+      reindex();
+    } else if (kind === 'msg.loopDrop') {
+      if (typeof parsed.loopId !== 'string') continue;
+      const kept = state.filter((m) => m.loopId !== parsed.loopId);
+      if (kept.length === state.length) continue;
+      state.length = 0;
+      for (const m of kept) state.push(m);
+      reindex();
+    }
+    // Unknown kind (written by a newer build): not a message, ignore it.
+  }
+
+  return { messages: state, corruptCount, totalLines };
+}
+
+module.exports = { foldMessageLog, LEDGER_KIND_PUT };

--- a/electron/messageLedgerFold.contract.test.ts
+++ b/electron/messageLedgerFold.contract.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment node
+
+/**
+ * Contract test: the Electron-main fold port must agree with the renderer's
+ * `foldMessageLog` on every shared fixture.
+ *
+ * Why this exists: the catalog (SQLite + FTS) is a projection of the very same
+ * JSONL the UI renders, and the two used to be kept in sync only by a comment
+ * ("mirrors dedupMessagesById"). Comments drift; a fixture replay does not.
+ * See `docs/abu-message-ledger-plan.md` §3.3 — one fold spec, three consumers.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import { foldMessageLog as foldTs } from '../src/core/session/messageLedger';
+import { loadFoldFixtures, projectFolded } from '../src/test/foldFixtures';
+
+const require_ = createRequire(import.meta.url);
+const { foldMessageLog: foldElectron } = require_('./messageLedgerFold.cjs') as {
+  foldMessageLog: (lines: readonly string[]) => {
+    messages: { id?: string; content?: unknown }[];
+    corruptCount: number;
+    totalLines: number;
+  };
+};
+
+describe('messageLedgerFold (Electron port) ↔ messageLedger (renderer)', () => {
+  const fixtures = loadFoldFixtures();
+
+  it('the fixture file is non-empty and covers the event kinds', () => {
+    expect(fixtures.length).toBeGreaterThan(5);
+    const allLines = fixtures.flatMap((c) => c.lines).join('\n');
+    for (const kind of ['msg.put', 'msg.tomb', 'msg.truncate', 'msg.loopDrop']) {
+      expect(allLines).toContain(kind);
+    }
+  });
+
+  for (const testCase of fixtures) {
+    it(`agrees on fixture: ${testCase.name}`, () => {
+      const electron = foldElectron(testCase.lines);
+      const ts = foldTs(testCase.lines);
+
+      // Both ports must match the fixture...
+      expect(projectFolded(electron.messages)).toEqual(testCase.expected.messages);
+      expect(electron.corruptCount).toBe(testCase.expected.corruptCount);
+      expect(electron.totalLines).toBe(testCase.expected.totalLines);
+
+      // ...and, byte for byte, each other.
+      expect(JSON.stringify(electron.messages)).toBe(JSON.stringify(ts.messages));
+      expect(electron.corruptCount).toBe(ts.corruptCount);
+      expect(electron.totalLines).toBe(ts.totalLines);
+    });
+  }
+});

--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -1762,14 +1762,18 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         if (streamFlushInFlight) return;
         streamFlushInFlight = true;
         try {
-          const { replaceMessageById } = await import('../session/conversationStorage');
+          const { snapshotMessageRevision } = await import('../session/conversationStorage');
           const currentMsg = getConversationReader().getConversation(conversationId)
             ?.messages.find((m) => m.id === assistantMsgId);
           // Re-read after the async import. If the turn completed while this
           // timer callback yielded, its final write is authoritative and this
           // older periodic snapshot must not overwrite it.
           if (!currentMsg?.isStreaming) return;
-          await replaceMessageById(conversationId, currentMsg);
+          // Snapshot, not ledger append: a ten-minute stream fires this ~120
+          // times, and each one would otherwise be a full copy of a message
+          // that only grows. The snapshot is overwritten in place and folded
+          // back in on load, so crash protection is unchanged.
+          await snapshotMessageRevision(conversationId, currentMsg);
         } catch {
           // Best-effort crash protection. Final turn persistence remains the
           // authoritative write when the request completes normally.

--- a/src/core/session/__fixtures__/messageLedgerFold.fixtures.json
+++ b/src/core/session/__fixtures__/messageLedgerFold.fixtures.json
@@ -1,0 +1,233 @@
+{
+  "$comment": [
+    "Shared fold fixtures for the message ledger (docs/abu-message-ledger-plan.md §3.3).",
+    "Replayed by every port of foldMessageLog so they can never drift:",
+    "  - src/core/session/messageLedger.test.ts        (TS, renderer)",
+    "  - electron/messageLedgerFold.contract.test.ts   (both TS and the Electron CJS port)",
+    "  - src-tauri/src/catalog_db.rs                   (Rust, legacy Tauri — NOT yet wired, see plan)",
+    "Each case lists the physical JSONL lines and the expected folded projection.",
+    "`expected.messages` pins id + content in order; `null` id means an id-less line."
+  ],
+  "cases": [
+    {
+      "name": "empty log",
+      "lines": [],
+      "expected": { "messages": [], "corruptCount": 0, "totalLines": 0 }
+    },
+    {
+      "name": "blank lines are skipped and never counted",
+      "lines": ["", "   ", "\t"],
+      "expected": { "messages": [], "corruptCount": 0, "totalLines": 0 }
+    },
+    {
+      "name": "bare legacy Message lines fold to themselves",
+      "lines": [
+        "{\"id\":\"m1\",\"role\":\"user\",\"content\":\"hi\",\"timestamp\":1}",
+        "{\"id\":\"m2\",\"role\":\"assistant\",\"content\":\"hello\",\"timestamp\":2}"
+      ],
+      "expected": {
+        "messages": [
+          { "id": "m1", "content": "hi" },
+          { "id": "m2", "content": "hello" }
+        ],
+        "corruptCount": 0,
+        "totalLines": 2
+      }
+    },
+    {
+      "name": "duplicate id keeps the last line IN PLACE (no move-to-end)",
+      "lines": [
+        "{\"id\":\"m1\",\"role\":\"user\",\"content\":\"v1\",\"timestamp\":1}",
+        "{\"id\":\"m2\",\"role\":\"assistant\",\"content\":\"between\",\"timestamp\":2}",
+        "{\"id\":\"m1\",\"role\":\"user\",\"content\":\"v2\",\"timestamp\":3}"
+      ],
+      "expected": {
+        "messages": [
+          { "id": "m1", "content": "v2" },
+          { "id": "m2", "content": "between" }
+        ],
+        "corruptCount": 0,
+        "totalLines": 3
+      }
+    },
+    {
+      "name": "explicit lk msg.put behaves exactly like a bare line",
+      "lines": [
+        "{\"id\":\"m1\",\"role\":\"user\",\"content\":\"v1\",\"timestamp\":1}",
+        "{\"lk\":\"msg.put\",\"pid\":\"m1\",\"id\":\"m1\",\"role\":\"user\",\"content\":\"v2\",\"timestamp\":2}"
+      ],
+      "expected": {
+        "messages": [{ "id": "m1", "content": "v2" }],
+        "corruptCount": 0,
+        "totalLines": 2
+      }
+    },
+    {
+      "name": "corrupt lines are skipped, intact lines survive",
+      "lines": [
+        "{\"id\":\"m1\",\"role\":\"user\",\"content\":\"ok\",\"timestamp\":1}",
+        "{\"id\":\"m2\",\"role\":\"user\",\"content\":\"trun",
+        "not json at all",
+        "{\"id\":\"m3\",\"role\":\"user\",\"content\":\"ok2\",\"timestamp\":3}"
+      ],
+      "expected": {
+        "messages": [
+          { "id": "m1", "content": "ok" },
+          { "id": "m3", "content": "ok2" }
+        ],
+        "corruptCount": 2,
+        "totalLines": 4
+      }
+    },
+    {
+      "name": "non-object JSON lines count as corrupt instead of crashing the fold",
+      "lines": [
+        "null",
+        "123",
+        "\"a string\"",
+        "[1,2,3]",
+        "{\"id\":\"m1\",\"role\":\"user\",\"content\":\"ok\",\"timestamp\":1}"
+      ],
+      "expected": {
+        "messages": [{ "id": "m1", "content": "ok" }],
+        "corruptCount": 4,
+        "totalLines": 5
+      }
+    },
+    {
+      "name": "id-less lines all collapse onto one shared key",
+      "lines": [
+        "{\"role\":\"user\",\"content\":\"first\",\"timestamp\":1}",
+        "{\"role\":\"user\",\"content\":\"second\",\"timestamp\":2}",
+        "{\"id\":\"m1\",\"role\":\"user\",\"content\":\"kept\",\"timestamp\":3}"
+      ],
+      "expected": {
+        "messages": [
+          { "id": null, "content": "second" },
+          { "id": "m1", "content": "kept" }
+        ],
+        "corruptCount": 0,
+        "totalLines": 3
+      }
+    },
+    {
+      "name": "msg.tomb removes its target",
+      "lines": [
+        "{\"id\":\"m1\",\"role\":\"user\",\"content\":\"a\",\"timestamp\":1}",
+        "{\"id\":\"m2\",\"role\":\"user\",\"content\":\"b\",\"timestamp\":2}",
+        "{\"lk\":\"msg.tomb\",\"id\":\"ev1\",\"role\":\"system\",\"content\":\"\",\"isSystem\":true,\"target\":\"m1\",\"timestamp\":3}"
+      ],
+      "expected": {
+        "messages": [{ "id": "m2", "content": "b" }],
+        "corruptCount": 0,
+        "totalLines": 3
+      }
+    },
+    {
+      "name": "a put AFTER a tomb resurrects the message at the end",
+      "lines": [
+        "{\"id\":\"m1\",\"role\":\"user\",\"content\":\"a\",\"timestamp\":1}",
+        "{\"id\":\"m2\",\"role\":\"user\",\"content\":\"b\",\"timestamp\":2}",
+        "{\"lk\":\"msg.tomb\",\"id\":\"ev1\",\"role\":\"system\",\"content\":\"\",\"isSystem\":true,\"target\":\"m1\",\"timestamp\":3}",
+        "{\"id\":\"m1\",\"role\":\"user\",\"content\":\"a-again\",\"timestamp\":4}"
+      ],
+      "expected": {
+        "messages": [
+          { "id": "m2", "content": "b" },
+          { "id": "m1", "content": "a-again" }
+        ],
+        "corruptCount": 0,
+        "totalLines": 4
+      }
+    },
+    {
+      "name": "msg.tomb for an unknown target is a no-op",
+      "lines": [
+        "{\"id\":\"m1\",\"role\":\"user\",\"content\":\"a\",\"timestamp\":1}",
+        "{\"lk\":\"msg.tomb\",\"id\":\"ev1\",\"role\":\"system\",\"content\":\"\",\"isSystem\":true,\"target\":\"nope\",\"timestamp\":2}"
+      ],
+      "expected": {
+        "messages": [{ "id": "m1", "content": "a" }],
+        "corruptCount": 0,
+        "totalLines": 2
+      }
+    },
+    {
+      "name": "msg.truncate removes from the anchor onward",
+      "lines": [
+        "{\"id\":\"m1\",\"role\":\"user\",\"content\":\"a\",\"timestamp\":1}",
+        "{\"id\":\"m2\",\"role\":\"assistant\",\"content\":\"b\",\"timestamp\":2}",
+        "{\"id\":\"m3\",\"role\":\"user\",\"content\":\"c\",\"timestamp\":3}",
+        "{\"lk\":\"msg.truncate\",\"id\":\"ev1\",\"role\":\"system\",\"content\":\"\",\"isSystem\":true,\"from\":\"m2\",\"timestamp\":4}"
+      ],
+      "expected": {
+        "messages": [{ "id": "m1", "content": "a" }],
+        "corruptCount": 0,
+        "totalLines": 4
+      }
+    },
+    {
+      "name": "edit-and-resend: messages appended AFTER a truncate must survive it",
+      "lines": [
+        "{\"id\":\"m1\",\"role\":\"user\",\"content\":\"a\",\"timestamp\":1}",
+        "{\"id\":\"m2\",\"role\":\"assistant\",\"content\":\"b\",\"timestamp\":2}",
+        "{\"lk\":\"msg.truncate\",\"id\":\"ev1\",\"role\":\"system\",\"content\":\"\",\"isSystem\":true,\"from\":\"m2\",\"timestamp\":3}",
+        "{\"id\":\"m3\",\"role\":\"user\",\"content\":\"edited\",\"timestamp\":4}",
+        "{\"id\":\"m4\",\"role\":\"assistant\",\"content\":\"new reply\",\"timestamp\":5}"
+      ],
+      "expected": {
+        "messages": [
+          { "id": "m1", "content": "a" },
+          { "id": "m3", "content": "edited" },
+          { "id": "m4", "content": "new reply" }
+        ],
+        "corruptCount": 0,
+        "totalLines": 5
+      }
+    },
+    {
+      "name": "msg.loopDrop removes every message of that loop",
+      "lines": [
+        "{\"id\":\"m1\",\"role\":\"user\",\"content\":\"a\",\"timestamp\":1,\"loopId\":\"L1\"}",
+        "{\"id\":\"m2\",\"role\":\"assistant\",\"content\":\"b\",\"timestamp\":2,\"loopId\":\"L1\"}",
+        "{\"id\":\"m3\",\"role\":\"user\",\"content\":\"c\",\"timestamp\":3,\"loopId\":\"L2\"}",
+        "{\"lk\":\"msg.loopDrop\",\"id\":\"ev1\",\"role\":\"system\",\"content\":\"\",\"isSystem\":true,\"loopId\":\"L1\",\"timestamp\":4}"
+      ],
+      "expected": {
+        "messages": [{ "id": "m3", "content": "c" }],
+        "corruptCount": 0,
+        "totalLines": 4
+      }
+    },
+    {
+      "name": "unknown future kind is ignored, never rendered as a message",
+      "lines": [
+        "{\"id\":\"m1\",\"role\":\"user\",\"content\":\"a\",\"timestamp\":1}",
+        "{\"lk\":\"msg.somethingNew\",\"id\":\"ev1\",\"role\":\"system\",\"content\":\"\",\"isSystem\":true,\"timestamp\":2}"
+      ],
+      "expected": {
+        "messages": [{ "id": "m1", "content": "a" }],
+        "corruptCount": 0,
+        "totalLines": 2
+      }
+    },
+    {
+      "name": "revision after truncate updates in place, does not reappend",
+      "lines": [
+        "{\"id\":\"m1\",\"role\":\"user\",\"content\":\"a\",\"timestamp\":1}",
+        "{\"id\":\"m2\",\"role\":\"assistant\",\"content\":\"b\",\"timestamp\":2}",
+        "{\"lk\":\"msg.truncate\",\"id\":\"ev1\",\"role\":\"system\",\"content\":\"\",\"isSystem\":true,\"from\":\"m2\",\"timestamp\":3}",
+        "{\"id\":\"m3\",\"role\":\"user\",\"content\":\"edited\",\"timestamp\":4}",
+        "{\"lk\":\"msg.put\",\"id\":\"m1\",\"role\":\"user\",\"content\":\"a-revised\",\"timestamp\":5}"
+      ],
+      "expected": {
+        "messages": [
+          { "id": "m1", "content": "a-revised" },
+          { "id": "m3", "content": "edited" }
+        ],
+        "corruptCount": 0,
+        "totalLines": 5
+      }
+    }
+  ]
+}

--- a/src/core/session/conversationStorage.test.ts
+++ b/src/core/session/conversationStorage.test.ts
@@ -1245,6 +1245,65 @@ describe('conversationStorage', () => {
       });
     });
 
+    describe('crash windows', () => {
+      it('keeps the snapshot file when a shutdown promotion never reaches the ledger', async () => {
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm1', content: '' }));
+        await storage.flushWrites();
+        await storage.snapshotMessageRevision('conv-1', makeMsg({ id: 'm1', content: 'unflushed' }));
+
+        // Both ledger write paths fail at exit. Dropping the snapshot anyway
+        // would discard the revision with no copy left anywhere.
+        vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+          if (cmd === 'append_file_text' || cmd === 'atomic_write_text') {
+            throw new Error('disk full');
+          }
+          return undefined;
+        });
+
+        await storage.shutdownConversationStorage();
+
+        expect(memFs.files.has(SNAPSHOT)).toBe(true);
+      });
+
+
+      it('does not let a torn last line swallow the next append', async () => {
+        // A crash mid-append (native append has no atomicity guarantee, see
+        // appendToFile) leaves the tail unterminated. Nothing rewrites the file
+        // any more, so without an explicit repair every later append is glued
+        // onto that stump and both messages parse as one corrupt line.
+        memFs.files.set(
+          MESSAGES,
+          JSON.stringify({ id: 'm1', role: 'user', content: 'a', timestamp: 1 }) + '\n'
+            + '{"id":"m2","role":"user","content":"tor',
+        );
+
+        await storage.loadMessages('conv-1');
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm3', content: 'after crash' }));
+        await storage.flushWrites();
+
+        const loaded = await storage.loadMessages('conv-1');
+        expect(loaded.map((m) => m.id)).toEqual(['m1', 'm3']);
+      });
+
+      it('a queued revision does not resurrect a message deleted before the drain', async () => {
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm1', content: 'a' }));
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm2', content: 'b' }));
+        await storage.flushWrites();
+
+        // Checkpoint write still sitting in the 100ms-debounced queue when the
+        // delete lands — the abort path does exactly this (agentLoop's ghost
+        // cleanup runs right behind the turn's last persist).
+        const queued = storage.replaceMessageById('conv-1', makeMsg({ id: 'm2', content: 'b-checkpoint' }));
+        for (let i = 0; i < 20; i++) await Promise.resolve();
+        await storage.deleteMessageById('conv-1', 'm2');
+        await storage.flushWrites();
+        await queued;
+
+        const loaded = await storage.loadMessages('conv-1');
+        expect(loaded.map((m) => m.id)).toEqual(['m1']);
+      });
+    });
+
     describe('write amplification budget', () => {
       // Plan §3.6: a tool-heavy conversation revises the same growing message
       // many times per turn. The acceptance criterion is that messages.jsonl

--- a/src/core/session/conversationStorage.test.ts
+++ b/src/core/session/conversationStorage.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { exists, readTextFile, writeTextFile, mkdir, remove, readDir } from '@tauri-apps/plugin-fs';
 import { invoke } from '@tauri-apps/api/core';
+import { foldMessageLog } from './messageLedger';
 import type { Message } from '@/types';
 
 // Must import AFTER vi.mock (global mock in setup.ts handles @tauri-apps/plugin-fs)
@@ -623,8 +624,12 @@ describe('conversationStorage', () => {
         makeMsg({ id: 'strict-write-msg', content: 'before' }),
       );
       await storage.flushWrites();
+      // Both write paths fail: the native append AND the read+rewrite it falls
+      // back to. A strict replacement must surface that, never report success.
       vi.mocked(invoke).mockImplementation(async (cmd: string) => {
-        if (cmd === 'atomic_write_text') throw new Error('disk full');
+        if (cmd === 'atomic_write_text' || cmd === 'append_file_text') {
+          throw new Error('disk full');
+        }
         return undefined;
       });
 
@@ -1038,6 +1043,287 @@ describe('conversationStorage', () => {
 
       const loaded = await storage.loadMessages('conv-1');
       expect(loaded[0].toolCalls![0].result).toBe(diskRef);
+    });
+  });
+  // ══════════════════════════════════════════════════════════
+  // Append-only ledger (docs/abu-message-ledger-plan.md, phase 2)
+  // ══════════════════════════════════════════════════════════
+
+  describe('ledger writes', () => {
+    const MESSAGES = '/Users/testuser/.abu/conversations/conv-1/messages.jsonl';
+    const SNAPSHOT = '/Users/testuser/.abu/conversations/conv-1/stream-snapshot.json';
+
+    function physicalLines(path = MESSAGES): Record<string, unknown>[] {
+      const raw = memFs.files.get(path) ?? '';
+      return raw.split('\n').filter((l) => l.trim() !== '').map((l) => JSON.parse(l));
+    }
+
+    describe('replaceMessageById', () => {
+      it('appends a revision instead of rewriting the matching line', async () => {
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm1', content: 'v1' }));
+        await storage.flushWrites();
+        await storage.replaceMessageById('conv-1', makeMsg({ id: 'm1', content: 'v2' }));
+        await storage.flushWrites();
+
+        const rows = physicalLines();
+        expect(rows).toHaveLength(2);
+        // The original line is untouched — that is what append-only means.
+        expect(rows[0]).toMatchObject({ id: 'm1', content: 'v1' });
+        expect(rows[1]).toMatchObject({ id: 'm1', content: 'v2' });
+      });
+
+      it('keeps the revised message at its original position in the fold', async () => {
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm1', content: 'first' }));
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm2', content: 'second' }));
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm3', content: 'third' }));
+        await storage.flushWrites();
+
+        await storage.replaceMessageById('conv-1', makeMsg({ id: 'm1', content: 'first-edited' }));
+        await storage.flushWrites();
+
+        const loaded = await storage.loadMessages('conv-1');
+        expect(loaded.map((m) => m.id)).toEqual(['m1', 'm2', 'm3']);
+        expect(loaded[0].content).toBe('first-edited');
+      });
+
+      it('collapses revisions that are still queued into a single line', async () => {
+        // No flush between the calls: all four writes sit in the queue at once,
+        // so the same-id merge must leave exactly one physical line.
+        void storage.appendMessage('conv-1', makeMsg({ id: 'm1', content: 'v1' }));
+        void storage.replaceMessageById('conv-1', makeMsg({ id: 'm1', content: 'v2' }));
+        void storage.replaceMessageById('conv-1', makeMsg({ id: 'm1', content: 'v3' }));
+        await storage.replaceMessageById('conv-1', makeMsg({ id: 'm1', content: 'v4' }));
+        await storage.flushWrites();
+
+        const rows = physicalLines();
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({ id: 'm1', content: 'v4' });
+      });
+
+      it('does not merge revisions of different messages into one line', async () => {
+        void storage.appendMessage('conv-1', makeMsg({ id: 'm1', content: 'a' }));
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm2', content: 'b' }));
+        await storage.flushWrites();
+
+        expect(physicalLines().map((r) => r.id)).toEqual(['m1', 'm2']);
+      });
+
+      it('is a no-op for an id the conversation never held', async () => {
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm1', content: 'a' }));
+        await storage.flushWrites();
+
+        await storage.replaceMessageById('conv-1', makeMsg({ id: 'ghost', content: 'x' }));
+        await storage.flushWrites();
+
+        // An append is an upsert by nature; the old rewrite was not, and the
+        // non-strict variant must keep behaving like the old one.
+        expect(physicalLines()).toHaveLength(1);
+      });
+
+      it('preserves a settled sandbox recovery action without re-reading the file', async () => {
+        const toolCall = {
+          id: 'tc-1',
+          name: 'run_command',
+          input: {},
+          sandboxRecovery: { kind: 'app-automation' as const, targetApp: 'Notes' },
+        };
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm1', toolCalls: [toolCall] }));
+        await storage.flushWrites();
+        await storage.replaceMessageByIdStrict('conv-1', makeMsg({
+          id: 'm1',
+          toolCalls: [{ ...toolCall, sandboxRecoveryAction: 'completed' as const }],
+        }));
+        await storage.flushWrites();
+
+        // A late whole-message write that lost the settled action must not
+        // regress it — the protection now comes from the in-memory record, not
+        // from reading the persisted row back.
+        await storage.replaceMessageById('conv-1', makeMsg({ id: 'm1', toolCalls: [toolCall] }));
+        await storage.flushWrites();
+
+        const loaded = await storage.loadMessages('conv-1');
+        expect(loaded[0].toolCalls?.[0].sandboxRecoveryAction).toBe('completed');
+      });
+
+      it('records a parent pointer on first write and never re-parents a revision', async () => {
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm1', content: 'a' }));
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm2', content: 'b' }));
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm3', content: 'c' }));
+        await storage.flushWrites();
+        await storage.replaceMessageById('conv-1', makeMsg({ id: 'm2', content: 'b-edited' }));
+        await storage.flushWrites();
+
+        const rows = physicalLines();
+        expect(rows[0].pid).toBeUndefined();   // first message of the log has no parent
+        expect(rows[1].pid).toBe('m1');
+        expect(rows[2].pid).toBe('m2');
+        // The revision keeps m2's original parent rather than pointing at the
+        // current tail (m3) — plan §3.2.
+        expect(rows[3]).toMatchObject({ id: 'm2', content: 'b-edited', pid: 'm1' });
+      });
+    });
+
+    describe('updateLastMessage', () => {
+      it('no longer overwrites a different message that happens to be last', async () => {
+        await storage.appendMessage('conv-1', makeMsg({ id: 'assistant-1', content: 'partial' }));
+        await storage.appendMessage('conv-1', makeMsg({ id: 'user-2', content: 'mid-stream question' }));
+        await storage.flushWrites();
+
+        await storage.updateLastMessage('conv-1', makeMsg({ id: 'assistant-1', content: 'complete' }));
+        await storage.flushWrites();
+
+        // The old blind last-line replace destroyed user-2 here.
+        const loaded = await storage.loadMessages('conv-1');
+        expect(loaded.map((m) => m.id)).toEqual(['assistant-1', 'user-2']);
+        expect(loaded[0].content).toBe('complete');
+        expect(loaded[1].content).toBe('mid-stream question');
+      });
+
+      it('writes nothing when the conversation has no file yet', async () => {
+        await storage.updateLastMessage('conv-1', makeMsg({ id: 'm1' }));
+        await storage.flushWrites();
+        expect(memFs.files.has(MESSAGES)).toBe(false);
+      });
+    });
+
+    describe('stream snapshot', () => {
+      it('keeps in-flight revisions out of the ledger but readable after a crash', async () => {
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm1', content: '' }));
+        await storage.flushWrites();
+
+        for (const chunk of ['a', 'ab', 'abc']) {
+          await storage.snapshotMessageRevision('conv-1', makeMsg({ id: 'm1', content: chunk }));
+        }
+
+        expect(physicalLines()).toHaveLength(1);       // ledger untouched
+        expect(memFs.files.has(SNAPSHOT)).toBe(true);  // but the state is durable
+
+        // Simulate the reload after a crash mid-stream.
+        vi.resetModules();
+        storage = await import('./conversationStorage');
+        const loaded = await storage.loadMessages('conv-1');
+        expect(loaded).toHaveLength(1);
+        expect(loaded[0].content).toBe('abc');
+      });
+
+      it('drops the buffered revision once a checkpoint commits it', async () => {
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm1', content: '' }));
+        await storage.flushWrites();
+        await storage.snapshotMessageRevision('conv-1', makeMsg({ id: 'm1', content: 'streaming' }));
+        expect(memFs.files.has(SNAPSHOT)).toBe(true);
+
+        await storage.replaceMessageById('conv-1', makeMsg({ id: 'm1', content: 'final' }));
+        await storage.flushWrites();
+
+        expect(memFs.files.has(SNAPSHOT)).toBe(false);
+        const loaded = await storage.loadMessages('conv-1');
+        expect(loaded[0].content).toBe('final');
+      });
+
+      it('promotes anything still buffered into the ledger on shutdown', async () => {
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm1', content: '' }));
+        await storage.flushWrites();
+        await storage.snapshotMessageRevision('conv-1', makeMsg({ id: 'm1', content: 'unflushed' }));
+
+        await storage.shutdownConversationStorage();
+
+        expect(memFs.files.has(SNAPSHOT)).toBe(false);
+        const rows = physicalLines();
+        expect(rows[rows.length - 1]).toMatchObject({ id: 'm1', content: 'unflushed' });
+      });
+
+      it('does not resurrect a message that was deleted while buffered', async () => {
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm1', content: 'a' }));
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm2', content: 'b' }));
+        await storage.flushWrites();
+        await storage.snapshotMessageRevision('conv-1', makeMsg({ id: 'm2', content: 'b-live' }));
+
+        await storage.deleteMessageById('conv-1', 'm2');
+
+        const loaded = await storage.loadMessages('conv-1');
+        expect(loaded.map((m) => m.id)).toEqual(['m1']);
+      });
+    });
+
+    describe('write amplification budget', () => {
+      // Plan §3.6: a tool-heavy conversation revises the same growing message
+      // many times per turn. The acceptance criterion is that messages.jsonl
+      // stays within 3x the folded content it represents.
+      //
+      // The simulation mirrors the real call sequence in agentLoop: each turn
+      // creates its OWN assistant message, buffers the streaming flushes and
+      // every tool result to the snapshot, then commits the finished message
+      // to the ledger at the batch checkpoint and again at turn end.
+      const TURNS = 4;
+      const TOOLS_PER_TURN = 3;
+      const STREAM_FLUSHES_PER_TURN = 6;
+
+      function assistantAfter(turn: number, toolResults: number): Message {
+        return {
+          id: `assistant-${turn}`,
+          role: 'assistant',
+          content: 'Working through the task. '.repeat(20),
+          timestamp: 100 + turn,
+          toolCalls: Array.from({ length: toolResults }, (_, i) => ({
+            id: `tc-${turn}-${i}`,
+            name: 'read_file',
+            input: { path: `/src/file-${turn}-${i}.ts` },
+            result: `contents of file ${i} `.repeat(40),
+          })),
+        };
+      }
+
+      function foldedBytes(path: string): number {
+        const raw = memFs.files.get(path) ?? '';
+        return foldMessageLog(raw.split('\n')).messages
+          .reduce((sum, m) => sum + JSON.stringify(m).length + 1, 0);
+      }
+
+      /**
+       * Drive one write all the way to disk as its own line. Draining
+       * explicitly instead of awaiting the 100 ms debounce keeps the
+       * simulation instant; the extra microtask turns just make sure the line
+       * has reached the queue before the drain (and cost nothing if it has).
+       */
+      async function commit(write: Promise<unknown>): Promise<void> {
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+        await storage.flushWrites();
+        await write;
+      }
+
+      async function runTurn(convId: string, turn: number, toLedger: boolean): Promise<void> {
+        await commit(storage.appendMessage(convId, assistantAfter(turn, 0)));
+        const revise = async (message: Message) => {
+          if (toLedger) await commit(storage.replaceMessageById(convId, message));
+          else await storage.snapshotMessageRevision(convId, message);
+        };
+        for (let i = 0; i < STREAM_FLUSHES_PER_TURN; i++) await revise(assistantAfter(turn, 0));
+        for (let i = 1; i <= TOOLS_PER_TURN; i++) await revise(assistantAfter(turn, i));
+        // Batch checkpoint, then the turn-end persist — both real ledger writes.
+        await commit(storage.replaceMessageById(convId, assistantAfter(turn, TOOLS_PER_TURN)));
+        await commit(storage.replaceMessageById(convId, assistantAfter(turn, TOOLS_PER_TURN)));
+      }
+
+      it('holds messages.jsonl within 3x the folded content for a tool-heavy conversation', async () => {
+        await commit(storage.appendMessage('conv-1', makeMsg({ id: 'user-1', content: 'do the thing', timestamp: 1 })));
+        for (let turn = 0; turn < TURNS; turn++) await runTurn('conv-1', turn, false);
+
+        const physical = (memFs.files.get(MESSAGES) ?? '').length;
+        const folded = foldedBytes(MESSAGES);
+        expect(folded).toBeGreaterThan(0);
+        expect(physical).toBeLessThanOrEqual(folded * 3);
+      });
+
+      it('would blow the budget if every revision became a ledger line', async () => {
+        // Guards the test above from passing vacuously: the identical turns with
+        // the snapshot governance bypassed must exceed the same threshold.
+        const path = '/Users/testuser/.abu/conversations/conv-2/messages.jsonl';
+        await commit(storage.appendMessage('conv-2', makeMsg({ id: 'user-1', content: 'do the thing', timestamp: 1 })));
+        for (let turn = 0; turn < TURNS; turn++) await runTurn('conv-2', turn, true);
+
+        const physical = (memFs.files.get(path) ?? '').length;
+        expect(physical).toBeGreaterThan(foldedBytes(path) * 3);
+      });
     });
   });
 });

--- a/src/core/session/conversationStorage.ts
+++ b/src/core/session/conversationStorage.ts
@@ -9,16 +9,24 @@
  *   conversations/
  *   ├── index.json              (lightweight metadata index)
  *   ├── {convId}/
- *   │   ├── messages.jsonl      (message bodies, append-only)
+ *   │   ├── messages.jsonl      (append-only ledger of message events)
+ *   │   ├── stream-snapshot.json (in-flight revisions, overwritten in place)
  *   │   ├── outputs/            (images, generated files)
  *   │   └── results/            (large tool results >8KB)
  *   └── ...
  *
  * Write strategy:
- *   - WriteQueue batches writes per file (100ms debounce)
+ *   - messages.jsonl is an append-only ledger. A revision is a second line
+ *     carrying the same id; `foldMessageLog` (messageLedger.ts) keeps the last
+ *     one, in place. Nothing rewrites an existing line except deletion, which
+ *     is still a rewrite until the tombstone phase lands.
+ *   - WriteQueue batches writes per file (100ms debounce) and collapses queued
+ *     revisions of the same message into one line
  *   - UUID-based dedup prevents duplicate writes on restart
  *   - Streaming tokens stay in memory; only complete messages hit disk
- *   - Periodic flush (5s) during streaming for crash protection
+ *   - The 5s crash-protection flush and per-tool-result writes go to
+ *     stream-snapshot.json, NOT the ledger — see the stream snapshot section
+ *     for why that budget matters
  */
 
 import { exists, readTextFile, mkdir, remove, readDir } from '@tauri-apps/plugin-fs';
@@ -26,8 +34,8 @@ import { invoke } from '@tauri-apps/api/core';
 import { appDataDir } from '@tauri-apps/api/path';
 import { joinPath } from '@/utils/pathUtils';
 import { atomicWrite } from '@/utils/atomicFs';
-import { foldMessageLog } from './messageLedger';
-import type { Message, MessageContent } from '@/types';
+import { foldMessageLog, type LedgerLine } from './messageLedger';
+import type { Message, MessageContent, SandboxRecoveryAction } from '@/types';
 
 // ════════════════════════════════════════════════════════════
 // Types
@@ -93,10 +101,14 @@ function indexFilePath(): string {
 // Per-file mutex — serializes read-modify-write against same path
 // ════════════════════════════════════════════════════════════
 //
-// Three call sites do non-atomic read-modify-write on messages.jsonl:
-//   - appendToFile (from drain)
-//   - replaceMessageById (flush each agent turn)
-//   - updateLastMessage (on stream completion)
+// Two call sites still do non-atomic read-modify-write on messages.jsonl:
+//   - appendToFile's fallback (from drain, when the native append is missing)
+//   - deleteMessageById (whole-file rewrite, until tombstones land)
+//
+// replaceMessageById and updateLastMessage used to be here too. They are pure
+// appends now, which is why they no longer take this lock — the class of bug
+// described below is structurally gone for them rather than held back by a
+// mutex.
 //
 // Without serialization two of these concurrent on the same file can
 // interleave — one reads a stale snapshot and later overwrites changes
@@ -143,18 +155,63 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
 
 interface PendingWrite {
   line: string;
-  resolve: () => void;
-  reject: (err: unknown) => void;
+  /**
+   * The message id this line writes, when the line is a `msg.put` that a newer
+   * revision of the same message is allowed to overwrite before it ever
+   * reaches disk. Undefined marks an order-sensitive line (an event row, a raw
+   * append) that must keep its position in the queue.
+   */
+  mergeKey?: string;
+  settlers: { resolve: () => void; reject: (err: unknown) => void }[];
 }
 
 const writeQueues = new Map<string, PendingWrite[]>();
 let drainTimer: ReturnType<typeof setTimeout> | null = null;
 const DRAIN_INTERVAL_MS = 100;
 
-function enqueueWrite(filePath: string, line: string): Promise<void> {
+/**
+ * Find a queued put for `mergeKey` that can absorb a newer revision of the
+ * same message.
+ *
+ * Scans backwards and gives up at the first order-sensitive line, because
+ * folding an event (a tombstone, say) depends on where it sits relative to the
+ * puts around it — collapsing a put across one would change the fold's result.
+ * Merging across puts of OTHER ids is safe: a merge keeps the message at the
+ * position it already claimed, and only a first put decides a position.
+ */
+function findMergeTarget(queue: PendingWrite[], mergeKey: string): number {
+  for (let i = queue.length - 1; i >= 0; i--) {
+    if (queue[i].mergeKey === mergeKey) return i;
+    if (queue[i].mergeKey === undefined) return -1;
+  }
+  return -1;
+}
+
+/** Whether a put for `messageId` is queued for `filePath` but not yet on disk. */
+function hasPendingPut(filePath: string, messageId: string): boolean {
+  const queue = writeQueues.get(filePath);
+  return queue ? findMergeTarget(queue, messageId) !== -1 : false;
+}
+
+/**
+ * Queue one line for `filePath`.
+ *
+ * With a `mergeKey`, a still-queued put for the same message is overwritten in
+ * place (last write wins) instead of a second line being queued. This is the
+ * first half of the write-amplification budget: once a replacement is an
+ * append, an unmerged queue would turn every in-flight burst of revisions
+ * (tool results landing one after another) into one physical line each.
+ */
+function enqueueWrite(filePath: string, line: string, mergeKey?: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const queue = writeQueues.get(filePath) ?? [];
-    queue.push({ line, resolve, reject });
+    const mergeAt = mergeKey === undefined ? -1 : findMergeTarget(queue, mergeKey);
+    if (mergeAt !== -1) {
+      queue[mergeAt].line = line;
+      queue[mergeAt].settlers.push({ resolve, reject });
+    } else {
+      queue.push({ line, mergeKey, settlers: [{ resolve, reject }] });
+    }
     writeQueues.set(filePath, queue);
     scheduleDrain();
   });
@@ -177,9 +234,9 @@ async function drainAll(): Promise<void> {
       const data = pending.map((p) => p.line).join('');
       try {
         await appendToFile(filePath, data);
-        pending.forEach((p) => p.resolve());
+        pending.forEach((p) => p.settlers.forEach((s) => s.resolve()));
       } catch (err) {
-        pending.forEach((p) => p.reject(err));
+        pending.forEach((p) => p.settlers.forEach((s) => s.reject(err)));
       }
     }),
   );
@@ -270,10 +327,191 @@ const writingIds = new Map<string, Promise<void>>();
  * Clear the dedup cache. Call when loading messages from disk
  * to populate the set with already-persisted message IDs.
  */
-function populateWrittenIds(messages: Message[]): void {
+function populateWrittenIds(convId: string, messages: Message[]): void {
   for (const msg of messages) {
     writtenIds.add(msg.id);
+    rememberPersistedMessage(msg);
+    const pid = (msg as LedgerLine).pid;
+    if (typeof pid === 'string') parentIdByMessage.set(msg.id, pid);
   }
+  const tail = messages[messages.length - 1];
+  if (tail) lastMessageIdByConv.set(convId, tail.id);
+}
+
+// ════════════════════════════════════════════════════════════
+// Ledger bookkeeping — what a revision needs that the file no longer tells us
+// ════════════════════════════════════════════════════════════
+//
+// A replacement used to read the persisted row back before rewriting it. An
+// append cannot: there is nothing to read without re-reading the whole file,
+// which is exactly the O(file size) cost this change exists to remove. The two
+// facts that read used to supply are tracked here instead.
+
+/**
+ * Per message, the sandbox recovery action already durable for each of its
+ * tool calls. Deliberately NOT the whole persisted message — this is the only
+ * field a revision must not silently regress (see
+ * `preservePersistedSandboxRecoveryActions`), and keeping just it costs a
+ * couple of short strings per tool call instead of a second copy of history.
+ */
+const persistedSandboxActions = new Map<string, Map<string, SandboxRecoveryAction>>();
+
+/**
+ * `pid` per message: the ledger tail at the moment the message was FIRST
+ * written. A revision must reuse it rather than re-parent itself to whatever
+ * is at the tail now (plan §3.2) — otherwise a 5 s streaming revision would
+ * rewrite the chain into nonsense.
+ */
+const parentIdByMessage = new Map<string, string>();
+
+/** Per conversation, the id of the last message in the folded log. */
+const lastMessageIdByConv = new Map<string, string>();
+
+function rememberPersistedMessage(message: Message): void {
+  if (!message.toolCalls?.length) return;
+  const actions = new Map<string, SandboxRecoveryAction>();
+  for (const toolCall of message.toolCalls) {
+    if (toolCall.sandboxRecoveryAction != null) {
+      actions.set(toolCall.id, toolCall.sandboxRecoveryAction);
+    }
+  }
+  if (actions.size > 0) persistedSandboxActions.set(message.id, actions);
+  else persistedSandboxActions.delete(message.id);
+}
+
+/**
+ * Serialize one `msg.put` line.
+ *
+ * `lk` is left off: an absent kind IS `msg.put` (plan §3.1), so omitting it
+ * keeps revision lines byte-identical in shape to the bare `Message` rows
+ * every previous version wrote — nothing about a revised log looks new to an
+ * older build. `pid` is written but never read (plan §3.2).
+ */
+function serializeLedgerPut(message: Message, pid: string | undefined): string {
+  const line = stripForDisk(message) as LedgerLine;
+  if (pid === undefined) delete line.pid;
+  else line.pid = pid;
+  return JSON.stringify(line) + '\n';
+}
+
+// ════════════════════════════════════════════════════════════
+// Stream snapshot — the hot revisions that must NOT enter the ledger
+// ════════════════════════════════════════════════════════════
+//
+// Plan §3.6. Once a replacement is an append, the two highest-frequency
+// writers stop being idempotent overwrites and start being physical lines:
+// the 5 s crash-protection flush during streaming, and the per-tool-result
+// write of the enclosing message. A ten-minute turn with N tool calls would
+// append the whole (growing) message on the order of N + 120 times.
+//
+// So those writers go to `stream-snapshot.json` instead — one atomic
+// whole-file overwrite per revision, no growth, and `loadMessages` folds it on
+// top of the ledger so crash recovery still sees the newest state. The ledger
+// only collects a revision at a stable checkpoint (tool batch done, turn end,
+// stop), which is what keeps revision lines per turn in the single digits.
+
+const STREAM_SNAPSHOT_FILENAME = 'stream-snapshot.json';
+
+interface StreamSnapshotFile {
+  version: 1;
+  messages: Message[];
+}
+
+/** convId → messageId → newest revision not yet checkpointed into the ledger. */
+const streamSnapshots = new Map<string, Map<string, Message>>();
+
+function streamSnapshotPath(convId: string): string {
+  return joinPath(basePath!, convId, STREAM_SNAPSHOT_FILENAME);
+}
+
+async function writeStreamSnapshot(convId: string, entries: Map<string, Message>): Promise<void> {
+  const path = streamSnapshotPath(convId);
+  try {
+    if (entries.size === 0) {
+      if (await exists(path)) await remove(path);
+      return;
+    }
+    const payload: StreamSnapshotFile = { version: 1, messages: [...entries.values()] };
+    await atomicWrite(path, JSON.stringify(payload));
+  } catch {
+    // Best-effort crash protection. The ledger checkpoint is the durable write;
+    // losing a snapshot only costs the in-flight revision.
+  }
+}
+
+/**
+ * Record an in-flight revision without touching the ledger.
+ *
+ * Use this for anything that fires on a timer or per tool result while a turn
+ * is still running. Use `replaceMessageById` at the checkpoints where the
+ * state is worth a permanent line.
+ */
+export async function snapshotMessageRevision(convId: string, message: Message): Promise<void> {
+  await ensureBase();
+  const entries = streamSnapshots.get(convId) ?? new Map<string, Message>();
+  entries.set(message.id, stripForDisk(message));
+  streamSnapshots.set(convId, entries);
+  await writeStreamSnapshot(convId, entries);
+}
+
+/**
+ * Forget the snapshot entry for a message the ledger has now recorded (or that
+ * has been deleted). Cheap no-op when there is nothing buffered for that id,
+ * which is the common case.
+ */
+async function dropStreamSnapshotEntry(convId: string, messageId: string): Promise<void> {
+  const entries = streamSnapshots.get(convId);
+  if (!entries?.delete(messageId)) return;
+  if (entries.size === 0) streamSnapshots.delete(convId);
+  await writeStreamSnapshot(convId, entries);
+}
+
+/** Read the snapshot file back and re-arm the in-memory buffer from it. */
+async function readStreamSnapshot(convId: string): Promise<Message[]> {
+  const path = streamSnapshotPath(convId);
+  try {
+    if (!(await exists(path))) return [];
+    const parsed = JSON.parse(await readTextFile(path)) as StreamSnapshotFile;
+    const messages = Array.isArray(parsed?.messages) ? parsed.messages : [];
+    if (messages.length === 0) return [];
+    const entries = new Map<string, Message>();
+    for (const message of messages) {
+      if (message && typeof message.id === 'string') entries.set(message.id, message);
+    }
+    streamSnapshots.set(convId, entries);
+    return [...entries.values()];
+  } catch {
+    // A damaged snapshot must never take the conversation down with it — the
+    // ledger alone is still a complete, if slightly older, history.
+    return [];
+  }
+}
+
+/**
+ * Promote every buffered revision into the ledger and drop the snapshot files.
+ * Called on shutdown so a snapshot never outlives the session that wrote it.
+ */
+export async function flushStreamSnapshots(): Promise<void> {
+  if (streamSnapshots.size === 0) return;
+  await ensureBase();
+  const pending: Promise<unknown>[] = [];
+  for (const [convId, entries] of [...streamSnapshots.entries()]) {
+    for (const message of entries.values()) {
+      pending.push(
+        enqueueWrite(
+          messagesPath(convId),
+          serializeLedgerPut(message, parentIdByMessage.get(message.id)),
+          message.id,
+        ).then(() => {
+          writtenIds.add(message.id);
+        }),
+      );
+    }
+    streamSnapshots.delete(convId);
+    pending.push(writeStreamSnapshot(convId, new Map()));
+  }
+  await flushWrites();
+  await Promise.allSettled(pending);
 }
 
 /**
@@ -604,13 +842,19 @@ export async function appendMessage(
 
   const write = (async () => {
     await ensureBase();
-    const line = JSON.stringify(stripForDisk(message)) + '\n';
-    await enqueueWrite(messagesPath(convId), line);
+    // `pid` = the ledger tail at append time (plan §3.2). Claimed synchronously
+    // so two appends racing through `ensureBase` still chain in write order.
+    const pid = lastMessageIdByConv.get(convId);
+    lastMessageIdByConv.set(convId, message.id);
+    if (pid !== undefined) parentIdByMessage.set(message.id, pid);
+    const line = serializeLedgerPut(message, pid);
+    await enqueueWrite(messagesPath(convId), line, message.id);
 
     // Only claim the id after the append has actually succeeded. Marking it
     // before I/O made a transient disk failure permanently suppress retry and
     // allowed Reliable Run to execute without a durable user message.
     writtenIds.add(message.id);
+    rememberPersistedMessage(message);
 
     // The catalog is a rebuildable projection; JSONL success above is the
     // hard requirement and the catalog bump remains best-effort.
@@ -678,17 +922,25 @@ export async function deleteMessageById(
 
     await atomicWrite(path, kept.length > 0 ? `${kept.join('\n')}\n` : '');
     writtenIds.delete(messageId);
+    // A buffered revision would otherwise resurrect the row on next load.
+    await dropStreamSnapshotEntry(convId, messageId);
     return true;
   });
 }
 
 /**
  * Replace a message in the JSONL file by its id.
- * Unlike updateLastMessage, this scans for the matching id, so it correctly
- * updates intermediate-turn messages even after later turns have appended new
- * lines. Used by the agent loop to flush each turn's full state (including
- * tool calls) immediately after the tool batch completes — without this,
- * only the very last turn's tool calls would survive a restart.
+ *
+ * Since the ledger change this appends a second line carrying the same id
+ * rather than rewriting the matching line in place: the fold keeps the last
+ * put for an id, at that id's original position, so an append expresses a
+ * revision exactly. That removes the read-modify-write — and with it the
+ * whole class of interleaved-rewrite corruption the file mutex was holding
+ * back — at the cost of the file growing by one line per checkpoint.
+ *
+ * Used by the agent loop to flush each turn's full state (including tool
+ * calls) at a checkpoint; the in-flight revisions between checkpoints go to
+ * `snapshotMessageRevision` instead so they never become lines at all.
  */
 const SETTLED_SANDBOX_RECOVERY_ACTIONS = new Set([
   'completed',
@@ -699,15 +951,12 @@ const SETTLED_SANDBOX_RECOVERY_ACTIONS = new Set([
 
 function preservePersistedSandboxRecoveryActions(
   incoming: Message,
-  persisted: Message,
+  persistedActions: Map<string, SandboxRecoveryAction> | undefined,
 ): Message {
-  if (!incoming.toolCalls?.length || !persisted.toolCalls?.length) return incoming;
-  const persistedById = new Map(
-    persisted.toolCalls.map((toolCall) => [toolCall.id, toolCall]),
-  );
+  if (!incoming.toolCalls?.length || !persistedActions?.size) return incoming;
   let changed = false;
   const toolCalls = incoming.toolCalls.map((toolCall) => {
-    const persistedAction = persistedById.get(toolCall.id)?.sandboxRecoveryAction;
+    const persistedAction = persistedActions.get(toolCall.id);
     const incomingAction = toolCall.sandboxRecoveryAction;
     const shouldPreserve =
       persistedAction != null
@@ -725,6 +974,26 @@ function preservePersistedSandboxRecoveryActions(
   return changed ? { ...incoming, toolCalls } : incoming;
 }
 
+/**
+ * Last-resort existence check for an id this process has neither written nor
+ * loaded. The old rewrite read the whole file on EVERY replace; this reads it
+ * only on a `writtenIds` miss, which in practice means never — both
+ * `loadMessages` and `appendMessage` populate that set. Folding rather than
+ * grepping means a message that a later event removed correctly reads as
+ * absent.
+ */
+async function ledgerContainsMessage(path: string, messageId: string): Promise<boolean> {
+  try {
+    const raw = await readTextFile(path);
+    if (!raw.includes(`"${messageId}"`)) return false;
+    const present = foldMessageLog(raw.split('\n')).messages.some((m) => m.id === messageId);
+    if (present) writtenIds.add(messageId);
+    return present;
+  } catch {
+    return false;
+  }
+}
+
 async function replaceMessageByIdInternal(
   convId: string,
   message: Message,
@@ -732,49 +1001,49 @@ async function replaceMessageByIdInternal(
 ): Promise<boolean> {
   await ensureBase();
   const path = messagesPath(convId);
-  if (!(await exists(path))) {
-    if (strict) throw new Error(`Conversation messages file does not exist: ${convId}`);
-    return false;
-  }
 
-  // Serialize with concurrent drain / updateLastMessage on the same path.
-  // We intentionally do NOT pre-flush via flushWrites(): drain would try
-  // to re-acquire the same lock and deadlock. The lock itself guarantees
-  // any queued drain runs before-or-after us, never mid-operation.
-  return withFileLock(path, async () => {
-    try {
-      const raw = await readTextFile(path);
-      const lines = raw.trimEnd().split('\n');
-      let replaced = false;
-      for (let i = 0; i < lines.length; i++) {
-        // Cheap pre-check: only parse lines that contain the id substring
-        if (!lines[i].includes(`"${message.id}"`)) continue;
-        try {
-          const parsed = JSON.parse(lines[i]) as Message;
-          if (parsed.id === message.id) {
-            const mergedMessage = preservePersistedSandboxRecoveryActions(message, parsed);
-            lines[i] = JSON.stringify(stripForDisk(mergedMessage));
-            replaced = true;
-            break;
-          }
-        } catch {
-          // Skip corrupt line
-        }
-      }
-
-      if (replaced) {
-        await atomicWrite(path, lines.join('\n') + '\n');
-        writtenIds.add(message.id);
-        return true;
-      }
-      if (strict) throw new Error(`Message "${message.id}" was not found in conversation "${convId}"`);
-      return false;
-    } catch (error) {
-      if (strict) throw error;
-      // Non-critical: leave the file as-is. Worst case the message disk state lags behind memory.
+  // An append is an upsert by nature; the old rewrite was not. Replacing an id
+  // the file never held used to be a no-op (and a throw under `strict`), and
+  // callers depend on that — a strict replace reporting success for a row that
+  // does not exist would make crash recovery lie about a saved choice. With no
+  // file scan left, `writtenIds` plus the still-queued puts are what answer
+  // "does this message exist on disk?" (plan §1, difference ②).
+  if (!hasPendingPut(path, message.id)) {
+    if (!(await exists(path))) {
+      if (strict) throw new Error(`Conversation messages file does not exist: ${convId}`);
       return false;
     }
-  });
+    if (!writtenIds.has(message.id) && !(await ledgerContainsMessage(path, message.id))) {
+      if (strict) throw new Error(`Message "${message.id}" was not found in conversation "${convId}"`);
+      return false;
+    }
+  }
+
+  try {
+    // The rewrite used to re-read the persisted row here to keep a settled
+    // sandbox recovery action from being clobbered by a stale in-memory one.
+    // Nothing is read now, so the same protection comes from the recorded
+    // per-message action map (plan §1, difference ①).
+    const merged = preservePersistedSandboxRecoveryActions(
+      message,
+      persistedSandboxActions.get(message.id),
+    );
+    await enqueueWrite(
+      path,
+      serializeLedgerPut(merged, parentIdByMessage.get(message.id)),
+      message.id,
+    );
+    writtenIds.add(message.id);
+    rememberPersistedMessage(merged);
+    // The ledger now carries this revision, so the crash-protection buffer
+    // must stop claiming a newer one.
+    await dropStreamSnapshotEntry(convId, message.id);
+    return true;
+  } catch (error) {
+    if (strict) throw error;
+    // Non-critical: leave the file as-is. Worst case the message disk state lags behind memory.
+    return false;
+  }
 }
 
 export async function replaceMessageById(
@@ -798,8 +1067,15 @@ export async function replaceMessageByIdStrict(
 }
 
 /**
- * Replace the last line in the JSONL file.
- * Used when streaming completes or tool results are added.
+ * Persist the tail of a conversation when streaming completes or tool results
+ * are added, for callers that do not know the message id they are finishing.
+ *
+ * This used to overwrite the last physical line WITHOUT checking its id, so a
+ * message that arrived mid-stream could be silently swallowed by the update of
+ * a different message. It now appends a put for `message.id` like any other
+ * revision, which means both rows survive the fold (plan §1, difference ③).
+ * That is a behaviour change, and a deliberate one: the failure it removes
+ * destroyed a message, and the cost is one extra line.
  */
 export async function updateLastMessage(
   convId: string,
@@ -807,29 +1083,28 @@ export async function updateLastMessage(
 ): Promise<void> {
   await ensureBase();
   const path = messagesPath(convId);
-  if (!(await exists(path))) return;
+  // Preserved from the rewrite era: with no conversation file there is nothing
+  // to finish, and this must not conjure one.
+  if (!hasPendingPut(path, message.id) && !(await exists(path))) return;
 
-  // Serialize with concurrent drain / replaceMessageById on the same path.
-  // Like replaceMessageById, we do not pre-flush — the lock does the job
-  // without the deadlock risk of flushWrites re-acquiring.
-  let updated = false;
   try {
-    await withFileLock(path, async () => {
-      const raw = await readTextFile(path);
-      const lines = raw.trimEnd().split('\n');
-      lines[lines.length - 1] = JSON.stringify(stripForDisk(message));
-      await atomicWrite(path, lines.join('\n') + '\n');
-      writtenIds.add(message.id);
-      updated = true;
-    });
+    const merged = preservePersistedSandboxRecoveryActions(
+      message,
+      persistedSandboxActions.get(message.id),
+    );
+    await enqueueWrite(
+      path,
+      serializeLedgerPut(merged, parentIdByMessage.get(message.id)),
+      message.id,
+    );
+    writtenIds.add(message.id);
+    rememberPersistedMessage(merged);
+    await dropStreamSnapshotEntry(convId, message.id);
   } catch {
-    // Swallow: fall through to append-fallback below
-  }
-  if (!updated) {
-    // If the in-lock update failed, appendMessage is a safer recovery — it
-    // re-uses the same lock internally so ordering is still preserved.
+    // Leave the id unclaimed so a later appendMessage can still get the
+    // message onto disk — the same recovery the old fallback provided, minus
+    // the second write path.
     writtenIds.delete(message.id);
-    await appendMessage(convId, message);
   }
 }
 
@@ -862,14 +1137,21 @@ export async function loadMessages(convId: string): Promise<Message[]> {
   // appendToFile falls through to read+rewrite and appends the same line again.
   // The fold additionally makes a repeated id an in-place revision rather than
   // a reorder, which is what lets the write side express "replace" as "append".
-  const { messages, corruptCount, totalLines } = foldMessageLog(raw.split('\n'));
+  // Revisions that a crash caught between checkpoints live in the stream
+  // snapshot, not the ledger. Folding them in as trailing puts applies them
+  // with exactly the ledger's own last-write-wins-in-place rule.
+  const snapshot = await readStreamSnapshot(convId);
+  const { messages, corruptCount, totalLines } = foldMessageLog([
+    ...raw.split('\n'),
+    ...snapshot.map((m) => JSON.stringify(m)),
+  ]);
   if (corruptCount > 0) {
     console.warn(
       `[conversationStorage] loadMessages(${convId}): skipped ${corruptCount}/${totalLines} corrupt line(s). ` +
         `The affected messages are lost, but ${messages.length} intact message(s) recovered.`,
     );
   }
-  populateWrittenIds(messages);
+  populateWrittenIds(convId, messages);
   return messages;
 }
 
@@ -879,6 +1161,10 @@ export async function loadMessages(convId: string): Promise<Message[]> {
  */
 export async function deleteConversationFiles(convId: string): Promise<void> {
   await ensureBase();
+  // Drop the crash-protection buffer first: leaving it armed would have a
+  // later flush recreate the conversation directory we are deleting.
+  streamSnapshots.delete(convId);
+  lastMessageIdByConv.delete(convId);
   // Remove new path
   const dir = convDir(convId);
   try {
@@ -1047,6 +1333,9 @@ export async function initConversationStorage(): Promise<void> {
  * Flushes all pending writes.
  */
 export async function shutdownConversationStorage(): Promise<void> {
+  // Promote buffered revisions into the ledger first, so a stream snapshot
+  // never outlives the session that produced it.
+  await flushStreamSnapshots();
   await flushWrites();
   await flushIndex();
 }

--- a/src/core/session/conversationStorage.ts
+++ b/src/core/session/conversationStorage.ts
@@ -26,6 +26,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { appDataDir } from '@tauri-apps/api/path';
 import { joinPath } from '@/utils/pathUtils';
 import { atomicWrite } from '@/utils/atomicFs';
+import { foldMessageLog } from './messageLedger';
 import type { Message, MessageContent } from '@/types';
 
 // ════════════════════════════════════════════════════════════
@@ -853,47 +854,23 @@ export async function loadMessages(convId: string): Promise<Message[]> {
     return [];
   }
 
-  // Per-line parse failures are tolerated: skip the bad line, keep the rest.
-  // Previously we .map()'d + caught the whole block, which meant any single
-  // corrupt line nuked the entire conversation for the UI even though most
-  // lines were fine. This is pure damage reduction for a storage bug we
-  // eventually need to fix on the write side (see conversationStorage write
-  // race / TODO in Task #15 follow-up).
-  const lines = raw.trimEnd().split('\n').filter((l) => l.length > 0);
-  const messages: Message[] = [];
-  let corruptCount = 0;
-  for (const line of lines) {
-    try {
-      messages.push(JSON.parse(line) as Message);
-    } catch {
-      corruptCount++;
-    }
-  }
+  // The whole read is one fold (see messageLedger.ts for the spec). It keeps
+  // the previous damage-reduction behaviour — a corrupt line is skipped, not
+  // fatal — and the previous keep-last-by-id dedup, which a non-idempotent
+  // append fallback can produce: if the native O(1) append durably writes a
+  // line but its invoke promise still rejects (IPC teardown / shutdown race),
+  // appendToFile falls through to read+rewrite and appends the same line again.
+  // The fold additionally makes a repeated id an in-place revision rather than
+  // a reorder, which is what lets the write side express "replace" as "append".
+  const { messages, corruptCount, totalLines } = foldMessageLog(raw.split('\n'));
   if (corruptCount > 0) {
     console.warn(
-      `[conversationStorage] loadMessages(${convId}): skipped ${corruptCount}/${lines.length} corrupt line(s). ` +
+      `[conversationStorage] loadMessages(${convId}): skipped ${corruptCount}/${totalLines} corrupt line(s). ` +
         `The affected messages are lost, but ${messages.length} intact message(s) recovered.`,
     );
   }
-  // Dedup by id, keeping the last occurrence. A duplicate line is not "corrupt"
-  // (so the skip-bad-lines net above can't catch it) but can arise from a
-  // non-idempotent append fallback: if the native O(1) append durably writes a
-  // line but its invoke promise still rejects (IPC teardown / shutdown race),
-  // appendToFile falls through to read+rewrite and appends the same line again.
-  // The last write reflects the most recent state; downstream consumers
-  // (chatStore, memdir extractor) don't dedup, so a duplicate would otherwise
-  // render — and be sent to the LLM — twice.
-  const deduped = dedupMessagesById(messages);
-  populateWrittenIds(deduped);
-  return deduped;
-}
-
-/** Keep the last occurrence of each message id, preserving order. */
-function dedupMessagesById(messages: Message[]): Message[] {
-  const lastIndex = new Map<string, number>();
-  messages.forEach((m, i) => lastIndex.set(m.id, i));
-  if (lastIndex.size === messages.length) return messages; // no dupes, fast path
-  return messages.filter((m, i) => lastIndex.get(m.id) === i);
+  populateWrittenIds(messages);
+  return messages;
 }
 
 /**

--- a/src/core/session/conversationStorage.ts
+++ b/src/core/session/conversationStorage.ts
@@ -243,6 +243,49 @@ async function drainAll(): Promise<void> {
 }
 
 /**
+ * Paths whose on-disk tail this process has already confirmed to be newline
+ * terminated. See `repairTornTail`.
+ */
+const tailCheckedPaths = new Set<string>();
+
+/**
+ * Prefix `data` with the newline a crashed append never got to write.
+ *
+ * Native append is not atomic (see `appendToFile` below), so a crash mid-write
+ * can leave the file ending in a partial line. That was self-healing while
+ * `replaceMessageById` rewrote the whole file — `lines.join('\n') + '\n'`
+ * re-terminated the stump within seconds. In an append-only ledger nothing
+ * ever rewrites, so the stump is permanent and the NEXT appended line gets
+ * glued onto it: one corrupt line, two messages lost instead of one.
+ *
+ * Checking costs one read of the file, once per path per process, on the first
+ * append only — `loadMessages` hands its own read to `noteTailFromRead` so the
+ * common path does not pay even that.
+ */
+async function repairTornTail(filePath: string, data: string): Promise<string> {
+  if (tailCheckedPaths.has(filePath)) return data;
+  try {
+    if (!(await exists(filePath))) {
+      tailCheckedPaths.add(filePath);
+      return data;
+    }
+    const raw = await readTextFile(filePath);
+    tailCheckedPaths.add(filePath);
+    if (raw.length === 0 || raw.endsWith('\n')) return data;
+    return `\n${data}`;
+  } catch {
+    // Unreadable: leave the flag unset so a later append tries again.
+    return data;
+  }
+}
+
+/** Record a tail already observed by a reader, so no append has to re-read it. */
+function noteTailFromRead(filePath: string, raw: string): void {
+  if (raw.length === 0 || raw.endsWith('\n')) tailCheckedPaths.add(filePath);
+  else tailCheckedPaths.delete(filePath);
+}
+
+/**
  * Append data to a file. Creates parent directory on first write.
  *
  * Part B1: tries the native `append_file_text` Rust command first — it opens
@@ -264,8 +307,9 @@ async function drainAll(): Promise<void> {
  *
  * Serialized against concurrent mutations on the same path via `withFileLock`.
  */
-async function appendToFile(filePath: string, data: string): Promise<void> {
+async function appendToFile(filePath: string, rawData: string): Promise<void> {
   return withFileLock(filePath, async () => {
+    const data = await repairTornTail(filePath, rawData);
     try {
       // Native O(1) append (Part B1). Falls back to read+atomic-rewrite below
       // if the command is unavailable or fails.
@@ -494,24 +538,38 @@ async function readStreamSnapshot(convId: string): Promise<Message[]> {
 export async function flushStreamSnapshots(): Promise<void> {
   if (streamSnapshots.size === 0) return;
   await ensureBase();
-  const pending: Promise<unknown>[] = [];
+  const promotions: { convId: string; done: Promise<unknown> }[] = [];
   for (const [convId, entries] of [...streamSnapshots.entries()]) {
     for (const message of entries.values()) {
-      pending.push(
-        enqueueWrite(
+      promotions.push({
+        convId,
+        done: enqueueWrite(
           messagesPath(convId),
           serializeLedgerPut(message, parentIdByMessage.get(message.id)),
           message.id,
         ).then(() => {
           writtenIds.add(message.id);
         }),
-      );
+      });
     }
     streamSnapshots.delete(convId);
-    pending.push(writeStreamSnapshot(convId, new Map()));
   }
   await flushWrites();
-  await Promise.allSettled(pending);
+
+  // Drop a snapshot file only AFTER its revision is durably in the ledger.
+  // Removing it in parallel with the promotion leaves a crash window in which
+  // neither copy exists, and a rejected promotion (disk full at exit) would
+  // discard the revision outright — keeping the file lets the next launch
+  // re-arm from it instead.
+  const results = await Promise.allSettled(promotions.map((p) => p.done));
+  const failedConvs = new Set(
+    promotions.filter((_, i) => results[i].status === 'rejected').map((p) => p.convId),
+  );
+  await Promise.allSettled(
+    [...new Set(promotions.map((p) => p.convId))]
+      .filter((convId) => !failedConvs.has(convId))
+      .map((convId) => writeStreamSnapshot(convId, new Map())),
+  );
 }
 
 /**
@@ -883,6 +941,14 @@ export async function deleteMessageById(
 ): Promise<boolean> {
   await ensureBase();
   const path = messagesPath(convId);
+  // Land every queued line BEFORE the rewrite reads the file. Since revisions
+  // became appends, a checkpoint put can still be sitting in the 100ms-debounced
+  // queue when a delete arrives (the abort path's ghost cleanup runs right
+  // behind the turn's last persist) — the rewrite would not see that line, and
+  // the later drain would append it back, resurrecting the deleted message.
+  // Draining here, outside `withFileLock`, is the same discipline
+  // `catalogReindexConversation` uses; doing it inside the lock would deadlock.
+  await flushWrites();
   if (!(await exists(path))) {
     if (writtenIds.has(messageId)) {
       throw new Error(`Conversation messages file does not exist for persisted message "${messageId}"`);
@@ -921,6 +987,8 @@ export async function deleteMessageById(
     }
 
     await atomicWrite(path, kept.length > 0 ? `${kept.join('\n')}\n` : '');
+    // The rewrite re-terminated the file, torn tail included.
+    tailCheckedPaths.add(path);
     writtenIds.delete(messageId);
     // A buffered revision would otherwise resurrect the row on next load.
     await dropStreamSnapshotEntry(convId, messageId);
@@ -1128,6 +1196,8 @@ export async function loadMessages(convId: string): Promise<Message[]> {
     );
     return [];
   }
+  // Free the next append from re-reading the file just to check its tail.
+  noteTailFromRead(path, raw);
 
   // The whole read is one fold (see messageLedger.ts for the spec). It keeps
   // the previous damage-reduction behaviour — a corrupt line is skipped, not

--- a/src/core/session/messageLedger.test.ts
+++ b/src/core/session/messageLedger.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { createLedgerEvent, foldMessageLog, type LedgerLine } from './messageLedger';
+import { loadFoldFixtures, projectFolded } from '@/test/foldFixtures';
+import type { Message } from '@/types';
+
+/**
+ * The pre-ledger dedup that `loadMessages` used before `foldMessageLog`.
+ * Kept verbatim here so the equivalence test below is a real comparison
+ * against the old behaviour, not against a paraphrase of it.
+ */
+function legacyDedupMessagesById(messages: Message[]): Message[] {
+  const lastIndex = new Map<string, number>();
+  messages.forEach((m, i) => lastIndex.set(m.id, i));
+  if (lastIndex.size === messages.length) return messages;
+  return messages.filter((m, i) => lastIndex.get(m.id) === i);
+}
+
+function legacyLoad(lines: string[]): Message[] {
+  const parsed: Message[] = [];
+  for (const line of lines.filter((l) => l.length > 0)) {
+    try {
+      parsed.push(JSON.parse(line) as Message);
+    } catch {
+      /* skip corrupt line */
+    }
+  }
+  return legacyDedupMessagesById(parsed);
+}
+
+describe('messageLedger', () => {
+  describe('foldMessageLog', () => {
+    for (const testCase of loadFoldFixtures()) {
+      it(`fixture: ${testCase.name}`, () => {
+        const result = foldMessageLog(testCase.lines);
+        expect(projectFolded(result.messages)).toEqual(testCase.expected.messages);
+        expect(result.corruptCount).toBe(testCase.expected.corruptCount);
+        expect(result.totalLines).toBe(testCase.expected.totalLines);
+      });
+    }
+
+    it('is a strictly sequential replay — a truncate never deletes lines written after it', () => {
+      // Edit-and-resend: deleteMessagesFrom(m2) is followed immediately by the
+      // new turn's messages. A "collect the delete set, apply at the end" fold
+      // would swallow the entire resent turn (plan §3.3).
+      const result = foldMessageLog([
+        JSON.stringify({ id: 'm1', role: 'user', content: 'a', timestamp: 1 }),
+        JSON.stringify({ id: 'm2', role: 'assistant', content: 'b', timestamp: 2 }),
+        JSON.stringify(createLedgerEvent('msg.truncate', { id: 'ev1', timestamp: 3, from: 'm2' })),
+        JSON.stringify({ id: 'm3', role: 'user', content: 'edited', timestamp: 4 }),
+      ]);
+      expect(result.messages.map((m) => m.id)).toEqual(['m1', 'm3']);
+    });
+
+    it('keeps the last revision at the ORIGINAL position, not at the end', () => {
+      const result = foldMessageLog([
+        JSON.stringify({ id: 'a', role: 'user', content: '1', timestamp: 1 }),
+        JSON.stringify({ id: 'b', role: 'assistant', content: '2', timestamp: 2 }),
+        JSON.stringify({ id: 'c', role: 'user', content: '3', timestamp: 3 }),
+        JSON.stringify({ id: 'a', role: 'user', content: '1-revised', timestamp: 4 }),
+      ]);
+      expect(result.messages.map((m) => m.id)).toEqual(['a', 'b', 'c']);
+      expect(result.messages[0].content).toBe('1-revised');
+    });
+
+    it('does not mutate the input lines array', () => {
+      const lines = [JSON.stringify({ id: 'a', role: 'user', content: '1', timestamp: 1 })];
+      const snapshot = [...lines];
+      foldMessageLog(lines);
+      expect(lines).toEqual(snapshot);
+    });
+  });
+
+  describe('equivalence with the pre-ledger dedup', () => {
+    it('matches legacy output exactly for a log of bare Message lines', () => {
+      const lines = [
+        JSON.stringify({ id: 'm1', role: 'user', content: 'a', timestamp: 1 }),
+        JSON.stringify({ id: 'm2', role: 'assistant', content: 'b', timestamp: 2 }),
+        JSON.stringify({ id: 'm3', role: 'user', content: 'c', timestamp: 3 }),
+      ];
+      expect(foldMessageLog(lines).messages).toEqual(legacyLoad(lines));
+    });
+
+    it('matches legacy output when a corrupt line sits in the middle', () => {
+      const lines = [
+        JSON.stringify({ id: 'm1', role: 'user', content: 'a', timestamp: 1 }),
+        '{"id":"m2","role":"user","content":"trun',
+        JSON.stringify({ id: 'm3', role: 'user', content: 'c', timestamp: 3 }),
+      ];
+      expect(foldMessageLog(lines).messages).toEqual(legacyLoad(lines));
+    });
+
+    it('DIVERGES from legacy only on duplicate ids — legacy moved the survivor to the end', () => {
+      // This is the one deliberate difference (plan §3.3 vs §5's "identical
+      // output" claim): the old dedup was a positional filter, so a duplicated
+      // id reordered the conversation. Appending revisions makes duplicate ids
+      // the normal case, so the in-place rule is the one that has to win.
+      const lines = [
+        JSON.stringify({ id: 'm1', role: 'user', content: 'v1', timestamp: 1 }),
+        JSON.stringify({ id: 'm2', role: 'assistant', content: 'b', timestamp: 2 }),
+        JSON.stringify({ id: 'm1', role: 'user', content: 'v2', timestamp: 3 }),
+      ];
+      expect(legacyLoad(lines).map((m) => m.id)).toEqual(['m2', 'm1']);
+      expect(foldMessageLog(lines).messages.map((m) => m.id)).toEqual(['m1', 'm2']);
+      // Same set, same survivors — only the order differs.
+      expect(new Set(foldMessageLog(lines).messages.map((m) => m.content)))
+        .toEqual(new Set(legacyLoad(lines).map((m) => m.content)));
+    });
+  });
+
+  describe('createLedgerEvent', () => {
+    const KINDS = ['msg.tomb', 'msg.truncate', 'msg.loopDrop'] as const;
+
+    for (const kind of KINDS) {
+      it(`${kind} is also a legal, invisible Message (rollback safety, plan §5.2)`, () => {
+        const event = createLedgerEvent(kind, { id: 'ev1', timestamp: 1000, target: 'm1', from: 'm1', loopId: 'L1' });
+        // Required by Message: content must exist (older renderers do content.length).
+        expect(event.content).toBe('');
+        expect(typeof event.content).toBe('string');
+        // Hidden by existing UI and harmless in an older build's LLM context.
+        expect(event.isSystem).toBe(true);
+        expect(event.role).toBe('system');
+        expect(event.id).toBe('ev1');
+        expect(event.timestamp).toBe(1000);
+        expect(event.lk).toBe(kind);
+      });
+    }
+
+    it('survives a JSON round-trip through the fold as an event, not a message', () => {
+      const event = createLedgerEvent('msg.tomb', { id: 'ev1', timestamp: 5, target: 'm1' });
+      const result = foldMessageLog([
+        JSON.stringify({ id: 'm1', role: 'user', content: 'a', timestamp: 1 }),
+        JSON.stringify(event),
+      ]);
+      expect(result.messages).toEqual([]);
+      expect(result.corruptCount).toBe(0);
+    });
+
+    it('omits optional payload fields that were not supplied', () => {
+      const event: LedgerLine = createLedgerEvent('msg.tomb', { id: 'ev1', timestamp: 5, target: 'm1' });
+      expect(event.from).toBeUndefined();
+      expect(event.loopId).toBeUndefined();
+      expect(event.pid).toBeUndefined();
+      expect(Object.prototype.hasOwnProperty.call(event, 'from')).toBe(false);
+    });
+  });
+});

--- a/src/core/session/messageLedger.ts
+++ b/src/core/session/messageLedger.ts
@@ -1,0 +1,216 @@
+/**
+ * Message ledger — the single authoritative fold from the append-only JSONL
+ * event log to the current `Message[]` projection.
+ *
+ * Design: `docs/abu-message-ledger-plan.md` §3.1 (event envelope) and §3.3
+ * (fold spec). Three consumers must agree byte-for-byte on the result:
+ *
+ *   1. `loadMessages()` in `conversationStorage.ts` (this implementation)
+ *   2. `scanConversationFile()` in `electron/messageLedgerFold.cjs`
+ *   3. `scan_conversation_file()` in `src-tauri/src/catalog_db.rs` (legacy Tauri)
+ *
+ * They cannot share a module (renderer / Electron main / Rust), so they are
+ * pinned to each other by a shared fixture file —
+ * `__fixtures__/messageLedgerFold.fixtures.json` — replayed by contract tests
+ * on every side. Change the fold? Change the fixtures, and every port turns
+ * red until it agrees again.
+ *
+ * ## Line format
+ *
+ * A ledger line is a plain `Message` object with at most two extra fields:
+ *
+ *   {"lk":"msg.put","pid":"m_122","id":"m_123","role":"user","content":"…"}
+ *
+ * `lk` (ledger kind) defaults to `msg.put` when absent, so every pre-ledger
+ * bare `Message` line is already a valid put — that is what makes the format
+ * change a zero-migration one (plan §5). `pid` (parent id) is write-only
+ * bookkeeping for a future branch/fork feature and is never read here.
+ *
+ * ## Fold semantics (plan §3.3)
+ *
+ * Strictly sequential, single pass: every event applies to the state folded
+ * from the lines BEFORE it, never to a globally pre-collected delete set. That
+ * ordering is load-bearing, not a detail — "edit and resend" appends a
+ * truncate event and then immediately appends the new turn's messages behind
+ * it. Collecting truncations first and applying them at the end would delete
+ * the very turn the user just produced. For the same reason a `msg.put` after
+ * a `msg.tomb` for the same id resurrects that message.
+ */
+
+import type { Message } from '@/types';
+
+/** Ledger event kinds. Absent `lk` means `msg.put`. */
+export type LedgerKind = 'msg.put' | 'msg.tomb' | 'msg.truncate' | 'msg.loopDrop';
+
+export const LEDGER_KIND_PUT = 'msg.put';
+
+/**
+ * One physical line of `messages.jsonl`.
+ *
+ * It extends `Message` rather than wrapping it in a `{type, payload}` envelope
+ * on purpose (plan §3.1): every stored line stays a legal `Message` for older
+ * app versions, so a downgrade renders the log instead of crashing on it.
+ */
+export interface LedgerLine extends Message {
+  /** Ledger kind. Omitted on puts — absent is the canonical spelling of `msg.put`. */
+  lk?: LedgerKind;
+  /**
+   * Parent pointer: the id of the last surviving message at append time.
+   * Written but never read (plan §3.2) — it exists so a future branch/fork
+   * feature does not have to guess the chain by re-reading line order.
+   */
+  pid?: string;
+  /** `msg.tomb`: id of the message being removed. */
+  target?: string;
+  /** `msg.truncate`: id of the first message to remove (it and everything after). */
+  from?: string;
+}
+
+export interface FoldResult {
+  /** Current projection, in conversation order. */
+  messages: Message[];
+  /** Lines that were not parseable JSON objects and were skipped. */
+  corruptCount: number;
+  /** Non-blank lines seen (corrupt ones included). */
+  totalLines: number;
+}
+
+/**
+ * Fields every event line must carry so that an older build parses it as a
+ * harmless, invisible `Message` instead of choking on it (plan §5.2):
+ * `content: ''` because `Message.content` is required and older renderers do
+ * `content.length`, and `isSystem: true` because that is the flag existing UI
+ * already uses to hide a message. `content: ''` also makes the row harmless if
+ * an older build still feeds system messages into the LLM context.
+ */
+export interface LedgerEventInit {
+  /** Unique id for the event row itself (never the id of the affected message). */
+  id: string;
+  timestamp: number;
+  /** `msg.tomb`: the message being removed. */
+  target?: string;
+  /** `msg.truncate`: the first message to remove. */
+  from?: string;
+  /** `msg.loopDrop`: the loop whose messages are removed. */
+  loopId?: string;
+  /** Parent pointer — see `LedgerLine.pid`. */
+  pid?: string;
+}
+
+/**
+ * Build an event line that is simultaneously a legal, invisible `Message`.
+ *
+ * Always construct event rows through this helper: the rollback-safety
+ * contract in plan §5.2 is exactly the four fields it hard-codes, and a
+ * hand-rolled object is one forgotten `content: ''` away from breaking an
+ * older build's renderer.
+ */
+export function createLedgerEvent(
+  kind: Exclude<LedgerKind, 'msg.put'>,
+  init: LedgerEventInit,
+): LedgerLine {
+  const event: LedgerLine = {
+    lk: kind,
+    id: init.id,
+    role: 'system',
+    content: '',
+    isSystem: true,
+    timestamp: init.timestamp,
+  };
+  if (init.pid !== undefined) event.pid = init.pid;
+  if (init.target !== undefined) event.target = init.target;
+  if (init.from !== undefined) event.from = init.from;
+  if (init.loopId !== undefined) event.loopId = init.loopId;
+  return event;
+}
+
+/**
+ * Replay an append-only message log into its current projection.
+ *
+ * Pure, no I/O — see the module doc for the semantics this implements and for
+ * the two sibling ports that must stay identical to it.
+ */
+export function foldMessageLog(lines: readonly string[]): FoldResult {
+  const state: LedgerLine[] = [];
+  let index = new Map<string | undefined, number>();
+  let corruptCount = 0;
+  let totalLines = 0;
+
+  const reindex = (): void => {
+    index = new Map<string | undefined, number>();
+    for (let i = 0; i < state.length; i++) index.set(state[i].id, i);
+  };
+
+  for (const rawLine of lines) {
+    if (rawLine.trim() === '') continue;
+    totalLines++;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawLine);
+    } catch {
+      corruptCount++;
+      continue;
+    }
+    // A line that parses to a non-object (null, number, string, array) cannot
+    // be a Message. Older code pushed it through and then threw on `.id`,
+    // taking the whole conversation down with it; counting it as corrupt keeps
+    // the damage to the one line.
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      corruptCount++;
+      continue;
+    }
+    const line = parsed as LedgerLine;
+    const kind: string = typeof line.lk === 'string' ? line.lk : LEDGER_KIND_PUT;
+
+    switch (kind) {
+      case LEDGER_KIND_PUT: {
+        // Note the map key is `line.id` verbatim, so every id-less line
+        // collapses onto one shared `undefined` key — the behaviour the
+        // pre-ledger dedup had and both ports deliberately mirror.
+        const at = index.get(line.id);
+        if (at === undefined) {
+          state.push(line);
+          index.set(line.id, state.length - 1);
+        } else {
+          // In place, NOT move-to-end: a revision must not reorder the
+          // conversation. This is the semantics that makes "replace a message"
+          // expressible as "append a second line with the same id".
+          state[at] = line;
+        }
+        break;
+      }
+      case 'msg.tomb': {
+        if (typeof line.target !== 'string') break;
+        const at = index.get(line.target);
+        if (at === undefined) break;
+        state.splice(at, 1);
+        reindex();
+        break;
+      }
+      case 'msg.truncate': {
+        if (typeof line.from !== 'string') break;
+        const at = index.get(line.from);
+        if (at === undefined) break;
+        state.length = at;
+        reindex();
+        break;
+      }
+      case 'msg.loopDrop': {
+        if (typeof line.loopId !== 'string') break;
+        const kept = state.filter((m) => m.loopId !== line.loopId);
+        if (kept.length === state.length) break;
+        state.length = 0;
+        for (const m of kept) state.push(m);
+        reindex();
+        break;
+      }
+      default:
+        // Unknown kind — written by a newer build. It is not a message, so it
+        // must not render; ignoring it is the forward-compatible choice.
+        break;
+    }
+  }
+
+  return { messages: state as Message[], corruptCount, totalLines };
+}

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -9,6 +9,7 @@ import {
 } from './chatStore';
 import type { Conversation } from '../types';
 import { createDocReference } from '@/types/chatReference';
+import { foldMessageLog } from '@/core/session/messageLedger';
 import { getI18n } from '../i18n';
 import {
   clearAllComposerDrafts,
@@ -544,7 +545,12 @@ describe('chatStore', () => {
 
       try {
         useChatStore.getState().updateUserMessageRun(id, message.id, { state: 'interrupted' });
-        await waitForConversationPersistence(id);
+        // The strict replacement is an append now, so it settles on the write
+        // queue's 100 ms drain rather than writing inline — under fake timers
+        // that drain has to be driven explicitly.
+        const persisted = waitForConversationPersistence(id);
+        await vi.advanceTimersByTimeAsync(200);
+        await persisted;
 
         expect(useChatStore.getState().conversations[id].messages[0]).toMatchObject({
           runState: 'interrupted',
@@ -915,8 +921,14 @@ describe('chatStore', () => {
 
         await waitForConversationPersistence(id);
         const rows = messagesJsonl.trim().split('\n').map((line) => JSON.parse(line));
-        expect(rows).toHaveLength(1);
-        expect(rows[0]).toMatchObject({
+        // The append and its final-content revision may land as one merged
+        // line (both still queued) or as two ledger lines (the append already
+        // drained). Either is correct — what must hold is that every row is
+        // the same message, so the fold yields exactly one, finished message.
+        expect(rows.every((row) => row.id === messageId)).toBe(true);
+        const folded = foldMessageLog(messagesJsonl.split('\n')).messages;
+        expect(folded).toHaveLength(1);
+        expect(folded[0]).toMatchObject({
           id: messageId,
           content: 'final answer',
           isStreaming: false,
@@ -932,10 +944,11 @@ describe('chatStore', () => {
   // ── cancelStreaming ──
   describe('cancelStreaming persistence', () => {
     // Simulate just enough fs for conversationStorage.replaceMessageById:
-    // the JSONL exists, holds the pre-stop row, and atomic_write_text
-    // captures the rewrite. Asserting at the fs layer exercises the real
-    // storage module (the store reaches it via a dynamic import that
-    // module-level vi.mock cannot intercept).
+    // the JSONL exists, holds the pre-stop row, and every write to it is
+    // captured. Asserting at the fs layer exercises the real storage module
+    // (the store reaches it via a dynamic import that module-level vi.mock
+    // cannot intercept). A replacement is an append now, so the revision
+    // arrives via append_file_text rather than a whole-file rewrite.
     let written: string[];
 
     beforeEach(() => {
@@ -944,10 +957,10 @@ describe('chatStore', () => {
       vi.mocked(readTextFile).mockImplementation(async () =>
         JSON.stringify({ id: 'a1', role: 'assistant', content: '部分输出', timestamp: 1 }) + '\n');
       vi.mocked(invoke).mockImplementation(async (cmd: string, args?: unknown) => {
-        const a = args as { path?: string; content?: string } | undefined;
-        if (cmd === 'atomic_write_text' && a?.path?.endsWith('messages.jsonl')) {
-          written.push(a.content ?? '');
-        }
+        const a = args as { path?: string; content?: string; data?: string } | undefined;
+        if (!a?.path?.endsWith('messages.jsonl')) return undefined;
+        if (cmd === 'atomic_write_text') written.push(a.content ?? '');
+        if (cmd === 'append_file_text') written.push(a.data ?? '');
         return undefined;
       });
     });
@@ -1049,9 +1062,11 @@ describe('chatStore', () => {
 
   // ── setMessageToolCalls — intent durability ──
   describe('setMessageToolCalls persistence', () => {
-    // Same fs simulation as the cancelStreaming block above: assert at the
-    // atomic_write_text layer, because the store reaches conversationStorage
-    // through a dynamic import that a module-level vi.mock cannot intercept.
+    // Same fs simulation as the cancelStreaming block above, but watching
+    // BOTH destinations: mid-turn revisions go to stream-snapshot.json (they
+    // are far too frequent to become permanent ledger lines) and checkpoints
+    // go to messages.jsonl. The durability claim this block defends is
+    // "reached disk", not "reached a particular file".
     let written: string[];
 
     beforeEach(() => {
@@ -1060,10 +1075,13 @@ describe('chatStore', () => {
       vi.mocked(readTextFile).mockImplementation(async () =>
         JSON.stringify({ id: 'a1', role: 'assistant', content: '', timestamp: 1 }) + '\n');
       vi.mocked(invoke).mockImplementation(async (cmd: string, args?: unknown) => {
-        const a = args as { path?: string; content?: string } | undefined;
-        if (cmd === 'atomic_write_text' && a?.path?.endsWith('messages.jsonl')) {
-          written.push(a.content ?? '');
+        const a = args as { path?: string; content?: string; data?: string } | undefined;
+        const path = a?.path ?? '';
+        if (!path.endsWith('messages.jsonl') && !path.endsWith('stream-snapshot.json')) {
+          return undefined;
         }
+        if (cmd === 'atomic_write_text') written.push(a?.content ?? '');
+        if (cmd === 'append_file_text') written.push(a?.data ?? '');
         return undefined;
       });
     });

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1129,10 +1129,16 @@ export const useChatStore = create<ChatStore>()(
         // only hit disk when finishStreaming / turn-boundary replaceMessageById fires —
         // so a crash/force-quit mid-stream (or a late-arriving result after the
         // enclosing message was already snapshotted) loses toolCalls on reload.
+        //
+        // This goes to the stream snapshot rather than the ledger: it fires once
+        // per tool result, and each write carries the whole message including
+        // every earlier result, so appending here would cost O(N²) bytes within
+        // a single tool-heavy turn. The turn-boundary checkpoint in agentLoop is
+        // what commits the batch to the ledger.
         const updatedMsg = get().conversations[convId]?.messages.find((m) => m.id === messageId);
         if (updatedMsg) {
-          import('../core/session/conversationStorage').then(({ replaceMessageById }) => {
-            replaceMessageById(convId, updatedMsg).catch(() => {});
+          import('../core/session/conversationStorage').then(({ snapshotMessageRevision }) => {
+            snapshotMessageRevision(convId, updatedMsg).catch(() => {});
           });
         }
       },
@@ -1419,10 +1425,15 @@ export const useChatStore = create<ChatStore>()(
         // anything" even though a side effect (rm, write_file, an API call) had
         // already run — the recovery path could not tell "not started" from
         // "started, unrecorded", and a retry would execute it twice.
+        //
+        // Same routing as updateToolCall: this is mid-turn state, so it belongs
+        // in the stream snapshot (durable, folded in on load) rather than as a
+        // permanent ledger line that the batch checkpoint would supersede
+        // seconds later anyway.
         const updatedMsg = get().conversations[convId]?.messages.find((m) => m.id === messageId);
         if (updatedMsg) {
-          import('../core/session/conversationStorage').then(({ replaceMessageById }) => {
-            replaceMessageById(convId, updatedMsg).catch(() => {});
+          import('../core/session/conversationStorage').then(({ snapshotMessageRevision }) => {
+            snapshotMessageRevision(convId, updatedMsg).catch(() => {});
           });
         }
       },

--- a/src/test/foldFixtures.ts
+++ b/src/test/foldFixtures.ts
@@ -1,0 +1,58 @@
+/**
+ * Loader for the shared message-ledger fold fixtures.
+ *
+ * The fixture file (`src/core/session/__fixtures__/messageLedgerFold.fixtures.json`)
+ * is the contract that keeps every port of `foldMessageLog` in step — the
+ * renderer TS one, the Electron-main CJS one, and eventually the Rust one in
+ * `src-tauri/src/catalog_db.rs`. It is read from disk as raw bytes rather than
+ * imported as a module so that all three read literally the same file.
+ *
+ * Lives under `src/test/` because it uses `node:fs`, which the renderer
+ * tsconfig (and the renderer boundary rule) rightly does not allow in `src/`
+ * proper.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface FoldFixtureExpectation {
+  id: string | null;
+  content: string;
+}
+
+export interface FoldFixtureCase {
+  name: string;
+  lines: string[];
+  expected: {
+    messages: FoldFixtureExpectation[];
+    corruptCount: number;
+    totalLines: number;
+  };
+}
+
+// Resolved through `fileURLToPath` on the raw string rather than `new URL(…)`:
+// under the happy-dom environment the global `URL` is happy-dom's, and Node's
+// fs rejects those instances ("The URL must be of scheme file").
+const FIXTURE_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../core/session/__fixtures__/messageLedgerFold.fixtures.json',
+);
+
+export function loadFoldFixtures(): FoldFixtureCase[] {
+  const raw = readFileSync(FIXTURE_PATH, 'utf8');
+  return (JSON.parse(raw) as { cases: FoldFixtureCase[] }).cases;
+}
+
+/**
+ * Project a folded result down to the shape the fixtures pin (id + content).
+ * Accepts the renderer's `Message[]` and the Electron port's plain objects
+ * alike — the whole point is to compare them against one another.
+ */
+export function projectFolded(
+  messages: readonly { id?: string; content?: unknown }[],
+): FoldFixtureExpectation[] {
+  return messages.map((m) => ({
+    id: m.id ?? null,
+    content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
+  }));
+}


### PR DESCRIPTION
Implements stages 1+2 of `docs/abu-message-ledger-plan.md` (plan adversarially reviewed and approved). Chat history moves from read-modify-rewrite to append-only: a write bug can now at worst append a wrong row, never corrupt the file.

## What

- **Stage 1 — fold (zero behavior change)**: `foldMessageLog` replays the log in strict order (in-place keep-last per id, tomb-then-put revives, truncate bounded); shared by `loadMessages` and the Electron catalog scan (delegation, not a copy). TS/JS parity pinned by a shared adversarial fixture + contract test (corrupt rows, empty file, no-id rows, revive, truncate-then-append).
- **Stage 2 — revisions append**: `replaceMessageById` / `updateLastMessage` append a same-id revision row instead of rewriting the file. §3.6 write-amplification governance: write-queue same-id merge; 5s streaming flush / `updateToolCall` / `setMessageToolCalls` go to `stream-snapshot.json` (atomic overwrite, folded back on load, promoted into the ledger only at checkpoint/shutdown). `pid` (parent pointer, branch-ready) written, never read.
- Every appended row is a valid v0.39.0 `Message` (rollback-safe; old builds see duplicate ids they already dedup + one unknown field).

## Independent review (adversarial, fresh context) — 3 🔴 crash windows found via failing-test-first, all fixed

1. Half-line poisoning: a crash-torn tail row used to be silently healed by full rewrites; pure append would glue the next row onto it (one crash loses 2 messages). Fix: per-process trailing-newline repair on first append/load.
2. Delete vs queued revision race: a queued same-id revision could resurrect a just-deleted message after drain. Fix: `flushWrites()` before whole-file rewrites (outside fileLock).
3. Shutdown promote raced snapshot deletion (`allSettled`), and a failed promote dropped revisions. Fix: snapshot deleted only after the ledger row is durably written; kept for next-boot reload otherwise.

Also verified: in-place keep-last matches actual UI ordering (array order, no timestamp sort anywhere in the render chain); size gate is load-shape-independent (2.19× committed test, 2.03× at 8×25×120 stress; adverse-path control rises 5.56×→18.6×).

## Real-device acceptance (dev Electron shell, driven end-to-end)

Long stream + 3 tool calls; edit-resend; quit/relaunch (history intact, ordered, no dupes); **kill -9 mid-stream → relaunch**: conversation fully intact. Disk audit after the kill: 21 rows / 0 bad rows, trailing newline intact, revision groups present, fold ratio **1.07×** (gate ≤3×).

## Known / deferred (documented)

- Truncate/delete still don't persist — pre-existing dev behavior, unchanged here; that is exactly stage 3's scope (tombstones).
- `src-tauri/catalog_db.rs` still does positional dedup — harmless at this stage (order-only drift in Tauri-compat metadata), **must** be aligned before stage 3 lands tombstones.
- Stale-snapshot-across-downgrade edge (snapshot from a crash + downgrade + edit + upgrade could re-apply old content) — design decision deferred; unreachable within a single version.

`npm run verify` exit 0 (376 files / 5307 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)