### PR TITLE
fix(computer-use): stop the session owner, not the viewed conversation

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -644,7 +644,10 @@ export default function ChatView() {
       {!activeConv.imPlatform && <SourceInfoBar conversation={activeConv} />}
 
       {/* Computer Use Status Bar — visible during screen control */}
-      <ComputerUseStatusBar onStop={() => useChatStore.getState().cancelStreaming(activeConv.id)} />
+      {/* The stopped conversation is the one that OWNS the CU session (passed
+          up by the bar), NOT `activeConv.id` — a background conversation can be
+          driving the screen while an unrelated tab is open. See the component. */}
+      <ComputerUseStatusBar onStop={(conversationId) => useChatStore.getState().cancelStreaming(conversationId)} />
 
       {/* Messages Area — overlay-scroll hides the native scrollbar (thumb shows
           only while scrolling, via the global is-scrolling toggle in main.tsx);

--- a/src/components/chat/ComputerUseStatusBar.test.tsx
+++ b/src/components/chat/ComputerUseStatusBar.test.tsx
@@ -1,29 +1,53 @@
 /// <reference types="@testing-library/jest-dom" />
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import ComputerUseStatusBar from './ComputerUseStatusBar';
+import { useChatStore } from '@/stores/chatStore';
+import type { CUState } from '@/core/agent/computerUseStatus';
 import { initLanguage } from '@/i18n';
 
-const snapshot = vi.hoisted(() => ({
-  status: 'active' as const,
+const ACTIVE_SNAPSHOT: CUState = {
+  status: 'active',
   stepCount: 2,
   currentAction: '输入文本',
-  phase: 'verifying' as const,
+  phase: 'verifying',
   targetApp: 'TextEdit',
-  capabilityMode: 'structured' as const,
+  capabilityMode: 'structured',
   latestScreenshot: null,
   activeConversationId: 'conversation-1',
   sessionWindowHidden: false,
   sessionStartTime: 1,
-}));
+};
+
+// Mutable so each test can pick who owns the session; the component reads it
+// through `useSyncExternalStore` on every render.
+const snapshot = vi.hoisted(() => ({ current: null as unknown }));
 
 vi.mock('@/core/agent/computerUseStatus', () => ({
   subscribeCUStatus: () => () => {},
-  getCUStatusSnapshot: () => snapshot,
+  getCUStatusSnapshot: () => snapshot.current,
 }));
 
+function setSnapshot(patch: Partial<CUState>) {
+  snapshot.current = { ...ACTIVE_SNAPSHOT, ...patch };
+}
+
+function meta(id: string, title: string) {
+  return { id, title, createdAt: 0, updatedAt: 0, messageCount: 0 };
+}
+
 describe('ComputerUseStatusBar', () => {
-  beforeEach(() => initLanguage('en-US'));
+  beforeEach(() => {
+    initLanguage('en-US');
+    setSnapshot({});
+    useChatStore.setState({
+      activeConversationId: 'conversation-1',
+      conversationIndex: {
+        'conversation-1': meta('conversation-1', 'Front chat'),
+        'conversation-2': meta('conversation-2', 'Nightly report'),
+      },
+    });
+  });
   afterEach(cleanup);
 
   it('shows safe target, mode, and phase without typed content', () => {
@@ -32,5 +56,58 @@ describe('ComputerUseStatusBar', () => {
     expect(screen.getByText('Controlling computer')).toBeInTheDocument();
     expect(screen.getByText('TextEdit · Structured mode · Verifying result')).toBeInTheDocument();
     expect(screen.queryByText(/private|password|typed/i)).not.toBeInTheDocument();
+  });
+
+  it('does not name an owner when the viewed conversation owns the session', () => {
+    render(<ComputerUseStatusBar onStop={() => {}} />);
+
+    expect(screen.queryByTestId('cu-owner')).not.toBeInTheDocument();
+  });
+
+  // The bug this component's doc block is about: the user is reading an idle
+  // conversation while a background one drives the screen.
+  it('stops the conversation that OWNS the session, not the one being viewed', () => {
+    setSnapshot({ activeConversationId: 'conversation-2' });
+    const onStop = vi.fn();
+    render(<ComputerUseStatusBar onStop={onStop} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /stop/i }));
+
+    expect(onStop).toHaveBeenCalledTimes(1);
+    expect(onStop).toHaveBeenCalledWith('conversation-2');
+    expect(onStop).not.toHaveBeenCalledWith('conversation-1');
+  });
+
+  it('names the owning conversation when it is not the one on screen', () => {
+    setSnapshot({ activeConversationId: 'conversation-2' });
+    render(<ComputerUseStatusBar onStop={() => {}} />);
+
+    expect(screen.getByTestId('cu-owner')).toHaveTextContent('Started by “Nightly report”');
+  });
+
+  it('falls back to a generic owner label when the title cannot be resolved', () => {
+    setSnapshot({ activeConversationId: 'conversation-gone' });
+    render(<ComputerUseStatusBar onStop={() => {}} />);
+
+    expect(screen.getByTestId('cu-owner')).toHaveTextContent('Started by “another chat”');
+  });
+
+  // No owner means nothing is actually running — falling back to the viewed
+  // conversation is exactly the bug, so the control is simply not offered.
+  it('renders no stop button when no conversation owns the session', () => {
+    setSnapshot({ activeConversationId: null });
+    const onStop = vi.fn();
+    render(<ComputerUseStatusBar onStop={onStop} />);
+
+    expect(screen.getByText('Controlling computer')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /stop/i })).not.toBeInTheDocument();
+    expect(onStop).not.toHaveBeenCalled();
+  });
+
+  it('renders nothing when idle', () => {
+    setSnapshot({ status: 'idle' });
+    const { container } = render(<ComputerUseStatusBar onStop={() => {}} />);
+
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/src/components/chat/ComputerUseStatusBar.tsx
+++ b/src/components/chat/ComputerUseStatusBar.tsx
@@ -1,14 +1,47 @@
 import { useSyncExternalStore } from 'react';
 import { Monitor, Square } from 'lucide-react';
 import { subscribeCUStatus, getCUStatusSnapshot } from '@/core/agent/computerUseStatus';
+import { useChatStore } from '@/stores/chatStore';
 import { useI18n, format } from '@/i18n';
 
-export default function ComputerUseStatusBar({ onStop }: { onStop?: () => void }) {
+/**
+ * Single indicator for the one physical screen Computer Use drives.
+ *
+ * ── Why Stop targets the session OWNER, not the open tab ──
+ * This banner is deliberately global: it shows whenever ANY conversation is
+ * driving the mouse/screen, because there is only one screen. But Abu's agent
+ * loop lets different conversations run concurrently (`runAgentLoop`'s guard
+ * only blocks a second loop on the SAME conversation), so the conversation
+ * that owns the CU session is not necessarily the one on screen — e.g. a
+ * background scheduled task takes control while the user is reading an idle
+ * chat. Stop used to be wired in ChatView as
+ * `cancelStreaming(activeConv.id)`, i.e. "cancel whatever tab is open", which
+ * in that case cancelled the innocent idle conversation and left the runaway
+ * session driving the screen.
+ *
+ * So the owner is resolved from the status snapshot's `activeConversationId`
+ * (the field `computerUseStatus.ts` maintains as the session's owner) and
+ * passed explicitly to `onStop`. Two consequences, both deliberate:
+ *
+ *  - There is NO fallback to the viewed conversation when no owner is
+ *    resolvable. "No owner" means nothing is actually running, and falling
+ *    back is exactly the bug above; the button is simply not rendered, the
+ *    same way a stop control with no session behind it is inert.
+ *  - When the owner is some OTHER conversation, the banner names it, so
+ *    "Stop" is not a blind button that silently acts on an off-screen chat.
+ */
+export default function ComputerUseStatusBar({ onStop }: { onStop?: (conversationId: string) => void }) {
   const { t } = useI18n();
   const status = useSyncExternalStore(subscribeCUStatus, getCUStatusSnapshot);
+  const ownerId = status.activeConversationId;
+  const viewingId = useChatStore((s) => s.activeConversationId);
+  // `conversationIndex` (not `conversations`) is the source of truth for what
+  // exists — the owning conversation may not be among the ~5 loaded ones.
+  const ownerTitle = useChatStore((s) => (ownerId ? s.conversationIndex[ownerId]?.title ?? null : null));
 
   if (status.status !== 'active') return null;
 
+  const isSelf = ownerId !== null && ownerId === viewingId;
   const phaseLabel = {
     checking: t.computerUse.phaseChecking,
     observing: t.computerUse.phaseObserving,
@@ -34,14 +67,21 @@ export default function ComputerUseStatusBar({ onStop }: { onStop?: () => void }
             <span>{t.computerUse.controlling}</span>
             {status.stepCount > 0 && ` ${format(t.computerUse.step, { step: status.stepCount })}`}
           </div>
+          {!isSelf && (
+            <div className="truncate text-caption font-medium" data-testid="cu-owner">
+              {format(t.computerUse.fromConversation, {
+                title: ownerTitle ?? t.computerUse.otherConversation,
+              })}
+            </div>
+          )}
           <div className="truncate text-caption text-[var(--abu-text-secondary)]">
             {[status.targetApp, modeLabel, phaseLabel].filter(Boolean).join(' · ')}
           </div>
         </div>
       </div>
-      {onStop && (
+      {onStop && ownerId && (
         <button
-          onClick={onStop}
+          onClick={() => onStop(ownerId)}
           className="flex items-center gap-1 px-2 py-1 text-minor text-[var(--abu-danger)] hover:text-[var(--abu-danger)] hover:bg-[var(--abu-danger-bg)] rounded transition-colors"
         >
           <Square className="h-3 w-3" />

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -2384,6 +2384,8 @@ const enUS: TranslationDict = {
 
   computerUse: {
     controlling: 'Controlling computer',
+    fromConversation: 'Started by “{title}”',
+    otherConversation: 'another chat',
     step: '· Step {step}',
     stop: 'Stop',
     overlayStep: 'Step {step}',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -2385,6 +2385,8 @@ const zhCN: TranslationDict = {
 
   computerUse: {
     controlling: '正在操控电脑',
+    fromConversation: '来自「{title}」',
+    otherConversation: '其他会话',
     step: '· 第 {step} 步',
     stop: '停止',
     overlayStep: '第 {step} 步',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -2584,6 +2584,11 @@ export interface TranslationDict {
   // Computer-use runtime status bar + screen-border overlay windows
   computerUse: {
     controlling: string;
+    /** Names the conversation that owns the CU session when it is NOT the
+     *  one on screen. Interpolates {title}. */
+    fromConversation: string;
+    /** Fallback for {title} above when the owner's title can't be resolved. */
+    otherConversation: string;
     /** Interpolates {step}, e.g. "· Step {step}". */
     step: string;
     stop: string;


### PR DESCRIPTION
## Summary
- The Computer Use status bar's Stop button was wired to cancel `activeConv.id` — whatever tab the user has open — instead of the conversation that actually owns the active session. Abu's agent loop allows different conversations to run concurrently, so a background conversation can be driving the screen while the user is viewing an unrelated, idle one; clicking Stop cancelled the innocent idle conversation and left the runaway session untouched.
- `ComputerUseStatusBar` now targets the owner via the status snapshot's `activeConversationId`, and does **not** fall back to the viewed conversation when no owner resolves (that fallback is the bug itself — verified against how Claude desktop / ChatGPT desktop handle the same "no lock holder" case, see the added `reference-cu-stop-ownership-firsthand` memory).
- When the owner isn't the conversation currently on screen, the banner now names it (`computerUse.fromConversation` / `otherConversation` i18n keys, zh + en), so Stop is never a blind action on an off-screen chat.

## Verification
- `npm run verify` (lint + typecheck + `gen:models:check` + coverage) exits 0.
- `ComputerUseStatusBar.test.tsx` expanded from 1 to 7 cases against the real component/store/i18n, including the exact bug scenario: viewing conversation A while conversation B owns the CU session → Stop targets B, never A.
- Confirmed via CDP (`--remote-debugging-port`) that this branch's dev Electron shell boots and renders correctly.
- **Outstanding**: a real-machine click-through of an actual CU session (background conversation driving the screen, user stopping it from an unrelated tab) was not completed — the isolated test profile used for this verification intentionally has no model API key configured, and the local screen-capture tooling used for this session couldn't attach to this dev build's window (confirmed via CDP to be an unrelated capture-tooling gap, not an app issue). Recommend a manual pass before/at merge.

## Test plan
- [x] `npm run verify` exits 0
- [x] `ComputerUseStatusBar.test.tsx` — 7/7 passing, covers cross-conversation ownership
- [ ] Manual: start a screen-observing CU task in conversation A, switch to idle conversation B, confirm the banner names A and Stop cancels A (not B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)