### PR TITLE
feat(telemetry): ping 每 UTC 日至多一次（修 DAU/留存系统性低估）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,7 +91,7 @@ import { useI18n } from '@/i18n';
 import CloseDialog from '@/components/common/CloseDialog';
 import SensitiveAuditDialog from '@/components/settings/SensitiveAuditDialog';
 import { checkForUpdate } from '@/core/updates/checker';
-import { sendConsolePing } from '@/utils/consolePing';
+import { usePingCadence } from '@/hooks/usePingCadence';
 import { fetchUnseenAnnouncements, markSeen, type AnnouncementItem } from '@/utils/consoleAnnouncement';
 import AnnouncementBanner from '@/components/common/AnnouncementBanner';
 import DisclaimerBanner from '@/components/common/DisclaimerBanner';
@@ -169,6 +169,7 @@ function App() {
   const showTodosInbox = useLabsFlag(LABS_TODOS_INBOX);
   const activeConv = useActiveConversation();
   const { t } = useI18n();
+  usePingCadence();
 
   useEffect(() => {
     let cancelled = false;
@@ -435,7 +436,6 @@ function App() {
     provisionFirstPartyMCPServers();
     initMCPStoreSync();
     initBuiltinBrowserRuntime();
-    sendConsolePing();
 
     // Hydrate API keys from the encrypted secret store. During Phase 2 the
     // plaintext apiKey is still persisted via localStorage as a fallback,

--- a/src/hooks/usePingCadence.test.ts
+++ b/src/hooks/usePingCadence.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const maybeSend = vi.fn()
+vi.mock('@/utils/consolePing', () => ({
+  maybeSendConsolePing: () => maybeSend(),
+}))
+
+import { usePingCadence } from './usePingCadence'
+
+describe('usePingCadence', () => {
+  beforeEach(() => {
+    maybeSend.mockClear()
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('挂载时打一次', () => {
+    renderHook(() => usePingCadence())
+    expect(maybeSend).toHaveBeenCalledTimes(1)
+  })
+
+  it('到达定时器间隔再打一次', () => {
+    renderHook(() => usePingCadence())
+    vi.advanceTimersByTime(30 * 60 * 1000)
+    expect(maybeSend).toHaveBeenCalledTimes(2)
+  })
+
+  it('窗口重新可见时补打', () => {
+    renderHook(() => usePingCadence())
+    maybeSend.mockClear()
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(maybeSend).toHaveBeenCalledTimes(1)
+  })
+
+  it('卸载后不再触发', () => {
+    const { unmount } = renderHook(() => usePingCadence())
+    maybeSend.mockClear()
+    unmount()
+    vi.advanceTimersByTime(60 * 60 * 1000)
+    expect(maybeSend).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/usePingCadence.ts
+++ b/src/hooks/usePingCadence.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react'
+import { maybeSendConsolePing } from '@/utils/consolePing'
+
+// 30 分钟：兜住「一直开着不关」的会话，跨午夜后自动补打
+const PING_INTERVAL_MS = 30 * 60 * 1000
+
+/**
+ * 让 console ping 每个 UTC 日至多一次：挂载时、窗口重新可见时、以及定时器周期各检查一次。
+ * 取代旧的「启动只打一次」，使长时间运行的会话仍能每天登记。
+ */
+export function usePingCadence(): void {
+  useEffect(() => {
+    maybeSendConsolePing()
+
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') maybeSendConsolePing()
+    }
+    document.addEventListener('visibilitychange', onVisible)
+    const timer = setInterval(() => maybeSendConsolePing(), PING_INTERVAL_MS)
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible)
+      clearInterval(timer)
+    }
+  }, [])
+}

--- a/src/utils/consolePing.test.ts
+++ b/src/utils/consolePing.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { pingDateUTC, shouldPingToday, maybeSendConsolePing } from './consolePing'
 
-// telemetry 目标固定为「已启用」，避免依赖 enterprise store
+// telemetry 目标可切换启用状态，避免依赖 enterprise store
+const mockTelemetry = vi.hoisted(() => ({ enabled: true }))
 vi.mock('./consoleTelemetryTarget', () => ({
-  getTelemetryTarget: () => ({ baseUrl: 'https://console.example', enabled: true }),
+  getTelemetryTarget: () => ({ baseUrl: 'https://console.example', enabled: mockTelemetry.enabled }),
 }))
 
 describe('pingDateUTC', () => {
@@ -28,11 +29,19 @@ describe('shouldPingToday', () => {
 
 describe('maybeSendConsolePing', () => {
   beforeEach(() => {
+    mockTelemetry.enabled = true
     localStorage.clear()
     vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true } as Response)))
   })
   afterEach(() => {
     vi.unstubAllGlobals()
+  })
+
+  it('遥测关闭时不发送也不记录日期', () => {
+    mockTelemetry.enabled = false
+    expect(maybeSendConsolePing(new Date('2026-08-11T10:00:00Z'))).toBe(false)
+    expect(fetch).not.toHaveBeenCalled()
+    expect(localStorage.getItem('abu_last_ping_date')).toBeNull()
   })
 
   it('首次调用发送一次并记录当天', () => {

--- a/src/utils/consolePing.test.ts
+++ b/src/utils/consolePing.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { pingDateUTC, shouldPingToday } from './consolePing'
+
+describe('pingDateUTC', () => {
+  it('返回 UTC 日历日期，与服务端 ping_date 对齐', () => {
+    expect(pingDateUTC(new Date('2026-08-11T23:30:00Z'))).toBe('2026-08-11')
+    expect(pingDateUTC(new Date('2026-08-12T00:10:00Z'))).toBe('2026-08-12')
+  })
+})
+
+describe('shouldPingToday', () => {
+  const now = new Date('2026-08-11T10:00:00Z')
+  it('从未打过 → 应打', () => {
+    expect(shouldPingToday(now, null)).toBe(true)
+  })
+  it('今天已打过 → 不打', () => {
+    expect(shouldPingToday(now, '2026-08-11')).toBe(false)
+  })
+  it('上次是昨天 → 应打', () => {
+    expect(shouldPingToday(now, '2026-08-10')).toBe(true)
+  })
+})

--- a/src/utils/consolePing.test.ts
+++ b/src/utils/consolePing.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from 'vitest'
-import { pingDateUTC, shouldPingToday } from './consolePing'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { pingDateUTC, shouldPingToday, maybeSendConsolePing } from './consolePing'
+
+// telemetry 目标固定为「已启用」，避免依赖 enterprise store
+vi.mock('./consoleTelemetryTarget', () => ({
+  getTelemetryTarget: () => ({ baseUrl: 'https://console.example', enabled: true }),
+}))
 
 describe('pingDateUTC', () => {
   it('返回 UTC 日历日期，与服务端 ping_date 对齐', () => {
@@ -18,5 +23,34 @@ describe('shouldPingToday', () => {
   })
   it('上次是昨天 → 应打', () => {
     expect(shouldPingToday(now, '2026-08-10')).toBe(true)
+  })
+})
+
+describe('maybeSendConsolePing', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true } as Response)))
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('首次调用发送一次并记录当天', () => {
+    expect(maybeSendConsolePing(new Date('2026-08-11T10:00:00Z'))).toBe(true)
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(localStorage.getItem('abu_last_ping_date')).toBe('2026-08-11')
+  })
+
+  it('同一天第二次不发送', () => {
+    maybeSendConsolePing(new Date('2026-08-11T10:00:00Z'))
+    expect(maybeSendConsolePing(new Date('2026-08-11T20:00:00Z'))).toBe(false)
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('跨到次日再次发送', () => {
+    maybeSendConsolePing(new Date('2026-08-11T10:00:00Z'))
+    expect(maybeSendConsolePing(new Date('2026-08-12T00:05:00Z'))).toBe(true)
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(localStorage.getItem('abu_last_ping_date')).toBe('2026-08-12')
   })
 })

--- a/src/utils/consolePing.ts
+++ b/src/utils/consolePing.ts
@@ -3,6 +3,16 @@ import { APP_VERSION } from './version'
 import { getPlatform } from './platform'
 import { getTelemetryTarget } from './consoleTelemetryTarget'
 
+/** UTC 日历日期（YYYY-MM-DD），与服务端 ping_date 分桶一致。 */
+export function pingDateUTC(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10)
+}
+
+/** 纯判断：该设备是否还没在 now 的 UTC 日打过 ping。 */
+export function shouldPingToday(now: Date, lastPingDate: string | null): boolean {
+  return lastPingDate !== pingDateUTC(now)
+}
+
 export function sendConsolePing(): void {
   const { baseUrl, enabled } = getTelemetryTarget()
   if (!enabled) return

--- a/src/utils/consolePing.ts
+++ b/src/utils/consolePing.ts
@@ -36,10 +36,14 @@ export function sendConsolePing(): void {
 }
 
 /**
- * 每个 UTC 日历日至多发送一次 ping，把当天记进 localStorage，同日后续触发变 no-op。
- * 服务端幂等，偶发重发无害。返回是否真的发送了。
+ * 尽力保证每个 UTC 日历日至多发送一次 ping（best-effort 遥测）。
+ * 仅在遥测启用时才登记与发送；关闭时既不登记也不发送、返回 false
+ * （否则关闭期间记了日期，当天再开启会漏打——企业版 config 延迟加载时尤甚）。
+ * 注意：日期在发送前登记且失败不重试——网络抖动可能漏掉当天，次日自愈（宁可少报也不轰炸服务端）。
+ * 返回 true 表示本次触发确实发起了一次发送。
  */
 export function maybeSendConsolePing(now: Date = new Date()): boolean {
+  if (!getTelemetryTarget().enabled) return false
   let last: string | null = null
   try {
     last = localStorage.getItem(LAST_PING_KEY)

--- a/src/utils/consolePing.ts
+++ b/src/utils/consolePing.ts
@@ -3,6 +3,8 @@ import { APP_VERSION } from './version'
 import { getPlatform } from './platform'
 import { getTelemetryTarget } from './consoleTelemetryTarget'
 
+const LAST_PING_KEY = 'abu_last_ping_date'
+
 /** UTC 日历日期（YYYY-MM-DD），与服务端 ping_date 分桶一致。 */
 export function pingDateUTC(now: Date = new Date()): string {
   return now.toISOString().slice(0, 10)
@@ -31,4 +33,25 @@ export function sendConsolePing(): void {
   }).catch(() => {
     // fire-and-forget，失败静默
   })
+}
+
+/**
+ * 每个 UTC 日历日至多发送一次 ping，把当天记进 localStorage，同日后续触发变 no-op。
+ * 服务端幂等，偶发重发无害。返回是否真的发送了。
+ */
+export function maybeSendConsolePing(now: Date = new Date()): boolean {
+  let last: string | null = null
+  try {
+    last = localStorage.getItem(LAST_PING_KEY)
+  } catch {
+    // localStorage 不可用时按「未打过」处理
+  }
+  if (!shouldPingToday(now, last)) return false
+  try {
+    localStorage.setItem(LAST_PING_KEY, pingDateUTC(now))
+  } catch {
+    // 忽略写入失败
+  }
+  sendConsolePing()
+  return true
 }


### PR DESCRIPTION
## 背景
Console 心跳 ping 此前只在 App 启动时打一次（`App.tsx` 的 `useEffect([])`）。开着不关、跨天继续用的用户从第二天起不再打卡 → **DAU/留存被系统性低估**（现状 DAU ≈ 当天冷启动过的去重设备数，是真实日活的下限）。

## 改动
- `consolePing.ts`：加 `pingDateUTC` / `shouldPingToday`（纯函数）+ `maybeSendConsolePing`——每个 **UTC 日历日至多发送一次**（localStorage `abu_last_ping_date`，与服务端 `ping_date` 的 `toISOString().slice(0,10)` 对齐；服务端已幂等）。
- `usePingCadence` hook：挂载 + `visibilitychange` + 30min 定时器三处触发，卸载清理。
- `App.tsx`：换掉旧的一次性 `sendConsolePing()`，改为顶层 `usePingCadence()`。

## 测试
- TDD 全程；`consolePing.test.ts` + `usePingCadence.test.ts` 共 **12 passing**（含 code-review 后新增「遥测关闭时不发不记」）。
- lint / typecheck 绿；husky 全程未用 `--no-verify`。

## Code review 处置（§15 先证伪）
- 修 #1/#5：遥测**关闭时不记日期、返回 false**（否则企业版 config 延迟加载期会记了日期当天漏打）。
- #2：JSDoc 如实标注 best-effort、失败不重试（次日自愈，不轰炸服务端）。
- #3（localStorage 抛异常刷屏）/#4（睡眠定时器）：Electron 下极低风险 / 被高估且 ≤30min 自愈，证伪未改。

## ⚠️ 合并前 checklist（DoD）
- [ ] **真机 Electron 验证**：启动看一次 `POST /api/ping`；DevTools 里把 `abu_last_ping_date` 改成昨天 + 切窗口触发 visibilitychange → 应补打一次；同日重复切换不再打。

🤖 Generated with [Claude Code](https://claude.com/claude-code)