### PR TITLE
fix(session): RB-03 — stale stream-snapshot entries can no longer beat the ledger

### DIFF
--- a/V0.40.0-RELEASE-READINESS-AUDIT.md
+++ b/V0.40.0-RELEASE-READINESS-AUDIT.md
@@ -1,0 +1,320 @@
+# v0.40.0 客户端发布准备审计
+
+> 日期：2026-08-19  
+> 审计候选：`origin/dev` @ `cc8d93fd5039f7023db7b9cdbc8e446cdb1618c2`  
+> 已发布基线：`v0.39.0` @ `bbf85d16c88c8acd069bc99cc8170e5324d6cdd6`  
+> 范围：`Abu-opensource` / Electron 客户端  
+> 结论：当前候选可进入 `v0.40.0` 收口，但不能切正式 RC 或稳定版。
+
+## 1. 执行摘要
+
+- `origin/dev` 比 `origin/main` 领先 77 个提交，`origin/main` 是 `origin/dev` 的祖先，后续仍可按 `dev -> main --ff-only` 发布。
+- `v0.39.0..origin/dev` 包含 12 个 first-parent PR merge，涉及 171 个文件，约 `+10,308/-1,337`。
+- 精确候选 SHA 的远端 Branch Policy、CI、E2E、`promotion-ready` 均为绿色；但远端 E2E 只运行普通 Playwright，不覆盖真实 Electron 产品 E2E。
+- 本地 `npm run verify`、build、Electron 基础验收、release workflow、parity 和泄露检查通过。
+- 真实 Electron 产品 E2E 在同一路径连续失败两次，另有权限、消息持久化、Computer Use 安全预算及遥测隐私问题。
+- 当前四处版本仍为 `0.39.0`，而正式 tag `v0.39.0` 已存在；双语 changelog 尚未记录本轮更新。
+
+因此，当前状态不是“门禁全绿后只差打 tag”，而是“需要先完成安全与数据完整性修复，再准备 `v0.40.0` RC”。
+
+## 2. 已通过的验证
+
+| 门禁 | 结果 |
+|---|---|
+| GitHub exact-SHA checks | Branch Policy、CI、E2E、`promotion-ready` 通过 |
+| `npm run verify` | 通过：382 个测试文件、5443 个测试 |
+| 覆盖率 | Statements 71.70%、Branches 61.74%、Functions 71.41%、Lines 73.38% |
+| `npm run build` | 通过；存在既有 CSS、dynamic import 与 chunk-size warnings |
+| `npm run release:check` | 对现有 `v0.39.0` 通过；不能证明新版本已准备好 |
+| `npm run test:electron:release-stage` | 通过：11/11 |
+| `npm run test:electron:release-workflow` | 通过：25/25 |
+| `npm run parity:check` | 通过：84 个命令满足、3 个已知 deferred 项 |
+| `bash scripts/enterprise-leak-guard.sh` | 通过 |
+| `npm run electron:test` | 通过：bootstrap、迁移、Host UI、安全、命令、浏览器运行时及 sidecar acceptance 全绿 |
+| `npm run test:e2e:electron` | **失败**：13 passed、1 failed、2 did not run；目标用例单独复跑仍失败 |
+
+说明：本次验证在精确 `origin/dev` SHA 的临时隔离 worktree 中执行。临时 worktree 已清理，没有修改候选源码。
+
+## 3. 发布阻断项
+
+### RB-01：停止流式回答后，部分回复未按 E2E 契约持久化
+
+**严重度：P0 / 发布阻断**
+
+失败用例：
+
+```text
+tests/e2e/task-lifecycle.spec.ts
+Electron product task lifecycle
+stops an open stream, persists its partial reply, and continues after restart
+```
+
+实际结果：
+
+- UI 已显示 provider 返回的部分回答。
+- Stop 按钮成功终止真实 loopback HTTP response。
+- UI 已恢复可编辑状态并显示“用户停止”状态。
+- 等待 45 秒后，磁盘仍不包含预期的完整 assistant partial message。
+- 完整套件失败一次后，目标用例单独复跑仍在同一断言失败，因此不能归类为一次性 flaky。
+- 后续“异常退出恢复 partial”和“sidecar crash 后恢复”两条 serial 测试没有运行。
+
+当前判断：
+
+- 问题位于新消息账本/流式 snapshot/最终 checkpoint 的用户路径内，但根因尚未完成定位。
+- 在查明并修复前，不应通过增加 timeout、跳过测试或降低断言来放行。
+- GitHub 的 `.github/workflows/e2e.yml` 执行 `npm run test:e2e`，不是 `npm run test:e2e:electron`，因此远端绿色 E2E 不能否定该失败。
+
+关闭条件：
+
+- [ ] 给出机制层根因说明。
+- [ ] 修复后目标用例连续多次通过。
+- [ ] 完整 `test:e2e:electron` 全绿，包含当前未运行的两条恢复测试。
+- [ ] 真机验证 Stop、重启、继续对话后上下文一致。
+
+### RB-02：`read_tools` 不是实际的只读安全边界
+
+**严重度：P0 / 权限越界 / 发布阻断**
+
+涉及路径：
+
+- `src/core/trigger/triggerPermission.ts`
+- `src/core/im/authGate.ts`
+- `src/core/permissions/permissionMode.ts`
+- `src/core/tools/registry.ts`
+- `src/core/tools/commandSafety.ts`
+- `src/core/tools/pathSafety.ts`
+- `src/core/tools/definitions/commandTools.ts`
+
+机制根因：
+
+- Trigger/IM 的拒绝回调只在 registry 已决定 `confirm` 时执行。
+- standard 模式会直接允许工作区内部、被标记为 safe 的命令。
+- `touch`、`mkdir` 等会产生写入的命令当前可被分类为 safe。
+- 一旦策略直接返回 `allow`，`read_tools` 拒绝回调不会被调用。
+- 既有的进程级 workspace write grant 也可能让文件路径检查提前通过。
+
+已做的无副作用复现：
+
+```text
+checkToolApproval(
+  "run_command",
+  { command: "touch marker", cwd: workspace },
+  read_tools deny callback
+)
+
+结果：decision = allow，deny callback 调用次数 = 0
+```
+
+诊断只调用审批决策函数，没有实际执行 `touch`。
+
+影响：
+
+- 定时任务或 IM channel 即使标记为“只读取信息，不做修改”，仍可能修改工作区。
+- 这是无人值守执行边界问题，不能只通过 UI 文案或 prompt 约束解决。
+
+关闭条件：
+
+- [ ] 在工具执行/审批入口建立不可绕过的 capability hard ceiling。
+- [ ] `run_command` 在 `read_tools` 下只允许经过语法验证的只读命令。
+- [ ] `write_file`、`edit_file` 等写工具不受历史 grant 或 autonomous 模式绕过。
+- [ ] 增加 Trigger 与 IM 的真实 `checkToolApproval` 端到端权限测试。
+
+### RB-03：旧 stream snapshot 可覆盖最终消息或复活已截断消息
+
+**严重度：P0 / 数据完整性 / 发布阻断**
+
+涉及路径：
+
+- `src/core/session/conversationStorage.ts`
+- `electron/messageLedgerFold.cjs`
+
+机制根因：
+
+- checkpoint 会先写入最终 ledger revision，再删除 stream snapshot。
+- truncate 会先写入 truncate event，再删除关联 snapshot。
+- snapshot 写入/删除错误会被 best-effort 路径吞掉。
+- 如果进程在两步之间退出，或 Windows 文件锁导致删除失败，旧 snapshot 会保留。
+- 重启加载时，snapshot 被当作 ledger 尾部的新 `put` 折叠，因此可能优先于更新的 final revision 或 truncate。
+- 旧 snapshot 还会重新进入内存，后续 shutdown flush 可能把错误状态永久化。
+
+已做的 fold 级复现：
+
+```text
+final ledger message "FINAL" + stale snapshot "partial"
+=> 折叠结果为 "partial"
+
+truncate m1 + stale snapshot put(m1)
+=> m1 被重新复活
+```
+
+影响：
+
+- 已完成回答可能退回部分内容。
+- 用户编辑可能丢失。
+- 已回退/删除的消息可能在重启后重新出现。
+
+关闭条件：
+
+- [ ] snapshot 带有可比较的 ledger revision/generation。
+- [ ] 旧 snapshot 不能覆盖更新 revision，不能跨 truncate tombstone 生效。
+- [ ] 删除失败有可观察、可重试或可安全忽略的语义。
+- [ ] 增加 crash window、remove failure、checkpoint、truncate 和 restart 回归测试。
+
+### RB-04：Computer Use 安全预算可在 batch 间重置
+
+**严重度：P0 / 安全控制失效 / 发布阻断**
+
+涉及路径：
+
+- `src/core/agent/toolExecutor.ts`
+- `src/core/agent/computerUseStatus.ts`
+- `electron/computerUseGate.cjs`
+
+机制根因：
+
+- 每个 Computer Use batch 开始时都会调用 `setComputerUseActive(true, conversationId)`。
+- 该调用会无条件覆盖 active owner，并把 `stepCount` 和 `sessionStartTime` 重置。
+- 因此同一任务跨多个 batch 时，声明的 30 步/5 分钟上限不能形成连续预算。
+- 在另一 conversation 尝试开始 CU 时，renderer 状态还可能在 host lease 拒绝之前短暂切换 owner，影响 Stop/status 的归属显示。
+
+已确认的边界：
+
+- Electron host 的 `activeTask`/task lease 会阻止两个前台任务同时实际控制鼠标键盘。
+- 因此本审计不主张“两个会话一定会同时执行物理操作”。
+- 已确认的问题是安全预算重置，以及 host 拒绝前 renderer owner/status 的竞态窗口。
+
+已做的状态级复现：
+
+```text
+同一 owner 已执行 29 步
+再次 setComputerUseActive(true, sameOwner)
+=> stepCount 重置为 0，limit check 返回未超限
+```
+
+关闭条件：
+
+- [ ] 只有取得全局 host lease 后才更新 renderer owner。
+- [ ] 同 owner 重入保持原有 step/time budget。
+- [ ] 增加多 conversation 竞争、Stop 归属及跨 batch 上限测试。
+- [ ] 真机验证 Stop 始终停止当前实际 CU owner。
+
+### RB-05：默认 crash telemetry 可能上传路径或业务文本
+
+**严重度：P1 / 隐私 / RC 阻断**
+
+涉及路径：
+
+- `electron/runtimeObservability.cjs`
+- `src/core/observability/shellCrashReports.ts`
+- `src/utils/consoleError.ts`
+- `src/stores/settingsStore.ts`
+
+机制根因：
+
+- crash observer 会保留任意异常的 `Error.message`。
+- 当前脱敏只识别少量 credential-shaped pattern，不能可靠识别路径、URL、命令、客户名、项目名或用户内容。
+- 默认设置为 `telemetryOptOut: false`，UI 又将该行为描述为 anonymous。
+
+已做的 observer 级复现：
+
+```text
+Failed reading /Users/alice/SecretClient/acquisition-plan.txt: board-memo
+```
+
+该消息经过当前处理后仍完整保留。配置了 telemetry target 的官方/企业构建可能将其与稳定 device ID 一起上传。
+
+关闭条件：
+
+- [ ] 推荐远端只发送错误类别、组件和预定义枚举，不发送任意 `Error.message`。
+- [ ] 如必须保留文本，需改为显式 opt-in，并调整“匿名”文案。
+- [ ] 对个人版、企业版、开启、关闭及无 telemetry target 路径做抓包/fixture 验证。
+
+### RB-06：新版本元数据与最终 RC 验收未准备
+
+**严重度：发布流程阻断**
+
+当前状态：
+
+- `package.json`、`tauri.conf.json`、`Cargo.toml`、`Cargo.lock` 均仍为 `0.39.0`。
+- `v0.39.0` 正式 tag 已存在并指向 `origin/main`。
+- `CHANGELOG.md` 与 `CHANGELOG.zh-CN.md` 在 `v0.39.0..origin/dev` 范围内均无更新。
+- `npm run release:check` 只证明现有 `0.39.0` 四处一致、双语结构有效，不能证明本轮新版本已准备。
+- 尚未完成最终签名 macOS arm64/x64、Windows installed RC、更新迁移和真实用户路径验收。
+
+关闭条件：
+
+- [ ] 阻断问题修复后，将四处版本统一升为 `0.40.0`。
+- [ ] 补齐中英文 changelog 与 release notes。
+- [ ] exact-SHA 全量门禁与独立对抗式复审通过。
+- [ ] 三平台最终 RC、签名/公证、安装、升级与迁移验证通过。
+
+## 4. Claude Code 断连后的遗留状态
+
+### 4.1 未提交 Chrome 扩展页修改
+
+工作树：
+
+```text
+/Users/shawn/Documents/Abu/Abu-opensource-worktrees/chrome-extensions-page
+```
+
+状态：
+
+- 分支：`fix/chrome-extensions-page-launch`
+- 8 个 modified files，尚无对应提交。
+- 约 `+167/-45`。
+- 基线比当前 `origin/dev` 落后约 91 个提交。
+- 修改主要涉及：
+  - macOS 通过 LaunchServices 打开 `chrome://extensions`。
+  - Windows 无法可靠通过命令行打开该内部页时，复制 URL 并显示中英文提示。
+  - Electron launcher、Capabilities UI、chrome setup、i18n 与测试。
+
+处理原则：
+
+- 原工作树必须原样保留，不能清理或直接强行 rebase。
+- 先保存 diff 快照，再从最新 `origin/dev` 创建独立恢复分支并应用修改。
+- 默认不把它作为 `v0.40.0` 阻断项；完成跨平台验证后再决定进入 `v0.40.0` 或 `v0.40.1`。
+
+### 4.2 未合入或重复的远端工作
+
+- PR `#219`：每日 telemetry cadence，尚未进入 `origin/dev`，且会继续触碰当前隐私风险区域；建议等 telemetry 边界稳定后再评估。
+- PR `#218`：streaming answer pane jitter。其 patch-equivalent 已通过其他合并提交进入 `origin/dev`，不是当前功能缺口，应避免重复合入。
+- 当前主 checkout 是 clean，但位于较旧的 `feat/ledger-truncate-only`，落后 `origin/dev`；不能直接作为 release worktree。
+
+## 5. 本轮主要功能变化背景
+
+`v0.39.0..origin/dev` 的主要变化包括：
+
+- append-only message ledger、message revision、truncate-only rewind。
+- 定时任务权限模式、browser state-changing always-ask 与权限收口。
+- prompt cache 稳定化、只读工具并行、工具并发安全判断、fuzzy patch fallback。
+- CJK bigram 记忆召回、写入脱敏、历史 secret sweep 与分享 redaction。
+- main/renderer/sidecar crash observability。
+- Computer Use status/Stop ownership 修复。
+- deterministic-test lint、flaky release gate 修复和依赖安全升级。
+
+这些变化涉及持久化、权限、遥测和 Computer Use 安全边界，因此推荐使用 minor 版本 `v0.40.0`，不作为 `v0.39.x` patch 发布。
+
+## 6. 推荐的收口顺序
+
+1. 从最新 `origin/dev` 创建独立 release-hardening worktree，冻结候选基线。
+2. 定位并修复 RB-01 Electron 停止/持久化失败，不假设它与 RB-03 必然同根因。
+3. 修复 RB-02 `read_tools` hard ceiling。
+4. 修复 RB-03 snapshot revision/truncate 语义。
+5. 修复 RB-04 Computer Use lease 与跨 batch budget。
+6. 将 RB-05 遥测改为 categorical-only，或明确选择显式 opt-in。
+7. 独立复审以上安全与数据改动。
+8. 决定是否纳入 Chrome 遗留修改；默认暂缓 PR `#219`。
+9. bump `0.40.0`、补双语 changelog，在 exact SHA 重跑所有门禁。
+10. 完成三平台最终 RC 和真实用户路径验收后，才允许 `dev -> main --ff-only`、tag 和正式发布。
+
+## 7. 审计边界与操作记录
+
+- 本轮只做代码、Git、GitHub 状态和本地测试审计，没有提交、推送、打 tag 或发布。
+- 为运行精确 `origin/dev` 门禁创建过临时隔离 worktree，验证结束后已删除。
+- 临时诊断测试只用于证明审批、fold、CU 状态和遥测行为，验证后已删除，没有留在源码树。
+- 当前屏幕锁定且用户不在机器旁，自动化 Electron 可运行，但不能替代最终签名应用的人工 Golden Journey。
+- 独立扫描/复审模型组合：
+  - 最近变更扫描：`gpt-5.6-luna + low`
+  - 静态发布审计：`gpt-5.6-terra + high`
+  - 对抗式安全复审：`gpt-5.6-sol + xhigh`

--- a/src/core/session/conversationStorage.test.ts
+++ b/src/core/session/conversationStorage.test.ts
@@ -1410,6 +1410,151 @@ describe('conversationStorage', () => {
       });
     });
 
+    // ══════════════════════════════════════════════════════════
+    // RB-03 (V0.40.0-RELEASE-READINESS-AUDIT.md): a crash-leftover stream
+    // snapshot is folded in as a trailing put with no regard for whether the
+    // ledger has since moved past it — a newer durable revision, or a
+    // truncate that removed the id, can both be silently overridden by the
+    // stale in-memory content. The fix stamps each snapshot entry with the
+    // ledger's byte length at capture time and drops the entry at load if
+    // the ledger contains, at or after that offset, either a newer put for
+    // the same id or a removal event that cut it.
+    //
+    // Every "stale leftover" case below manipulates `memFs.files` directly
+    // to restore a snapshot file AFTER the normal drop path (checkpoint /
+    // truncate) already deleted it — that is exactly what a crash between
+    // the ledger write landing and the snapshot delete completing leaves
+    // behind, and is not reachable by driving the public API alone.
+    describe('RB-03: stale stream-snapshot supersede guard', () => {
+      it('audit repro 1: a stale snapshot must not override a newer final ledger revision', async () => {
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm1', content: '' }));
+        await storage.flushWrites();
+        await storage.snapshotMessageRevision('conv-1', makeMsg({ id: 'm1', content: 'partial' }));
+        const staleSnapshot = memFs.files.get(SNAPSHOT);
+        expect(staleSnapshot).toBeDefined();
+
+        // The checkpoint lands the final revision and (in the non-crash case)
+        // deletes the now-superseded snapshot file.
+        await storage.replaceMessageById('conv-1', makeMsg({ id: 'm1', content: 'FINAL' }));
+        await storage.flushWrites();
+        expect(memFs.files.has(SNAPSHOT)).toBe(false);
+
+        // Simulate a crash between that ledger append landing and the
+        // snapshot delete completing: the stale file survives on disk.
+        memFs.files.set(SNAPSHOT, staleSnapshot!);
+        vi.resetModules();
+        storage = await import('./conversationStorage');
+
+        const loaded = await storage.loadMessages('conv-1');
+        expect(loaded).toHaveLength(1);
+        expect(loaded[0].content).toBe('FINAL');
+      });
+
+      it('audit repro 2: a stale snapshot must not revive a message a truncate already cut', async () => {
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm1', content: 'a' }));
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm2', content: 'b' }));
+        await storage.flushWrites();
+        await storage.snapshotMessageRevision('conv-1', makeMsg({ id: 'm2', content: 'b-live' }));
+        const staleSnapshot = memFs.files.get(SNAPSHOT);
+        expect(staleSnapshot).toBeDefined();
+
+        await storage.appendTruncateEvent('conv-1', 'm2', { pid: 'm1', removedIds: ['m2'] });
+        await storage.flushWrites();
+        expect(memFs.files.has(SNAPSHOT)).toBe(false);
+
+        // Simulate the same crash window as above, but on the truncate path.
+        memFs.files.set(SNAPSHOT, staleSnapshot!);
+        vi.resetModules();
+        storage = await import('./conversationStorage');
+
+        const loaded = await storage.loadMessages('conv-1');
+        expect(loaded.map((m) => m.id)).toEqual(['m1']);
+      });
+
+      it('checkpoint-then-crash-before-delete via updateLastMessage also drops the stale entry', async () => {
+        // Same hazard as audit repro 1, exercised through the OTHER checkpoint
+        // call site (`updateLastMessage`, used when the caller does not know
+        // the finishing message's id ahead of time) to cover both drop sites.
+        await storage.appendMessage('conv-1', makeMsg({ id: 'assistant-1', content: '' }));
+        await storage.flushWrites();
+        await storage.snapshotMessageRevision('conv-1', makeMsg({ id: 'assistant-1', content: 'streaming...' }));
+        const staleSnapshot = memFs.files.get(SNAPSHOT);
+        expect(staleSnapshot).toBeDefined();
+
+        await storage.updateLastMessage('conv-1', makeMsg({ id: 'assistant-1', content: 'complete' }));
+        await storage.flushWrites();
+        expect(memFs.files.has(SNAPSHOT)).toBe(false);
+
+        memFs.files.set(SNAPSHOT, staleSnapshot!);
+        vi.resetModules();
+        storage = await import('./conversationStorage');
+
+        const loaded = await storage.loadMessages('conv-1');
+        expect(loaded).toHaveLength(1);
+        expect(loaded[0].content).toBe('complete');
+      });
+
+      it('a legacy (pre-fix) unstamped snapshot keeps the old unconditional-merge behavior', async () => {
+        memFs.files.set(
+          MESSAGES,
+          JSON.stringify(makeMsg({ id: 'm1', content: 'FINAL' })) + '\n',
+        );
+        // v1 on-disk shape: no `stamp` on any entry — a build predating this
+        // fix could have left this file behind.
+        memFs.files.set(
+          SNAPSHOT,
+          JSON.stringify({
+            version: 1,
+            messages: [{ id: 'm1', role: 'user', content: 'legacy-partial', timestamp: 1 }],
+          }),
+        );
+
+        const loaded = await storage.loadMessages('conv-1');
+        // Unchanged from pre-fix behavior: an unstamped entry has nothing to
+        // compare against the ledger, so it still folds in unconditionally.
+        expect(loaded[0].content).toBe('legacy-partial');
+      });
+
+      it('a snapshot entry with no later ledger write still applies (crash-protection survives)', async () => {
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm1', content: '' }));
+        await storage.flushWrites();
+        await storage.snapshotMessageRevision('conv-1', makeMsg({ id: 'm1', content: 'still-streaming' }));
+
+        // Crash before any checkpoint ever reaches the ledger — the buffered
+        // revision is the ONLY copy of this content anywhere.
+        vi.resetModules();
+        storage = await import('./conversationStorage');
+
+        const loaded = await storage.loadMessages('conv-1');
+        expect(loaded).toHaveLength(1);
+        expect(loaded[0].content).toBe('still-streaming');
+      });
+
+      it('a truncate BEFORE the snapshot stamp does not drop a post-truncate revival', async () => {
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm1', content: 'a' }));
+        await storage.flushWrites();
+        await storage.appendTruncateEvent('conv-1', 'm1', { removedIds: ['m1'] });
+        await storage.flushWrites();
+
+        // The user revives m1 (a fresh put after the truncate — the fold's
+        // put-after-truncate resurrection rule) and it is still streaming
+        // when the crash-protection buffer captures it, well AFTER the
+        // truncate's offset.
+        await storage.appendMessage('conv-1', makeMsg({ id: 'm1', content: 'revived' }));
+        await storage.flushWrites();
+        await storage.snapshotMessageRevision('conv-1', makeMsg({ id: 'm1', content: 'revived-streaming' }));
+
+        vi.resetModules();
+        storage = await import('./conversationStorage');
+
+        const loaded = await storage.loadMessages('conv-1');
+        // Must NOT be misfiltered by the earlier (now-irrelevant) truncate —
+        // the revival the user performed after it must survive.
+        expect(loaded.map((m) => m.id)).toEqual(['m1']);
+        expect(loaded[0].content).toBe('revived-streaming');
+      });
+    });
+
     describe('crash windows', () => {
       it('keeps the snapshot file when a shutdown promotion never reaches the ledger', async () => {
         await storage.appendMessage('conv-1', makeMsg({ id: 'm1', content: '' }));

--- a/src/core/session/conversationStorage.ts
+++ b/src/core/session/conversationStorage.ts
@@ -10,7 +10,11 @@
  *   ├── index.json              (lightweight metadata index)
  *   ├── {convId}/
  *   │   ├── messages.jsonl      (append-only ledger of message events)
- *   │   ├── stream-snapshot.json (in-flight revisions, overwritten in place)
+ *   │   ├── stream-snapshot.json (in-flight revisions, overwritten in place;
+ *   │   │                        each entry carries a `stamp` — the ledger
+ *   │   │                        byte watermark at capture time, RB-03 fix —
+ *   │   │                        so a stale crash-leftover entry can be told
+ *   │   │                        apart from one the ledger hasn't touched)
  *   │   ├── outputs/            (images, generated files)
  *   │   └── results/            (large tool results >8KB)
  *   └── ...
@@ -38,7 +42,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { appDataDir } from '@tauri-apps/api/path';
 import { joinPath } from '@/utils/pathUtils';
 import { atomicWrite } from '@/utils/atomicFs';
-import { foldMessageLog, createLedgerEvent, type LedgerLine } from './messageLedger';
+import { foldMessageLog, createLedgerEvent, LEDGER_KIND_PUT, type LedgerLine } from './messageLedger';
 import type { Message, MessageContent, SandboxRecoveryAction } from '@/types';
 
 // ════════════════════════════════════════════════════════════
@@ -257,6 +261,15 @@ async function drainAll(): Promise<void> {
       flightKeys.forEach((k) => inFlightPutKeys.add(k));
       try {
         await appendToFile(filePath, data);
+        // Ledger byte watermark (RB-03 fix, §3.6 addendum): the append that
+        // just landed durably grew messages.jsonl by exactly `data.length`
+        // (repairTornTail's rare leading-newline byte is a bounded, accepted
+        // exception — see its doc comment — immaterial to the >= comparisons
+        // this watermark feeds in loadMessages). Advance before claiming ids
+        // below so a snapshot written moments later already reflects this
+        // append's offset.
+        const watermarkConvId = convIdFromMessagesFilePath(filePath);
+        if (watermarkConvId) advanceLedgerBytes(watermarkConvId, data.length);
         // Claim the ids HERE, synchronously with the drain settling — not in
         // the callers' microtask continuations — so there is no instant where
         // a durably-landed put is in neither writtenIds nor the in-flight set
@@ -443,6 +456,37 @@ const parentIdByMessage = new Map<string, string>();
 /** Per conversation, the id of the last message in the folded log. */
 const lastMessageIdByConv = new Map<string, string>();
 
+/**
+ * Per conversation, the byte length of `messages.jsonl` this process last
+ * confirmed durable — either by reading it (`loadMessages`) or by appending
+ * to it (`drainAll`). RB-03 fix: an append-only ledger's length only ever
+ * grows, so stamping a stream-snapshot entry with this value at capture time
+ * (see `snapshotMessageRevision`) gives `loadMessages` a byte offset it can
+ * compare against the ledger's later state — a "has anything durable
+ * happened to this id since the snapshot was taken" check — instead of
+ * blindly folding every snapshot entry in as a trailing put regardless of
+ * how stale it is.
+ */
+const ledgerBytesByConv = new Map<string, number>();
+
+/**
+ * Extract the conversation id from a `messages.jsonl` path built by
+ * `messagesPath`. Every `enqueueWrite` call in this module targets that path
+ * (never `index.json` or the stream snapshot file, which use their own write
+ * paths), so a drained write can always be attributed back to its
+ * conversation for the byte watermark above without threading `convId`
+ * through the write-queue machinery itself.
+ */
+function convIdFromMessagesFilePath(filePath: string): string | undefined {
+  const parts = filePath.split('/');
+  if (parts.length < 2 || parts[parts.length - 1] !== 'messages.jsonl') return undefined;
+  return parts[parts.length - 2];
+}
+
+function advanceLedgerBytes(convId: string, delta: number): void {
+  ledgerBytesByConv.set(convId, (ledgerBytesByConv.get(convId) ?? 0) + delta);
+}
+
 function rememberPersistedMessage(message: Message): void {
   if (!message.toolCalls?.length) return;
   const actions = new Map<string, SandboxRecoveryAction>();
@@ -488,26 +532,45 @@ function serializeLedgerPut(message: Message, pid: string | undefined): string {
 
 const STREAM_SNAPSHOT_FILENAME = 'stream-snapshot.json';
 
+/**
+ * One buffered revision plus the ledger byte watermark (RB-03 fix) it was
+ * captured against. `stamp` is `undefined` for an entry read back from a
+ * legacy (pre-fix) on-disk file — see `readStreamSnapshot` — which must keep
+ * the old unconditional-merge behavior rather than being misread as "stamp
+ * zero" (that would make every legacy entry look supersede-able by literally
+ * any ledger content).
+ */
+interface StreamSnapshotEntry {
+  message: Message;
+  stamp?: number;
+}
+
 interface StreamSnapshotFile {
-  version: 1;
-  messages: Message[];
+  version: 1 | 2;
+  /** v1 (legacy on-disk shape, still parsed for back-compat): no watermark. */
+  messages?: Message[];
+  /** v2 (current writer shape): per-entry ledger byte watermark. */
+  entries?: StreamSnapshotEntry[];
 }
 
 /** convId → messageId → newest revision not yet checkpointed into the ledger. */
-const streamSnapshots = new Map<string, Map<string, Message>>();
+const streamSnapshots = new Map<string, Map<string, StreamSnapshotEntry>>();
 
 function streamSnapshotPath(convId: string): string {
   return joinPath(basePath!, convId, STREAM_SNAPSHOT_FILENAME);
 }
 
-async function writeStreamSnapshot(convId: string, entries: Map<string, Message>): Promise<void> {
+async function writeStreamSnapshot(
+  convId: string,
+  entries: Map<string, StreamSnapshotEntry>,
+): Promise<void> {
   const path = streamSnapshotPath(convId);
   try {
     if (entries.size === 0) {
       if (await exists(path)) await remove(path);
       return;
     }
-    const payload: StreamSnapshotFile = { version: 1, messages: [...entries.values()] };
+    const payload: StreamSnapshotFile = { version: 2, entries: [...entries.values()] };
     await atomicWrite(path, JSON.stringify(payload));
   } catch {
     // Best-effort crash protection. The ledger checkpoint is the durable write;
@@ -524,8 +587,15 @@ async function writeStreamSnapshot(convId: string, entries: Map<string, Message>
  */
 export async function snapshotMessageRevision(convId: string, message: Message): Promise<void> {
   await ensureBase();
-  const entries = streamSnapshots.get(convId) ?? new Map<string, Message>();
-  entries.set(message.id, stripForDisk(message));
+  const entries = streamSnapshots.get(convId) ?? new Map<string, StreamSnapshotEntry>();
+  entries.set(message.id, {
+    message: stripForDisk(message),
+    // RB-03 fix: how much of this conversation's ledger this process had
+    // confirmed durable at the moment this revision was captured. See
+    // `ledgerBytesByConv`'s doc comment and `loadMessages`' snapshot-merge
+    // step, which is what this stamp exists for.
+    stamp: ledgerBytesByConv.get(convId) ?? 0,
+  });
   streamSnapshots.set(convId, entries);
   await writeStreamSnapshot(convId, entries);
 }
@@ -542,25 +612,246 @@ async function dropStreamSnapshotEntry(convId: string, messageId: string): Promi
   await writeStreamSnapshot(convId, entries);
 }
 
-/** Read the snapshot file back and re-arm the in-memory buffer from it. */
-async function readStreamSnapshot(convId: string): Promise<Message[]> {
+/**
+ * Read the snapshot file back, WITHOUT re-arming the in-memory buffer — the
+ * caller (`loadMessages`) must run the stale-entry guard first (RB-03 fix)
+ * and only then decide what actually gets armed, or a superseded entry would
+ * be written straight back into memory before it's ever filtered.
+ */
+async function readStreamSnapshot(convId: string): Promise<Map<string, StreamSnapshotEntry>> {
   const path = streamSnapshotPath(convId);
   try {
-    if (!(await exists(path))) return [];
+    if (!(await exists(path))) return new Map();
     const parsed = JSON.parse(await readTextFile(path)) as StreamSnapshotFile;
-    const messages = Array.isArray(parsed?.messages) ? parsed.messages : [];
-    if (messages.length === 0) return [];
-    const entries = new Map<string, Message>();
-    for (const message of messages) {
-      if (message && typeof message.id === 'string') entries.set(message.id, message);
+    const entries = new Map<string, StreamSnapshotEntry>();
+    if (Array.isArray(parsed?.entries)) {
+      // v2 (current) shape: per-entry watermark.
+      for (const entry of parsed.entries) {
+        const message = entry?.message;
+        if (message && typeof message.id === 'string') {
+          entries.set(message.id, {
+            message,
+            stamp: typeof entry.stamp === 'number' ? entry.stamp : undefined,
+          });
+        }
+      }
+    } else if (Array.isArray(parsed?.messages)) {
+      // v1 (legacy) shape: no watermark on any entry.
+      for (const message of parsed.messages) {
+        if (message && typeof message.id === 'string') {
+          entries.set(message.id, { message, stamp: undefined });
+        }
+      }
     }
-    streamSnapshots.set(convId, entries);
-    return [...entries.values()];
+    return entries;
   } catch {
     // A damaged snapshot must never take the conversation down with it — the
     // ledger alone is still a complete, if slightly older, history.
-    return [];
+    return new Map();
   }
+}
+
+/**
+ * Companion pass to `messageLedger.ts`'s `foldMessageLog`: walks the same raw
+ * ledger lines in the same order and applies the same put/tomb/truncate/
+ * loopDrop state transitions, but tracks each line's BYTE OFFSET into `raw`
+ * instead of building `Message` objects. Deliberately NOT merged into
+ * `foldMessageLog` itself — that function is pinned byte-for-byte to
+ * `electron/messageLedgerFold.cjs` and `src-tauri/src/catalog_db.rs` via a
+ * shared fixture file (see `messageLedger.ts`'s module doc), and byte offsets
+ * are a TypeScript-only concern for the stream-snapshot supersede guard below
+ * with no equivalent on the other two ports.
+ *
+ * Must mirror `foldMessageLog`'s survivorship decisions exactly (same
+ * id-collapsing on `undefined`, same in-place-not-move-to-end put semantics,
+ * same corrupt/non-object line skipping) — see `loadMessages`' snapshot-merge
+ * step for why a divergence here would silently mis-classify a snapshot
+ * entry as stale or as still-valid.
+ */
+interface LedgerOffsetInfo {
+  /** id → offset of the put line that currently establishes its presence
+   * (the LAST put for that id, since a revision lands in place — only set
+   * for ids the ledger-only fold still contains). */
+  putOffsetById: Map<string, number>;
+  /** id → offset of the removal event (tomb/truncate/loopDrop) that most
+   * recently removed the id, for ids the ledger-only fold does NOT currently
+   * contain. A later revival put clears this entry, mirroring the fold's own
+   * put-after-tomb resurrection rule (messageLedger.ts module doc). */
+  removedOffsetById: Map<string, number>;
+}
+
+function computeLedgerOffsetInfo(raw: string): LedgerOffsetInfo {
+  const putOffsetById = new Map<string, number>();
+  const removedOffsetById = new Map<string, number>();
+  let liveIds: string[] = [];
+  let liveLoopIds: (string | undefined)[] = [];
+  let indexOf = new Map<string, number>();
+
+  const reindex = (): void => {
+    indexOf = new Map<string, number>();
+    for (let i = 0; i < liveIds.length; i++) indexOf.set(liveIds[i], i);
+  };
+
+  let offset = 0;
+  for (const rawLine of raw.split('\n')) {
+    // `String.prototype.split('\n')` eats exactly one '\n' between segments,
+    // so re-adding it per segment reconstructs each segment's true starting
+    // offset in `raw` — see this function's tests for the boundary check.
+    const consumed = rawLine.length + 1;
+    const lineOffset = offset;
+    offset += consumed;
+
+    if (rawLine.trim() === '') continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawLine);
+    } catch {
+      continue;
+    }
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) continue;
+    const line = parsed as LedgerLine;
+    const kind: string = typeof line.lk === 'string' ? line.lk : LEDGER_KIND_PUT;
+
+    switch (kind) {
+      case LEDGER_KIND_PUT: {
+        if (typeof line.id !== 'string') break;
+        const id = line.id;
+        const at = indexOf.get(id);
+        if (at === undefined) {
+          indexOf.set(id, liveIds.length);
+          liveIds.push(id);
+          liveLoopIds.push(line.loopId);
+        } else {
+          liveLoopIds[at] = line.loopId; // in place — a revision, not a reorder
+        }
+        putOffsetById.set(id, lineOffset);
+        removedOffsetById.delete(id); // put-after-removal revives it
+        break;
+      }
+      case 'msg.tomb': {
+        if (typeof line.target !== 'string') break;
+        const at = indexOf.get(line.target);
+        if (at === undefined) break;
+        liveIds.splice(at, 1);
+        liveLoopIds.splice(at, 1);
+        reindex();
+        putOffsetById.delete(line.target);
+        removedOffsetById.set(line.target, lineOffset);
+        break;
+      }
+      case 'msg.truncate': {
+        if (typeof line.from !== 'string') break;
+        const at = indexOf.get(line.from);
+        if (at === undefined) break;
+        const cut = liveIds.slice(at);
+        liveIds.length = at;
+        liveLoopIds.length = at;
+        reindex();
+        for (const cutId of cut) {
+          putOffsetById.delete(cutId);
+          removedOffsetById.set(cutId, lineOffset);
+        }
+        break;
+      }
+      case 'msg.loopDrop': {
+        if (typeof line.loopId !== 'string') break;
+        const dropLoopId = line.loopId;
+        const keepIds: string[] = [];
+        const keepLoopIds: (string | undefined)[] = [];
+        const droppedIds: string[] = [];
+        for (let i = 0; i < liveIds.length; i++) {
+          if (liveLoopIds[i] === dropLoopId) droppedIds.push(liveIds[i]);
+          else {
+            keepIds.push(liveIds[i]);
+            keepLoopIds.push(liveLoopIds[i]);
+          }
+        }
+        if (droppedIds.length === 0) break;
+        liveIds = keepIds;
+        liveLoopIds = keepLoopIds;
+        reindex();
+        for (const droppedId of droppedIds) {
+          putOffsetById.delete(droppedId);
+          removedOffsetById.set(droppedId, lineOffset);
+        }
+        break;
+      }
+      default:
+        // Unknown kind — written by a newer build. Ignored, same as the fold.
+        break;
+    }
+  }
+
+  return { putOffsetById, removedOffsetById };
+}
+
+/**
+ * RB-03 fix: drop any stream-snapshot entry the ledger has already made
+ * stale, instead of always folding every buffered revision in as a trailing
+ * put. An entry is stale when, at or after the byte offset it was stamped
+ * against (`entry.stamp` — see `snapshotMessageRevision`), the ledger either
+ * (a) contains a newer `msg.put` for the SAME id (a durable checkpoint landed
+ * and this process just never got to delete the now-superseded snapshot
+ * file), or (b) was cut by a truncate/tomb/loopDrop event whose fold-time
+ * effect removed that id (a stale snapshot must not revive a message the
+ * user already deleted). An entry with no stamp (`undefined` — a legacy
+ * on-disk file predating this fix) keeps the previous unconditional-merge
+ * behavior, same as an entry the ledger has genuinely not touched since it
+ * was captured (the crash-protection purpose this buffer exists for).
+ *
+ * `raw.length < entry.stamp` is a defensive third case: an append-only
+ * ledger's length only grows, so a *current* length shorter than what this
+ * entry was stamped against means something OUTSIDE this fold rewrote
+ * `messages.jsonl` since capture (e.g. a downgrade-then-reupgrade across a
+ * pre-ledger build, the scenario `feat/snapshot-watermark` guards at the
+ * whole-file level) — per-entry, a stamp that outreaches the current ledger
+ * is definitionally stale too, regardless of whether either offset check
+ * above fires.
+ *
+ * Best-effort: when anything is dropped, the filtered set is written back to
+ * disk (and the in-memory buffer re-armed from it — see `loadMessages`) so
+ * the stale entry does not resurface on a future load if this call's own
+ * `writeStreamSnapshot` never lands; either way the guard re-evaluates fresh
+ * on every load, so a delete failure just gets filtered again next time
+ * (audit RB-03 close condition: delete-failure tolerance follows free).
+ */
+async function filterStaleSnapshotEntries(
+  convId: string,
+  raw: string,
+  snapshotEntries: Map<string, StreamSnapshotEntry>,
+): Promise<Map<string, StreamSnapshotEntry>> {
+  if (snapshotEntries.size === 0) return snapshotEntries;
+  const anyStamped = [...snapshotEntries.values()].some((entry) => entry.stamp !== undefined);
+  if (!anyStamped) return snapshotEntries;
+
+  const { putOffsetById, removedOffsetById } = computeLedgerOffsetInfo(raw);
+  const survivors = new Map<string, StreamSnapshotEntry>();
+  const droppedIds: string[] = [];
+  for (const [id, entry] of snapshotEntries) {
+    if (entry.stamp === undefined) {
+      survivors.set(id, entry);
+      continue;
+    }
+    const stamp = entry.stamp;
+    const putOffset = putOffsetById.get(id);
+    const removedOffset = removedOffsetById.get(id);
+    const stale =
+      (putOffset !== undefined && putOffset >= stamp)
+      || (removedOffset !== undefined && removedOffset >= stamp)
+      || raw.length < stamp;
+    if (stale) droppedIds.push(id);
+    else survivors.set(id, entry);
+  }
+
+  if (droppedIds.length > 0) {
+    console.warn(
+      `[conversationStorage] loadMessages(${convId}): dropping ${droppedIds.length} stale ` +
+        `stream-snapshot entr${droppedIds.length === 1 ? 'y' : 'ies'} superseded by the ledger ` +
+        `(ids: ${droppedIds.join(', ')}).`,
+    );
+    await writeStreamSnapshot(convId, survivors);
+  }
+  return survivors;
 }
 
 /**
@@ -572,7 +863,7 @@ export async function flushStreamSnapshots(): Promise<void> {
   await ensureBase();
   const promotions: { convId: string; done: Promise<unknown> }[] = [];
   for (const [convId, entries] of [...streamSnapshots.entries()]) {
-    for (const message of entries.values()) {
+    for (const { message } of entries.values()) {
       promotions.push({
         convId,
         done: enqueueWrite(
@@ -1253,6 +1544,10 @@ export async function loadMessages(convId: string): Promise<Message[]> {
   }
   // Free the next append from re-reading the file just to check its tail.
   noteTailFromRead(path, raw);
+  // Ledger byte watermark (RB-03 fix): this read is now the freshest
+  // known-durable length for this conversation's ledger — see
+  // `ledgerBytesByConv`'s doc comment.
+  ledgerBytesByConv.set(convId, raw.length);
 
   // The whole read is one fold (see messageLedger.ts for the spec). It keeps
   // the previous damage-reduction behaviour — a corrupt line is skipped, not
@@ -1264,11 +1559,17 @@ export async function loadMessages(convId: string): Promise<Message[]> {
   // a reorder, which is what lets the write side express "replace" as "append".
   // Revisions that a crash caught between checkpoints live in the stream
   // snapshot, not the ledger. Folding them in as trailing puts applies them
-  // with exactly the ledger's own last-write-wins-in-place rule.
-  const snapshot = await readStreamSnapshot(convId);
+  // with exactly the ledger's own last-write-wins-in-place rule — MINUS any
+  // entry the stale-snapshot guard (RB-03 fix) determines the ledger has
+  // already superseded (a newer put for the same id, or a truncate/tomb/
+  // loopDrop that removed it, at or after the entry's byte-offset stamp).
+  const rawSnapshotEntries = await readStreamSnapshot(convId);
+  const snapshotEntries = await filterStaleSnapshotEntries(convId, raw, rawSnapshotEntries);
+  if (snapshotEntries.size > 0) streamSnapshots.set(convId, snapshotEntries);
+  else streamSnapshots.delete(convId);
   const { messages, corruptCount, totalLines } = foldMessageLog([
     ...raw.split('\n'),
-    ...snapshot.map((m) => JSON.stringify(m)),
+    ...[...snapshotEntries.values()].map((entry) => JSON.stringify(entry.message)),
   ]);
   if (corruptCount > 0) {
     console.warn(
@@ -1290,6 +1591,7 @@ export async function deleteConversationFiles(convId: string): Promise<void> {
   // later flush recreate the conversation directory we are deleting.
   streamSnapshots.delete(convId);
   lastMessageIdByConv.delete(convId);
+  ledgerBytesByConv.delete(convId);
   // Remove new path
   const dir = convDir(convId);
   try {


### PR DESCRIPTION
Fixes release blocker RB-03 (see V0.40.0-RELEASE-READINESS-AUDIT.md + its 附录 disposition note): per-entry ledger byte-offset supersede guard; both audit fold-level repros pinned as failing-then-passing tests. Complementary to #220 (downgrade shrink watermark) — coordinated identifiers, trivial merge either order. Full vitest 5449/5449 + verify exit 0 rerun by the reviewing session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)