### PR TITLE
refactor(chat): share the thinking status line + animate the thinking pane's completion swap

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -36,6 +36,11 @@ import { Input } from '@/components/ui/input';
 import UsageChip from './UsageChip';
 import { shouldShowTypingIndicator } from './typingIndicator';
 import { groupMessagesByLoop } from './messageGrouping';
+import { ThinkingStatusLine, AssistantRowAvatar } from './ThinkingStatusLine';
+import {
+  VIRTUOSO_ITEM_TRAILING_PAD,
+  TYPING_FOOTER_GAP_COMPENSATION,
+} from './chatSpacing';
 
 /**
  * Context passed to the Virtuoso `Footer` component (the streaming typing
@@ -55,7 +60,8 @@ interface MessageListContext {
 // Row wrapper for each virtualized message group. Spacing between groups
 // MUST be padding, not margin (react-virtuoso guidance: margins on measured
 // rows break height measurement/collapse behavior), so this replaces the
-// previous `space-y-5` (margin) gap with a `pb-5` (padding-bottom) applied
+// previous `space-y-5` (margin) gap with a padding-bottom
+// (VIRTUOSO_ITEM_TRAILING_PAD in chatSpacing.ts) applied
 // to every row uniformly. This is deliberately unconditional (no "skip on
 // last item" special-casing): virtualized rows are NOT reliably
 // `:first-child`/`:last-child` in the DOM (whichever row is topmost/
@@ -71,7 +77,7 @@ const VirtuosoMessageItem: NonNullable<Components<Message[], MessageListContext>
   context: _context,
   ...props
 }) => (
-  <div {...props} className="pb-5">
+  <div {...props} className={VIRTUOSO_ITEM_TRAILING_PAD}>
     {children}
   </div>
 );
@@ -83,28 +89,16 @@ const VirtuosoTypingFooter: NonNullable<Components<Message[], MessageListContext
   context,
 }) => {
   if (!context?.showTypingIndicator) return null;
-  // Layout mirrors a MessageGroup's assistant row (avatar mt-0.5, gap-3,
-  // text-body tertiary label with no extra padding) so the hand-off from this
-  // footer to the real assistant placeholder — and then to the TaskBlock
-  // header / "已处理 Xs" fold header — keeps the label on the same baseline
-  // at the same size instead of hopping between typographies ("错行").
-  // -mt-1: this footer sits after the last row's pb-5 (20px) item padding,
-  // while the in-group placeholder row it hands off to sits after the group's
-  // internal space-y-4 (16px) — without the compensation the label hops up
-  // 4px at the swap (measured frame-by-frame from a screen recording).
+  // Layout mirrors a MessageGroup's assistant row (shared AssistantRowAvatar,
+  // gap-3, shared ThinkingStatusLine) so the hand-off from this footer to the
+  // real assistant placeholder — and then to the TaskBlock header / "已处理
+  // Xs" fold header — keeps the label on the same baseline at the same size
+  // instead of hopping between typographies ("错行"). The negative top margin
+  // bridges the item-pad vs in-group-gap difference — see chatSpacing.ts.
   return (
-    <div className="-mt-1 flex gap-3">
-      <div className="w-7 h-7 mt-0.5 rounded-full overflow-hidden shrink-0">
-        <img src={abuAvatar} alt="Abu" className="w-full h-full object-cover" />
-      </div>
-      <div className="flex items-center gap-1.5">
-        <span className="text-body text-[var(--abu-text-tertiary)]">
-          {context.retryingLabel ?? context.thinkingLabel}
-        </span>
-        <span className="typing-dot w-1.5 h-1.5 rounded-full bg-[var(--abu-clay-60)]" />
-        <span className="typing-dot w-1.5 h-1.5 rounded-full bg-[var(--abu-clay-60)]" />
-        <span className="typing-dot w-1.5 h-1.5 rounded-full bg-[var(--abu-clay-60)]" />
-      </div>
+    <div className={cn(TYPING_FOOTER_GAP_COMPENSATION, 'flex gap-3')}>
+      <AssistantRowAvatar />
+      <ThinkingStatusLine label={context.retryingLabel ?? context.thinkingLabel} />
     </div>
   );
 };
@@ -728,7 +722,12 @@ export default function ChatView() {
               retryingLabel: retryInfo
                 ? format(t.chat.retrying, { attempt: retryInfo.attempt, max: retryInfo.maxAttempts })
                 : null,
-              thinkingLabel: t.chat.thinking,
+              // status.thinking ("思考中", no trailing ellipsis) — the same
+              // string the in-group placeholder shows and the TaskBlock active
+              // header reduces to (it strips the ellipsis). chat.thinking
+              // ("思考中…") here made the "…" blink out at the footer →
+              // placeholder hand-off, and reads odd before the animated dots.
+              thinkingLabel: t.status.thinking,
             }}
             itemContent={(index, group) =>
               group.length === 1 && isCompactBoundary(group[0]) ? (

--- a/src/components/chat/MessageGroup.tsx
+++ b/src/components/chat/MessageGroup.tsx
@@ -29,8 +29,9 @@ import { snapshotToExecutionSteps } from '@/core/agent/executionSnapshot';
 import { runAgentLoopDispatched } from '@/core/agent/agentLoopRunner';
 import { allWorkingDirectories } from '@/core/permissions/workingDirs';
 import { homeDir } from '@tauri-apps/api/path';
-import abuAvatar from '@/assets/abu-avatar.png';
 import { cn } from '@/lib/utils';
+import { ThinkingStatusLine, AssistantRowAvatar } from './ThinkingStatusLine';
+import { GROUP_CONTENT_GAP } from './chatSpacing';
 
 interface MessageGroupProps {
   messages: Message[];
@@ -783,7 +784,8 @@ export default function MessageGroup({ messages, isLastGroup: isLastGroupProp = 
         // transition-colors lives on the base class so the highlight fades both
         // in AND out (a conditional transition class vanishes with the bg and
         // makes the removal instant).
-        'message-group space-y-4 w-full rounded-lg transition-colors duration-700',
+        'message-group w-full rounded-lg transition-colors duration-700',
+        GROUP_CONTENT_GAP,
         highlightMessageId != null &&
           messages.some((m) => m.id === highlightMessageId) &&
           'bg-[var(--abu-clay-bg-15)]',
@@ -811,11 +813,7 @@ export default function MessageGroup({ messages, isLastGroup: isLastGroupProp = 
       {(assistantMsgs.length > 0 || isStopped) && (
         <div className="flex gap-3 w-full overflow-hidden group">
           {/* ABU Avatar - only shown once for the group */}
-          <div className="shrink-0 mt-0.5">
-            <div className="w-7 h-7 rounded-full overflow-hidden">
-              <img src={abuAvatar} alt="Abu" className="w-full h-full object-cover" />
-            </div>
-          </div>
+          <AssistantRowAvatar />
 
           {/* Content area */}
           <div className="flex-1 min-w-0 overflow-hidden">
@@ -845,18 +843,10 @@ export default function MessageGroup({ messages, isLastGroup: isLastGroupProp = 
                 itself, so a plan card from an earlier turn in the same group does
                 not suppress the dots for the fresh empty turn that follows. */}
             {isStreaming && !streamingHasContent && (
-              /* Geometry MUST mirror the TaskBlock active header and the
-                 "已处理 Xs" fold header that replace this row in later states:
-                 text-body (not text-minor), tertiary color, no top padding,
-                 mb-2 below. The old text-minor + py-2 version put the label
-                 2px smaller and ~8px lower than its successors, so every
-                 state swap read as the label jumping up a line ("错行"). */
-              <div className="flex items-center gap-1.5 mb-2">
-                <span className="text-body text-[var(--abu-text-tertiary)]">{t.status.thinking}</span>
-                <span className="typing-dot w-1.5 h-1.5 rounded-full bg-[var(--abu-clay-60)]" />
-                <span className="typing-dot w-1.5 h-1.5 rounded-full bg-[var(--abu-clay-60)]" />
-                <span className="typing-dot w-1.5 h-1.5 rounded-full bg-[var(--abu-clay-60)]" />
-              </div>
+              /* mb-2 matches the TaskBlock header / "已处理 Xs" fold header
+                 buttons that replace this row in later states; the label
+                 geometry itself lives in the shared ThinkingStatusLine. */
+              <ThinkingStatusLine label={t.status.thinking} className="mb-2" />
             )}
 
             {/* Render segments: text blocks and merged step groups.

--- a/src/components/chat/TaskBlock.test.tsx
+++ b/src/components/chat/TaskBlock.test.tsx
@@ -1,6 +1,6 @@
 /// <reference types="@testing-library/jest-dom" />
 
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
 import { afterEach, describe, it, expect } from 'vitest';
 import TaskBlock, { generateSummary, type UnifiedStep } from './TaskBlock';
 import { getI18n, getLocale, format } from '@/i18n';
@@ -93,5 +93,81 @@ describe('TaskBlock — expand-on-mount wrappers', () => {
     expect(wrapper!.querySelector('.flow-timeline')).not.toBeNull();
     expect(wrapper!.hasAttribute('inert')).toBe(true);
     expect(wrapper!.getAttribute('aria-hidden')).toBe('true');
+  });
+});
+
+// The thinking pane's running and completed states share one skeleton so the
+// running → completed swap is a class mutation on mounted nodes, not a subtree
+// replacement — the old two-structure swap landed a ~24px height change
+// (toggle button + gap) in one frame, below SmoothHeight's threshold.
+describe('TaskBlock — thinking pane running → completed', () => {
+  afterEach(() => cleanup());
+
+  const t = getI18n();
+  const findThinkingToggle = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes(t.chat.thinkingProcess),
+    );
+  // The button's own animated slot (button → .pb-2 → slot). `closest` would
+  // walk past it up to the timeline wrapper, which is also a .block-expand.
+  const toggleSlot = (toggle: HTMLElement) => toggle.parentElement!.parentElement!;
+
+  it('keeps the streamed content mounted and animates the toggle button in', () => {
+    const { container, rerender } = render(
+      <TaskBlock executionSteps={[execThinkingStep()]} isActive />,
+    );
+    // Running: pane content present, no toggle button yet.
+    expect(container.textContent).toContain('reasoning tokens streaming in');
+    expect(findThinkingToggle(container)).toBeUndefined();
+
+    rerender(
+      <TaskBlock
+        executionSteps={[execThinkingStep({ status: 'completed', duration: 3 })]}
+        isActive={false}
+      />,
+    );
+    // Completed: the content pre is still mounted, inside an OPEN panel
+    // (thinkingExpanded persists across the transition)…
+    const pre = container.querySelector('pre');
+    expect(pre?.textContent).toContain('reasoning tokens streaming in');
+    expect(pre!.closest('.block-expand')!.classList.contains('block-expand-open')).toBe(true);
+    // …and the toggle button grows in through an animated slot instead of
+    // landing its height in one frame.
+    const toggle = findThinkingToggle(container);
+    expect(toggle).toBeDefined();
+    expect(toggleSlot(toggle!).classList.contains('block-expand')).toBe(true);
+    expect(toggleSlot(toggle!).classList.contains('block-expand-enter')).toBe(true);
+  });
+
+  it('collapse via the toggle rolls the panel up (closed + inert), not unmounted; history mounts render the button statically', () => {
+    const { container } = render(
+      <TaskBlock
+        executionSteps={[execThinkingStep({ status: 'completed', duration: 3 })]}
+        isActive={false}
+      />,
+    );
+    // Fresh settled mount: the timeline only mounts when the user opens the
+    // summary header, so expand it first.
+    fireEvent.click(container.querySelector('button')!);
+    // Toggle button present but NOT inside an enter-animated slot (history
+    // remounts must not animate), panel starts collapsed.
+    const toggle = findThinkingToggle(container);
+    expect(toggle).toBeDefined();
+    expect(toggleSlot(toggle!).classList.contains('block-expand')).toBe(true);
+    expect(toggleSlot(toggle!).classList.contains('block-expand-enter')).toBe(false);
+    const panel = container.querySelector('pre')!.closest('.block-expand')!;
+    expect(panel.classList.contains('block-expand-closed')).toBe(true);
+    expect(panel.hasAttribute('inert')).toBe(true);
+
+    fireEvent.click(toggle!);
+    expect(panel.classList.contains('block-expand-open')).toBe(true);
+    expect(panel.hasAttribute('inert')).toBe(false);
+
+    fireEvent.click(toggle!);
+    // Roll-up: still mounted, clipped closed.
+    expect(panel.classList.contains('block-expand-closed')).toBe(true);
+    expect(container.querySelector('pre')?.textContent).toContain(
+      'reasoning tokens streaming in',
+    );
   });
 });

--- a/src/components/chat/TaskBlock.tsx
+++ b/src/components/chat/TaskBlock.tsx
@@ -31,6 +31,7 @@ import { generateCompletionMessage } from '@/utils/workflowExtractor';
 import { getToolLabel } from '@/utils/toolLabels';
 import { useTaskExecutionStore } from '@/stores/taskExecutionStore';
 import DetailBlockView from './DetailBlockView';
+import { TypingDots } from './ThinkingStatusLine';
 
 // Unified step type for rendering
 export type UnifiedStep = {
@@ -352,13 +353,7 @@ export default function TaskBlock({ steps, executionSteps, isActive, isStopped =
           className="flex items-center gap-1.5 text-body text-[var(--abu-text-tertiary)] hover:text-[var(--abu-text-primary)] transition-colors mb-2"
         >
           <span>{isActive ? summary.replace(/\.{3}$/, '').replace(/…$/, '') : summary}</span>
-          {isActive && (
-            <span className="inline-flex items-center gap-[3px] ml-0.5">
-              <span className="typing-dot w-[3px] h-[3px] rounded-full bg-[var(--abu-clay)]" />
-              <span className="typing-dot w-[3px] h-[3px] rounded-full bg-[var(--abu-clay)]" />
-              <span className="typing-dot w-[3px] h-[3px] rounded-full bg-[var(--abu-clay)]" />
-            </span>
-          )}
+          {isActive && <TypingDots size="sm" className="ml-0.5" />}
           <ChevronDown
             className={cn(
               'h-3.5 w-3.5 transition-transform',
@@ -557,6 +552,13 @@ function TaskStepItem({ step, showConnector, hasLaterToolStep, locale, t }: {
     }
     prevThinkingRunning.current = isRunning;
   }, [isThinking, isRunning]);
+  // Latches true once this step's thinking pane has rendered in its streaming
+  // state (set-state-during-render derived-state pattern). The completed-state
+  // toggle button animates open only when it replaces the live pane (running →
+  // completed swap in this mounted component); history/remount renders show it
+  // statically.
+  const [thinkingRanLive, setThinkingRanLive] = useState(false);
+  if (isThinking && isRunning && !thinkingRanLive) setThinkingRanLive(true);
 
   // Once thinking is done and execution has moved on to a tool step, auto-collapse
   // the reasoning so attention shifts to the running work. Fires once; the user can
@@ -609,47 +611,63 @@ function TaskStepItem({ step, showConnector, hasLaterToolStep, locale, t }: {
   // collapsible once the thinking phase is done (preserves expanded state from streaming).
   const renderThinkingDetail = () => {
     if (!isThinking || !step.detail) return null;
-    if (isRunning) {
-      return (
-        // block-expand + enter: the pane can also first mount inside an
-        // ALREADY open timeline (a later turn's thinking starting after tool
-        // steps), where the timeline-level mount animation won't fire — so the
-        // pane animates its own height open too. Same one-frame-jump rationale
-        // as the timeline wrapper above. Always open; it leaves by the
-        // timeline collapsing around it, so no closed state here.
-        <div className="block-expand block-expand-open block-expand-enter mt-1 rounded-lg bg-[var(--abu-bg-muted)] border border-[var(--abu-bg-hover)] overflow-hidden">
-          <div ref={thinkingScrollRef} className="px-3 py-2 max-h-48 overflow-y-auto">
-            <pre className="text-minor text-[var(--abu-text-tertiary)] italic whitespace-pre-wrap break-words leading-relaxed font-sans m-0">
-              {step.detail}
-              <span className="streaming-cursor inline-block ml-0.5" />
-            </pre>
+    if (!isRunning && !isCompleted) return null;
+    const panelOpen = isRunning || thinkingExpanded;
+    return (
+      // Running and completed share ONE skeleton (toggle-button slot above a
+      // block-expand panel) so the running → completed swap mutates classes on
+      // mounted nodes instead of replacing the subtree — the old two-structure
+      // version landed a ~24px height change in one frame (below
+      // SmoothHeight's 40px threshold), a small residual hop. Now the button
+      // slot grows in via block-expand-enter and the panel — kept mounted —
+      // rolls up/down over the shared 280ms transition on later toggles,
+      // including the auto-collapse when execution moves on to a tool step.
+      <div className="mt-1">
+        {isCompleted && (
+          <div
+            className={cn(
+              'block-expand block-expand-open',
+              thinkingRanLive && 'block-expand-enter',
+            )}
+          >
+            {/* pb-2 (the button→panel gap) sits inside the animated slot so it
+                grows in with the button instead of jumping in separately. */}
+            <div className="pb-2">
+              <button
+                onClick={() => setThinkingExpanded(!thinkingExpanded)}
+                className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-caption bg-[var(--abu-bg-hover)] text-[var(--abu-text-muted)] hover:bg-[var(--abu-bg-pressed)] hover:text-[var(--abu-text-tertiary)] transition-colors"
+              >
+                {thinkingExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+                {t.chat.thinkingProcess}
+              </button>
+            </div>
+          </div>
+        )}
+        {/* block-expand-enter while running: the pane can first mount inside
+            an ALREADY open timeline (a later turn's thinking starting after
+            tool steps), where the timeline-level mount animation won't fire —
+            so the pane animates its own height open too. Same one-frame-jump
+            rationale as the timeline wrapper above. */}
+        <div
+          inert={!panelOpen || undefined}
+          aria-hidden={!panelOpen || undefined}
+          className={cn(
+            'block-expand',
+            panelOpen ? 'block-expand-open' : 'block-expand-closed',
+            isRunning && 'block-expand-enter',
+          )}
+        >
+          <div className="rounded-lg bg-[var(--abu-bg-muted)] border border-[var(--abu-bg-hover)] overflow-hidden">
+            <div ref={thinkingScrollRef} className="px-3 py-2 max-h-48 overflow-y-auto">
+              <pre className="text-minor text-[var(--abu-text-tertiary)] italic whitespace-pre-wrap break-words leading-relaxed font-sans m-0">
+                {step.detail}
+                {isRunning && <span className="streaming-cursor inline-block ml-0.5" />}
+              </pre>
+            </div>
           </div>
         </div>
-      );
-    }
-    if (isCompleted) {
-      return (
-        <div className="mt-1">
-          <button
-            onClick={() => setThinkingExpanded(!thinkingExpanded)}
-            className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-caption bg-[var(--abu-bg-hover)] text-[var(--abu-text-muted)] hover:bg-[var(--abu-bg-pressed)] hover:text-[var(--abu-text-tertiary)] transition-colors"
-          >
-            {thinkingExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-            {t.chat.thinkingProcess}
-          </button>
-          {thinkingExpanded && (
-            <div className="mt-2 rounded-lg bg-[var(--abu-bg-muted)] border border-[var(--abu-bg-hover)] overflow-hidden">
-              <div className="px-3 py-2 max-h-48 overflow-y-auto">
-                <pre className="text-minor text-[var(--abu-text-tertiary)] italic whitespace-pre-wrap break-words leading-relaxed font-sans m-0">
-                  {step.detail}
-                </pre>
-              </div>
-            </div>
-          )}
-        </div>
-      );
-    }
-    return null;
+      </div>
+    );
   };
 
   // Render legacy collapsible details (backward compatibility)

--- a/src/components/chat/ThinkingStatusLine.tsx
+++ b/src/components/chat/ThinkingStatusLine.tsx
@@ -1,0 +1,74 @@
+import { cn } from '@/lib/utils';
+import abuAvatar from '@/assets/abu-avatar.png';
+
+// Single source of truth for the "thinking…" status typography shared by the
+// three rows that hand off to each other during a turn's lifecycle:
+//   1. ChatView's VirtuosoTypingFooter (before the assistant group exists)
+//   2. MessageGroup's in-group placeholder (group exists, no content yet)
+//   3. TaskBlock's active header (first thinking/tool step has arrived)
+// Because each state swap REPLACES the previous row in the same visual spot,
+// the label must keep the exact same size and baseline across all three — any
+// divergence reads as the text hopping lines ("错行"). Keeping the markup here
+// means a typography tweak propagates to every call site automatically.
+
+/** The three bouncing dots. `md` is the standalone status-line size; `sm` is
+ *  the compact inline variant the TaskBlock active header appends to its
+ *  summary text. */
+export function TypingDots({
+  size = 'md',
+  className,
+}: {
+  size?: 'md' | 'sm';
+  className?: string;
+}) {
+  const dot =
+    size === 'md'
+      ? 'typing-dot w-1.5 h-1.5 rounded-full bg-[var(--abu-clay-60)]'
+      : 'typing-dot w-[3px] h-[3px] rounded-full bg-[var(--abu-clay)]';
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center',
+        size === 'md' ? 'gap-1.5' : 'gap-[3px]',
+        className,
+      )}
+    >
+      <span className={dot} />
+      <span className={dot} />
+      <span className={dot} />
+    </span>
+  );
+}
+
+/** One status row: tertiary text-body label + bouncing dots. text-body (not
+ *  text-minor) and no vertical padding of its own — successors (TaskBlock
+ *  active header, "已处理 Xs" fold header) are text-body buttons with mb-2,
+ *  so callers that need the mb-2 pass it via className. */
+export function ThinkingStatusLine({
+  label,
+  className,
+}: {
+  label: string;
+  className?: string;
+}) {
+  return (
+    <div className={cn('flex items-center gap-1.5', className)}>
+      <span className="text-body text-[var(--abu-text-tertiary)]">{label}</span>
+      <TypingDots />
+    </div>
+  );
+}
+
+/** The 28px assistant-row avatar. Shared by MessageGroup's group row and the
+ *  typing footer that mimics it — identical markup keeps the label's
+ *  horizontal offset (avatar width + gap) and top alignment (mt-0.5) in sync
+ *  across the footer → group hand-off. */
+export function AssistantRowAvatar() {
+  return (
+    <div className="shrink-0 mt-0.5">
+      <div className="w-7 h-7 rounded-full overflow-hidden">
+        <img src={abuAvatar} alt="Abu" className="w-full h-full object-cover" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/chatSpacing.ts
+++ b/src/components/chat/chatSpacing.ts
@@ -1,0 +1,20 @@
+// Vertical rhythm around chat rows — the three class constants below are
+// arithmetically coupled, so they live in one place instead of as magic
+// numbers scattered across ChatView/MessageGroup. If you change either gap,
+// re-derive the compensation.
+
+/** Trailing padding under every virtualized row (ChatView's Virtuoso Item).
+ *  Bottom padding instead of a margin/gap because react-virtuoso measures
+ *  item heights from the wrapper box — see the comment at the Item component.
+ *  Visually this is the 20px gap BETWEEN message groups. */
+export const VIRTUOSO_ITEM_TRAILING_PAD = 'pb-5'; // 20px
+
+/** Gap between rows INSIDE one message group (MessageGroup's root space-y). */
+export const GROUP_CONTENT_GAP = 'space-y-4'; // 16px
+
+/** The typing footer renders after the last row's trailing pad (20px), but it
+ *  stands in for the group's next in-group row, which would sit at the
+ *  group-content gap (16px). Compensate the difference so the hand-off from
+ *  footer to in-group placeholder doesn't hop 4px (measured frame-by-frame
+ *  from a screen recording). */
+export const TYPING_FOOTER_GAP_COMPENSATION = '-mt-1'; // 4px = 20px − 16px


### PR DESCRIPTION
## 背景

思考块生命周期修复(036f6bbc)遗留的三个 cleanup finding,全部落地:

1. **「思考中 ●●●」状态行抽共享组件** — 新增 `ThinkingStatusLine.tsx`(状态行 + TypingDots md/sm 两档 + 28px AssistantRowAvatar)。原先三处手工复制、靠注释要求像素级一致的 markup(ChatView 打字 Footer / MessageGroup 组内占位 / TaskBlock 活跃头)全部改为引用共享组件,排版改动自动同步。
2. **`-mt-1` 魔法偏移结构化** — 新增 `chatSpacing.ts`,把 Virtuoso item `pb-5`(20px)、组内 `space-y-4`(16px)、Footer 补偿 `-mt-1`(4px = 20−16)三个耦合常量集中一处并写明推导关系。
3. **思考面板 running→completed 残跳** — `renderThinkingDetail` 原先在两个结构不同的子树间整树替换(~24px 高度差一帧落地,低于 SmoothHeight 40px 阈值)。现两态共享同一骨架:「思考过程」按钮经 block-expand-enter 动画长出(仅接替同挂载内的流式面板时;历史挂载静态渲染),按钮→面板间隙随动画一起进入,面板保持挂载、沿用 280ms grid 过渡滚卷开合(关闭时 inert + aria-hidden),自动收起从闪没变为滚卷。

顺带修复抽取时实锤的一处不一致:Footer label 原为 `chat.thinking`(「思考中…」)而后继状态均为「思考中」,切换瞬间省略号闪烁;已统一为 `status.thinking`。

## 测试

- `npm run verify` 退出码 0(lint + typecheck + 全量测试 + 覆盖率门禁)
- `TaskBlock.test.tsx` 新增 2 条测试钉住新行为:running→completed 内容保持挂载+按钮动画槽进入;历史挂载不动画、折叠为 roll-up 非卸载
- 真实 Electron 壳(`npm run electron:dev`)实拍全链路:Footer 占位→组内占位→活跃头+流式面板→思考完成(含自动收起、工具步后第二个思考面板在已开时间轴内挂载),逐帧同字号同基线

## 已知遗留(不属本 PR 回归)

用户真机实测状态切换**仍有跳动**,具体时机待复现定位(跟进记录:memory `project-abu-thinking-jump-followup`)。候选嫌疑:SmoothHeight 阈值下的其他一帧落差、Footer→组内占位切换时序、流式增长与 bottom-stick 交互;结构性根治方向为 claude.ai 式底部 spacer 锚定滚动重构。本 PR 是该区域的净改善与后续重构的铺垫,不声称除根。

🤖 Generated with [Claude Code](https://claude.com/claude-code)