### PR TITLE
test(e2e): RB-01 — recover-predicate follows the snapshot v2 shape

### DIFF
--- a/tests/e2e/task-lifecycle.spec.ts
+++ b/tests/e2e/task-lifecycle.spec.ts
@@ -211,12 +211,18 @@ function diskContains(rootDir: string, expectedText: string, fileName = 'message
  * in EITHER of two places: a checkpointed `messages.jsonl` line (stable
  * checkpoints only — tool batch done, turn end, stop) or the per-turn
  * `stream-snapshot.json` (one atomic whole-file overwrite per revision,
- * written on a timer/per-tool-result while a turn is still running; shape
- * `{"version":1,"messages":[Message,...]}`, see conversationStorage.ts
- * `writeStreamSnapshot`). `loadMessages` folds the snapshot on top of the
- * ledger on load, so either location recovers the exact content after an
- * abrupt termination. This predicate pins that widened contract rather than
- * the old ledger-only shape.
+ * written on a timer/per-tool-result while a turn is still running, see
+ * conversationStorage.ts `writeStreamSnapshot`). `loadMessages` folds the
+ * snapshot on top of the ledger on load, so either location recovers the
+ * exact content after an abrupt termination. This predicate pins that widened
+ * contract rather than the old ledger-only shape.
+ *
+ * Both on-disk snapshot shapes count, because a machine upgrading into this
+ * build can still be holding a snapshot written by the previous one:
+ *   v1 (legacy writer) `{"version":1,"messages":[Message,...]}`
+ *   v2 (current writer) `{"version":2,"entries":[{"message":Message,...},...]}`
+ * — the per-entry `stamp` watermark the RB-03 supersede guard added is not
+ * part of the recoverability contract, so it is deliberately not asserted here.
  */
 function diskContainsRecoverableAssistantMessage(rootDir: string, expectedContent: string): boolean {
   const matchesAssistantMessage = (message: { role?: unknown; content?: unknown }): boolean =>
@@ -247,10 +253,18 @@ function diskContainsRecoverableAssistantMessage(rootDir: string, expectedConten
           const parsed = JSON.parse(fs.readFileSync(entryPath, 'utf8')) as {
             version?: unknown;
             messages?: unknown;
+            entries?: unknown;
           };
-          if (parsed.version !== 1 || !Array.isArray(parsed.messages)) return false;
-          return parsed.messages.some((message) =>
-            matchesAssistantMessage(message as { role?: unknown; content?: unknown }));
+          if (parsed.version === 1 && Array.isArray(parsed.messages)) {
+            return parsed.messages.some((message) =>
+              matchesAssistantMessage(message as { role?: unknown; content?: unknown }));
+          }
+          if (parsed.version === 2 && Array.isArray(parsed.entries)) {
+            return parsed.entries.some((snapshotEntry) =>
+              matchesAssistantMessage(
+                (snapshotEntry as { message?: { role?: unknown; content?: unknown } }).message ?? {}));
+          }
+          return false;
         } catch {
           return false;
         }


### PR DESCRIPTION
## Summary
- PR #221 (the RB-03 supersede guard) changed the stream-snapshot writer to a per-entry shape (`{"version":2,"entries":[{message,stamp}]}`), but `diskContainsRecoverableAssistantMessage` — widened only one PR earlier by #222 — still returned false for anything whose `version` wasn't `1`. The whole serial task-lifecycle block failed against a product that persists correctly: a test contract lagging the writer, not a recovery regression.
- Parse both shapes. v1 stays supported because a machine upgrading into this build can still hold a v1 snapshot written by the previous one.
- The `role === 'assistant'` and exact-content assertions are untouched, no timeout was added, and nothing was relaxed to a fuzzy string search. The per-entry `stamp` is not part of the recoverability contract and is deliberately not asserted.

## 🔴 Merge this first
Any branch based on current `dev` fails full `test:e2e:electron` on this predicate. Confirmed empirically: the RB-04 branch (which touches only `computerUseGate.cjs`, `computerUseStatus.ts` and tests — nothing in the persistence path) fails at `task-lifecycle.spec.ts:463` on the same assertion; with this fix the same suite is 16/16.

## Verification
- `npm run test:e2e:electron` — **16/16 passed, exit 0**, including all three serial lifecycle cases: stop-and-persist-and-continue, abrupt-termination recovery, and sidecar-crash recovery.
- `tsc --noEmit` and `eslint` clean.

## Test plan
- [x] Full `npm run test:e2e:electron` green
- [x] The three serial lifecycle cases run (not skipped by an earlier failure)
- [x] No timeout added, no assertion weakened

🤖 Generated with [Claude Code](https://claude.com/claude-code)