### PR TITLE
fix(agent): F2 — carry the run-scoped tool denylist into delegated work

### DIFF
--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -1001,6 +1001,14 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         imContext: options?.imContext,
         parentConversationId: conversationId,
         settingsReader: entrySettingsReader,
+        // The `@agent` route reaches runSubagent WITHOUT passing through
+        // `delegate_to_agent`, so it never inherited either run-scoped tool
+        // restriction. An unattended tier is picked by the channel, but the
+        // prompt is user-authored — an IM message on a read-only channel
+        // beginning with `@researcher` delegated a subagent with no ceiling
+        // at all, which is the one hole a roster on the parent cannot see.
+        allowedTools: options?.allowedTools,
+        blockedTools: options?.blockedTools,
       });
 
       // runSubagentLoop RETURNS a (partial/cancelled) SubagentResult on abort

--- a/src/core/agent/subagentLoop.ts
+++ b/src/core/agent/subagentLoop.ts
@@ -204,6 +204,16 @@ export interface SubagentLoopOptions {
   filePermissionCallback?: FilePermissionCallback;
   /** Parent-run tool whitelist inherited by delegated work. */
   allowedTools?: string[];
+  /**
+   * Parent-run tool denylist inherited by delegated work — the twin of
+   * `allowedTools`, and inherited for the same reason: a run-scoped
+   * restriction that stops at the delegation boundary is not a restriction,
+   * it is a detour. `allowedTools` was already forwarded here; this was not,
+   * so an unattended tier that removed a tool from its own roster
+   * (`request_workspace` on every trigger/IM run, the whole browser
+   * namespace on the read-only ones) got it back by delegating.
+   */
+  blockedTools?: string[];
   onProgress?: (event: SubagentProgressEvent) => void;
   /** IM context — provides correct workspace path in headless mode */
   imContext?: IMContext;
@@ -333,6 +343,16 @@ export async function runSubagentLoop(options: SubagentLoopOptions): Promise<Sub
     if (options.allowedTools && options.allowedTools.length > 0) {
       tools = tools.filter((tool) =>
         options.allowedTools!.some((pattern) => matchesToolName(tool.name, pattern)),
+      );
+    }
+    // Pattern-matched like every other blockedTools check (agentLoop.ts's
+    // resolveTools, toolExecutor's executeToolBatch, agentLoopRunner's
+    // assertRunToolAllowed): the list carries namespace wildcards such as
+    // `abu-browser__*`, so exact-name matching would let most of a blocked
+    // namespace through.
+    if (options.blockedTools && options.blockedTools.length > 0) {
+      tools = tools.filter((tool) =>
+        !options.blockedTools!.some((pattern) => matchesToolName(tool.name, pattern)),
       );
     }
     // Always strip the orchestration tools from sub-agents to prevent recursive
@@ -673,6 +693,11 @@ export async function runSubagentLoop(options: SubagentLoopOptions): Promise<Sub
           }
           if (options.allowedTools?.length && !options.allowedTools.some((pattern) => matchesToolPattern(tc.name, pattern, tc.input))) {
             return { id: tc.id, result: `Error: tool "${tc.name}" is not allowed for this agent run` };
+          }
+          // Denylist checked at execution too, not just when the tool list
+          // was assembled: the model can name a tool that was never offered.
+          if (options.blockedTools?.some((pattern) => matchesToolName(tc.name, pattern))) {
+            return { id: tc.id, result: `Error: tool "${tc.name}" is blocked for this agent run` };
           }
 
           // Emit preToolCall — may block or modify input

--- a/src/core/tools/definitions/agentTools.test.ts
+++ b/src/core/tools/definitions/agentTools.test.ts
@@ -21,7 +21,15 @@ vi.mock('../../agent/subagentAbort', () => ({
   createSubagentController: vi.fn(),
 }));
 vi.mock('../../../stores/chatStore', () => ({
-  useChatStore: { getState: vi.fn().mockReturnValue({ activeConversationId: 'test', getActiveConversation: vi.fn() }) },
+  useChatStore: {
+    getState: vi.fn().mockReturnValue({
+      activeConversationId: 'test',
+      getActiveConversation: vi.fn(),
+      setAgentStatus: vi.fn(),
+      addActiveAgent: vi.fn(),
+      removeActiveAgent: vi.fn(),
+    }),
+  },
 }));
 vi.mock('../../../stores/settingsStore', () => ({
   useSettingsStore: { getState: vi.fn().mockReturnValue({ disabledSkills: [] }) },
@@ -39,10 +47,57 @@ vi.mock('../../../utils/validation', () => ({
 vi.mock('../helpers/toolHelpers', () => ({
   getSystemInfoData: vi.fn().mockResolvedValue({ home: '/Users/testuser' }),
 }));
+vi.mock('../../agent/ports/settingsReader', () => ({
+  getSettingsReader: () => ({ getSnapshot: () => ({ disabledAgents: [], disabledSkills: [] }) }),
+}));
 
 describe('delegateToAgentTool', () => {
   it('is explicitly marked concurrency-safe — a fan-out of independent sub-agent delegations must stay parallel, not silently fall back to the fail-closed default', () => {
     expect(delegateToAgentTool.isConcurrencySafe).toBe(true);
+  });
+
+  // A run-scoped restriction that stops at the delegation boundary is not a
+  // restriction. `allowedTools` was forwarded here; `blockedTools` was not,
+  // so an unattended tier that had removed a tool from its own roster got it
+  // back by delegating. Asserted on the call to runSubagent, because the
+  // regression this guards against is a call site forgetting to forward.
+  it('forwards BOTH run-scoped tool restrictions into the delegated run', async () => {
+    const { agentRegistry } = await import('../../agent/registry');
+    const { getCurrentLoopContext } = await import('../../agent/permissionBridge');
+    const { createSubagentController } = await import('../../agent/subagentAbort');
+    const { runSubagentLoop } = await import('../../agent/subagentLoop');
+
+    vi.mocked(agentRegistry.getAgent).mockReturnValue({
+      name: 'researcher',
+      description: 'test',
+      systemPrompt: 'test',
+    } as never);
+    vi.mocked(createSubagentController).mockReturnValue({
+      signal: new AbortController().signal,
+      cleanup: vi.fn(),
+    } as never);
+    vi.mocked(runSubagentLoop).mockResolvedValue({ text: 'done' } as never);
+    vi.mocked(getCurrentLoopContext).mockReturnValue({
+      allowedTools: ['read_file'],
+      blockedTools: ['request_workspace', 'abu-browser__*'],
+      toolCallToStepId: new Map(),
+      loopId: 'loop-1',
+      conversationId: 'conv-1',
+      eventRouter: {
+        getCurrentStepId: () => undefined,
+        addChildStepToDelegate: () => undefined,
+        completeChildStep: () => undefined,
+      },
+    } as never);
+
+    await delegateToAgentTool.execute({ agent_name: 'researcher', task: 'look something up' });
+
+    expect(vi.mocked(runSubagentLoop)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedTools: ['read_file'],
+        blockedTools: ['request_workspace', 'abu-browser__*'],
+      }),
+    );
   });
 });
 

--- a/src/core/tools/definitions/agentTools.ts
+++ b/src/core/tools/definitions/agentTools.ts
@@ -313,6 +313,7 @@ export const delegateToAgentTool: ToolDefinition = {
         commandConfirmCallback: loopCtx?.commandConfirmCallback,
         filePermissionCallback: loopCtx?.filePermissionCallback,
         allowedTools: loopCtx?.allowedTools,
+        blockedTools: loopCtx?.blockedTools,
         ...getSubagentRunInheritance(loopCtx),
         onProgress,
       });

--- a/src/core/tools/definitions/orchestrationTools.ts
+++ b/src/core/tools/definitions/orchestrationTools.ts
@@ -392,6 +392,7 @@ export const runAgentBatchTool: ToolDefinition = {
             commandConfirmCallback: loopCtx?.commandConfirmCallback,
             filePermissionCallback: loopCtx?.filePermissionCallback,
             allowedTools: loopCtx?.allowedTools,
+            blockedTools: loopCtx?.blockedTools,
             ...getSubagentRunInheritance(loopCtx),
             onProgress: (event) => {
               try {


### PR DESCRIPTION
## The bug
`runSubagent` inherited `allowedTools` but not `blockedTools`, and `subagentLoop` had no notion of the denylist at all — grep returned **zero** hits. A run-scoped restriction that stops at the delegation boundary is not a restriction, it is a detour: an unattended tier that removed a tool from its own roster (`request_workspace` on every trigger and IM run, the whole browser-automation namespace on the read-only ones) got it back by delegating.

Surfaced as a lead while implementing #228 and confirmed in independent review; verified here by reading all three call sites and `getSubagentRunInheritance`, which forwards only `parentConversationId` and `settingsReader`.

## The larger half — the `@agent` route
The third delegation entry point is why this is more than symmetry. The `@agent` prefix route in `agentLoop.ts` reaches `runSubagent` **without** passing through `delegate_to_agent`, and forwarded **neither** restriction.

The tier is chosen by the channel, but the prompt is user-authored — so an IM message on a **read-only** channel beginning with `@researcher` delegated a subagent with **no ceiling at all**. That is the one hole a roster on the parent run cannot see, and it applies to #228's roster as much as to the pre-existing browser ceiling. #228's module comment has been corrected to state this rather than promise a propagation it did not have.

## The fix
Forward both restrictions from all three entry points, and enforce `blockedTools` in `subagentLoop` at both points `allowedTools` is already enforced — when the tool list is assembled, and again at execution, since the model can name a tool that was never offered. Pattern-matched rather than exact-name, because the list carries namespace wildcards like `abu-browser__*`.

## Verification
- `npm run verify` — **exit 0** (383 files, 5470 tests).
- The regression test asserts on the **call into `runSubagent`**, because what this guards against is a call site forgetting to forward.

## Relationship to the other RB work
Complements **#228**: that PR made `read_tools` a fail-closed roster, which does propagate through `delegate_to_agent`; this closes the `@agent` route and restores the denylist half for every tier. Neither depends on the other to merge, but the ceiling is only whole with both.

## Test plan
- [x] `npm run verify` exit 0
- [x] `delegate_to_agent` forwards both restrictions
- [x] `subagentLoop` enforces the denylist at list-assembly and at execution
- [ ] Independent security review

🤖 Generated with [Claude Code](https://claude.com/claude-code)