### PR TITLE
fix(chat): keep the stop revision on the tracked persistence queue

### DIFF
--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1646,13 +1646,29 @@ export const useChatStore = create<ChatStore>()(
         // Persist the stop mutation (terminal + cancelled tool calls) — without
         // this the live view shows "已停止" while reload shows the pre-stop
         // JSONL snapshot (often a blank bubble).
+        //
+        // MUST go through trackConversationPersistence, not a bare
+        // fire-and-forget: the assistant placeholder's own append (addMessage's
+        // diskAppend) rides that per-conversation serial queue, and under load
+        // it can still be in flight when Stop lands. An untracked
+        // replaceMessageById then overtakes the append, finds no row on disk,
+        // and hits the upsert guard's silent no-op (`id-not-found`) — the
+        // placeholder lands moments later as a permanent content:"" ghost and
+        // the visible partial reply is durably lost. frameApplier.ts defends
+        // its session replacements against exactly this with
+        // waitForConversationPersistence; chaining onto the tracked queue
+        // gives this path the same ordering AND makes the write visible to
+        // finalizeAbortedRun's durability barrier.
         if (cancelledMsgId) {
           const finalMsg = useChatStore.getState().conversations[convId]
             ?.messages.find((m) => m.id === cancelledMsgId);
           if (finalMsg) {
-            import('../core/session/conversationStorage').then(({ replaceMessageById }) => {
-              replaceMessageById(convId, finalMsg).catch(() => {});
-            }).catch(() => {});
+            trackConversationPersistence(
+              convId,
+              () => import('../core/session/conversationStorage').then(({ replaceMessageById }) =>
+                replaceMessageById(convId, finalMsg)
+              ),
+            );
           }
         }
       },


### PR DESCRIPTION
## 这不是测试 flake，是数据丢失

发版门禁卡住的那个「间歇性 E2E」——`stops an open stream, persists its partial reply`——查下来是**真实的产品缺陷**：用户停止一次流式回答后，屏幕上看得见的部分回复可能在下次加载时消失，且全程无任何报错。

## 根因（埋点实证）

assistant 占位行的落盘 append 走 `trackConversationPersistence` 的会话级串行队列；停止修订**没有**——它是一个裸的 fire-and-forget `import().then()`。

负载下修订抢在仍在飞行中的占位 append 之前到达 → `replaceMessageByIdInternal` 发现磁盘上还没有该 id → 走非 strict 的**静默 no-op** → 占位行随后落盘，成为永久的 `content:""` 幽灵行 → 可见的部分回复被持久性丢弃。

而 `finalizeAbortedRun` 的 `waitForConversationPersistence` 屏障**看不见**这个未追踪的写入，所以它照常 resolve。整条链上：守卫静默返回 false + 两层空 catch + 屏障无感知 —— 没有任何一处会出声。

两轮埋点运行的差异只有一行：

```
失败轮：[stop-debug] replaceInternal SKIP id-not-found conv=… id=…
成功轮：（无）
```

## 改动

19 行，1 个文件。把停止修订挂进 `trackConversationPersistence`：既排在占位 append 之后，也进入耐久性屏障。`frameApplier.ts` 对它的 session replacement 早就用 `waitForConversationPersistence` 做同样的防护，这里只是让停止路径拿到同等保证。

## 验证

- **6 轮连续全量 `test:e2e:electron` 全绿**（每轮 1.1–1.5 分钟）。同一台机器、同一套流程，**修复前 2–3 轮内必挂**。
- `npm run verify` 退出码 0：386 测试文件 / 5519 用例全过。

## 一处需要复审注意的遗留

我尝试写 store 层单元回归测试，**三次都无法区分有无修复**（回退修复后仍然通过）。与其留一个给虚假信心的测试，我把它删了 —— 当前的守卫是那个 E2E 用例（它本来就抓到了这个 bug）。补一个能区分的单测建议单独立项。

🤖 Generated with [Claude Code](https://claude.com/claude-code)