### PR TITLE
test(smoke): gate the hard-crash step on the run's durable terminal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "abu",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "abu",
-      "version": "0.39.0",
+      "version": "0.40.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.95.2",

--- a/scripts/electron-packaged-smoke.mjs
+++ b/scripts/electron-packaged-smoke.mjs
@@ -3236,6 +3236,20 @@ print(json.dumps({"executable": sys.executable, "files": [str(p) for p in [docx_
       // launcher wrapper through app.process(), and killing that wrapper does
       // not crash the packaged application.
       await restoredInput.waitFor({ state: 'visible', timeout: READY_TIMEOUT });
+      // Wait for the aborted run's DURABLE terminal, not a UI proxy. Killing
+      // the command tree happens on the sidecar's fast path; the shell still
+      // has to finalize the run before the conversation leaves 'running', and
+      // ChatInput stages anything submitted before that as a follow-up — the
+      // abort terminal then parks the queue as paused and this crash task
+      // never starts. The Stop button is no good as the gate either: it hides
+      // on `agentStatus`, which flips on the click itself, while ChatInput
+      // reads `conversation.status`, which flips ~20ms later at the end of
+      // finalization. `runState":"interrupted"` is written as part of that
+      // same finalization, so seeing it on disk means the run really settled.
+      await waitUntil(
+        () => diskContains(appDataDir, '"runState":"interrupted"'),
+        'the stopped run to reach its durable interrupted terminal',
+      );
       await restoredInput.fill(crashPrompt);
       await restoredInput.press('Enter');
       await waitUntil(


### PR DESCRIPTION
解除 v0.40.0 发版阻塞。两个 mac 平台的 `build-mac` 都确定性挂在第 16 步「对已公证的构建包做冒烟测试」，65 项检查里只有 `packagedHardCrashKillsCommandTree` 为 false。

## 根因

冒烟脚本把「OS 命令进程树已死」当成了「会话已 settle」：

- 杀进程树走 sidecar 快路径
- 壳层还要完成中止收尾，会话才离开 `running`
- 在这之前提交，ChatInput 会把消息**暂存为后续**，中止终态随即把队列置为暂停 → 崩溃任务从未启动 → 超时

## 窗口有多大：15–27ms（实测三次）

| 运行 | 点停止 | 状态变 idle | 窗口 |
|---|---|---|---|
| 1 | 1395.6ms | 1415.1ms | 19.5ms |
| 2 | 1309.6ms | 1336.2ms | 26.6ms |
| 3 | 875.4ms | 890.3ms | 14.9ms |

人打字+回车做不到 20ms；零延迟的脚本每次必中。

## 为什么不用 `waitForChatIdle`

先试过，**没用**（打包冒烟实跑验证）。它等停止按钮消失，而按钮绑 `agentStatus`（点击瞬间翻转）；ChatInput 读的是 `conversation.status`（收尾结束才翻转）。等错了信号。

改为等磁盘上的 `runState":"interrupted"` —— 它由同一段收尾流程持久化写下，经 100ms 写入防抖，比状态翻转晚约 75–85ms。

## 产品代码未改

暂停队列是设计行为（有可见提示 + 「继续队列」按钮，消息不丢）；20ms 的窗口人碰不到；为它调整中止路径的状态机顺序是真实风险换零用户收益。

## 顺带修

`package-lock.json` 的版本字段在 v0.40.0 bump 时被漏掉（仍是 0.39.0），任何 `npm install` 都会重写它。已同步。

## 验证

- 打包冒烟 **3/3 PASSED**（macOS arm64，同一台机器修复前是稳定失败）
- `npm run release:check` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)