### PR TITLE
test(smoke): absorb the staged-follow-up race instead of timing it

### DIFF
--- a/scripts/electron-packaged-smoke.mjs
+++ b/scripts/electron-packaged-smoke.mjs
@@ -3236,24 +3236,33 @@ print(json.dumps({"executable": sys.executable, "files": [str(p) for p in [docx_
       // launcher wrapper through app.process(), and killing that wrapper does
       // not crash the packaged application.
       await restoredInput.waitFor({ state: 'visible', timeout: READY_TIMEOUT });
-      // Wait for the aborted run's DURABLE terminal, not a UI proxy. Killing
-      // the command tree happens on the sidecar's fast path; the shell still
-      // has to finalize the run before the conversation leaves 'running', and
-      // ChatInput stages anything submitted before that as a follow-up — the
-      // abort terminal then parks the queue as paused and this crash task
-      // never starts. The Stop button is no good as the gate either: it hides
-      // on `agentStatus`, which flips on the click itself, while ChatInput
-      // reads `conversation.status`, which flips ~20ms later at the end of
-      // finalization. `runState":"interrupted"` is written as part of that
-      // same finalization, so seeing it on disk means the run really settled.
-      await waitUntil(
-        () => diskContains(appDataDir, '"runState":"interrupted"'),
-        'the stopped run to reach its durable interrupted terminal',
-      );
+      // Killing the stopped task's command tree happens on the sidecar's fast
+      // path, before the shell finishes finalizing the aborted run and the
+      // conversation leaves 'running'. Anything submitted inside that gap is
+      // staged as a follow-up by ChatInput, and the abort terminal then parks
+      // the queue as paused — so the crash task never starts.
+      //
+      // Do NOT try to gate this on a timing signal. Two attempts failed here:
+      // the Stop button hides on `agentStatus` (flipped by the click itself,
+      // not at the end of finalization), and the durable `runState`
+      // "interrupted" row is written at the START of finalization, so relying
+      // on the write debounce to push it past the end only held on the faster
+      // arm64 runner and lost the race on Intel. Absorb the staging instead:
+      // if this prompt was parked, resume it, which is exactly what a user
+      // would do and leaves nothing to time.
       await restoredInput.fill(crashPrompt);
       await restoredInput.press('Enter');
+      const resumeQueueButton = window
+        .locator('button:has-text("继续队列"), button:has-text("Resume queue")')
+        .last();
       await waitUntil(
-        () => fs.existsSync(crashTree.resultPath),
+        async () => {
+          if (fs.existsSync(crashTree.resultPath)) return true;
+          if (await resumeQueueButton.isVisible().catch(() => false)) {
+            await resumeQueueButton.click().catch(() => {});
+          }
+          return fs.existsSync(crashTree.resultPath);
+        },
         'the hard-crash command tree to start',
       );
       readLiveTaggedTree(crashTree.resultPath, crashTree.marker, 'hard Electron crash');


### PR DESCRIPTION
承接 #234。那次修复让 `build-mac (arm64)` 和 `build-windows` 转绿，但 **x64 仍挂在同一项** `packagedHardCrashKillsCommandTree`，症状一模一样（界面停在「队列已暂停」）。

## 为什么 #234 不够

我在 #234 里把门槛设成「`runState":"interrupted"` 落盘」，理由是写入有 100ms 防抖、会晚于状态翻转。

**但这个终态是在收尾流程的开头写的**（`agentLoopRunner.ts` 的 `updateSessionMessageState`），不是结尾。所以那个门槛实际上是在赌「收尾剩余部分的耗时 < 100ms」——arm64 上成立，Intel runner 慢，赌输了。

连同 #234 之前那次，两个门槛都错在同一个思路上：**换个信号继续赛跑**。

| 尝试 | 门槛 | 失败原因 |
|---|---|---|
| 1 | 停止按钮消失 | 绑 `agentStatus`（点击瞬间翻转），而 ChatInput 读 `conversation.status`（收尾结束才翻转） |
| 2 | 终态落盘 | 终态写在收尾开头，靠防抖抢时间，慢机器上失效 |

## 这次不猜时序

提交之后轮询：命令树起来了就过；出现「继续队列」就点它，再等命令树。

**没有任何时序假设**——不管窗口多宽、机器多慢，两条路都通向命令树启动。顺带覆盖了真实用户撞上这个窗口时的恢复路径。

这一步不再验证「提交立刻派发」，但那本来不是它的目的：它测的是 SIGKILL 能否拆掉命令树，让命令跑起来只是前置条件。用一个会随机失败的前置条件守护真正要测的断言，本身就是错的。

## 验证

打包冒烟 **3/3 PASSED**（macOS arm64），且**全程 6-8 个忙循环占满 CPU**，用于逼近击垮上一版修复的慢 runner 时序。空闲机器上跑绿说明不了问题——这正是上次判断失误的地方。

🤖 Generated with [Claude Code](https://claude.com/claude-code)