### PR TITLE
fix(chat): guard Enter against IMEs and stop Alt+Enter reordering input

### DIFF
--- a/src/components/chat/ChatInput.keyboard.test.tsx
+++ b/src/components/chat/ChatInput.keyboard.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Keyboard contract for the composer.
+ *
+ * Written after users reported "阿布的聊天框不能换行". Shift+Enter was in fact
+ * working; what was missing was any coverage pinning it down, so nothing
+ * stopped a future edit from swallowing it. These tests pin the four rules
+ * the composer promises: Enter sends, Shift+Enter does not, Alt+Enter inserts
+ * a newline itself, and an IME composition suppresses all of it.
+ *
+ * jsdom does not implement a textarea's own editing behavior, so "Shift+Enter
+ * inserts \n" is asserted where it lives — natively, i.e. by proving we never
+ * preventDefault. The real insertion is covered end-to-end in
+ * tests/e2e/chat-newline.spec.ts against the actual Electron shell.
+ */
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import ChatInput from './ChatInput';
+import { useChatStore } from '@/stores/chatStore';
+import { clearAllComposerDrafts } from '@/stores/composerDraftStore';
+import { useEnterpriseStore } from '@/stores/enterpriseStore';
+
+const typeInto = (textarea: HTMLTextAreaElement, value: string) => {
+  fireEvent.change(textarea, { target: { value } });
+};
+
+describe('ChatInput keyboard contract', () => {
+  beforeEach(() => {
+    clearAllComposerDrafts();
+    useEnterpriseStore.setState({ mode: { kind: 'personal' }, initialized: true });
+    useChatStore.setState({
+      conversations: {},
+      conversationIndex: {},
+      activeConversationId: null,
+      pendingInput: null,
+      pendingInputAppend: null,
+      pendingReferences: [],
+      pendingAttachmentPaths: [],
+    });
+    useChatStore.getState().createConversation();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  const setup = () => {
+    const onSend = vi.fn();
+    render(<ChatInput variant="chat" onSend={onSend} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    typeInto(textarea, 'hello');
+    return { onSend, textarea };
+  };
+
+  it('sends on a plain Enter', () => {
+    const { onSend, textarea } = setup();
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not send on Shift+Enter, and leaves the newline to the textarea', () => {
+    const { onSend, textarea } = setup();
+    const notPrevented = fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
+    expect(onSend).not.toHaveBeenCalled();
+    // fireEvent returns false once something called preventDefault. We must
+    // NOT prevent it: the default action is exactly the newline we want.
+    expect(notPrevented).toBe(true);
+  });
+
+  it('inserts a newline at the caret on Alt+Enter without sending', () => {
+    const { onSend, textarea } = setup();
+    textarea.setSelectionRange(2, 2);
+    fireEvent.keyDown(textarea, { key: 'Enter', altKey: true });
+    expect(onSend).not.toHaveBeenCalled();
+    expect(textarea.value).toBe('he\nllo');
+    expect(textarea.selectionStart).toBe(3);
+  });
+
+  describe('IME composition suppresses Enter', () => {
+    it('while nativeEvent.isComposing is set', () => {
+      const { onSend, textarea } = setup();
+      fireEvent.keyDown(textarea, { key: 'Enter', isComposing: true });
+      expect(onSend).not.toHaveBeenCalled();
+    });
+
+    it('while a Windows IME reports keyCode 229', () => {
+      // 搜狗 / 微信 / 微软拼音: the Enter that commits a candidate arrives as
+      // keyCode 229 and may leave isComposing false. Sending here would fire
+      // off half-typed pinyin.
+      const { onSend, textarea } = setup();
+      fireEvent.keyDown(textarea, { key: 'Enter', keyCode: 229 });
+      expect(onSend).not.toHaveBeenCalled();
+    });
+
+    it('between compositionstart and compositionend', () => {
+      const { onSend, textarea } = setup();
+      fireEvent.compositionStart(textarea);
+      fireEvent.keyDown(textarea, { key: 'Enter' });
+      expect(onSend).not.toHaveBeenCalled();
+    });
+
+    it('and Alt+Enter stays inert too, rather than splitting the candidate', () => {
+      const { textarea } = setup();
+      fireEvent.compositionStart(textarea);
+      fireEvent.keyDown(textarea, { key: 'Enter', altKey: true });
+      expect(textarea.value).toBe('hello');
+    });
+  });
+});

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -10,6 +10,7 @@ import { useFileDragDrop } from '@/hooks/useFileDragDrop';
 import { uint8ArrayToBase64 } from '@/utils/base64';
 import { getBaseName, IMAGE_MIME_MAP } from '@/utils/pathUtils';
 import { isImageFile } from '@/components/chat/FileAttachment';
+import { isImeComposing, insertNewlineAtCursor } from '@/components/chat/composerKeys';
 import { enqueueUserInput } from '@/core/agent/userInputQueue';
 import { useChatStore, useActiveConversation } from '@/stores/chatStore';
 import ContextIndicator from '@/components/chat/ContextIndicator';
@@ -776,7 +777,7 @@ export default function ChatInput({ variant, onSend, disabled, scenarioPlacehold
         setSelectedIndex((prev) => (prev + 1) % suggestions.length);
         return;
       }
-      if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey && !e.altKey && !composingRef.current)) {
+      if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey && !e.altKey && !isImeComposing(e, composingRef.current))) {
         e.preventDefault();
         applySuggestion(suggestions[selectedIndex]);
         return;
@@ -800,25 +801,17 @@ export default function ChatInput({ variant, onSend, disabled, scenarioPlacehold
         return;
       }
     }
-    // Option/Alt + Enter → insert newline at cursor position (Mac: Option+Enter, Win: Alt+Enter)
-    if (e.key === 'Enter' && e.altKey && !composingRef.current) {
+    // Option/Alt + Enter → insert newline at cursor position (Mac: Option+Enter, Win: Alt+Enter).
+    // Shift+Enter needs no branch here: we simply don't preventDefault, and the
+    // textarea inserts the newline itself. Alt+Enter is not a native editing
+    // command, so it does need this one.
+    if (e.key === 'Enter' && e.altKey && !isImeComposing(e, composingRef.current)) {
       e.preventDefault();
       const textarea = textareaRef.current;
-      if (textarea) {
-        const start = textarea.selectionStart ?? text.length;
-        const end = textarea.selectionEnd ?? text.length;
-        const newVal = text.substring(0, start) + '\n' + text.substring(end);
-        setText(newVal);
-        requestAnimationFrame(() => {
-          if (textareaRef.current) {
-            textareaRef.current.selectionStart = start + 1;
-            textareaRef.current.selectionEnd = start + 1;
-          }
-        });
-      }
+      if (textarea) setText(insertNewlineAtCursor(textarea));
       return;
     }
-    if (e.key === 'Enter' && !e.shiftKey && !e.altKey && !composingRef.current) {
+    if (e.key === 'Enter' && !e.shiftKey && !e.altKey && !isImeComposing(e, composingRef.current)) {
       e.preventDefault();
       handleSend();
     }
@@ -1081,6 +1074,8 @@ export default function ChatInput({ variant, onSend, disabled, scenarioPlacehold
                   size="icon"
                   onClick={handleSend}
                   disabled={!hasContent}
+                  title={t.chat.sendTooltip}
+                  aria-label={t.chat.sendTooltip}
                   className={cn(
                     'h-7 w-7 shrink-0 rounded-lg transition-colors',
                     hasContent
@@ -1163,6 +1158,8 @@ export default function ChatInput({ variant, onSend, disabled, scenarioPlacehold
                     size="icon"
                     onClick={handleSend}
                     disabled={!hasContent || disabled}
+                    title={t.chat.sendTooltip}
+                    aria-label={t.chat.sendTooltip}
                     className={cn(
                       'h-7 w-7 rounded-lg transition-colors',
                       hasContent && !disabled

--- a/src/components/chat/composerKeys.test.ts
+++ b/src/components/chat/composerKeys.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { insertNewlineAtCursor, isImeComposing } from './composerKeys';
+
+/** Minimal stand-in for the fields isImeComposing actually reads. */
+const keyEvent = (opts: { keyCode?: number; isComposing?: boolean } = {}) => ({
+  keyCode: opts.keyCode ?? 13,
+  nativeEvent: { isComposing: opts.isComposing ?? false },
+});
+
+describe('isImeComposing', () => {
+  it('is false for a plain Enter outside any composition', () => {
+    expect(isImeComposing(keyEvent(), false)).toBe(false);
+  });
+
+  it('honors the standard isComposing flag', () => {
+    expect(isImeComposing(keyEvent({ isComposing: true }), false)).toBe(true);
+  });
+
+  it('honors keyCode 229, which is all a Windows IME reports', () => {
+    // 搜狗 / 微信 / 微软拼音 fire keydown with keyCode 229 and, on some
+    // builds, leave isComposing false. Without this arm the composer would
+    // send half-typed pinyin on the Enter that commits the candidate.
+    expect(isImeComposing(keyEvent({ keyCode: 229, isComposing: false }), false)).toBe(true);
+  });
+
+  it('honors our own flag, for WebKit firing compositionend before keydown', () => {
+    expect(isImeComposing(keyEvent(), true)).toBe(true);
+  });
+});
+
+describe('insertNewlineAtCursor', () => {
+  const textarea = (value: string, start: number, end = start) => {
+    const el = document.createElement('textarea');
+    el.value = value;
+    document.body.appendChild(el);
+    el.setSelectionRange(start, end);
+    return el;
+  };
+
+  it('inserts at the caret and returns the new value', () => {
+    const el = textarea('ABCDEF', 3);
+    expect(insertNewlineAtCursor(el)).toBe('ABC\nDEF');
+    expect(el.value).toBe('ABC\nDEF');
+  });
+
+  it('leaves the caret directly after the newline, synchronously', () => {
+    // The regression this guards: the old implementation restored the caret
+    // in a requestAnimationFrame, so characters typed before that frame ran
+    // landed at the stale offset and came out reordered.
+    const el = textarea('ABC', 3);
+    insertNewlineAtCursor(el);
+    expect(el.selectionStart).toBe(4);
+    expect(el.selectionEnd).toBe(4);
+  });
+
+  it('replaces the selection rather than duplicating it', () => {
+    const el = textarea('ABCDEF', 1, 4);
+    expect(insertNewlineAtCursor(el)).toBe('A\nEF');
+    expect(el.selectionStart).toBe(2);
+  });
+
+  it('appends at the end when the caret sits at the end', () => {
+    const el = textarea('AB', 2);
+    expect(insertNewlineAtCursor(el)).toBe('AB\n');
+    expect(el.selectionStart).toBe(3);
+  });
+});

--- a/src/components/chat/composerKeys.ts
+++ b/src/components/chat/composerKeys.ts
@@ -1,0 +1,58 @@
+/**
+ * Keyboard helpers for the chat composer.
+ *
+ * Lives outside ChatInput.tsx so the two behaviors users actually complained
+ * about — "Enter fires while my IME is still composing" and "the caret jumps
+ * after Option+Enter" — can be unit-tested without mounting the composer.
+ */
+
+/**
+ * True while an IME composition owns this key event, i.e. the keystroke is
+ * the user talking to their input method, not to us.
+ *
+ * Three signals, because no single one covers every platform we ship on:
+ *
+ *  - `nativeEvent.isComposing` — the standard flag. Chromium sets it on
+ *    keydown fired inside a composition session.
+ *  - `keyCode === 229` — what Windows IMEs (搜狗 / 微信 / 微软拼音) report for
+ *    every composition keydown. Some of them never set `isComposing`, so on
+ *    Windows this is the signal that actually fires. Deprecated on the web
+ *    platform but still the only reliable Windows IME tell.
+ *  - `composing` — our own compositionstart/compositionend flag. WebKit fires
+ *    `compositionend` BEFORE the Enter keydown that committed the candidate,
+ *    so ChatInput resets the flag one macrotask late and this keeps that
+ *    keydown guarded.
+ *
+ * Matches what ChatGPT's desktop composer does (`isComposing || keyCode === 229`),
+ * plus our WebKit-ordering fallback.
+ */
+export function isImeComposing(
+  e: Pick<React.KeyboardEvent, 'keyCode'> & { nativeEvent: Pick<KeyboardEvent, 'isComposing'> },
+  composing: boolean,
+): boolean {
+  return composing || e.nativeEvent.isComposing || e.keyCode === 229;
+}
+
+/**
+ * Insert a newline at the caret and return the resulting value.
+ *
+ * `setRangeText` mutates the DOM node synchronously and we place the caret
+ * ourselves, so the caller can push the same value into React state without
+ * the caret ever being wrong in between. The previous implementation set
+ * state first and restored the caret in a `requestAnimationFrame`, which lost
+ * the race against fast typing — characters typed before the frame ran landed
+ * at the old offset and came out reordered (firsthand: typing 第三行 right
+ * after Option+Enter produced 三行第).
+ *
+ * The caret is assigned explicitly rather than via `selectionMode: 'end'`,
+ * whose jsdom implementation disagrees with the spec — keeping the two engines
+ * we run on (Chromium in the app, jsdom in unit tests) on one behavior.
+ */
+export function insertNewlineAtCursor(textarea: HTMLTextAreaElement): string {
+  const start = textarea.selectionStart ?? textarea.value.length;
+  const end = textarea.selectionEnd ?? textarea.value.length;
+  textarea.setRangeText('\n', start, end);
+  textarea.selectionStart = start + 1;
+  textarea.selectionEnd = start + 1;
+  return textarea.value;
+}

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -212,6 +212,7 @@ const enUS: TranslationDict = {
     inputPlaceholderWithSkill: 'Enter parameters...',
     inputPlaceholderWithAgent: 'Enter task description...',
     inputPlaceholderMidTask: 'Add instructions (Abu reads next turn)...',
+    sendTooltip: 'Send (Enter) · New line (Shift + Enter)',
     start: 'Start',
     stop: 'Stop',
     welcomeTitle: 'Leave it to Abu ✨',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -212,6 +212,7 @@ const zhCN: TranslationDict = {
     inputPlaceholderWithSkill: '输入参数...',
     inputPlaceholderWithAgent: '输入任务描述...',
     inputPlaceholderMidTask: '追加指令（阿布会在下轮读取）...',
+    sendTooltip: '发送（Enter）· 换行（Shift + Enter）',
     start: '开始',
     stop: '停止',
     welcomeTitle: '交给阿布就行啦 ✨',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -243,6 +243,8 @@ export interface TranslationDict {
     inputPlaceholderWithSkill: string;
     inputPlaceholderWithAgent: string;
     inputPlaceholderMidTask: string;
+    /** Send button tooltip, spells out both shortcuts. */
+    sendTooltip: string;
     start: string;
     stop: string;
     welcomeTitle: string;

--- a/tests/e2e/chat-newline.spec.ts
+++ b/tests/e2e/chat-newline.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * Real-Electron regression for composer newlines.
+ *
+ * Users reported "阿布的聊天框不能换行". Shift+Enter turned out to work; what
+ * did not exist was any test proving it, in a shell where a stray global
+ * keydown listener or an accelerator could silently take Enter away. jsdom
+ * cannot cover this — a textarea's own newline insertion and the auto-grow
+ * that makes it *visible* are real-browser behaviors — so it is pinned here,
+ * against the actual Electron window.
+ *
+ * See tests/e2e/electronHelpers.ts for the launch story.
+ */
+import { expect, test } from '@playwright/test';
+import type { ElectronApplication, Page } from 'playwright';
+import {
+  closeAbuElectron,
+  createElectronDataRoot,
+  launchAbuElectron,
+  removeElectronDataRoot,
+  type ElectronDataRoot,
+} from './electronHelpers';
+
+const READY_TIMEOUT = 45_000;
+const CHAT_PLACEHOLDER = '想让阿布帮你做点什么？';
+const QUICK_START_TITLE = '快速入门';
+
+let app: ElectronApplication | undefined;
+let dataRoot: ElectronDataRoot | undefined;
+
+/** Resolve the composer, with the fresh-profile quick-start guide dismissed. */
+async function openComposer(page: Page) {
+  await page.waitForLoadState('domcontentloaded');
+  const input = page.getByPlaceholder(CHAT_PLACEHOLDER).first();
+  await expect(input).toBeVisible({ timeout: READY_TIMEOUT });
+
+  const quickStart = page.getByText(QUICK_START_TITLE, { exact: true });
+  await quickStart.waitFor({ state: 'visible', timeout: 1_500 }).catch(() => {});
+  if (await quickStart.isVisible()) {
+    await page.keyboard.press('Escape');
+    await expect(quickStart).toBeHidden();
+  }
+
+  await input.click();
+  await input.fill('');
+  return input;
+}
+
+const heightOf = (input: ReturnType<Page['getByPlaceholder']>) =>
+  input.evaluate((el) => (el as HTMLTextAreaElement).clientHeight);
+
+
+test.describe.serial('Composer newlines — real Electron', () => {
+  test.beforeEach(async () => {
+    const launched = await launchAbuElectron(createElectronDataRoot());
+    app = launched.app;
+    dataRoot = launched;
+  });
+
+  test.afterEach(async () => {
+    if (app) {
+      await closeAbuElectron(app);
+      app = undefined;
+    }
+    if (dataRoot) {
+      removeElectronDataRoot(dataRoot);
+      dataRoot = undefined;
+    }
+  });
+
+  test('shift-enter-inserts-a-newline', async () => {
+    const page = await app!.firstWindow({ timeout: READY_TIMEOUT });
+    const input = await openComposer(page);
+
+    await page.keyboard.type('第一行');
+    await page.keyboard.press('Shift+Enter');
+    await page.keyboard.type('第二行');
+
+    expect(await input.inputValue()).toBe('第一行\n第二行');
+  });
+
+  test('alt-enter-inserts-a-newline-without-reordering-what-follows', async () => {
+    // The bug this pins: the newline used to be applied via React state with
+    // the caret restored in a requestAnimationFrame. Characters typed before
+    // that frame ran landed at the stale offset, so 第三行 came out as 三行第.
+    const page = await app!.firstWindow({ timeout: READY_TIMEOUT });
+    const input = await openComposer(page);
+
+    await page.keyboard.type('第一行');
+    await page.keyboard.press('Alt+Enter');
+    await page.keyboard.type('第二行');
+
+    expect(await input.inputValue()).toBe('第一行\n第二行');
+  });
+
+  test('composer-grows-as-lines-are-added', async () => {
+    // A newline the box never grows to show reads to users as "no newline".
+    const page = await app!.firstWindow({ timeout: READY_TIMEOUT });
+    const input = await openComposer(page);
+
+    await page.keyboard.type('行1');
+    const singleLine = await heightOf(input);
+
+    for (const line of ['行2', '行3', '行4']) {
+      await page.keyboard.press('Shift+Enter');
+      await page.keyboard.type(line);
+    }
+
+    expect(await input.inputValue()).toBe('行1\n行2\n行3\n行4');
+    expect(await heightOf(input)).toBeGreaterThan(singleLine);
+  });
+
+  test('send-button-spells-out-both-shortcuts', async () => {
+    // The composer itself stays free of standing hint text, so the button's
+    // accessible name is the only place the shortcuts are written down.
+    const page = await app!.firstWindow({ timeout: READY_TIMEOUT });
+    await openComposer(page);
+    await page.keyboard.type('你好');
+
+    await expect(
+      page.getByLabel('发送（Enter）· 换行（Shift + Enter）'),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
用户反馈「阿布的聊天框不能换行」。实测下来 Shift+Enter 本身是好的 —— 缺的是**没有任何测试钉住它**，也**没有任何界面告诉用户它存在**。

排查全程在真实 Electron 壳里驱动（`tests/e2e/` 夹具真启 `electron/main.cjs`），不是读码推断。三个发现：

### 1. Alt+Enter 会把后续输入打乱（真 BUG）

旧实现用 React state 改文本、再在 `requestAnimationFrame` 里恢复光标，输不过快速打字：在那一帧跑起来之前敲下的字符落在了旧偏移上。实测复现：

```
输入 "第一行" → Shift+Enter → "第二行" → Option+Enter → 打 "第三行"
结果："第一行\n第二行\n三行第"   ← 「第」被挤到了最后
```

`insertNewlineAtCursor()` 改用 `setRangeText` 直接改 DOM 并同步落光标，竞态消失。

### 2. IME 守卫缺了 Windows 唯一可靠的那条信号

原来是自研的 `compositionstart/end` + `setTimeout(0)`，**没有 `isComposing`，也没有 `keyCode === 229`**。229 是 Windows 输入法（搜狗 / 微信 / 微软拼音）组合态 keydown 的上报值，其中一些**根本不设 `isComposing`** —— 于是在 Windows 上，用户按 Enter 确认候选词时可能把半截拼音发出去。

`isImeComposing()` 三条信号都查，并保留原有 flag 兜住 WebKit（它在 Enter keydown **之前**就发 `compositionend`，原注释说的是对的）。

### 3. 界面上零处说明怎么换行

`grep` 全仓 locale，`换行`、`Shift` 一个都搜不到；placeholder 只有「想让阿布帮你做点什么？」，发送按钮连 tooltip 都没有。用户按 Enter，消息飞出去，自然得出「不能换行」。

发送按钮现在在 `title` 和无障碍名里写明两个快捷键。

> 常驻提示文案试过，评审认为碍事，已撤掉 —— 发现性由后续的设置项承担（见叠加 PR）。

## 测试

两个行为都挪进 `composerKeys.ts`，可以脱离组件单测；`tests/e2e/chat-newline.spec.ts` 钉住只有真浏览器才能体现的部分 —— textarea 自己的换行插入，以及让换行**可见**的高度自适应。

- `npm run verify` 退出码 0
- 真机 Electron E2E 全绿
- 改动前 `ChatInput` 对 Enter / Shift+Enter 行为**零覆盖**

## 已知未覆盖

反馈用户在 **Windows + 中文输入法**，我手上只有 macOS，**这条路径无法实测**。`keyCode === 229` 守卫是照业内做法补的，实际效果需要发版后向该用户确认。

另外，若输入法把 Shift 整个吃掉（搜狗/微信在 Windows 上 Shift 是中英切换键），本 PR 帮不上 —— 那需要一条不含 Shift 的路径，见叠加的 `feat/composer-enter-behavior`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)