### PR TITLE
refactor(llm): english-ify the non-vision image placeholder prompt

### DIFF
--- a/src/core/llm/messageNormalizer.test.ts
+++ b/src/core/llm/messageNormalizer.test.ts
@@ -380,7 +380,7 @@ describe('messageNormalizer', () => {
         if (turns[0].kind === 'user') {
           expect(turns[0].content).toHaveLength(2);
           expect(turns[0].content[0]).toEqual({ type: 'text', text: 'Check this' });
-          expect(turns[0].content[1]).toMatchObject({ type: 'text', text: expect.stringContaining('不支持图片理解') });
+          expect(turns[0].content[1]).toMatchObject({ type: 'text', text: expect.stringContaining('does not support image understanding') });
         }
       });
     });

--- a/src/core/llm/messageNormalizer.ts
+++ b/src/core/llm/messageNormalizer.ts
@@ -148,11 +148,12 @@ function convertUserContent(
     }
   }
 
-  // If images were stripped, add a hint
+  // If images were stripped, add a hint. LLM-facing → English (the reply
+  // language is set by the response-language section, not by this string).
   if (imageCount > 0 && !supportsVision) {
     blocks.push({
       type: 'text',
-      text: `[用户上传了${imageCount}张图片，但当前模型不支持图片理解，也无法通过 read_file 等工具间接查看图片。请直接告知用户当前模型不支持图片识别，建议切换到支持视觉的模型。]`,
+      text: `[The user attached ${imageCount} image(s), but the current model does not support image understanding, and the images cannot be viewed indirectly through tools such as read_file. Tell the user directly that the current model does not support image recognition, and suggest switching to a vision-capable model.]`,
     });
   }
 


### PR DESCRIPTION
## What

`convertUserContent()` in `src/core/llm/messageNormalizer.ts` emitted two LLM-facing placeholder strings that disagreed on language:

- the stripped-base64 one was English, with an explicit comment saying `LLM-facing → English`
- the non-vision "images were stripped" hint was Chinese

Both go into the prompt sent to the model, so the Chinese one violated the file's own stated convention (and `AGENTS.md` §1, which puts LLM system prompts in English).

## Change

Rewrote the non-vision hint in English, preserving its instruction to tell the user their model lacks image support and to suggest a vision-capable one. Reply language is set by the `response-language` section (`src/core/agent/prompts/responseLanguage.ts`), not by this string — Chinese users still get Chinese answers.

Updated the one test asserting on the old Chinese substring (`messageNormalizer.test.ts:383`).

## Notes

- `openai-vision-gating.test.ts:84` asserts `toContain('could not be loaded')`, which targets the *other* (already-English) placeholder — unaffected, left alone.
- Repo-wide grep for `不支持图片` turns up no other test or source dependency; the remaining hits are UI-facing `zh-CN.ts` i18n entries that stay Chinese by design.

## Verification

`npm run verify` → exit 0 (lint + typecheck + `gen:models:check` + full suite with coverage thresholds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)