### PR TITLE
test: stop cold module transforms from timing out the first test body

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -56,6 +56,38 @@ These rules are **mandatory** for every new test:
 Global Tauri API mocks live in `src/test/setup.ts` and are applied automatically to every test file.
 Add new Tauri plugin mocks there rather than per-test.
 
+### Heavy module loading belongs in `beforeAll`, never in the first test body
+
+`vitest.config.ts` deliberately leaves `testTimeout` at the default **5 s** so hung tests fail
+fast, and sets `hookTimeout: 30000` so setup gets headroom. That split is a trap for any file
+whose tests re-import a large module graph.
+
+`vi.resetModules()` drops the *evaluated-module* cache but **not** Vite's *transform* cache, so
+the FIRST import of a graph pays the whole cold transform and every later one is cheap. Measured
+in `agentLoopRunner.test.ts`: first import **4012 ms**, second **9 ms**, rest 9-845 ms. Left in
+the first test's body, that 4 s crosses the 5 s ceiling as soon as a second worker transforms
+concurrently or v8 coverage is on — which is exactly what made four tests randomly red in
+`npm run verify` (fixed 2026-08-21).
+
+It does not stay a one-test failure. **Vitest does not cancel a test body that has timed out** —
+the abandoned continuation resumes later and runs against whatever test is live by then, *after*
+that test's `beforeEach` already reset the shared mocks. One slow test became three or four
+unrelated red assertions with impossible-looking symptoms (a handler registered twice, a mock
+recording zero calls).
+
+Rules:
+
+- **Warm the graph in `beforeAll`**, not in the first `it()`. It runs under the 30 s
+  `hookTimeout`, and the transform cache it fills is reused by every later `vi.resetModules()`.
+  This applies to a lazily `await import()`ed hot path too, not just an explicit `importFresh()`
+  helper — see `agentPipeline.integration.test.ts`.
+- **When capturing a handler out of a shared registration mock, take the newest match**
+  (`calls.findLast(...)` / `calls.at(-1)`), never `calls.find(...)` / `calls[0]`. The running
+  test always registers last, so this makes a leaked stale registration harmless.
+- Before blaming cross-file pollution for this shape of failure, check per-test durations with
+  `npx vitest run --reporter=verbose` and look for a body near 5000 ms. As of this writing the
+  slowest body in the whole suite is 1946 ms; anything approaching 5 s is the bug.
+
 **Flaky test quarantine:** If a test is found to be flaky (non-deterministic failure), open a
 GitHub issue tagged `flaky-test` and move the test into `src/__tests__/quarantine/` with a
 `// QUARANTINED: <issue-url>` comment. Quarantined tests are excluded from CI gates but included

--- a/src/__tests__/agentPipeline.integration.test.ts
+++ b/src/__tests__/agentPipeline.integration.test.ts
@@ -4,7 +4,7 @@
  * Tests the full message → LLM → tool execution → response pipeline.
  * Uses mocked LLM adapter to simulate various response scenarios.
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
 import { useChatStore } from '../stores/chatStore';
 import { useSettingsStore } from '../stores/settingsStore';
 import { useTaskExecutionStore } from '../stores/taskExecutionStore';
@@ -335,6 +335,19 @@ import * as contextManagerModule from '../core/context/contextManager';
 import * as toolSearchModule from '../core/tools/toolSearch';
 
 describe('Agent Pipeline Integration', () => {
+  // runAgentLoop lazily `await import()`s these on its hot path, so the FIRST
+  // test in this file paid their cold Vite transform inside its own body
+  // (measured 3.9 s vs 18 ms for the next test) against the default 5 s
+  // testTimeout — and under v8 coverage or a loaded runner it crossed the line.
+  // A timed-out body is not cancelled, so it kept mutating shared state after
+  // vitest moved on. Warm them here instead: hookTimeout is 30 s.
+  beforeAll(async () => {
+    await Promise.all([
+      import('../core/agent/entryOrchestration'),
+      import('../core/memdir/relevance'),
+    ]);
+  });
+
   beforeEach(() => {
     useChatStore.setState({
       conversations: {},

--- a/src/core/agent/agentLoopRunner.test.ts
+++ b/src/core/agent/agentLoopRunner.test.ts
@@ -10,7 +10,7 @@
  * `sessions`/`handlersRegistered`/`emittersInstalled` state must not leak
  * across tests.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 
 // ── Mocked dependencies ─────────────────────────────────────────────────
 
@@ -428,7 +428,10 @@ async function importFresh() {
 
 /** Pull the handler fn registered for a given method out of a mocked onSidecarNotification/onSidecarRequest call list. */
 function handlerFor(mock: ReturnType<typeof vi.fn>, method: string): (params: unknown) => unknown {
-  const call = mock.mock.calls.find((c) => c[0] === method);
+  // Newest registration wins: the running test always registers last, so a
+  // stale handler leaked in by an abandoned (timed-out) test body cannot be
+  // picked up ahead of it.
+  const call = mock.mock.calls.findLast((c) => c[0] === method);
   if (!call) throw new Error(`no handler registered for ${method}`);
   return call[1] as (params: unknown) => unknown;
 }
@@ -444,6 +447,20 @@ function makeSession(overrides: Partial<{ conversationId: string; loopId: string
 }
 
 describe('agentLoopRunner', () => {
+  // The FIRST import of this module graph pays Vite's cold transform cost
+  // (measured ~4.0 s here; more under v8 coverage or a loaded runner), and the
+  // default 5 s testTimeout applies to test BODIES only. Left inside the first
+  // `await importFresh()` that cost blew the timeout; vitest then failed that
+  // test WITHOUT cancelling its body, so the abandoned continuation later ran
+  // ensureHandlersRegistered() against the *next* test's freshly-reset mocks —
+  // turning one slow test into a cascade of unrelated red assertions.
+  // Paying it here instead is safe: hookTimeout is 30 s, and vi.resetModules()
+  // drops the evaluated-module cache but NOT the transform cache, so every
+  // later importFresh() only re-evaluates (~10-400 ms).
+  beforeAll(async () => {
+    await import('./agentLoopRunner');
+  });
+
   beforeEach(() => {
     onSidecarNotification.mockReset();
     onSidecarRequest.mockReset();
@@ -639,7 +656,7 @@ describe('agentLoopRunner', () => {
         accepted: true,
         userMessageId: 'msg-connection',
       });
-      const handler = onSidecarConnectionState.mock.calls[0][0] as (
+      const handler = onSidecarConnectionState.mock.calls.at(-1)![0] as (
         event: { state: 'connected' | 'recovering' | 'failed'; reason: string },
       ) => void;
 

--- a/src/core/agent/subagentRunner.test.ts
+++ b/src/core/agent/subagentRunner.test.ts
@@ -8,7 +8,7 @@
  * exactly once" / "capture the ONE registered tool.invoke handler" tests
  * need that isolation.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import type { SubagentDefinition } from '../../types';
 
 // ── Mocked dependencies (thin forwarding factories over stable outer
@@ -124,6 +124,15 @@ async function importFresh() {
 }
 
 describe('subagentRunner', () => {
+  // Same cold-transform hazard as agentLoopRunner.test.ts: left in the first
+  // test body, the first importFresh() here measured 2.7 s against the 5 s
+  // testTimeout — and a timed-out body is not cancelled, so it keeps mutating
+  // the shared mocks after vitest has moved on. Pay it under the 30 s
+  // hookTimeout instead.
+  beforeAll(async () => {
+    await import('./subagentRunner');
+  });
+
   beforeEach(() => {
     getSidecarStatus.mockReset();
     sidecarRequestMock.mockReset();


### PR DESCRIPTION
Fixes four tests that turned `npm run verify` red at random on `origin/dev` (reproduced on a clean checkout of `bc6dd4e7` with no modifications, so this predates any recent feature work):

- `src/core/agent/agentLoopRunner.test.ts` — "registers every handler exactly once across multiple calls", "projects connection recovery and failure onto active user-run lifecycle state"
- `src/__tests__/agentPipeline.integration.test.ts` — "complete conversation: user message → LLM text response → done", "shows an actionable local error and skips the provider when the latest input is too large"

## Root cause

**A timing race that presents as state leakage, because vitest does not cancel a test body that has already timed out.**

`importFresh()` is `vi.resetModules()` + a dynamic re-import, run once per test (~195× in `agentLoopRunner.test.ts`). `resetModules()` drops the *evaluated-module* cache but **not** Vite's *transform* cache, so the **first** call pays the cold transform for the whole graph and every later one is cheap — measured **4012 ms**, then **9 ms**, then 9–845 ms.

That 4 s sat inside the **first test's body**, against the deliberate 5 s `testTimeout` default. With a second worker transforming concurrently, or under v8 coverage, it crosses the line. Cold-cache verbose run on the **unmodified** files:

| test | duration |
|---|---|
| `registers every handler exactly once` | **5264 ms** — timed out |
| `projects connection recovery …` | **5140 ms** — timed out |
| `complete conversation: user message …` | **3942 ms** (next test in that file: 18 ms) |

Vitest then failed those tests but let their bodies keep running. The abandoned continuation later called `ensureHandlersRegistered()` against whatever test was live by then — *after* that test's `beforeEach` had already reset the shared sidecar mocks. The victim read the handler at index 0 and got a stale one bound to a dead module instance with an empty `sessions` map. Hence `applyDeltaFrames` with 0 calls and `updateUserMessageRun` with `[]`.

Confirmed by instrumenting the mocks: registration counts went **12 → 24 → 36** across three consecutive tests, with the connection-state mock at 2 registrations where 1 was expected.

### Is it a deeper mechanism issue with more instances?

Yes, and all of them were measured. Four files use the `importFresh` pattern; `subagentRunner.test.ts` was next in line at **2748 ms** (55% of budget). `agentPipeline.integration.test.ts` had the same hazard *without* that pattern — its cost came from `runAgentLoop`'s hot-path `await import()`s. The real class is "first test body pays a cold module transform against a 5 s ceiling."

## Fix — 3 test files, no production code

- **Trigger removed**: warm the graph in `beforeAll`, which runs under the config's existing `hookTimeout: 30000` instead of the 5 s body budget.
  `5264 → 16 ms`, `5140 → 7 ms`, `3942 → 325 ms`, `2748 → 46 ms`
- **Amplifier removed**: `handlerFor()` now takes the newest matching registration (`findLast`) and the connection-state test uses `calls.at(-1)`, so a handler leaked in by an abandoned body can't be picked up ahead of the running test's own. This is what keeps one slow test from cascading into three or four unrelated red assertions.

A second commit records the trap in `TESTING.md` §3 (anti-flaky rules), since the `testTimeout` / `hookTimeout` split is deliberate policy and its interaction with per-test `vi.resetModules()` is not obvious.

## Verification

| Gate | Result |
|---|---|
| `npm run build` | pass |
| `npm run lint` | exit 0 |
| **`npm run verify`** | **exit 0** — 386 files, **5519 tests passed** |
| Reported repro recipe ×5 | **5/5 green** |
| Full-suite verbose scan | slowest remaining test body **1946 ms** vs the 5000 ms budget |

No coverage threshold touched, nothing quarantined, `vitest.config.ts` unchanged.

Note on conditions: all of the above was measured with the machine at **load average 46–59 on 8 cores** (unrelated concurrent builds), i.e. ~6× oversubscribed and considerably harsher than the original repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)