### PR TITLE
fix(agent): stop staging a send into a run that already ended

### DIFF
--- a/src/core/agent/agentLoopRunner.test.ts
+++ b/src/core/agent/agentLoopRunner.test.ts
@@ -433,13 +433,18 @@ function handlerFor(mock: ReturnType<typeof vi.fn>, method: string): (params: un
   return call[1] as (params: unknown) => unknown;
 }
 
-function makeSession(overrides: Partial<{ conversationId: string; loopId: string }> = {}) {
+function makeSession(
+  overrides: Partial<{ conversationId: string; loopId: string; terminalPublished: boolean }> = {},
+) {
   return {
     conversationId: overrides.conversationId ?? 'conv-1',
     loopId: overrides.loopId ?? 'loop-1',
     options: {},
     shellAbortController: new AbortController(),
     toolCallToStepId: new Map<string, string>(),
+    ...(overrides.terminalPublished === undefined
+      ? {}
+      : { terminalPublished: overrides.terminalPublished }),
   };
 }
 
@@ -3133,6 +3138,43 @@ describe('agentLoopRunner', () => {
         expect(result).toEqual({ reason: 'enqueued' });
         expect(enqueueUserInputMock).toHaveBeenCalledWith('conv-1', 'more instructions');
         expect(notifySidecar).not.toHaveBeenCalledWith('agent.enqueueInput', expect.anything());
+        expect(sidecarRequestMock).not.toHaveBeenCalled();
+      });
+
+      it('starts a new run instead of staging into a session whose terminal is already published', async () => {
+        // Regression: the crashed/stopped run stays REGISTERED while its
+        // teardown finishes (persistence + the Computer Use lease release over
+        // IPC), long after the UI shows the run as over. A send in that window
+        // used to be staged into the dead run and then parked as a paused
+        // queue chip, so it never reached the model — the real-Electron
+        // sidecar-crash E2E lost this race on busy machines.
+        const { runAgentLoopDispatched, registerRunSession } = await importFresh();
+        registerRunSession('run-tearing-down', makeSession({
+          conversationId: 'conv-1',
+          terminalPublished: true,
+        }));
+        sidecarRequestMock.mockResolvedValue({ reason: 'completed' });
+
+        const result = await runAgentLoopDispatched('conv-1', 'sent right after the error banner');
+
+        expect(result).toEqual({ reason: 'completed' });
+        expect(enqueueUserInputMock).not.toHaveBeenCalled();
+        expect(notifySidecar).not.toHaveBeenCalledWith('agent.enqueueInput', expect.anything());
+        expect(sidecarRequestMock).toHaveBeenCalled();
+      });
+
+      it('still stages into a sibling session that has NOT published its terminal', async () => {
+        const { runAgentLoopDispatched, registerRunSession } = await importFresh();
+        registerRunSession('run-tearing-down', makeSession({
+          conversationId: 'conv-1',
+          terminalPublished: true,
+        }));
+        registerRunSession('run-live', makeSession({ conversationId: 'conv-1', loopId: 'loop-2' }));
+
+        const result = await runAgentLoopDispatched('conv-1', 'more instructions');
+
+        expect(result).toEqual({ reason: 'enqueued' });
+        expect(enqueueUserInputMock).toHaveBeenCalledWith('conv-1', 'more instructions');
         expect(sidecarRequestMock).not.toHaveBeenCalled();
       });
 

--- a/src/core/agent/agentLoopRunner.ts
+++ b/src/core/agent/agentLoopRunner.ts
@@ -238,6 +238,21 @@ export interface RunSession {
   terminalPromise?: Promise<AgentRunTerminal>;
   resolveTerminal?: (terminal: AgentRunTerminal) => void;
   failureFinalizationPromise?: Promise<void>;
+  /**
+   * Set the moment a terminal finalizer (`finalizeFailedRun` /
+   * `finalizeAbortedRun`) starts, i.e. before it publishes the visible
+   * terminal state. The session stays REGISTERED past that point — the
+   * finalizer still has to await persistence, and the dispatch `finally`
+   * still has to release the Computer Use lease over IPC — so for a few
+   * hundred milliseconds `findRunSessionForConversation` keeps answering
+   * "a run owns this conversation" while the UI already shows the run as
+   * over (banner up, Stop hidden, composer editable). A send inside that
+   * window was staged into this dead run's queue and then parked by
+   * `runAgentLoopDispatched`'s pause branch, so it never reached the model.
+   * `findJoinableRunSessionForConversation` reads this flag so the staging
+   * decision matches what the user can see.
+   */
+  terminalPublished?: boolean;
   runtimeStartedAt?: number;
   firstDeltaAt?: number;
   firstFrameApplied?: boolean;
@@ -257,6 +272,24 @@ export function registerRunSession(runId: string, session: RunSession): void {
 export function findRunSessionForConversation(conversationId: string): RunSession | undefined {
   for (const session of sessions.values()) {
     if (session.conversationId === conversationId) return session;
+  }
+  return undefined;
+}
+
+/**
+ * The still-joinable session for a conversationId — the concurrency guard's
+ * view of "is a run live for this conversation right now". Unlike
+ * `findRunSessionForConversation` it skips sessions whose terminal has
+ * already been published (see `RunSession.terminalPublished`), so a send
+ * made after the run visibly ended starts its own run instead of being
+ * staged into a session that is only still registered because its teardown
+ * has not finished. Full scan rather than filtering the first match: during
+ * the teardown window a newer, genuinely live session for the same
+ * conversation can already be registered behind the dying one.
+ */
+function findJoinableRunSessionForConversation(conversationId: string): RunSession | undefined {
+  for (const session of sessions.values()) {
+    if (session.conversationId === conversationId && !session.terminalPublished) return session;
   }
   return undefined;
 }
@@ -509,6 +542,10 @@ async function finalizeFailedRun(
 ): Promise<void> {
   if (session.failureFinalizationPromise) return session.failureFinalizationPromise;
 
+  // Before anything else: this run is over. Nothing sent from here on may be
+  // staged into it — see `RunSession.terminalPublished`.
+  session.terminalPublished = true;
+
   session.failureFinalizationPromise = (async () => {
     session.dropFrames = true;
     updateSessionMessageState(session, state, displayMessage);
@@ -545,6 +582,11 @@ async function finalizeFailedRun(
  */
 async function finalizeAbortedRun(session: RunSession, source: 'ack' | 'watchdog' | 'run-terminal'): Promise<void> {
   if (session.abortFinalizationPromise) return session.abortFinalizationPromise;
+
+  // Before anything else — including the queue pause below, which is meant to
+  // preserve follow-ups staged while the run was still live, not to swallow
+  // ones typed after it ended. See `RunSession.terminalPublished`.
+  session.terminalPublished = true;
 
   session.abortFinalizationPromise = (async () => {
     try {
@@ -631,7 +673,7 @@ async function finalizeAbortedRun(session: RunSession, source: 'ack' | 'watchdog
         .then(({ drainCapabilitySetupRequests }) => drainCapabilitySetupRequests(session.loopId))
         .catch(() => {});
       void import('../session/checkpoint')
-        .then(({ clearCheckpoint }) => clearCheckpoint(session.conversationId))
+        .then(({ clearCheckpointForLoop }) => clearCheckpointForLoop(session.conversationId, session.loopId))
         .catch(() => {});
       void import('../tools/definitions/computerTools')
         .then(({ closeAxSession }) => closeAxSession(session.conversationId, session.loopId))
@@ -2066,7 +2108,7 @@ async function runSingleAgentLoopDispatched(
     const getBusyError = (): string => hasImages
       ? getI18n().chat.attachmentDuringRun
       : getI18n().chat.conversationBusy;
-    const runningSession = findRunSessionForConversation(conversationId);
+    const runningSession = findJoinableRunSessionForConversation(conversationId);
     if (runningSession?.runId) {
       const interactive = isInteractiveDesktop(options, runningConv);
       if (!interactive || hasImages || !stageable) {
@@ -2667,7 +2709,12 @@ async function runSingleAgentLoopDispatched(
     unregisterRunSession(runId);
     shellAbortController.signal.removeEventListener('abort', onShellAbort);
     if (!handedOffToLocal) {
-      abortRegistry.clearAbortController(conversationId);
+      // Ownership-checked: everything above the `finally` can outlive this
+      // run's visible terminal (persistence, the Computer Use lease release
+      // over IPC), and a send made in that window now legitimately starts a
+      // new run — see `RunSession.terminalPublished`. An unconditional clear
+      // here would delete THAT run's controller and leave its Stop inert.
+      abortRegistry.clearAbortController(conversationId, shellAbortController);
     }
   }
 }

--- a/src/core/agent/ports/abortRegistry.test.ts
+++ b/src/core/agent/ports/abortRegistry.test.ts
@@ -42,6 +42,30 @@ describe('createInProcessAbortRegistry', () => {
     expect(registry.hasAbortController('conv-abort-a')).toBe(false);
   });
 
+  it('clearAbortController(convId, owned) leaves a NEWER run\'s controller registered', () => {
+    // Regression: a run tearing down asynchronously (its visible terminal
+    // already published) must not delete the controller a newer run has since
+    // registered for the same conversation — that would leave the live run's
+    // Stop button inert.
+    const registry = createInProcessAbortRegistry();
+    const dying = registry.getAbortController('conv-abort-a');
+    registry.clearAbortController('conv-abort-a');
+    const replacement = registry.getAbortController('conv-abort-a');
+    expect(replacement).not.toBe(dying);
+
+    registry.clearAbortController('conv-abort-a', dying);
+
+    expect(registry.hasAbortController('conv-abort-a')).toBe(true);
+    expect(registry.getAbortController('conv-abort-a')).toBe(replacement);
+  });
+
+  it('clearAbortController(convId, owned) still clears while that controller is the registered one', () => {
+    const registry = createInProcessAbortRegistry();
+    const controller = registry.getAbortController('conv-abort-a');
+    registry.clearAbortController('conv-abort-a', controller);
+    expect(registry.hasAbortController('conv-abort-a')).toBe(false);
+  });
+
   it('is scoped per conversation id', () => {
     const registry = createInProcessAbortRegistry();
     registry.getAbortController('conv-abort-a');

--- a/src/core/agent/ports/abortRegistry.ts
+++ b/src/core/agent/ports/abortRegistry.ts
@@ -39,8 +39,11 @@ export interface AbortRegistry {
    *  exists yet for `convId` (this is chatStore's real behavior, not this
    *  port's invention; see chatStore.ts's `getAbortController`). */
   getAbortController(convId: string): AbortController;
-  /** Mirrors chatStore's `clearAbortController`. */
-  clearAbortController(convId: string): void;
+  /** Mirrors chatStore's `clearAbortController`. `owned` makes the clear
+   *  ownership-checked — the controller is dropped only if it is still the
+   *  registered one, so a run whose teardown outlives its visible terminal
+   *  cannot delete a newer run's controller. */
+  clearAbortController(convId: string, owned?: AbortController): void;
 }
 
 /** Default in-process implementation over the Zustand store's synchronous
@@ -51,7 +54,7 @@ export function createInProcessAbortRegistry(): AbortRegistry {
   return {
     hasAbortController: (convId) => useChatStore.getState().hasAbortController(convId),
     getAbortController: (convId) => useChatStore.getState().getAbortController(convId),
-    clearAbortController: (convId) => useChatStore.getState().clearAbortController(convId),
+    clearAbortController: (convId, owned) => useChatStore.getState().clearAbortController(convId, owned),
   };
 }
 

--- a/src/core/session/checkpoint.test.ts
+++ b/src/core/session/checkpoint.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Checkpoints are keyed by CONVERSATION, but a run's fire-and-forget teardown
+ * can outlive its own visible terminal (see agentLoopRunner.ts's
+ * `RunSession.terminalPublished`). By then the next turn may already own the
+ * conversation, so an unconditional clear would strip the live turn of its
+ * crash recovery. These tests pin the loop-scoped variant that closes that.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { exists, readTextFile, remove } from '@tauri-apps/plugin-fs';
+import { clearCheckpointForLoop, type Checkpoint } from './checkpoint';
+
+const existsMock = vi.mocked(exists);
+const readTextFileMock = vi.mocked(readTextFile);
+const removeMock = vi.mocked(remove);
+
+function checkpoint(loopId: string): Checkpoint {
+  return {
+    conversationId: 'conv-1',
+    loopId,
+    turnCount: 1,
+    lastMessageId: 'msg-1',
+    status: 'llm_calling',
+    timestamp: 0,
+  };
+}
+
+describe('clearCheckpointForLoop', () => {
+  beforeEach(() => {
+    existsMock.mockReset().mockResolvedValue(true);
+    readTextFileMock.mockReset().mockResolvedValue('');
+    removeMock.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('removes the checkpoint while it still belongs to the loop', async () => {
+    readTextFileMock.mockResolvedValue(JSON.stringify(checkpoint('loop-1')));
+
+    await clearCheckpointForLoop('conv-1', 'loop-1');
+
+    expect(removeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves a checkpoint written by a newer loop alone', async () => {
+    readTextFileMock.mockResolvedValue(JSON.stringify(checkpoint('loop-2')));
+
+    await clearCheckpointForLoop('conv-1', 'loop-1');
+
+    expect(removeMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no checkpoint file exists', async () => {
+    existsMock.mockResolvedValue(false);
+
+    await clearCheckpointForLoop('conv-1', 'loop-1');
+
+    expect(readTextFileMock).not.toHaveBeenCalled();
+    expect(removeMock).not.toHaveBeenCalled();
+  });
+
+  it('leaves an unreadable checkpoint for the startup orphan scan instead of throwing', async () => {
+    readTextFileMock.mockResolvedValue('{ not json');
+
+    await expect(clearCheckpointForLoop('conv-1', 'loop-1')).resolves.toBeUndefined();
+    expect(removeMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/session/checkpoint.ts
+++ b/src/core/session/checkpoint.ts
@@ -89,6 +89,30 @@ export async function clearCheckpoint(convId: string): Promise<void> {
   }
 }
 
+/**
+ * Clear the checkpoint only while it still belongs to `loopId`.
+ *
+ * A run's teardown can outlive its own visible terminal (see
+ * `agentLoopRunner.ts`'s `RunSession.terminalPublished`), so by the time this
+ * fire-and-forget cleanup runs, the next turn may already own the
+ * conversation — and checkpoints are keyed by conversation, not by loop.
+ * Deleting unconditionally there would strip the LIVE turn of its crash
+ * recovery. Reading first costs one extra file read on a path that is already
+ * best-effort.
+ */
+export async function clearCheckpointForLoop(convId: string, loopId: string): Promise<void> {
+  try {
+    const path = await checkpointPath(convId);
+    if (!(await exists(path))) return;
+    const current = JSON.parse(await readTextFile(path)) as Checkpoint;
+    if (current.loopId !== loopId) return;
+    await remove(path);
+  } catch {
+    // Non-critical — an unreadable/corrupt checkpoint is left for the startup
+    // orphan scan, which already handles stale entries.
+  }
+}
+
 // ════════════════════════════════════════════════════════════
 // Orphan detection (startup scan)
 // ════════════════════════════════════════════════════════════

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -550,7 +550,13 @@ interface ChatActions {
    * action's own doc for the full branching rationale.
    */
   cancelStreaming: (convId: string, opts?: { fromSidecarFrame?: boolean }) => void;
-  clearAbortController: (convId: string) => void;
+  /**
+   * Drop the conversation's registered controller. Pass `owned` to make the
+   * clear ownership-checked: a run tearing down asynchronously must not
+   * delete a controller that a NEWER run has since registered for the same
+   * conversation, which would leave that run's Stop button inert.
+   */
+  clearAbortController: (convId: string, owned?: AbortController) => void;
   /**
    * Clear a conversation's single-turn-lifecycle skill activation state
    * (`activeSkills`/`activeSkillArgs`). Extracted from an agentLoop.ts
@@ -1673,7 +1679,8 @@ export const useChatStore = create<ChatStore>()(
         }
       },
 
-      clearAbortController: (convId) => {
+      clearAbortController: (convId, owned) => {
+        if (owned && abortControllers.get(convId) !== owned) return;
         abortControllers.delete(convId);
       },
 


### PR DESCRIPTION
## What

A send made right after a run visibly ended was staged into that dead run and then parked as a paused queue chip, so it never reached the model.

The terminal finalizers publish the visible terminal state — banner up, Stop hidden, composer editable — and only then finish tearing the run down: awaiting persistence, then a dynamic import plus two IPC calls to release the Computer Use lease. The `RunSession` stays registered across that whole tail, so for a few hundred milliseconds `findRunSessionForConversation` kept answering "a run owns this conversation" while the UI showed the opposite. The concurrency guard read that, called `enqueueUserInput`, and `runAgentLoopDispatched`'s error branch then paused the queue.

This is the same defect #235 worked around at the Stop terminal by clicking Resume; this is it at the sidecar-crash terminal.

## Why now

`tests/e2e/task-lifecycle.spec.ts:594` ("recovers after the active sidecar process crashes…") is flaky on an untouched `origin/dev`: 1 pass in 4 on a busy machine, timing out at `expect.poll(() => taskRequests(mock).length).toBe(2)` with `Received: 1`.

Measured on the real Electron E2E, the window between "status flipped to `error`" and "session unregistered":

| run | window | follow-up landed after unregister |
|---|---|---|
| 1 | 572 ms | +340 ms |
| 2 | 284 ms | +1249 ms |
| 3 | 298 ms | +377 ms |

On an idle machine the test wins by ~300 ms. When it loses, the user's message becomes a queued pill behind a manual 继续队列 click, from a composer that looked completely idle — confirmed by probing the DOM in a forced-window run.

## How

- Mark the session `terminalPublished` at the top of `finalizeFailedRun` and `finalizeAbortedRun`, and give the concurrency guard its own `findJoinableRunSessionForConversation` that skips such sessions. Full scan rather than filtering the first match: during the teardown window a newer, genuinely live session for the same conversation can already be registered behind the dying one.

Once a new run can start in that window, two conversation-keyed cleanups in the old run's teardown become hazards, so both are scoped:

- `clearAbortController` takes an optional `owned` controller and drops it only while it is still the registered one. An unconditional clear would delete the newer run's controller and leave its Stop inert.
- `clearCheckpointForLoop` reads the checkpoint before removing it and leaves one written by another loop alone, so the teardown cannot strip the live turn of its crash recovery.

## Verification

- **Decisive**: with an injected 20 s teardown delay — which reproduces the failure deterministically before this change (and fails even at 6 s) — the sidecar-crash E2E passes in 5.5–7.7 s, twice. The outcome is now independent of teardown duration, not merely a narrower window.
- Full Electron E2E: **17/17**, including the Stop test that exercises `finalizeAbortedRun`.
- `npm run verify` clean; 5527 unit tests green.
- 5 new regression tests. The two guard tests were checked against the pre-fix code path and fail there, so they are not vacuous. `checkpoint.test.ts` is new — that module had no tests.

**The E2E spec itself is unchanged** — no retry, no widened timeout.

## Follow-ups (not in this PR)

- `scripts/electron-packaged-smoke.mjs`'s "poll for the command tree or click 继续队列" workaround from #235 should now be unnecessary, but removing it needs verification in a real packaged build (`pack:electron` + `smoke:electron:packaged`).
- `tests/e2e/global-setup.ts` does not build `electron/sandbox-launcher`. In a fresh worktree the missing binary makes the sidecar unspawnable and surfaces as `mcp_write: no live process for id "abu-sidecar"` — a misleading failure worth closing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)