### PR TITLE
fix: drop stale browser automation fallback, make runtime downloads proxy-aware

### DIFF
--- a/electron/browserHost.cjs
+++ b/electron/browserHost.cjs
@@ -260,20 +260,30 @@ function browserSessionForViews() {
   return browserSession;
 }
 
+// Only two sources are trusted: the packaged copy, and the extension's own build
+// output. There is deliberately no fallback to the committed
+// src-tauri/browser-extension/ bundle — that copy is synced for the Tauri bundle,
+// so falling through to it would silently run a build of unknown vintage whenever
+// the dev build output is missing, making DOM-layer fixes look ineffective.
 function automationRuntimePath() {
   const candidates = [
     process.resourcesPath
       ? path.join(process.resourcesPath, 'browser-extension', 'content.js')
       : '',
     path.join(__dirname, '..', 'abu-chrome-extension', 'dist', 'content.js'),
-    path.join(__dirname, '..', 'src-tauri', 'browser-extension', 'content.js'),
   ].filter(Boolean);
-  return candidates.find((candidate) => fs.existsSync(candidate)) || candidates[0];
+  return candidates.find((candidate) => fs.existsSync(candidate)) || null;
 }
 
 function loadAutomationRuntime() {
   if (automationRuntime !== null) return automationRuntime;
   const runtimePath = automationRuntimePath();
+  if (!runtimePath) {
+    throw new Error(
+      'browser automation runtime is missing (no content.js in the packaged resources ' +
+        'or in abu-chrome-extension/dist/); build it with `npm run build:browser-extension`'
+    );
+  }
   try {
     automationRuntime = fs.readFileSync(runtimePath, 'utf8');
     return automationRuntime;

--- a/scripts/setup-electron-runtimes.mjs
+++ b/scripts/setup-electron-runtimes.mjs
@@ -5,6 +5,7 @@ import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import { pipeline } from 'node:stream/promises';
 import { Readable } from 'node:stream';
+import { setTimeout } from 'node:timers/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -16,6 +17,29 @@ const RUNTIME_TARGET_ROOT = path.join(ROOT, 'electron', '.runtime');
 const NODE_TARGET = path.join(RUNTIME_TARGET_ROOT, 'node-runtime');
 const PYTHON_TARGET = path.join(RUNTIME_TARGET_ROOT, 'python-runtime');
 const MARKER_NAME = '.abu-runtime.json';
+
+// Node's fetch (undici) ignores HTTP(S)_PROXY unless NODE_USE_ENV_PROXY is set, so
+// on networks where these hosts are only reachable through a proxy every download
+// dies as a bare `TypeError: fetch failed` that names neither the proxy nor a fix.
+// Opt in before the first fetch creates the global dispatcher (NO_PROXY is honoured).
+const PROXY_ENV_KEYS = ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy'];
+const envProxy = PROXY_ENV_KEYS.map((key) => process.env[key]).find(Boolean) || null;
+const envProxySupported = Number(process.versions.node.split('.')[0]) >= 24;
+
+function redactProxy(value) {
+  try {
+    const url = new URL(value);
+    if (!url.username && !url.password) return url.origin;
+    return `${url.origin} (credentials hidden)`;
+  } catch {
+    return '(unparseable proxy URL)';
+  }
+}
+
+if (envProxy && envProxySupported && !process.env.NODE_USE_ENV_PROXY) {
+  process.env.NODE_USE_ENV_PROXY = '1';
+  console.log(`[runtime] using proxy from environment: ${redactProxy(envProxy)}`);
+}
 
 const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
 const args = new Set(process.argv.slice(2));
@@ -68,13 +92,74 @@ function run(file, commandArgs, options = {}) {
   return options.capture ? String(result.stdout || '').trim() : '';
 }
 
-async function download(url, destination) {
-  console.log(`[runtime] downloading ${url}`);
+const DOWNLOAD_ATTEMPTS = 3;
+
+function describeError(error) {
+  return error?.cause?.code || error?.code
+    || (error instanceof Error ? error.message : String(error));
+}
+
+// Deterministic HTTP answers (a wrong URL, a 403) will not improve on a retry;
+// dropped sockets and timeouts routinely do, which is the normal failure mode
+// when the archive is pulled through a proxy.
+function isRetryable(error) {
+  if (typeof error?.status === 'number') {
+    return error.status === 408 || error.status === 429 || error.status >= 500;
+  }
+  return true;
+}
+
+function downloadFailureHint(error) {
+  const lines = [`  cause: ${describeError(error)}`];
+  if (envProxy && !envProxySupported) {
+    lines.push(
+      `  a proxy is configured (${redactProxy(envProxy)}) but Node ${process.versions.node}`,
+      '  cannot apply it to fetch — that needs Node 24+. Upgrade Node and re-run.'
+    );
+  } else if (envProxy) {
+    lines.push(
+      `  downloads are going through ${redactProxy(envProxy)}; a proxy that drops long`,
+      '  transfers will fail here repeatedly. Retry, or fetch the archive another way.'
+    );
+  } else {
+    lines.push(
+      '  no HTTP(S)_PROXY is set. If this host is only reachable through a proxy on',
+      '  your network, set HTTPS_PROXY and re-run.'
+    );
+  }
+  return lines.join('\n');
+}
+
+async function downloadOnce(url, destination) {
   const response = await fetch(url, { redirect: 'follow' });
   if (!response.ok || !response.body) {
-    throw new Error(`download failed (${response.status} ${response.statusText}): ${url}`);
+    const error = new Error(`HTTP ${response.status} ${response.statusText}`);
+    error.status = response.status;
+    throw error;
   }
+  // The body can still abort mid-stream, so the write is part of the attempt.
   await pipeline(Readable.fromWeb(response.body), fs.createWriteStream(destination, { flags: 'wx' }));
+}
+
+async function download(url, destination) {
+  console.log(`[runtime] downloading ${url}`);
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      await downloadOnce(url, destination);
+      return;
+    } catch (error) {
+      // 'wx' refuses an existing file, so a partial write must go before a retry.
+      fs.rmSync(destination, { force: true });
+      if (attempt >= DOWNLOAD_ATTEMPTS || !isRetryable(error)) {
+        throw new Error(
+          `download failed after ${attempt} attempt(s): ${url}\n${downloadFailureHint(error)}`,
+          { cause: error }
+        );
+      }
+      console.warn(`[runtime] attempt ${attempt}/${DOWNLOAD_ATTEMPTS} failed (${describeError(error)}); retrying`);
+      await setTimeout(attempt * 1000);
+    }
+  }
 }
 
 function verifyArchive(filePath, expectedSha256) {


### PR DESCRIPTION
两个独立修复，各自一个 commit。

## 1. `fix(electron)` — 删掉会掩盖构建缺失的 fallback

`automationRuntimePath()` 原先有三个候选，第三个是已提交的 `src-tauri/browser-extension/content.js`。改了 `abu-chrome-extension/src/` 但没重新构建时，它会静默兜住，让人以为跑的是新代码 —— DOM 层的修改看起来"不生效"，没有报错、也没有版本提示。

删掉该候选，改为抛错并点名 `npm run build:browser-extension`。原来的 `|| candidates[0]` 还会报出误导性路径：dev 下它指向 Electron 自己的 `Resources/` 目录，该路径根本不存在。

**`src-tauri/browser-extension/` 的文件保留** —— `src-tauri/tauri.conf.json` 仍把它列在 `bundle.resources` 里，Tauri 构建还在消费。

> 补充：起初怀疑该产物已陈旧，实测推翻了 —— 跑 CI 自己那条同步门禁（`diff -r --exclude='*.map'`），新构建产物与已提交 bundle 逐字节一致。真实缺陷不是"加载旧脚本"，而是掩盖构建缺失，删除依然正确。

## 2. `fix(scripts)` — 让运行时下载能走代理

Node 的 fetch（undici）默认不读 `HTTP(S)_PROXY`，所以在 nodejs.org 或 GitHub Releases 只能经代理访问的网络上，`setup:electron-runtimes` 会稳定失败，且只报一句 `TypeError: fetch failed`，既不提代理也不提解法。

它挡住 6 条命令，其中 `setup:electron-dev` 是新人上手的第一步；`dist/pack:electron` 和 `electron:*-test` 门禁同样受影响。CI 不受影响（runner 直连 GitHub）。

修了两层：

- **连接层** —— 在首次 fetch 创建 global dispatcher 之前自设 `NODE_USE_ENV_PROXY=1`（`NO_PROXY` 由 Node 原生处理）。日志里的代理 URL 做了脱敏，带凭证的显示 `(credentials hidden)`。
- **传输层** —— 经代理的下载还会中途掉线，原代码把它暴露成从 body pipeline 抛出的、未捕获的 `TypeError: terminated`。把 body 写入纳入同一次尝试，瞬时失败重试 3 次并退避；重试前先删残片（原代码用 `flags: 'wx'`，不删必然 EEXIST）。确定性的 HTTP 应答（如 404）不重试。

## 验证

- `npm run verify` → exit 0（386/386 文件、5519/5519 测试）
- `npm run electron:dev:check` → exit 0
- 代理修复端到端实测：不带任何手工 env、强制重装 Python，走完下载 → SHA-256 校验 → 解压 → pip 装 23 个包，exit 0
- 重试路径：用故意掐断连接的本地假代理逼出 `attempt 1/3 failed ... retrying`

未验证项（如实标注）：重试前删残片防 `wx` EEXIST 的那条路径 —— 精确复现"写到一半掉线"成本不划算，未构造。

> 上述门禁是在 rebase 到最新 dev **之前**跑的（rebase 无冲突，dev 的 6 个新提交不碰这两个文件）。合并后的组合状态以 CI 为准。

🤖 Generated with [Claude Code](https://claude.com/claude-code)