### PR TITLE
feat(llm): declare DeepSeek's vision route so images reach the model

### DIFF
--- a/scripts/gen-model-data.ts
+++ b/scripts/gen-model-data.ts
@@ -105,8 +105,9 @@ export function loadAndMerge(): ModelRecord[] {
   }
   const volc = JSON.parse(readFileSync(resolve(DATA, 'overlay/volcengine.json'), 'utf8')).models as ModelRecord[];
   const local = JSON.parse(readFileSync(resolve(DATA, 'overlay/local-models.json'), 'utf8')).models as ModelRecord[];
+  const deepseek = JSON.parse(readFileSync(resolve(DATA, 'overlay/deepseek.json'), 'utf8')).models as ModelRecord[];
   const overrides = JSON.parse(readFileSync(resolve(DATA, 'overlay/abu-overrides.json'), 'utf8')).overrides as Record<string, Partial<ModelRecord>>;
-  return mergeLayers(snapshot, [...volc, ...local], overrides);
+  return mergeLayers(snapshot, [...volc, ...local, ...deepseek], overrides);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/src/core/llm/costTracker.test.ts
+++ b/src/core/llm/costTracker.test.ts
@@ -88,6 +88,18 @@ describe('costTracker', () => {
       expect(cost).toBeCloseTo(0.0028, 4);
     });
 
+    // overlay/deepseek.json deliberately omits `pricing` for the vision route so it
+    // inherits deepseek-v4-flash's numbers by id prefix (official docs price the two
+    // identically). Pin that: if findPricing's prefix scan ever changes, the vision
+    // model would silently fall through to $0 and every turn would report free.
+    it('deepseek-v4-flash-vision-exp inherits deepseek-v4-flash pricing by id prefix', () => {
+      const usage = { inputTokens: 1_000_000, outputTokens: 1_000_000 };
+      const vision = calculateTurnCost('deepseek-v4-flash-vision-exp', usage);
+      const flash = calculateTurnCost('deepseek-v4-flash', usage);
+      expect(flash).toBeGreaterThan(0);
+      expect(vision).toBeCloseTo(flash, 6);
+    });
+
     it('handles zero uncached input with cache tokens', () => {
       // All input from cache — inputTokens = 0 (uncached), cache fields populated
       const cost = calculateTurnCost('claude-sonnet-4', {

--- a/src/core/llm/generated/modelData.generated.ts
+++ b/src/core/llm/generated/modelData.generated.ts
@@ -1797,6 +1797,15 @@ export const GENERATED_KNOWN_MODELS: Record<string, ModelCapabilities> = {
     maxOutputTokens: 8192,
     outputCeiling: 8192,
     contextWindow: 204800
+  },
+  'deepseek-v4-flash-vision-exp': {
+    vision: true,
+    thinking: 'uncontrollable',
+    toolResultImages: 'workaround',
+    documentBlock: false,
+    maxOutputTokens: 32768,
+    outputCeiling: 384000,
+    contextWindow: 1000000
   }
 };
 

--- a/src/core/llm/model-data/README.md
+++ b/src/core/llm/model-data/README.md
@@ -1,19 +1,23 @@
 # Model data — how to keep it fresh
 
 Model capability/pricing metadata is **generated at build time**, not hand-maintained.
-Three layers merge into `../generated/modelData.generated.ts`, which `modelCapabilities.ts`
-(`KNOWN_MODELS`) and `costTracker.ts` (`MODEL_PRICING`) consume.
+A pinned snapshot, the model overlays, and the per-id override layer merge into
+`../generated/modelData.generated.ts`, which `modelCapabilities.ts` (`KNOWN_MODELS`) and
+`costTracker.ts` (`MODEL_PRICING`) consume.
 
 ```
 vendor/models-dev.snapshot.json   ← pinned models.dev export. NEVER hand-edit.
 overlay/volcengine.json           ← 火山豆包/aggregator models models.dev lacks (hand-written)
+overlay/local-models.json         ← Ollama/LM Studio local models (hand-written)
+overlay/deepseek.json             ← DeepSeek models newer than the snapshot (hand-written)
 overlay/abu-overrides.json        ← per-id Abu-private fields + corrections (hand-written)
         │
         ▼  scripts/gen-model-data.ts   (npm run gen:models)
    ../generated/modelData.generated.ts  ← GENERATED, committed, do-not-edit
 ```
 
-**Precedence (per field):** `abu-overrides > volcengine > models.dev > classifier-derived`.
+**Precedence (per field):** `abu-overrides > model overlays > models.dev > classifier-derived`.
+The model overlays are concatenated, so an id must appear in only one of them.
 
 ## Why two output fields
 
@@ -51,8 +55,29 @@ clean whole-file replace — no merge conflicts with your edits.
 
 ## Add a model models.dev doesn't have
 
-Edit `overlay/volcengine.json` (or add another overlay file in the same shape:
-`{ "models": [ ModelRecord, ... ] }`), then `npm run gen:models` → `npm test` → commit.
+Edit the overlay that owns that vendor (or add another overlay file in the same shape:
+`{ "models": [ ModelRecord, ... ] }` — then wire it into `loadAndMerge()` in
+`scripts/gen-model-data.ts`), then `npm run gen:models` → `npm test` → commit.
+
+**Worked example — `overlay/deepseek.json` (`deepseek-v4-flash-vision-exp`).** DeepSeek's
+vision route shipped after the pinned snapshot, and it is the only DeepSeek id that accepts
+image input. Three choices in that entry are worth copying when the next such model lands:
+
+- **Overlay, not a `modelCapabilities.ts` pattern.** The runtime pattern fallback is
+  `/deepseek/i → vision:false`, so the vision id would otherwise resolve as text-only and
+  `normalizeMessages` would strip every image. Fixing that in the pattern would move the
+  default for the whole `deepseek-*` family; an overlay entry is scoped to one exact id, and
+  following an `-exp` id as it moves stays a one-line JSON edit.
+- **Mirror the sibling model, vary only what actually differs.** Every field is copied from
+  `deepseek-v4-flash` (the vision route is that model plus image input, and the official
+  pricing table lists identical price/context/max-output) except `vision` and
+  `toolResultImages`. `toolResultImages: "workaround"` because DeepSeek tool messages carry
+  string content only — `openai-compatible.ts` already re-emits tool-result images as a
+  following user message, which is what that label names.
+- **Omit `pricing` when a shorter id prefix already prices it.** `costTracker`'s
+  `findPricing` matches by longest id prefix, so `deepseek-v4-flash-vision-exp` inherits
+  `deepseek-v4-flash`'s numbers. Hand-copying them would go stale the first time a snapshot
+  refresh repriced flash, and nothing would flag the drift.
 
 ## Correct a wrong upstream value
 

--- a/src/core/llm/model-data/overlay/deepseek.json
+++ b/src/core/llm/model-data/overlay/deepseek.json
@@ -1,0 +1,26 @@
+{
+  "_comment": [
+    "DeepSeek models the pinned models.dev snapshot does not carry yet.",
+    "Fields mirror deepseek-v4-flash (the vision route is that model plus image input,",
+    "and official pricing lists both identically) except vision + toolResultImages.",
+    "pricing is omitted on purpose so findPricing's id-prefix match inherits flash's.",
+    "See ../README.md 'Add a model models.dev doesn't have' for the full rationale."
+  ],
+  "models": [
+    {
+      "id": "deepseek-v4-flash-vision-exp",
+      "label": "DeepSeek V4 Flash Vision (Exp)",
+      "family": "deepseek-flash",
+      "providers": ["deepseek"],
+      "vision": true,
+      "thinking": "uncontrollable",
+      "toolResultImages": "workaround",
+      "documentBlock": false,
+      "contextWindow": 1000000,
+      "maxOutputTokens": 32768,
+      "outputCeiling": 384000,
+      "reasoning": true,
+      "pdfInput": false
+    }
+  ]
+}

--- a/src/core/llm/modelCapabilities.test.ts
+++ b/src/core/llm/modelCapabilities.test.ts
@@ -92,6 +92,40 @@ describe('modelCapabilities', () => {
       expect(resolveCapabilities('qwen3-max').vision).toBe(false);
       expect(resolveCapabilities('deepseek-chat').vision).toBe(false);
     });
+
+    // DeepSeek's vision route arrived after the pinned models.dev snapshot, so it is
+    // declared in overlay/deepseek.json. Without that entry the /deepseek/i pattern
+    // fallback resolves vision:false, normalizeMessages strips every image, and the
+    // model is told the route cannot see pictures — i.e. the feature is silently dead.
+    it('deepseek-v4-flash-vision-exp is the one vision-capable DeepSeek route', () => {
+      expect(resolveCapabilities('deepseek-v4-flash-vision-exp').vision).toBe(true);
+    });
+
+    // The overlay is scoped to one exact id on purpose. If someone "fixes" this in the
+    // /deepseek/i pattern instead, the whole family flips to vision:true and every
+    // text-only DeepSeek route starts sending images that the provider rejects.
+    it('does not leak vision to its text-only DeepSeek siblings', () => {
+      expect(resolveCapabilities('deepseek-v4-flash').vision).toBe(false);
+      expect(resolveCapabilities('deepseek-v4-pro').vision).toBe(false);
+      expect(resolveCapabilities('deepseek-reasoner').vision).toBe(false);
+      // Unlisted deepseek ids keep the conservative pattern fallback.
+      expect(resolveCapabilities('deepseek-v9-imaginary').vision).toBe(false);
+    });
+
+    // The vision route is v4-flash plus image input; official docs give both the same
+    // context/max-output. Only vision and toolResultImages may differ — a drift here
+    // means the overlay was edited without checking it against its sibling.
+    it('mirrors deepseek-v4-flash except for the image-related fields', () => {
+      const vision = resolveCapabilities('deepseek-v4-flash-vision-exp');
+      const flash = resolveCapabilities('deepseek-v4-flash');
+      expect(vision.contextWindow).toBe(flash.contextWindow);
+      expect(vision.maxOutputTokens).toBe(flash.maxOutputTokens);
+      expect(vision.outputCeiling).toBe(flash.outputCeiling);
+      expect(vision.thinking).toBe(flash.thinking);
+      // DeepSeek tool messages carry string content only, so tool-result images ride
+      // a following user message (openai-compatible.ts) rather than the tool role.
+      expect(vision.toolResultImages).toBe('workaround');
+    });
   });
 
   describe('computeReasoningParams — content floor', () => {

--- a/src/core/llm/openai-vision-gating.test.ts
+++ b/src/core/llm/openai-vision-gating.test.ts
@@ -6,6 +6,7 @@ const mockFetch = vi.fn();
 vi.mock('./tauriFetch', () => ({ getTauriFetch: () => Promise.resolve(mockFetch) }));
 
 import { OpenAICompatibleAdapter } from './openai-compatible';
+import { resolveCapabilities } from './modelCapabilities';
 
 function makeSSEResponse(chunks: unknown[]): Response {
   const lines = chunks.map((c) => `data: ${JSON.stringify(c)}\n\n`);
@@ -82,5 +83,69 @@ describe('OpenAICompatibleAdapter — stripped image (empty base64) must not rea
     expect(wire).not.toContain('image_url');
     expect(wire).toContain('看看这张图'); // text still delivered
     expect(wire).toContain('could not be loaded'); // placeholder, not silent drop
+  });
+});
+
+// The two tests above prove the serializer honours the `supportsVision` flag it is
+// handed. This one closes the remaining link: that the *model id* Abu ships resolves
+// to that flag, so declaring a route vision-capable actually changes the bytes on the
+// wire. Without it, overlay/deepseek.json could say vision:true while images still
+// got stripped, and every unit test above would stay green.
+describe('OpenAICompatibleAdapter — DeepSeek vision route carries images end to end', () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  const userImage: Message[] = [
+    {
+      id: 'u1', role: 'user', timestamp: 1,
+      content: [
+        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'BASE64PNG' } },
+        { type: 'text', text: '这张图里是什么' },
+      ],
+    } as unknown as Message,
+  ];
+
+  type WirePart = { type: string; text?: string };
+
+  // The serializer collapses an all-text user message to a bare string and only
+  // emits a parts array when a non-text part (i.e. an image) survives, so read
+  // both shapes rather than assuming one.
+  async function sendAs(modelId: string): Promise<{ wire: string; userText: string }> {
+    mockFetch.mockResolvedValueOnce(makeSSEResponse([{ choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] }]));
+    await new OpenAICompatibleAdapter().chat(
+      userImage,
+      opts({ model: modelId, supportsVision: resolveCapabilities(modelId).vision }),
+      () => {},
+    );
+    const sent = JSON.parse(mockFetch.mock.calls[0][1].body as string).messages as
+      { role: string; content: string | WirePart[] }[];
+    const content = sent.find((m) => m.role === 'user')?.content ?? '';
+    return {
+      wire: JSON.stringify(sent),
+      userText: typeof content === 'string'
+        ? content
+        : content.filter((part) => part.type === 'text').map((part) => part.text ?? '').join(''),
+    };
+  }
+
+  it('deepseek-v4-flash-vision-exp receives the image as an image_url data URL', async () => {
+    const { wire } = await sendAs('deepseek-v4-flash-vision-exp');
+    expect(wire).toContain('image_url');
+    expect(wire).toContain('data:image/png;base64,BASE64PNG');
+    expect(wire).toContain('这张图里是什么');
+  });
+
+  it('deepseek-v4-flash gets the text plus an explicit no-vision note, never the image', async () => {
+    const prompt = '这张图里是什么';
+    const { wire, userText } = await sendAs('deepseek-v4-flash');
+    expect(wire).not.toContain('image_url');
+    expect(wire).not.toContain('BASE64PNG');
+    expect(userText).toContain(prompt);
+
+    // Degrades loudly: a note rides along so the model knows an image was dropped,
+    // rather than silently seeing a picture-less prompt and inventing a description.
+    // Asserted as "carries more than the user's own words" rather than by matching
+    // the note's text, because its wording — and its language — is owned by
+    // messageNormalizer and may be rewritten without changing this contract.
+    expect(userText.replace(prompt, '').trim().length).toBeGreaterThan(0);
   });
 });

--- a/src/utils/providerConfigs.ts
+++ b/src/utils/providerConfigs.ts
@@ -157,6 +157,10 @@ export const PROVIDER_CONFIGS = {
     models: [
       { id: 'deepseek-v4-pro', label: 'DeepSeek V4 Pro' },
       { id: 'deepseek-v4-flash', label: 'DeepSeek V4 Flash' },
+      // The only DeepSeek route that accepts image input. Its vision capability
+      // is declared in model-data/overlay/deepseek.json — without that entry the
+      // /deepseek/i pattern fallback would resolve vision:false and strip images.
+      { id: 'deepseek-v4-flash-vision-exp', label: 'DeepSeek V4 Flash Vision (Exp)' },
     ],
   },
   moonshot: {


### PR DESCRIPTION
## Why

DeepSeek opened its vision API (`deepseek-v4-flash-vision-exp`) on 2026-08-21. Abu's protocol layer was **already compatible** — `openai-compatible.ts` emits exactly the `image_url` data URL the route expects, and tool-result images already ride a following user message.

The blocker was one line in the capability table: the new id fell through the `/deepseek/i` pattern to `vision: false`, so `normalizeMessages` stripped every image and handed the model a note saying it cannot see pictures — which also pointed the user at the wrong fix ("switch models").

Counted per provider: of the 11 builtin providers with a model list, 8 already ship a vision model. Only DeepSeek (0/2) and Xiaomi MiMo (0/2) were fully text-only — and only DeepSeek now has an official vision route to declare.

## Three choices worth reviewing

**Overlay, not a pattern.** `-exp` is an experimental id that will move, and widening `/deepseek/i` would flip the whole `deepseek-*` family — sending images to text-only routes that reject them. `overlay/deepseek.json` is scoped to one exact id and is a one-line edit to follow.

**Mirror the sibling, vary only what differs.** Every field is copied from `deepseek-v4-flash` (the vision route is that model plus image input; the official pricing table lists identical price/context/max-output) except `vision` and `toolResultImages`. `toolResultImages: "workaround"` because DeepSeek tool messages carry string content only.

**`pricing` omitted on purpose.** `costTracker`'s `findPricing` matches by longest id prefix, so this id inherits flash's numbers. Hand-copying them would go stale the first time a snapshot refresh repriced flash, with nothing to flag the drift. A test pins the inheritance.

`model-data/README.md` documents all three for the next model like this.

## Side effect

DeepSeek's computer-use tier moves from `structured` to `full`, since that tier derives from vision support — closing the limitation recorded in `docs/2026-08-12-computer-use-m1-checkpoint.md`.

## Verification

`npm run verify` exit 0 (387 files / 5533 tests).

Tests cover the declaration, that text-only siblings and unlisted `deepseek-*` ids stay `vision:false`, that it does not drift from flash on shared fields, that pricing is inherited, and — end to end — that the model id now changes the bytes on the wire.

**Real DeepSeek key, Electron shell**: the model described the contents of a pasted screenshot. Runtime telemetry recorded `modelId=deepseek-v4-flash-vision-exp`, `modelTier=full`, `capabilitySource=builtin` — the last field confirming the capability came from the builtin table, not from a manually declared `supportsImages`.

## Known gap

A user who manually added this model id *before* this change has `supportsImages: false` persisted locally, and that takes precedence over the table. The model shipped 2026-08-21, so the affected population is ~nil; no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)