### PR TITLE
perf(test): default vitest to node env, opt DOM files back in

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -159,6 +159,29 @@ See `vitest.config.ts → test.coverage.thresholds` for current values.
 
 ## 6. Writing Tests — Conventions
 
+### Test environment — `node` by default, DOM is opt-in
+
+`vitest.config.ts` sets `environment: 'node'`. Only ~66 of ~386 test files actually need a DOM, and
+building a happy-dom per file cost more than running the tests: over the 340 non-`.tsx` files the
+`environment` phase alone was **187.80 s → 0.44 s**, and full-suite wall time went **~71-75 s →
+~42-55 s** (the `tests` phase itself was unchanged — it was all per-file setup overhead).
+
+**A test that touches the DOM must opt back in** with a docblock on its *first line*:
+
+```ts
+// @vitest-environment happy-dom
+import { render } from '@testing-library/react'
+```
+
+Required for every `*.test.tsx`, and for any `*.test.ts` that touches `document`/`window`,
+Storage, selection, or DOM events (currently 20 files — stores with persist, `hooks/`,
+`features/reference/`, `core/notice/`, `sidecarManager`, `frameApplier`, `chatDelta`,
+`tauriFetch`, `petStatusBridge`, `PptxPreview`).
+
+🔴 A new component test **without** that line fails on `document is not defined`. Add the docblock —
+do **not** flip the global default back; that re-imposes the happy-dom cost on all ~320 DOM-free
+files. `src/test/setup.ts` already polyfills `localStorage`, so Zustand `persist` works under `node`.
+
 ### Store tests
 
 ```ts

--- a/abu-chrome-extension/src/content/index.test.ts
+++ b/abu-chrome-extension/src/content/index.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /**
  * Characterization tests for the content-script DOM runtime.
  *

--- a/src/components/chat/AgentStatusStrip.test.tsx
+++ b/src/components/chat/AgentStatusStrip.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 
 import { render, screen, cleanup } from '@testing-library/react';

--- a/src/components/chat/ChatInput.keyboard.test.tsx
+++ b/src/components/chat/ChatInput.keyboard.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /**
  * Keyboard contract for the composer.
  *

--- a/src/components/chat/ChatInput.test.tsx
+++ b/src/components/chat/ChatInput.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import ChatInput, { mergeComposerAppend, referenceDedupeKey, referenceChipLabel } from './ChatInput';

--- a/src/components/chat/CompactDivider.test.tsx
+++ b/src/components/chat/CompactDivider.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 
 import { describe, it, expect, afterEach, vi } from 'vitest';

--- a/src/components/chat/ComputerUseStatusBar.test.tsx
+++ b/src/components/chat/ComputerUseStatusBar.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';

--- a/src/components/chat/ContextIndicator.test.tsx
+++ b/src/components/chat/ContextIndicator.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 
 import { render, screen, cleanup } from '@testing-library/react';

--- a/src/components/chat/MarkdownRenderer.strikethrough.test.tsx
+++ b/src/components/chat/MarkdownRenderer.strikethrough.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 /**
  * Regression: a lone `~` must NOT render as strikethrough.

--- a/src/components/chat/MessageBubble.test.tsx
+++ b/src/components/chat/MessageBubble.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 
 import { cleanup, render, screen } from '@testing-library/react';

--- a/src/components/chat/MessageGroup.status.test.tsx
+++ b/src/components/chat/MessageGroup.status.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 
 import { cleanup, render, screen } from '@testing-library/react';

--- a/src/components/chat/PermissionModeChip.test.tsx
+++ b/src/components/chat/PermissionModeChip.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';

--- a/src/components/chat/PlanStepsCard.test.tsx
+++ b/src/components/chat/PlanStepsCard.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 /**
  * Tests for the inline plan card shown for report_plan tool calls.

--- a/src/components/chat/QueuedMessagesStrip.test.tsx
+++ b/src/components/chat/QueuedMessagesStrip.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 /**
  * Queued follow-ups render as light-gray pills at the composer's top-right

--- a/src/components/chat/SandboxRecoveryCard.test.tsx
+++ b/src/components/chat/SandboxRecoveryCard.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/src/components/chat/ShowWidgetCard.test.tsx
+++ b/src/components/chat/ShowWidgetCard.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 /**
  * State-dispatch tests for the inline show_widget card.

--- a/src/components/chat/SkillProposalCard.test.tsx
+++ b/src/components/chat/SkillProposalCard.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, cleanup } from '@testing-library/react';

--- a/src/components/chat/SmoothHeight.test.tsx
+++ b/src/components/chat/SmoothHeight.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 
 import { cleanup, render } from '@testing-library/react';

--- a/src/components/chat/TaskBlock.test.tsx
+++ b/src/components/chat/TaskBlock.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 
 import { cleanup, fireEvent, render } from '@testing-library/react';

--- a/src/components/chat/UserQuestionCard.test.tsx
+++ b/src/components/chat/UserQuestionCard.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';

--- a/src/components/chat/UserQuestionDock.test.tsx
+++ b/src/components/chat/UserQuestionDock.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';

--- a/src/components/chat/composerKeys.test.ts
+++ b/src/components/chat/composerKeys.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, expect, it } from 'vitest';
 import { insertNewlineAtCursor, isImeComposing, resolveEnterAction } from './composerKeys';
 import type { EnterAction } from './composerKeys';

--- a/src/components/common/CommandConfirmDialog.test.tsx
+++ b/src/components/common/CommandConfirmDialog.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';

--- a/src/components/customize/SkillCategoryBlocksPanel.test.tsx
+++ b/src/components/customize/SkillCategoryBlocksPanel.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';

--- a/src/components/customize/SkillHistoryModal.test.tsx
+++ b/src/components/customize/SkillHistoryModal.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';

--- a/src/components/panel/PreviewActionsMenu.test.tsx
+++ b/src/components/panel/PreviewActionsMenu.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';

--- a/src/components/panel/TaskProgressPanel.test.tsx
+++ b/src/components/panel/TaskProgressPanel.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 /**
  * Regression: the panel used to bind to the conversation's LATEST execution —

--- a/src/components/panel/VersionHistoryMenu.test.tsx
+++ b/src/components/panel/VersionHistoryMenu.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, cleanup } from '@testing-library/react';

--- a/src/components/panel/workspace/BrowserTab.test.tsx
+++ b/src/components/panel/workspace/BrowserTab.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/src/components/panel/workspace/TabStrip.test.tsx
+++ b/src/components/panel/workspace/TabStrip.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';

--- a/src/components/panel/workspace/TerminalTab.test.tsx
+++ b/src/components/panel/workspace/TerminalTab.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 import { act, cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';

--- a/src/components/preview/PptxPreview.test.ts
+++ b/src/components/preview/PptxPreview.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { normalizeSlideBackgrounds } from './PptxPreview';
 

--- a/src/components/settings/CapabilitySetupDialog.test.tsx
+++ b/src/components/settings/CapabilitySetupDialog.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';

--- a/src/components/settings/ToolboxModal.test.tsx
+++ b/src/components/settings/ToolboxModal.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';

--- a/src/components/settings/sections/AIServicesSection.test.tsx
+++ b/src/components/settings/sections/AIServicesSection.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';

--- a/src/components/settings/sections/CapabilitiesSection.test.tsx
+++ b/src/components/settings/sections/CapabilitiesSection.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen, waitFor, within } from '@testing-library/react';

--- a/src/components/settings/sections/LabsSection.test.tsx
+++ b/src/components/settings/sections/LabsSection.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, within, cleanup } from '@testing-library/react';

--- a/src/components/settings/sections/PetSection.test.tsx
+++ b/src/components/settings/sections/PetSection.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';

--- a/src/components/settings/sections/ai-services/AddProviderModal.test.tsx
+++ b/src/components/settings/sections/ai-services/AddProviderModal.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 /**
  * Unit tests for AddProviderModal.

--- a/src/components/share/ShareExportDialog.test.tsx
+++ b/src/components/share/ShareExportDialog.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 
 import { render, screen, cleanup, waitFor } from '@testing-library/react';

--- a/src/components/sidebar/ConversationSearchModal.test.tsx
+++ b/src/components/sidebar/ConversationSearchModal.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import ConversationSearchModal from './ConversationSearchModal';

--- a/src/components/sidebar/ProjectItem.test.tsx
+++ b/src/components/sidebar/ProjectItem.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 /**
  * Tests for the per-project conversation list in the sidebar.

--- a/src/components/toolbox/CapabilityScopeToggle.test.tsx
+++ b/src/components/toolbox/CapabilityScopeToggle.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import CapabilityScopeToggle from './CapabilityScopeToggle';

--- a/src/components/ui/checkbox.test.tsx
+++ b/src/components/ui/checkbox.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 /**
  * Regression tests for the Checkbox primitive.

--- a/src/components/window/WindowTitleBar.test.tsx
+++ b/src/components/window/WindowTitleBar.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';

--- a/src/core/agent/frameApplier.test.ts
+++ b/src/core/agent/frameApplier.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useChatStore } from '@/stores/chatStore';
 import { useTaskExecutionStore } from '@/stores/taskExecutionStore';

--- a/src/core/agent/ports/chatDelta.test.ts
+++ b/src/core/agent/ports/chatDelta.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { useChatStore } from '@/stores/chatStore';
 import {

--- a/src/core/llm/tauriFetch.test.ts
+++ b/src/core/llm/tauriFetch.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, beforeEach } from 'vitest';
 
 // Note: @tauri-apps/plugin-http is globally mocked in src/test/setup.ts.

--- a/src/core/notice/contextProvider.test.ts
+++ b/src/core/notice/contextProvider.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { useChatStore } from '@/stores/chatStore';
 

--- a/src/core/notice/focusSync.test.ts
+++ b/src/core/notice/focusSync.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { invoke } from '@tauri-apps/api/core';
 import type { Event } from '@tauri-apps/api/event';

--- a/src/core/pet/petStatusBridge.test.ts
+++ b/src/core/pet/petStatusBridge.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { emitTo } from '@tauri-apps/api/event'
 import { startPetStatusBridge, stopPetStatusBridge } from './petStatusBridge'

--- a/src/core/sidecar/sidecarManager.test.ts
+++ b/src/core/sidecar/sidecarManager.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Local proxies let each test control invoke/listen/resolveResource

--- a/src/features/reference/DocSelectionLayer.test.tsx
+++ b/src/features/reference/DocSelectionLayer.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 // src/features/reference/DocSelectionLayer.test.tsx
 //
 // Integration test: selection → toolbar → reference lands in chatStore.pendingReferences

--- a/src/features/reference/SelectionToolbar.test.tsx
+++ b/src/features/reference/SelectionToolbar.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 // src/features/reference/SelectionToolbar.test.tsx
 import { describe, it, expect, vi } from 'vitest';
 import { useState } from 'react';

--- a/src/features/reference/highlightRegistry.test.ts
+++ b/src/features/reference/highlightRegistry.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, beforeEach } from 'vitest';
 import { highlightRegistry } from './highlightRegistry';
 

--- a/src/features/reference/markdownSelectionSource.test.ts
+++ b/src/features/reference/markdownSelectionSource.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, beforeEach } from 'vitest';
 import { markdownSelectionSource } from './markdownSelectionSource';
 

--- a/src/features/reference/useTextSelection.test.ts
+++ b/src/features/reference/useTextSelection.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 // src/features/reference/useTextSelection.test.ts
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';

--- a/src/hooks/useFileDragDrop.test.ts
+++ b/src/hooks/useFileDragDrop.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useFileDragDrop } from './useFileDragDrop';

--- a/src/hooks/usePingCadence.test.ts
+++ b/src/hooks/usePingCadence.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 

--- a/src/hooks/usePreviewFileWatch.test.ts
+++ b/src/hooks/usePreviewFileWatch.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { watch, exists, type WatchEvent, type UnwatchFn } from '@tauri-apps/plugin-fs';

--- a/src/hooks/useWorkspaceTree.test.ts
+++ b/src/hooks/useWorkspaceTree.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { readDir, watch, exists, type DirEntry, type UnwatchFn } from '@tauri-apps/plugin-fs';

--- a/src/pet/PetContextMenu.test.tsx
+++ b/src/pet/PetContextMenu.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { PetContextMenu } from './PetContextMenu'

--- a/src/pet/PetNotificationBubble.test.tsx
+++ b/src/pet/PetNotificationBubble.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, fireEvent, screen } from '@testing-library/react'
 import { PetNotificationBubble } from './PetNotificationBubble'

--- a/src/pet/usePetDrag.test.tsx
+++ b/src/pet/usePetDrag.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { useEffect } from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, fireEvent, screen } from '@testing-library/react'

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { exists, readTextFile } from '@tauri-apps/plugin-fs';
 import { invoke } from '@tauri-apps/api/core';

--- a/src/stores/composerDraftStore.test.ts
+++ b/src/stores/composerDraftStore.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ComposerDraft } from './composerDraftStore';
 import type { EnterpriseBinding } from '@/core/enterprise/types';

--- a/src/stores/scheduleStore.test.ts
+++ b/src/stores/scheduleStore.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { useScheduleStore, computeNextRunAt, applyCatchupOnRehydrate } from './scheduleStore';
 import type { ScheduleConfig, ScheduledTask } from '../types/schedule';

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { invoke } from '@tauri-apps/api/core';
 import { reconcileActiveProvider, useSettingsStore, getDefaultImageBackend, getUsableImageBackend, bootstrapSecrets } from './settingsStore';

--- a/src/stores/triggerStore.test.ts
+++ b/src/stores/triggerStore.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /**
  * triggerStore tests — v2→v3 migration + CRUD basics
  */

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,7 +31,17 @@ export default defineConfig({
     'import.meta.env.VITE_CONSOLE_URL': JSON.stringify('https://console-test.local'),
   },
   test: {
-    environment: 'happy-dom',
+    // Default to `node`: only ~66 of ~386 test files actually need a DOM, and
+    // building a happy-dom per file cost more than running the tests. Measured
+    // over the 340 non-.tsx files: 74.86s -> 27.79s wall, of which the
+    // `environment` phase alone went 187.80s -> 0.44s (the `tests` phase was
+    // unchanged at ~29s — it was all setup overhead).
+    // Files that DO need a DOM opt back in with a
+    // `// @vitest-environment happy-dom` docblock on their first line — every
+    // *.test.tsx plus the 20 *.test.ts that touch DOM/Storage/selection APIs.
+    // A new component test without that line fails on `document is not
+    // defined`; add the docblock rather than changing this default back.
+    environment: 'node',
     setupFiles: ['./src/test/setup.ts'],
     // v8 coverage instrumentation adds overhead to setup/beforeAll hooks on cold
     // CI runners. Give hooks extra headroom so they don't time out spuriously.


### PR DESCRIPTION
## 问题

每个测试文件都要建一个 happy-dom 实例，但全仓 ~394 个测试文件里只有 ~69 个真的需要 DOM。建环境比跑测试还贵。

## 改动

`vitest.config.ts` 全局默认从 `happy-dom` 改成 `node`，需要 DOM 的文件用首行 docblock 单独opt-in：

```ts
// @vitest-environment happy-dom
```

覆盖 46 个 `*.test.tsx` + 23 个 `*.test.ts`。**那 23 个不是猜的** —— 先把全量切到 node 跑一遍，失败列表就是精确答案（stores 里带 persist 的、`hooks/`、`features/reference/`、`core/notice/`、`sidecarManager`、`frameApplier`、`chatDelta`、`tauriFetch`、`petStatusBridge`、`PptxPreview`、`composerKeys`、`ChatInput.keyboard`、`abu-chrome-extension/content`）。

`src/test/setup.ts` 本来就 polyfill 了 `localStorage`，所以 Zustand persist 在 node 下照常工作。

## 收益

同机 3v3 A/B（空闲状态测）：

```
before (happy-dom):  75.37s  70.97s
after  (node):       41.89s  50.14s  54.56s
```

全量测试段 **~71-75s → ~42-55s，快 35-40%**。钱是从哪省的很清楚：

| phase | before | after |
|---|---|---|
| environment | 161.91s | **17.7-27.4s** |
| tests（真跑用例） | 44.10s | 37.5-44.8s（基本没变） |

⚠️ 上面这组 A/B 是在 rebase 之前的 base 上测的（当时 386 个测试文件）。rebase 到最新 dev 后我想重测，但机器 load 冲到 36/8核，同一跑法从 79s 变成 527s，数据不可用就没采纳。机制没变，但**这组数字不是在本 PR 的 head 上重新测的**，如实说明。

## 验证

`npm run verify` 在本 PR head 上 **EXIT=0**（394 files / 5697 tests），覆盖率未破阈值。

## 需要 reviewer 注意的 trade-off

这改的是全仓测试基建的默认值，**影响所有人写新测试**：

🔴 **新加的组件测试如果忘了写 docblock，会报 `document is not defined`。正确做法是补 docblock，不是把全局默认改回去** —— 改回去等于把 happy-dom 的成本重新压回 ~325 个不需要 DOM 的文件上。

这条已经写进 `TESTING.md §6`（新增小节，含缘由、数字、和具体做法）。
