### PR TITLE
fix(test): keep the enterprise suite on a DOM environment

### DIFF
--- a/vitest.enterprise.config.ts
+++ b/vitest.enterprise.config.ts
@@ -38,6 +38,13 @@ const enterpriseConfig = mergeConfig(
       },
     },
     test: {
+      // The enterprise suite is a thin umbrella over the private repository's
+      // tests, many of which render React components. 0b68c42b flipped the
+      // base default to `node`, which this config inherits through mergeConfig
+      // — but the private files can't carry per-file `@vitest-environment`
+      // docblocks from here, so restore the DOM default suite-wide. At ~200
+      // tests the node-env startup win is noise.
+      environment: 'happy-dom',
       // Replaced below because mergeConfig concatenates array values.
       include: [],
     },


### PR DESCRIPTION
## 背景
整体审查（v0.40.0..dev 对抗式 review）的 CONFIRMED finding：#250 把 vitest 默认环境切到 node 后，`vitest.enterprise.config.ts` 经 mergeConfig 继承了该默认，而企业套件是私有仓库测试的伞壳——大量测试要渲染 React，且私有文件没法从本仓贴 `@vitest-environment` docblock。实测 `npm run test:enterprise` 在 8 个文件 71 个测试上挂 `document is not defined`，OSS 门禁跑不到这批文件所以 CI 全绿。

## 修法
配置级恢复企业套件的 happy-dom 默认（而非逐 shim 贴 docblock——.ts shim 也在导入渲染型测试，逐文件是打地鼠，且下一个新 shim 还会踩）。~200 个测试的规模下 node 环境的启动收益可忽略。

## 验证
- 修复前：8 failed files / 71 failed tests（document is not defined）
- 修复后：**24 files / 205 tests 全绿**（私有仓库 sibling @ 8fa110f）
- `npm run verify:quick` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)