### PR TITLE
fix(agent): guard in-process checkpoint clears with the owning loopId

### DIFF
--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -1274,8 +1274,8 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       import('../tools/definitions/computerTools').then(({ closeAxSession }) => {
         closeAxSession(conversationId, loopId).catch(() => {});
       }).catch(() => {});
-      import('../session/checkpoint').then(({ clearCheckpoint }) => {
-        clearCheckpoint(conversationId);
+      import('../session/checkpoint').then(({ clearCheckpointForLoop }) => {
+        clearCheckpointForLoop(conversationId, loopId);
       }).catch(() => {});
       break;
     }
@@ -2416,8 +2416,8 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
           closeAxSession(conversationId, loopId).catch(() => {});
         }).catch(() => {});
         // Clear crash recovery checkpoint — loop completed normally
-        import('../session/checkpoint').then(({ clearCheckpoint }) => {
-          clearCheckpoint(conversationId);
+        import('../session/checkpoint').then(({ clearCheckpointForLoop }) => {
+          clearCheckpointForLoop(conversationId, loopId);
         }).catch(() => {});
         // Mark conversation status — error if recovery exhausted, otherwise completed.
         // no_progress is a soft stop (visible marker, status completed) like maxTurns.
@@ -2575,8 +2575,8 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         // Auto-deactivate skills on abort
         deactivateAllSkills(conversationId);
         // Clear crash recovery checkpoint — loop aborted by user
-        import('../session/checkpoint').then(({ clearCheckpoint }) => {
-          clearCheckpoint(conversationId);
+        import('../session/checkpoint').then(({ clearCheckpointForLoop }) => {
+          clearCheckpointForLoop(conversationId, loopId);
         }).catch(() => {});
         // Close any open AX session (releases CFRetain'd element refs)
         import('../tools/definitions/computerTools').then(({ closeAxSession }) => {
@@ -2674,8 +2674,8 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         closeAxSession(conversationId, loopId).catch(() => {});
       }).catch(() => {});
       // Clear crash recovery checkpoint — loop ended with error
-      import('../session/checkpoint').then(({ clearCheckpoint }) => {
-        clearCheckpoint(conversationId);
+      import('../session/checkpoint').then(({ clearCheckpointForLoop }) => {
+        clearCheckpointForLoop(conversationId, loopId);
       }).catch(() => {});
       // Mark conversation as error and send notification
       chatDelta.setConversationStatus(conversationId, 'error');

--- a/src/core/session/checkpoint.ts
+++ b/src/core/session/checkpoint.ts
@@ -8,8 +8,12 @@
  * Lifecycle:
  *   agentLoop turn start  → writeCheckpoint({ status: 'llm_calling' })
  *   tool execution start  → writeCheckpoint({ status: 'tool_executing' })
- *   loop normal end       → clearCheckpoint()
- *   loop abort / error    → clearCheckpoint()
+ *   loop normal end       → clearCheckpointForLoop()
+ *   loop abort / error    → clearCheckpointForLoop()
+ *   (the unguarded clearCheckpoint() is for callers that own no loopId,
+ *    e.g. discarding recovery for a conversation from the startup UI —
+ *    loop teardown must use the guarded variant, because teardown can
+ *    outlive the turn and the next turn may already own the conversation)
  *   app startup           → findOrphanedCheckpoints() → show recovery UI
  */
 


### PR DESCRIPTION
## 背景
整体审查（v0.40.0..dev）finding（PLAUSIBLE，验证者给出具体交错窗口）：sidecar 路径（agentLoopRunner.ts:676）已因"teardown 可能晚于回合终态"改用带 loopId 守卫的 `clearCheckpointForLoop`，但 in-process 路径 agentLoop.ts 四处终态清理（max-turns break / 正常结束 / abort / error）仍用无守卫的 `clearCheckpoint`。这四处都是 fire-and-forget 动态 import，执行时并发守卫已清、状态已置 idle——新回合可以立即启动并写入自己的检查点，随后被旧回合迟到的无守卫 clear 误删，新回合此后崩溃则无恢复点。

## 修法
四处全部换成 `clearCheckpointForLoop(conversationId, loopId)`（loopId 四处均在作用域内，机械替换）；同步修正 checkpoint.ts 生命周期注释——它此前仍推荐 loop teardown 用无守卫版本，会误导后来者。

## 验证
- `vitest src/core/agent`：47 文件 / 840 测试全绿
- `checkpoint.test.ts`：4/4（clearCheckpointForLoop 的守卫语义已有既有测试钉住）
- typecheck 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)