### PR TITLE
fix(chat): admit a pasted .bmp as an image, matching the drag path

### DIFF
--- a/src/utils/imageUtils.test.ts
+++ b/src/utils/imageUtils.test.ts
@@ -37,11 +37,13 @@ describe('sniffImageMediaType', () => {
       expect(sniffImageMediaType(head(0x25, 0x50, 0x44, 0x46, 0x2d))).toBeNull();
     });
 
-    it('rejects TIFF and BMP — real images, but not types the composer can send', () => {
+    it('rejects TIFF — Chromium cannot decode it, so admission could not re-encode it', () => {
       expect(sniffImageMediaType(head(0x49, 0x49, 0x2a, 0x00))).toBeNull(); // TIFF little-endian
       expect(sniffImageMediaType(head(0x4d, 0x4d, 0x00, 0x2a))).toBeNull(); // TIFF big-endian
-      expect(sniffImageMediaType(head(0x42, 0x4d))).toBeNull(); // BMP
     });
+    // BMP moved out of this list deliberately: the admission gate re-encodes
+    // wire-illegal-but-decodable types now, and drag-drop already admitted
+    // `.bmp` by extension — see the BMP describe block below.
 
     it('rejects RIFF containers that are not WebP (e.g. WAV)', () => {
       const wav = head(0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45);
@@ -72,5 +74,20 @@ describe('sniffImageMediaType', () => {
       // `…/id=6571367.107158211` — the name says ".107158211", the bytes say PNG.
       expect(sniffImageMediaType(PNG)).toBe('image/png');
     });
+  });
+});
+
+describe('sniffImageMediaType — BMP', () => {
+  // Pasting a copied .bmp file used to fall through to the file-badge path:
+  // the sniffer knew only the four wire-safe signatures, and on macOS the
+  // pasteboard temp item carries no usable name or type — so the picture
+  // became an unreadable `id=…` badge. Drag-drop admitted the same file by
+  // extension, so the two entrances disagreed. BMP bytes are now recognised;
+  // the admission gate re-encodes them to a wire-safe format downstream.
+  it('recognises BMP bytes so paste matches the drag path', () => {
+    const bmp = new Uint8Array(16);
+    bmp[0] = 0x42; // 'B'
+    bmp[1] = 0x4d; // 'M'
+    expect(sniffImageMediaType(bmp)).toBe('image/bmp');
   });
 });

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -12,6 +12,7 @@ const JPEG_SIGNATURE = [0xff, 0xd8, 0xff];
 const GIF_SIGNATURE = [0x47, 0x49, 0x46, 0x38]; // "GIF8" — covers 87a and 89a
 const RIFF_SIGNATURE = [0x52, 0x49, 0x46, 0x46]; // "RIFF"
 const WEBP_SIGNATURE = [0x57, 0x45, 0x42, 0x50]; // "WEBP", at offset 8
+const BMP_SIGNATURE = [0x42, 0x4d]; // "BM"
 
 function startsWith(bytes: Uint8Array, signature: number[], offset = 0): boolean {
   if (bytes.length < offset + signature.length) return false;
@@ -27,8 +28,11 @@ function startsWith(bytes: Uint8Array, signature: number[], offset = 0): boolean
  * Extension- and mime-based routing both misfile that as a plain document, so
  * the picture is lost. The bytes are the only honest signal.
  *
- * Only the four types the composer can actually send are recognised
- * (`SUPPORTED_IMAGE_TYPES`); anything else stays a file attachment, which is
+ * Recognised types are the four the composer can send as-is
+ * (`SUPPORTED_IMAGE_TYPES`) plus BMP, which the admission gate re-encodes to a
+ * wire-safe format (`fitImageToDimension`) — the drag path already admits
+ * `.bmp` by extension, so the paste path recognising the same bytes keeps the
+ * two entrances consistent. Anything else stays a file attachment, which is
  * what it was before. Pass at least `IMAGE_MAGIC_PREFIX_BYTES` bytes.
  */
 export function sniffImageMediaType(bytes: Uint8Array): string | null {
@@ -36,5 +40,6 @@ export function sniffImageMediaType(bytes: Uint8Array): string | null {
   if (startsWith(bytes, JPEG_SIGNATURE)) return 'image/jpeg';
   if (startsWith(bytes, GIF_SIGNATURE)) return 'image/gif';
   if (startsWith(bytes, RIFF_SIGNATURE) && startsWith(bytes, WEBP_SIGNATURE, 8)) return 'image/webp';
+  if (startsWith(bytes, BMP_SIGNATURE)) return 'image/bmp';
   return null;
 }


### PR DESCRIPTION
发版验收实测（Case 2）发现：**粘贴**复制的 .bmp 走了文件角标路径（嗅探器只认四种 wire 签名、声明类型白名单不含 image/bmp），而 macOS 剪贴板给的是 `id=…` 临时路径，agent 读取直接失败；**拖拽**同一文件却按扩展名正常入图，两个入口行为不一致。

修法：嗅探器加 BMP 魔数（'BM'）。#252 建的入口重编码能力会把它自动转成 wire 合法格式，无需其他改动。TIFF 保持拒绝（Chromium 解不了码、重编码链路无从工作）。按测试文件政策同一提交刻意反转 1 条钉住断言。

验证：utils + chat 套件 63 文件 / 780 测试全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)