### PR TITLE
fix(chat): materialize the draft before persisting a user-run revision

### DIFF
--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -2493,3 +2493,55 @@ describe('chatStore', () => {
   });
 
 });
+
+describe('updateUserMessageRun with multimodal content (regression: revoked immer draft)', () => {
+  // `updatedMessage = { ...message }` shallow-copied the immer draft, so a
+  // multimodal content ARRAY stayed a nested draft proxy — revoked the moment
+  // the producer returned. The tracked persistence then serialized a revoked
+  // proxy ("Cannot perform 'IsArray' on a proxy that has been revoked"):
+  // every runState revision for an image-carrying row failed to persist, the
+  // ledger showed the run stuck at `pending`, and the dispatch promise
+  // rejection silently handed the just-sent draft back to the composer.
+  // Found by v0.41.0 release acceptance (conversation mt47q9iznggop0).
+  it('persists state transitions on an image-carrying row instead of rejecting', async () => {
+    const id = useChatStore.getState().createConversation();
+    const message = {
+      id: 'client-msg-img',
+      role: 'user',
+      content: 'placeholder',
+      timestamp: FIXED_TIMESTAMP,
+      runId: 'run-img',
+      clientMessageId: 'client-msg-img',
+      runState: 'pending',
+    } as const;
+    useChatStore.getState().addMessage(id, message);
+    vi.mocked(exists).mockResolvedValue(true);
+    vi.mocked(readTextFile).mockResolvedValue(`${JSON.stringify(message)}\n`);
+
+    try {
+      // The image path first upgrades the durable row to multimodal content…
+      useChatStore.getState().updateUserMessageRun(id, 'client-msg-img', {
+        state: 'pending',
+        content: [
+          { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'aGk=' } },
+          { type: 'text', text: '这是啥' },
+        ],
+      });
+      await waitForConversationPersistence(id);
+
+      // …then advances the run state on the now-array-carrying draft row.
+      useChatStore.getState().updateUserMessageRun(id, 'client-msg-img', { state: 'running' });
+      await waitForConversationPersistence(id);
+      useChatStore.getState().updateUserMessageRun(id, 'client-msg-img', { state: 'completed' });
+      await waitForConversationPersistence(id);
+
+      const row = useChatStore.getState().conversations[id].messages[0];
+      expect(row.runState).toBe('completed');
+      expect(Array.isArray(row.content)).toBe(true);
+    } finally {
+      vi.mocked(exists).mockReset();
+      vi.mocked(exists).mockResolvedValue(false);
+      vi.mocked(readTextFile).mockReset();
+    }
+  });
+});

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1338,7 +1338,11 @@ export const useChatStore = create<ChatStore>()(
               if (meta) {
                 meta.messageCount = conv.messages.length;
                 meta.updatedAt = conv.updatedAt;
-                metaToPersist = { ...meta };
+                // `current`, not a spread: same revoked-draft hazard as
+                // updateUserMessageRun above — `meta.model` is a nested object,
+                // so a shallow copy of the draft hands the async persistence a
+                // child proxy that is revoked when this producer returns.
+                metaToPersist = current(meta);
               }
             }
           }

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
+import { current } from 'immer';
 import type { Message, Conversation, AgentStatus, RetryInfo, TokenUsage, ConversationStatus, ToolCallForContext, ToolResultContent, ToolCall, NoticeCardAction, SandboxRecoveryAction, ToolExecutionMetadata, UserQuestionResult } from '../types';
 import type { ExecutionStepSnapshot, PlannedStep } from '../types/execution';
 import { useWorkspaceStore } from './workspaceStore';
@@ -1275,7 +1276,14 @@ export const useChatStore = create<ChatStore>()(
           if ('delegateAgent' in patch) message.delegateAgent = patch.delegateAgent;
           conv.updatedAt = Date.now();
           conv.contextCache = undefined;
-          updatedMessage = { ...message };
+          // `current`, not a spread: `message` is an immer draft, and a shallow
+          // copy keeps nested values (a multimodal `content` ARRAY) as draft
+          // proxies that are revoked the moment this producer returns. The
+          // tracked persistence below then serializes a revoked proxy —
+          // "Cannot perform 'IsArray' on a proxy that has been revoked" — so
+          // every runState revision for an image-carrying row failed to
+          // persist and the ledger showed the run stuck at `pending`.
+          updatedMessage = current(message);
         });
 
         if (!updatedMessage) return;


### PR DESCRIPTION
发版验收实测（对话 mt47q9iznggop0）追出的**阻断级** bug——一个根因、四个症状：

1. 带图轮次账本 runState 永远卡 `pending`（崩溃恢复会误判为未完成轮次）
2. 发送成功、回答正常，但草稿被**静默回填**进输入框（无任何 toast）
3. 日志 `applyDeltaFrames threw` / `abort finalization failed`: Cannot perform 'IsArray' on a proxy that has been revoked
4. 纯文本轮次完全正常（string content 按值展开，躲过一劫）

**根因**：`updateUserMessageRun` 在 producer 内用 `{ ...message }` 浅拷贝 immer 草稿留给异步持久化。多模态 content 数组是嵌套草稿代理，producer 返回即被撤销；持久化队列随后在 `stripForDisk`（conversationStorage.ts:1076）序列化时命中 revoked proxy，整条 tracked persistence 链 reject——账本修订丢失 + dispatch promise reject 触发 ChatInput 的"发送被拒还草稿"路径。

**修法**：immer `current()` 深物化后再交给持久化（一行 + 注释）。

**验证**：回归测试先证伪——去掉修复，测试在生产同款抛错点失败；加回修复 143/143 绿。chatStore 全套通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)