### PR TITLE
fix(chat): infer completion for stale pending rows whose loop replied

### DIFF
--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -2545,3 +2545,47 @@ describe('updateUserMessageRun with multimodal content (regression: revoked imme
     }
   });
 });
+
+describe('sanitizeLoadedMessages — stale pending rows whose loop actually replied', () => {
+  // The immer draft-leak (fixed alongside) left every image-carrying user row
+  // permanently 'pending' in the ledger — including all of v0.40.0's. On load
+  // those rows were branded runState 'failed' ("发送失败" + retry) even though
+  // the substantive assistant reply sits right below them, and retrying such
+  // a row re-sends a stripped (empty-data) image. A stale-active row whose
+  // loopId has a substantive assistant reply is now inferred completed.
+  it('marks a pending user row completed when its loop has a real reply', () => {
+    const sanitized = sanitizeLoadedMessages([
+      {
+        id: 'u1', role: 'user', content: [{ type: 'text', text: '这是啥' }],
+        timestamp: 1, runState: 'pending', loopId: 'loop-a',
+      },
+      {
+        id: 'a1', role: 'assistant', content: '这是一张渐变图。',
+        timestamp: 2, loopId: 'loop-a',
+      },
+    ] as never);
+    expect(sanitized[0].runState).toBe('completed');
+    expect(sanitized[0].runError).toBeUndefined();
+  });
+
+  it('still fails a pending row whose loop never produced a reply', () => {
+    const sanitized = sanitizeLoadedMessages([
+      {
+        id: 'u1', role: 'user', content: 'hello',
+        timestamp: 1, runState: 'pending', loopId: 'loop-b',
+      },
+      // Ghost placeholder — empty assistant row, filtered out and NOT a reply.
+      { id: 'a1', role: 'assistant', content: '', timestamp: 2, loopId: 'loop-b' },
+    ] as never);
+    expect(sanitized[0].runState).toBe('failed');
+    expect(sanitized).toHaveLength(1);
+  });
+
+  it('does not touch terminal rows', () => {
+    const sanitized = sanitizeLoadedMessages([
+      { id: 'u1', role: 'user', content: 'x', timestamp: 1, runState: 'completed', loopId: 'loop-c' },
+      { id: 'a1', role: 'assistant', content: 'y', timestamp: 2, loopId: 'loop-c' },
+    ] as never);
+    expect(sanitized[0].runState).toBe('completed');
+  });
+});

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -37,8 +37,16 @@ const TERMINAL_RUN_STATES = new Set<Message['runState']>([
   'interrupted',
 ]);
 
-function recoverInterruptedUserRun(msg: Message): Message {
+function recoverInterruptedUserRun(msg: Message, answeredLoopIds?: ReadonlySet<string>): Message {
   if (msg.role !== 'user' || !ACTIVE_RUN_STATES.has(msg.runState)) return msg;
+  // A stale-active row whose loop demonstrably produced a substantive reply
+  // did complete — only its terminal runState revision was lost (the immer
+  // draft-leak fixed alongside this shipped every image-carrying row that
+  // way, including all of v0.40.0's). Branding those rows "发送失败" invites
+  // a retry of a turn that already succeeded.
+  if (msg.loopId && answeredLoopIds?.has(msg.loopId)) {
+    return { ...msg, runState: 'completed' };
+  }
   return {
     ...msg,
     runState: 'failed',
@@ -63,10 +71,27 @@ export function sanitizeImportedMessage(msg: Message): Message {
   });
 }
 
+/** A non-ghost assistant row: real text, tool activity, or thinking. Shared
+ * by the ghost filter below and the completed-run inference above it. */
+function isSubstantiveAssistant(msg: Message): boolean {
+  if (msg.role !== 'assistant') return false;
+  const text = typeof msg.content === 'string'
+    ? msg.content
+    : msg.content.filter(c => c.type === 'text').map(c => (c as { type: 'text'; text: string }).text).join('');
+  return text.trim().length > 0
+    || (msg.toolCalls?.length ?? 0) > 0
+    || (msg.toolCallsForContext?.length ?? 0) > 0
+    || !!msg.thinking;
+}
+
 /** Strip ghost assistant messages and clear stale isStreaming flags after loading from disk.
  * Ghost messages are empty assistant placeholders written before content arrived
  * (crash / network failure before streaming started). They must not reach the LLM. */
 export function sanitizeLoadedMessages(messages: Message[]): Message[] {
+  const answeredLoopIds = new Set<string>();
+  for (const msg of messages) {
+    if (msg.loopId && isSubstantiveAssistant(msg)) answeredLoopIds.add(msg.loopId);
+  }
   return messages
     .map((msg) => {
       const toolCalls = msg.toolCalls?.map((tc) => {
@@ -87,18 +112,9 @@ export function sanitizeLoadedMessages(messages: Message[]): Message[] {
         ...msg,
         isStreaming: false,
         toolCalls,
-      });
+      }, answeredLoopIds);
     })
-    .filter(msg => {
-      if (msg.role !== 'assistant') return true;
-      const text = typeof msg.content === 'string'
-        ? msg.content
-        : msg.content.filter(c => c.type === 'text').map(c => (c as { type: 'text'; text: string }).text).join('');
-      return text.trim().length > 0
-        || (msg.toolCalls?.length ?? 0) > 0
-        || (msg.toolCallsForContext?.length ?? 0) > 0
-        || !!msg.thinking;
-    });
+    .filter(msg => msg.role !== 'assistant' || isSubstantiveAssistant(msg));
 }
 
 /** Build an in-memory Conversation + Meta from a validated ShareBundle.


### PR DESCRIPTION
验收复测发现的存量伤（对话 mt47q9iznggop0 重启后）：immer 草稿泄漏（#259 已修根因）让 **v0.40.0 起所有带图轮次**的账本 runState 永远停在 pending。加载时 `recoverInterruptedUserRun` 把悬空活动态一律翻成 failed——升级用户打开老对话会看到成片假"发送失败/重试"，且点重试会把已瘦身（data 为空）的图片再发一遍。

修法：`sanitizeLoadedMessages` 先收集"拥有实质助手回复"的 loopId 集合（复用幽灵行判定谓词，顺手提取共用），悬空活动态的用户行若命中即推断为 completed；真死掉的轮次保持 failed+重试不变。

验证：chatStore 146/146（新增 3 条：有回复推断 completed / 幽灵行不算回复仍 failed / 终态行不动）。

遗留跟进（不在本 PR）：重试路径重建图片只带 source.data 不带 filePath，重启后重试会发空图。

🤖 Generated with [Claude Code](https://claude.com/claude-code)