### PR TITLE
fix(chat): carry image filePath through retry/edit/regenerate rebuilds

### DIFF
--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -16,6 +16,7 @@ import { useI18n, format } from '@/i18n';
 import { getBaseName, loadLocalImage } from '@/utils/pathUtils';
 import { formatRelativeTime } from '@/utils/messageTime';
 import { computeRewindImpact } from '@/utils/rewindImpact';
+import { rebuildImageAttachments } from './imageAttachmentRebuild';
 import ConfirmDialog from '@/components/common/ConfirmDialog';
 import abuAvatar from '@/assets/abu-avatar.png';
 
@@ -460,7 +461,7 @@ export default function MessageBubble({
   const handleSaveEdit = async (newContent: string) => {
     if (!convId) return;
     // Preserve image blocks from original message content
-    const originalImages = getImageBlocks(message.content);
+    const imageAttachments = rebuildImageAttachments(message.content, `edit-${Date.now()}`);
     setIsEditing(false);
 
     const proceed = async () => {
@@ -470,13 +471,7 @@ export default function MessageBubble({
       // edited resend stays on the same agent / skill — otherwise the message
       // falls back to the default `general` route and the expert is lost.
       const routedContent = reattachRoutingPrefix(newContent, message);
-      // Regenerate response, passing original images if any
-      const imageAttachments = originalImages.map((img, i) => ({
-        id: `edit-${Date.now()}-${i}`,
-        data: img.source.data,
-        mediaType: img.source.media_type,
-      }));
-      await runAgentLoopDispatched(convId, routedContent, imageAttachments.length > 0 ? { images: imageAttachments } : undefined);
+      await runAgentLoopDispatched(convId, routedContent, imageAttachments ? { images: imageAttachments } : undefined);
     };
 
     // `message` is a user message and, per the invariant documented on
@@ -494,12 +489,7 @@ export default function MessageBubble({
 
   const handleRunRetry = async () => {
     if (!convId || !activeConv || message.role !== 'user') return;
-    const originalImages = getImageBlocks(message.content);
-    const imageAttachments = originalImages.map((img, i) => ({
-      id: `run-retry-${Date.now()}-${i}`,
-      data: img.source.data,
-      mediaType: img.source.media_type,
-    }));
+    const imageAttachments = rebuildImageAttachments(message.content, `run-retry-${Date.now()}`);
     const routedContent = reattachRoutingPrefix(getTextContent(message.content), message);
     // Rewind semantics (plan stage 3): truncate from the retried turn's FIRST
     // message. `message` is itself that first message when it belongs to a
@@ -517,7 +507,7 @@ export default function MessageBubble({
       await runAgentLoopDispatched(
         convId,
         routedContent,
-        imageAttachments.length > 0 ? { images: imageAttachments } : undefined,
+        imageAttachments ? { images: imageAttachments } : undefined,
       );
     };
 
@@ -567,17 +557,12 @@ export default function MessageBubble({
       // post-routing cleanInput, so the prefix is otherwise lost.
       const routedContent = reattachRoutingPrefix(userContent, targetUserMsg);
       // Preserve image blocks from original user message
-      const originalImages = getImageBlocks(targetUserMsg.content);
-      const imageAttachments = originalImages.map((img, i) => ({
-        id: `regen-${Date.now()}-${i}`,
-        data: img.source.data,
-        mediaType: img.source.media_type,
-      }));
+      const imageAttachments = rebuildImageAttachments(targetUserMsg.content, `regen-${Date.now()}`);
 
       const proceed = async () => {
         // Delete from user message onwards and regenerate
         useChatStore.getState().deleteMessagesFrom(convId, targetUserMsg.id);
-        await runAgentLoopDispatched(convId, routedContent, imageAttachments.length > 0 ? { images: imageAttachments } : undefined);
+        await runAgentLoopDispatched(convId, routedContent, imageAttachments ? { images: imageAttachments } : undefined);
       };
 
       const impact = computeRewindImpact(messages, targetUserMsg.loopId, targetUserMsg.id);

--- a/src/components/chat/MessageGroup.tsx
+++ b/src/components/chat/MessageGroup.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { Sparkles, ChevronDown, ChevronRight } from 'lucide-react';
-import type { Message, MessageContent, ToolCall, ImageAttachment } from '@/types';
+import type { Message, MessageContent, ToolCall } from '@/types';
 import { TOOL_NAMES, isDisplayHiddenStepBackedTool } from '@/core/tools/toolNames';
 import type { ExecutionStep } from '@/types/execution';
 import type { WorkflowStep } from '@/utils/workflowExtractor';
@@ -32,6 +32,7 @@ import { homeDir } from '@tauri-apps/api/path';
 import { cn } from '@/lib/utils';
 import { ThinkingStatusLine, AssistantRowAvatar } from './ThinkingStatusLine';
 import { GROUP_CONTENT_GAP } from './chatSpacing';
+import { rebuildImageAttachments } from './imageAttachmentRebuild';
 
 interface MessageGroupProps {
   messages: Message[];
@@ -544,22 +545,7 @@ export default function MessageGroup({ messages, isLastGroup: isLastGroupProp = 
     const convId = activeConv.id;
     const userContent = getTextContent(userMsg.content);
 
-    let retryImages: ImageAttachment[] | undefined;
-    if (Array.isArray(userMsg.content)) {
-      const imgBlocks = userMsg.content.filter((c): c is Extract<MessageContent, { type: 'image' }> => c.type === 'image');
-      if (imgBlocks.length > 0) {
-        retryImages = imgBlocks.map((img, i) => ({
-          id: `retry-${i}`,
-          data: img.source.data,
-          mediaType: img.source.media_type,
-          // Carry the admission resize record. Dropping it re-sent the
-          // downscaled image with no <image_resize_notice>, so a retried turn —
-          // often the one asking about coordinates or fine print — had the model
-          // reading a shrunken picture believing it was full size.
-          ...(img.resized ? { resized: img.resized } : {}),
-        }));
-      }
-    }
+    const retryImages = rebuildImageAttachments(userMsg.content, 'retry');
 
     const firstAssistantInLoop = assistantMsgs[0];
 

--- a/src/components/chat/imageAttachmentRebuild.test.ts
+++ b/src/components/chat/imageAttachmentRebuild.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for rebuildImageAttachments — the shared pure function that turns
+ * a persisted user message's image blocks back into ImageAttachments for every
+ * re-dispatch path (retry, edit-resend, regenerate).
+ */
+import { describe, it, expect } from 'vitest';
+import { rebuildImageAttachments } from './imageAttachmentRebuild';
+import type { MessageContent } from '@/types';
+
+const imgBlock = (over: Partial<Extract<MessageContent, { type: 'image' }>> = {}): MessageContent => ({
+  type: 'image',
+  source: { type: 'base64', media_type: 'image/png', data: 'BASE64' },
+  ...over,
+});
+
+describe('rebuildImageAttachments', () => {
+  it('plain string content → no images', () => {
+    expect(rebuildImageAttachments('hello', 'retry')).toBeUndefined();
+  });
+
+  it('multimodal content without image blocks → no images', () => {
+    expect(rebuildImageAttachments([{ type: 'text', text: 'hi' }], 'retry')).toBeUndefined();
+  });
+
+  it('carries base64 + mediaType and namespaces ids by prefix', () => {
+    const [att] = rebuildImageAttachments([imgBlock(), { type: 'text', text: 'look' }], 'retry')!;
+    expect(att).toMatchObject({ id: 'retry-0', data: 'BASE64', mediaType: 'image/png' });
+  });
+
+  // Regression (v0.41.0 验收): after an app restart the persisted block has
+  // source.data === '' (stripped on disk) and only filePath left. The rebuilt
+  // attachment used to drop filePath, so retry dispatched an empty image —
+  // model answered "图片没能加载出来" and the thumbnail was blank. The snapshot
+  // path must ride along so send-path rehydration and the thumbnail's
+  // resolveFileSource fallback can recover the pixels.
+  it('data-stripped block: attachment carries filePath', () => {
+    const stripped = imgBlock({
+      source: { type: 'base64', media_type: 'image/png', data: '' },
+      filePath: '/outputs/images/2026-08-20_0.png',
+    });
+    const [att] = rebuildImageAttachments([stripped], 'retry')!;
+    expect(att.filePath).toBe('/outputs/images/2026-08-20_0.png');
+    expect(att.data).toBe('');
+  });
+
+  it('carries filePath alongside fresh data on a same-session retry (snapshot reuse)', () => {
+    const [att] = rebuildImageAttachments([imgBlock({ filePath: '/outputs/images/a.png' })], 'retry')!;
+    expect(att.filePath).toBe('/outputs/images/a.png');
+    expect(att.data).toBe('BASE64');
+  });
+
+  it('block without filePath → attachment has no filePath key', () => {
+    const [att] = rebuildImageAttachments([imgBlock()], 'retry')!;
+    expect('filePath' in att).toBe(false);
+  });
+
+  it('still carries the admission resize record', () => {
+    const resized = { fromWidth: 2940, fromHeight: 1846, toWidth: 2000, toHeight: 1256 };
+    const [att] = rebuildImageAttachments([imgBlock({ resized })], 'retry')!;
+    expect(att.resized).toEqual(resized);
+  });
+});

--- a/src/components/chat/imageAttachmentRebuild.ts
+++ b/src/components/chat/imageAttachmentRebuild.ts
@@ -1,0 +1,38 @@
+import type { ImageAttachment, Message, MessageContent } from '@/types';
+
+/**
+ * Rebuild ImageAttachments from a persisted user message's image blocks, for
+ * every path that re-dispatches an existing message: retry, edit-resend, and
+ * regenerate.
+ *
+ * Two fields must ride along with the base64, and every rebuild site must go
+ * through this one function so none of them forgets:
+ *
+ * - `filePath`: after an app restart the persisted `source.data` is empty
+ *   (stripped on disk — see stripForDisk), and the snapshot under
+ *   outputs/images/ is then the only source of pixels, for the send-path
+ *   rehydration and the thumbnail's resolveFileSource fallback alike.
+ *   Dropping it dispatched a blank image ("图片没能加载出来").
+ * - `resized`: the admission downscale record. Dropping it re-sent the
+ *   downscaled image with no <image_resize_notice>, so a retried turn — often
+ *   the one asking about coordinates or fine print — had the model reading a
+ *   shrunken picture believing it was full size.
+ *
+ * `idPrefix` namespaces the rebuilt attachment ids per call site
+ * (e.g. `retry` → `retry-0`).
+ */
+export function rebuildImageAttachments(
+  content: Message['content'],
+  idPrefix: string,
+): ImageAttachment[] | undefined {
+  if (!Array.isArray(content)) return undefined;
+  const imgBlocks = content.filter((c): c is Extract<MessageContent, { type: 'image' }> => c.type === 'image');
+  if (imgBlocks.length === 0) return undefined;
+  return imgBlocks.map((img, i) => ({
+    id: `${idPrefix}-${i}`,
+    data: img.source.data,
+    mediaType: img.source.media_type,
+    ...(img.resized ? { resized: img.resized } : {}),
+    ...(img.filePath ? { filePath: img.filePath } : {}),
+  }));
+}

--- a/src/core/agent/agentLoop.test.ts
+++ b/src/core/agent/agentLoop.test.ts
@@ -592,3 +592,28 @@ describe('buildUserMessageContent — resize record', () => {
     expect(content[0].resized).toBeUndefined();
   });
 });
+
+describe('buildUserMessageContent — snapshot filePath reuse (retry)', () => {
+  // Regression: a retried attachment rebuilt from a persisted message carries
+  // its outputs/images/ snapshot in filePath, and post-restart its data is ''.
+  // The block must keep that path — re-deriving it from the (empty) base64
+  // wrote an empty file, and the no-disk degradation path dropped it entirely,
+  // stranding the image with neither pixels nor a way to rehydrate them.
+  it('keeps the attachment filePath on the image block even when data is stripped', async () => {
+    const content = await buildUserMessageContent('c1', 'look', [
+      { id: 'i1', data: '', mediaType: 'image/png' as const, filePath: '/outputs/images/snap.png' },
+    ]) as { type: string; filePath?: string; source: { data: string } }[];
+
+    expect(content[0].type).toBe('image');
+    expect(content[0].filePath).toBe('/outputs/images/snap.png');
+    expect(content[0].source.data).toBe('');
+  });
+
+  it('prefers the existing snapshot path over re-saving for a same-session retry', async () => {
+    const content = await buildUserMessageContent('c1', 'look', [
+      { id: 'i1', data: 'BASE64', mediaType: 'image/png' as const, filePath: '/outputs/images/snap.png' },
+    ]) as { filePath?: string }[];
+
+    expect(content[0].filePath).toBe('/outputs/images/snap.png');
+  });
+});

--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -165,6 +165,11 @@ async function saveUserImagesToDisk(
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
     return await Promise.all(
       images.map(async (img, index) => {
+        // Retry of a persisted message: the attachment already points at its
+        // outputs/images/ snapshot. Reuse it — re-encoding from `data` would
+        // write a duplicate copy, or an EMPTY file when the base64 was
+        // stripped on persist (post-restart retry).
+        if (img.filePath) return img.filePath;
         try {
           const ext = MIME_TO_EXT[img.mediaType] || 'png';
           const fileName = `${timestamp}_${index}.${ext}`;
@@ -210,7 +215,10 @@ export async function buildUserMessageContent(
       media_type: img.mediaType,
       data: img.data,
     },
-    filePath: savedPaths[i],
+    // Prefer the attachment's own snapshot path (retry rebuild) — savedPaths
+    // degrades to undefined on the no-disk / write-failure paths, and losing
+    // an existing filePath there would strand a stripped image for good.
+    filePath: img.filePath ?? savedPaths[i],
     ...(img.resized ? { resized: img.resized } : {}),
   }));
   if (text) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -239,6 +239,11 @@ export interface ImageAttachment {
    *  original resolution — otherwise it reads coordinates and fine print off a
    *  shrunken picture believing it is full size. */
   resized?: { fromWidth: number; fromHeight: number; toWidth: number; toHeight: number };
+  /** Disk snapshot under outputs/images/, set when the attachment is rebuilt
+   *  from a persisted image block (retry). After an app restart `data` is empty
+   *  (stripped on persist) — this path is the only way the send-path
+   *  rehydration and the thumbnail can recover the pixels. */
+  filePath?: string;
 }
 
 // Thinking block for extended thinking


### PR DESCRIPTION
## 问题

v0.41.0 验收发现的「假发送失败 → 重试 → 空图」链条的最后一环（前两环已由 fix/reconcile-stale-pending-runs 与 #259 修复）：

应用重启后，持久化消息里的图片块 `source.data` 已被 `stripForDisk` 清空，只剩 `filePath` 指向 `outputs/images/` 快照。此时点重试，`handleRetry` 重建 `ImageAttachment` 只带 `{id, data, mediaType, resized}` 不带 `filePath` —— 空数据图片被发给模型（模型回复"图片没能加载出来"），缩略图也无法显示。

## 同机制同类

排查发现这不是孤例：MessageBubble 里的 **编辑重发 `handleSaveEdit`、`handleRunRetry`、regenerate** 三处有完全相同的重建代码，同样丢 `filePath`，而且连此前在 MessageGroup 修过的 `resized` 也一直在丢（同 bug 的另一半从未修到这三处）。

## 修法

- 新增共享纯函数 `imageAttachmentRebuild.ts#rebuildImageAttachments`，四个重建点全部收敛到它，`filePath` 与 `resized` 强制随行，避免再出现"修一处漏三处"
- `ImageAttachment` 类型新增可选 `filePath`
- `buildUserMessageContent` / `saveUserImagesToDisk`：attachment 已带 `filePath` 时直接复用快照路径，不再从 base64 重新编码落盘——重启后 base64 为空，原逻辑会写出 0 字节文件把像素彻底弄丢；同时 `filePath: img.filePath ?? savedPaths[i]` 保证无盘/写失败降级路径也不丢已有路径

重建出的消息块带 `filePath` 且 `data` 为空时，发送路径由既有的 `rehydrateForSend` 从快照恢复像素，显示层由既有的 `resolveFileSource` 兜底恢复缩略图——本 PR 不改这两条恢复链路，只保证路径能到达它们。

## 测试

- 新增 `imageAttachmentRebuild.test.ts`（7 例），含回归用例：**data 为空但 filePath 存在的图片块，重建的 attachment 必须携带 filePath**
- `agentLoop.test.ts` 新增 2 例：图片块保留 attachment 的 filePath（含 data 被剥离场景）、同会话重试优先复用快照路径
- `npm run verify` 本地亲跑，退出码 0（lint + typecheck + 全量测试 + 覆盖率）

🤖 Generated with [Claude Code](https://claude.com/claude-code)