### PR TITLE
fix(terminal): visible selection + copy/paste conventions + selection-to-chat toolbar

### DIFF
--- a/src/components/panel/workspace/TerminalTab.test.tsx
+++ b/src/components/panel/workspace/TerminalTab.test.tsx
@@ -1,14 +1,22 @@
 // @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
-import { act, cleanup, render, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import TerminalTab from './TerminalTab';
-import { initLanguage } from '@/i18n';
+import TerminalTab, { handleTerminalCopyPasteKeys } from './TerminalTab';
+import type { Terminal } from '@xterm/xterm';
+import { getI18n, initLanguage } from '@/i18n';
+import { isMacOS } from '@/utils/platform';
+import { useChatStore } from '@/stores/chatStore';
 
 interface FakeTerminalInstance {
   options: Record<string, unknown>;
   cols: number;
   rows: number;
+  selection: string;
+  clearSelection: () => void;
+  selectAll: () => void;
+  paste: (text: string) => void;
+  focus: () => void;
 }
 
 const terminalInstances: FakeTerminalInstance[] = [];
@@ -18,6 +26,8 @@ vi.mock('@xterm/xterm', () => {
     options: Record<string, unknown>;
     cols = 80;
     rows = 24;
+    /** Test hook: what getSelection()/hasSelection() report. */
+    selection = '';
     constructor(opts: Record<string, unknown>) {
       // xterm's real `options` is a live object whose properties can be
       // reassigned post-construction to repaint — mirror that shape here.
@@ -28,6 +38,25 @@ vi.mock('@xterm/xterm', () => {
     open() {}
     write() {}
     onData() {}
+    onSelectionChange() {
+      return { dispose: () => {} };
+    }
+    onScroll() {
+      return { dispose: () => {} };
+    }
+    attachCustomKeyEventHandler() {}
+    getSelection() {
+      return this.selection;
+    }
+    hasSelection() {
+      return this.selection.length > 0;
+    }
+    clearSelection = vi.fn(() => {
+      this.selection = '';
+    });
+    selectAll = vi.fn();
+    paste = vi.fn();
+    focus = vi.fn();
     dispose() {}
   }
   return { Terminal: FakeTerminal };
@@ -48,53 +77,87 @@ vi.mock('@tauri-apps/api/event', () => ({
   listen: (...args: unknown[]) => listen(...args),
 }));
 
+vi.mock('@/utils/platform', () => ({
+  isMacOS: vi.fn(() => true),
+  isWindows: vi.fn(() => false),
+}));
+
 // Two distinct fake palettes so a light/dark toggle produces a visible diff.
 const LIGHT_VARS: Record<string, string> = {
   '--abu-bg-base': '#fdfcf9',
   '--abu-text-primary': '#141413',
   '--abu-clay': '#d97757',
+  '--abu-clay-20': 'rgba(217, 119, 87, 0.2)',
 };
 const DARK_VARS: Record<string, string> = {
   '--abu-bg-base': '#1f1d1b',
   '--abu-text-primary': '#f0ede8',
   '--abu-clay': '#d97757',
+  '--abu-clay-20': 'rgba(217, 119, 87, 0.2)',
 };
 
+function expectedTheme(vars: Record<string, string>) {
+  return {
+    background: vars['--abu-bg-base'],
+    foreground: vars['--abu-text-primary'],
+    cursor: vars['--abu-clay'],
+    selectionBackground: vars['--abu-clay-20'],
+  };
+}
+
+const clipboardWriteText = vi.fn().mockResolvedValue(undefined);
+const clipboardReadText = vi.fn().mockResolvedValue('');
+
+beforeEach(() => {
+  initLanguage('en-US');
+  invoke.mockReset();
+  invoke.mockResolvedValue(undefined);
+  listen.mockReset();
+  listen.mockResolvedValue(() => {});
+  terminalInstances.length = 0;
+  document.documentElement.classList.remove('dark');
+  vi.mocked(isMacOS).mockReturnValue(true);
+  clipboardWriteText.mockClear();
+  clipboardReadText.mockClear();
+  clipboardReadText.mockResolvedValue('');
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: clipboardWriteText, readText: clipboardReadText },
+    configurable: true,
+  });
+  useChatStore.setState({ pendingReferences: [] });
+
+  vi.spyOn(window, 'getComputedStyle').mockImplementation(() => {
+    const vars = document.documentElement.classList.contains('dark') ? DARK_VARS : LIGHT_VARS;
+    return {
+      getPropertyValue: (name: string) => vars[name] ?? '',
+    } as CSSStyleDeclaration;
+  });
+});
+
+afterEach(() => {
+  document.documentElement.classList.remove('dark');
+  cleanup();
+  vi.restoreAllMocks();
+});
+
 describe('TerminalTab theming', () => {
-  beforeEach(() => {
-    initLanguage('en-US');
-    invoke.mockReset();
-    invoke.mockResolvedValue(undefined);
-    listen.mockReset();
-    listen.mockResolvedValue(() => {});
-    terminalInstances.length = 0;
-    document.documentElement.classList.remove('dark');
-
-    vi.spyOn(window, 'getComputedStyle').mockImplementation(() => {
-      const vars = document.documentElement.classList.contains('dark') ? DARK_VARS : LIGHT_VARS;
-      return {
-        getPropertyValue: (name: string) => vars[name] ?? '',
-      } as CSSStyleDeclaration;
-    });
-  });
-
-  afterEach(() => {
-    document.documentElement.classList.remove('dark');
-    cleanup();
-    vi.restoreAllMocks();
-  });
-
   it('builds the terminal with theme colors read from the app\'s --abu-* tokens, not a hardcoded palette', async () => {
     render(<TerminalTab tabId="terminal-theme-initial" />);
 
     await waitFor(() => {
       expect(terminalInstances).toHaveLength(1);
     });
-    expect(terminalInstances[0].options.theme).toEqual({
-      background: LIGHT_VARS['--abu-bg-base'],
-      foreground: LIGHT_VARS['--abu-text-primary'],
-      cursor: LIGHT_VARS['--abu-clay'],
+    expect(terminalInstances[0].options.theme).toEqual(expectedTheme(LIGHT_VARS));
+  });
+
+  it('sets an explicit selectionBackground — xterm\'s white default is invisible on the light theme', async () => {
+    render(<TerminalTab tabId="terminal-theme-selection" />);
+
+    await waitFor(() => {
+      expect(terminalInstances).toHaveLength(1);
     });
+    const theme = terminalInstances[0].options.theme as { selectionBackground?: string };
+    expect(theme.selectionBackground).toBe(LIGHT_VARS['--abu-clay-20']);
   });
 
   it('repaints the existing terminal on a light/dark toggle without killing the pty session', async () => {
@@ -116,11 +179,7 @@ describe('TerminalTab theming', () => {
       document.documentElement.classList.add('dark');
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
-    expect(terminalInstances[0].options.theme).toEqual({
-      background: DARK_VARS['--abu-bg-base'],
-      foreground: DARK_VARS['--abu-text-primary'],
-      cursor: DARK_VARS['--abu-clay'],
-    });
+    expect(terminalInstances[0].options.theme).toEqual(expectedTheme(DARK_VARS));
 
     // Still the same single terminal instance — no dispose/recreate cycle.
     expect(terminalInstances).toHaveLength(1);
@@ -128,5 +187,140 @@ describe('TerminalTab theming', () => {
     const killCallsAfter = invoke.mock.calls.filter(([cmd]) => cmd === 'pty_kill').length;
     expect(spawnCallsAfter).toBe(spawnCallsBefore);
     expect(killCallsAfter).toBe(killCallsBefore);
+  });
+});
+
+describe('handleTerminalCopyPasteKeys', () => {
+  function fakeTerm(selection: string) {
+    return {
+      getSelection: () => selection,
+      hasSelection: () => selection.length > 0,
+      clearSelection: vi.fn(),
+      paste: vi.fn(),
+    } as unknown as Terminal;
+  }
+  const keydown = (init: KeyboardEventInit) => new KeyboardEvent('keydown', init);
+
+  it('Ctrl+Shift+C copies the selection and is not sent to the pty', () => {
+    const term = fakeTerm('ls -la');
+    const handled = handleTerminalCopyPasteKeys(term, keydown({ key: 'C', ctrlKey: true, shiftKey: true }));
+    expect(handled).toBe(false);
+    expect(clipboardWriteText).toHaveBeenCalledWith('ls -la');
+  });
+
+  it('Ctrl+Shift+V pastes from the clipboard and is not sent to the pty', async () => {
+    clipboardReadText.mockResolvedValue('echo hi');
+    const term = fakeTerm('');
+    const handled = handleTerminalCopyPasteKeys(term, keydown({ key: 'V', ctrlKey: true, shiftKey: true }));
+    expect(handled).toBe(false);
+    await waitFor(() => {
+      expect(term.paste).toHaveBeenCalledWith('echo hi');
+    });
+  });
+
+  it('on Windows, Ctrl+C with an active selection copies and clears it instead of sending SIGINT', () => {
+    vi.mocked(isMacOS).mockReturnValue(false);
+    const term = fakeTerm('npm test');
+    const handled = handleTerminalCopyPasteKeys(term, keydown({ key: 'c', ctrlKey: true }));
+    expect(handled).toBe(false);
+    expect(clipboardWriteText).toHaveBeenCalledWith('npm test');
+    expect(term.clearSelection).toHaveBeenCalled();
+  });
+
+  it('on Windows, Ctrl+C without a selection stays SIGINT (passes through to the pty)', () => {
+    vi.mocked(isMacOS).mockReturnValue(false);
+    const term = fakeTerm('');
+    expect(handleTerminalCopyPasteKeys(term, keydown({ key: 'c', ctrlKey: true }))).toBe(true);
+    expect(clipboardWriteText).not.toHaveBeenCalled();
+  });
+
+  it('on macOS, Ctrl+C always passes through (⌘C handles copy via the app menu)', () => {
+    const term = fakeTerm('selected');
+    expect(handleTerminalCopyPasteKeys(term, keydown({ key: 'c', ctrlKey: true }))).toBe(true);
+    expect(clipboardWriteText).not.toHaveBeenCalled();
+  });
+});
+
+describe('TerminalTab context menu', () => {
+  it('right-click opens a copy/paste/select-all menu; copy is disabled without a selection', async () => {
+    const { container } = render(<TerminalTab tabId="terminal-menu-empty" />);
+    await waitFor(() => expect(terminalInstances).toHaveLength(1));
+    const host = container.querySelector('div.overflow-hidden') as HTMLDivElement;
+
+    fireEvent.contextMenu(host, { clientX: 40, clientY: 40 });
+
+    const t = getI18n();
+    const copyBtn = screen.getByRole('button', { name: t.workspace.terminalCopy });
+    expect(copyBtn).toBeDisabled();
+    expect(screen.getByRole('button', { name: t.workspace.terminalPaste })).toBeEnabled();
+    expect(screen.getByRole('button', { name: t.workspace.terminalSelectAll })).toBeEnabled();
+  });
+
+  it('copy writes the terminal selection to the clipboard; paste feeds clipboard text into the terminal', async () => {
+    clipboardReadText.mockResolvedValue('pasted-text');
+    const { container } = render(<TerminalTab tabId="terminal-menu-actions" />);
+    await waitFor(() => expect(terminalInstances).toHaveLength(1));
+    const term = terminalInstances[0];
+    const host = container.querySelector('div.overflow-hidden') as HTMLDivElement;
+    const t = getI18n();
+
+    term.selection = 'copied-output';
+    fireEvent.contextMenu(host, { clientX: 40, clientY: 40 });
+    fireEvent.click(screen.getByRole('button', { name: t.workspace.terminalCopy }));
+    expect(clipboardWriteText).toHaveBeenCalledWith('copied-output');
+    expect(term.focus).toHaveBeenCalled();
+
+    fireEvent.contextMenu(host, { clientX: 40, clientY: 40 });
+    fireEvent.click(screen.getByRole('button', { name: t.workspace.terminalPaste }));
+    await waitFor(() => {
+      expect(term.paste).toHaveBeenCalledWith('pasted-text');
+    });
+  });
+});
+
+describe('TerminalTab selection → add to chat', () => {
+  it('shows the selection toolbar on mouseup over a selection, and "Add to chat" pushes a terminal reference', async () => {
+    const { container } = render(<TerminalTab tabId="terminal-selection-ref" />);
+    await waitFor(() => expect(terminalInstances).toHaveLength(1));
+    const term = terminalInstances[0];
+    const host = container.querySelector('div.overflow-hidden') as HTMLDivElement;
+
+    term.selection = 'error: ENOENT no such file';
+    fireEvent.mouseUp(host, { button: 0, clientX: 100, clientY: 100 });
+
+    const t = getI18n();
+    const addBtn = await screen.findByRole('button', { name: new RegExp(t.reference.addToChat) });
+    fireEvent.click(addBtn);
+
+    const refs = useChatStore.getState().pendingReferences;
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({
+      kind: 'doc-selection',
+      source: {
+        path: 'terminal://terminal-selection-ref',
+        name: t.workspace.terminalTitle,
+        docType: 'text',
+      },
+      selection: { text: 'error: ENOENT no such file' },
+    });
+    // Committing clears the terminal selection and dismisses the toolbar.
+    expect(term.clearSelection).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: new RegExp(t.reference.addToChat) })).toBeNull();
+    });
+  });
+
+  it('does not show the toolbar when mouseup yields only whitespace selection', async () => {
+    const { container } = render(<TerminalTab tabId="terminal-selection-ws" />);
+    await waitFor(() => expect(terminalInstances).toHaveLength(1));
+    terminalInstances[0].selection = '   \n  ';
+    const host = container.querySelector('div.overflow-hidden') as HTMLDivElement;
+
+    fireEvent.mouseUp(host, { button: 0, clientX: 50, clientY: 50 });
+
+    // Debounce window (120 ms) must elapse before asserting absence.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    const t = getI18n();
+    expect(screen.queryByRole('button', { name: new RegExp(t.reference.addToChat) })).toBeNull();
   });
 });

--- a/src/components/panel/workspace/TerminalTab.tsx
+++ b/src/components/panel/workspace/TerminalTab.tsx
@@ -1,13 +1,16 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Terminal, type ITheme } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
-import { useActiveConversation } from '@/stores/chatStore';
-import { useI18n, format } from '@/i18n';
+import { useActiveConversation, useChatStore } from '@/stores/chatStore';
+import { useI18n, format, getI18n } from '@/i18n';
 import { createLogger } from '@/core/logging/logger';
 import { useEffectiveThemeIsDark } from '@/hooks/useEffectiveThemeIsDark';
+import { isMacOS } from '@/utils/platform';
+import { SelectionToolbar } from '@/features/reference/SelectionToolbar';
+import { createDocReference } from '@/types/chatReference';
 
 const terminalLogger = createLogger('terminal');
 
@@ -17,6 +20,11 @@ const terminalLogger = createLogger('terminal');
  * jarring black box against Abu's warm light theme (the default since the
  * v0.42 migration). `--abu-bg-base` matches the surrounding workspace panel
  * card, so the terminal blends into it instead of looking bolted on.
+ *
+ * `selectionBackground` MUST be set explicitly: xterm's built-in default is
+ * `rgba(255,255,255,0.3)` (white), which is invisible on the light theme's
+ * near-white background — users dragged to select and saw nothing, and
+ * concluded copying was broken. The clay fill matches the app's ::selection.
  */
 function resolveTerminalTheme(): ITheme {
   const styles = getComputedStyle(document.documentElement);
@@ -25,7 +33,71 @@ function resolveTerminalTheme(): ITheme {
     background: read('--abu-bg-base'),
     foreground: read('--abu-text-primary'),
     cursor: read('--abu-clay'),
+    selectionBackground: read('--abu-clay-20'),
   };
+}
+
+function copyTerminalSelection(term: Terminal): void {
+  const text = term.getSelection();
+  if (!text) return;
+  navigator.clipboard.writeText(text).catch((err) => {
+    terminalLogger.error('Failed to copy terminal selection', { error: String(err) });
+  });
+}
+
+async function pasteClipboardIntoTerminal(term: Terminal): Promise<void> {
+  try {
+    const text = await navigator.clipboard.readText();
+    if (text) term.paste(text);
+  } catch (err) {
+    terminalLogger.error('Failed to paste into terminal', { error: String(err) });
+  }
+}
+
+/**
+ * Clipboard keyboard conventions (same split as VS Code / Windows Terminal):
+ * - macOS ⌘C/⌘V already work natively (menu roles dispatch DOM copy/paste
+ *   events that xterm handles), so nothing to intercept there.
+ * - Ctrl+Shift+C / Ctrl+Shift+V: always copy/paste (all platforms — xterm
+ *   maps neither, so without this they were dead keys).
+ * - Windows/Linux Ctrl+C: copy when a selection exists (then clear it so the
+ *   next Ctrl+C is SIGINT again); plain SIGINT otherwise.
+ * Exported for tests via module scope; returns xterm's "handled" contract:
+ * `false` means "consumed, don't send to the pty".
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function handleTerminalCopyPasteKeys(term: Terminal, e: KeyboardEvent): boolean {
+  if (e.type !== 'keydown') return true;
+  const key = e.key.toLowerCase();
+  const ctrlOnly = e.ctrlKey && !e.altKey && !e.metaKey;
+  if (ctrlOnly && e.shiftKey && key === 'c') {
+    e.preventDefault();
+    copyTerminalSelection(term);
+    return false;
+  }
+  if (ctrlOnly && e.shiftKey && key === 'v') {
+    e.preventDefault();
+    void pasteClipboardIntoTerminal(term);
+    return false;
+  }
+  if (!isMacOS() && ctrlOnly && !e.shiftKey && key === 'c' && term.hasSelection()) {
+    e.preventDefault();
+    copyTerminalSelection(term);
+    term.clearSelection();
+    return false;
+  }
+  return true;
+}
+
+interface TerminalContextMenuState {
+  x: number;
+  y: number;
+  hasSelection: boolean;
+}
+
+interface TerminalSelectionState {
+  text: string;
+  rect: DOMRect;
 }
 
 /**
@@ -41,6 +113,17 @@ export default function TerminalTab({ tabId }: { tabId: string }) {
   const conversation = useActiveConversation();
   const { t } = useI18n();
   const isDark = useEffectiveThemeIsDark();
+  const [contextMenu, setContextMenu] = useState<TerminalContextMenuState | null>(null);
+  // Selection → "add to chat" toolbar (same reference flow as the doc preview's
+  // DocSelectionLayer). xterm keeps its own selection model — window.getSelection()
+  // never sees it — so the toolbar is driven by xterm's selection API instead.
+  const [sel, setSel] = useState<TerminalSelectionState | null>(null);
+  const [editing, setEditing] = useState(false);
+  // Read synchronously inside native-event handlers registered once per pty
+  // session — a state closure would go stale (same pattern as useTextSelection).
+  const editingRef = useRef(editing);
+  // eslint-disable-next-line react-hooks/refs
+  editingRef.current = editing;
 
   // Resolve the starting cwd once, at mount time: the active conversation's
   // workspace dir if resolvable, else undefined (Rust falls back to the
@@ -63,6 +146,7 @@ export default function TerminalTab({ tabId }: { tabId: string }) {
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
     term.open(container);
+    term.attachCustomKeyEventHandler((e) => handleTerminalCopyPasteKeys(term, e));
 
     // A keep-alive-hidden ancestor (`hidden` -> display:none) reports 0
     // client dimensions; fitting against that would collapse the terminal to
@@ -79,6 +163,39 @@ export default function TerminalTab({ tabId }: { tabId: string }) {
 
     let disposed = false;
     const unlistenFns: UnlistenFn[] = [];
+
+    // Show the toolbar on mouseup (not during drag — parity with
+    // useTextSelection's debounce): left button only, and only when xterm
+    // actually holds a non-whitespace selection. The rect anchors the toolbar
+    // at the release point; xterm's buffer coordinates have no cheap DOM rect.
+    let mouseUpTimer: ReturnType<typeof setTimeout> | null = null;
+    const onMouseUp = (e: MouseEvent) => {
+      if (e.button !== 0) return;
+      const { clientX, clientY } = e;
+      if (mouseUpTimer) clearTimeout(mouseUpTimer);
+      mouseUpTimer = setTimeout(() => {
+        const text = term.getSelection();
+        if (text.trim()) {
+          setSel({ text, rect: new DOMRect(clientX, clientY, 0, 0) });
+          setEditing(false);
+        }
+      }, 120);
+    };
+    container.addEventListener('mouseup', onMouseUp);
+
+    // Dismissals — all skipped while the comment editor is open so a scroll
+    // or stray keystroke doesn't discard typed text (parity with the doc
+    // layer). The commit path uses the text captured at mouseup, so a later
+    // selection collapse can't lose the reference content.
+    const dismiss = () => {
+      if (editingRef.current) return;
+      setSel((s) => (s ? null : s));
+    };
+    const selectionDisposable = term.onSelectionChange(() => {
+      if (!term.hasSelection()) dismiss();
+    });
+    const scrollDisposable = term.onScroll(dismiss);
+    window.addEventListener('resize', dismiss);
 
     async function start() {
       fitIfVisible();
@@ -106,6 +223,8 @@ export default function TerminalTab({ tabId }: { tabId: string }) {
         unlistenFns.push(exitUnlisten);
 
         term.onData((data) => {
+          // Typing while the toolbar is up means the user moved on — dismiss.
+          dismiss();
           void invoke('pty_write', { id: tabId, data });
         });
 
@@ -146,11 +265,18 @@ export default function TerminalTab({ tabId }: { tabId: string }) {
     return () => {
       disposed = true;
       if (resizeTimer) clearTimeout(resizeTimer);
+      if (mouseUpTimer) clearTimeout(mouseUpTimer);
       resizeObserver.disconnect();
+      container.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('resize', dismiss);
+      selectionDisposable.dispose();
+      scrollDisposable.dispose();
       unlistenFns.forEach((fn) => fn());
       void invoke('pty_kill', { id: tabId });
       term.dispose();
       termRef.current = null;
+      setSel(null);
+      setContextMenu(null);
     };
   // t is stable from the i18n singleton; cwdRef is a ref (identity-stable).
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -163,5 +289,111 @@ export default function TerminalTab({ tabId }: { tabId: string }) {
     if (termRef.current) termRef.current.options.theme = resolveTerminalTheme();
   }, [isDark]);
 
-  return <div ref={containerRef} className="h-full w-full overflow-hidden px-2 py-1" />;
+  // Context menu: dismiss on any outside mousedown or Escape (same lifecycle
+  // as TabStrip's tab context menu).
+  useEffect(() => {
+    if (!contextMenu) return;
+    const onMouseDown = (e: MouseEvent) => {
+      if ((e.target as HTMLElement | null)?.closest?.('[data-terminal-context-menu]')) return;
+      setContextMenu(null);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setContextMenu(null);
+    };
+    document.addEventListener('mousedown', onMouseDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [contextMenu]);
+
+  const openContextMenu = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    const term = termRef.current;
+    if (!term) return;
+    setContextMenu({ x: e.clientX, y: e.clientY, hasSelection: term.hasSelection() });
+  }, []);
+
+  const menuAction = useCallback((action: 'copy' | 'paste' | 'selectAll') => {
+    const term = termRef.current;
+    setContextMenu(null);
+    if (!term) return;
+    if (action === 'copy') copyTerminalSelection(term);
+    else if (action === 'paste') void pasteClipboardIntoTerminal(term);
+    else term.selectAll();
+    term.focus();
+  }, []);
+
+  const commitSelection = useCallback(
+    (comment?: string) => {
+      if (!sel) return;
+      // getI18n(), not the hook's `t`: keeps this callback stable and the
+      // reference name correct even if the locale flipped mid-selection.
+      const ref = createDocReference({
+        path: `terminal://${tabId}`,
+        name: getI18n().workspace.terminalTitle,
+        docType: 'text',
+        text: sel.text,
+        comment,
+      });
+      useChatStore.getState().addPendingReference(ref);
+      termRef.current?.clearSelection();
+      setSel(null);
+      setEditing(false);
+    },
+    [sel, tabId],
+  );
+
+  const menuItemClass =
+    'w-full text-left px-3 py-1.5 text-minor text-[var(--abu-text-primary)] hover:bg-[var(--abu-bg-hover)] disabled:opacity-40 disabled:hover:bg-transparent';
+
+  return (
+    <div className="relative h-full w-full">
+      <div
+        ref={containerRef}
+        className="h-full w-full overflow-hidden px-2 py-1"
+        onContextMenu={openContextMenu}
+      />
+      {contextMenu && (
+        <div
+          data-terminal-context-menu
+          className="fixed z-[60] min-w-[150px] rounded-md border border-[var(--abu-border)] bg-[var(--abu-bg-muted)] shadow-md py-1"
+          style={{
+            top: Math.min(contextMenu.y, window.innerHeight - 120),
+            left: Math.min(contextMenu.x, window.innerWidth - 158),
+          }}
+        >
+          <button
+            type="button"
+            className={menuItemClass}
+            disabled={!contextMenu.hasSelection}
+            onClick={() => menuAction('copy')}
+          >
+            {t.workspace.terminalCopy}
+          </button>
+          <button type="button" className={menuItemClass} onClick={() => menuAction('paste')}>
+            {t.workspace.terminalPaste}
+          </button>
+          <button type="button" className={menuItemClass} onClick={() => menuAction('selectAll')}>
+            {t.workspace.terminalSelectAll}
+          </button>
+        </div>
+      )}
+      {sel && (
+        <SelectionToolbar
+          rect={sel.rect}
+          editing={editing}
+          onEditingChange={setEditing}
+          onAdd={() => commitSelection()}
+          onComment={(c) => commitSelection(c)}
+          onDismiss={() => {
+            setSel(null);
+            setEditing(false);
+          }}
+          enableKeyboard={false}
+        />
+      )}
+    </div>
+  );
 }

--- a/src/features/reference/SelectionToolbar.tsx
+++ b/src/features/reference/SelectionToolbar.tsx
@@ -15,14 +15,18 @@ interface Props {
   onAdd: () => void;
   onComment: (comment: string) => void;
   onDismiss: () => void;
+  /** Document-level ⌘J/Enter shortcuts. Hosts where those keys are live input
+   *  (the terminal: Enter runs the shell command) must opt out — otherwise the
+   *  toolbar would hijack a keystroke the user aimed at the host. */
+  enableKeyboard?: boolean;
 }
 
-export function SelectionToolbar({ rect, editing, onEditingChange, onAdd, onComment, onDismiss }: Props) {
+export function SelectionToolbar({ rect, editing, onEditingChange, onAdd, onComment, onDismiss, enableKeyboard = true }: Props) {
   const { t } = useI18n();
 
   // Keyboard: ⌘/Ctrl+J → open comment editor; Enter → add (only when not in editor)
   useEffect(() => {
-    if (editing) return;
+    if (editing || !enableKeyboard) return;
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && (e.key === 'j' || e.key === 'J')) {
         e.preventDefault();
@@ -34,7 +38,7 @@ export function SelectionToolbar({ rect, editing, onEditingChange, onAdd, onComm
     };
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
-  }, [editing, onAdd, onEditingChange]);
+  }, [editing, enableKeyboard, onAdd, onEditingChange]);
 
   // Estimated size of the toolbar buttons row; used for edge-clamping without
   // a ResizeObserver (acceptable V1 approximation — real size is within ~10 px).
@@ -68,7 +72,7 @@ export function SelectionToolbar({ rect, editing, onEditingChange, onAdd, onComm
           >
             <MessageSquarePlus className="h-3.5 w-3.5" />
             {t.reference.commentToChat}
-            <span className="text-caption text-[var(--abu-text-tertiary)]">{mod} J</span>
+            {enableKeyboard && <span className="text-caption text-[var(--abu-text-tertiary)]">{mod} J</span>}
           </button>
           <div className="h-4 w-px bg-[var(--abu-border-subtle)]" />
           <button
@@ -78,7 +82,7 @@ export function SelectionToolbar({ rect, editing, onEditingChange, onAdd, onComm
           >
             <MessageSquare className="h-3.5 w-3.5" />
             {t.reference.addToChat}
-            <span className="text-caption text-[var(--abu-text-tertiary)]">↵</span>
+            {enableKeyboard && <span className="text-caption text-[var(--abu-text-tertiary)]">↵</span>}
           </button>
         </div>
       )}

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -1740,6 +1740,9 @@ const enUS: TranslationDict = {
     startHere: 'Start from here',
     terminalProcessExited: '[process exited]',
     terminalStartFailed: 'Failed to start terminal: {error}',
+    terminalCopy: 'Copy',
+    terminalPaste: 'Paste',
+    terminalSelectAll: 'Select All',
     browser: {
       back: 'Back',
       forward: 'Forward',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -1741,6 +1741,9 @@ const zhCN: TranslationDict = {
     startHere: '从这里开始',
     terminalProcessExited: '[进程已退出]',
     terminalStartFailed: '终端启动失败：{error}',
+    terminalCopy: '复制',
+    terminalPaste: '粘贴',
+    terminalSelectAll: '全选',
     browser: {
       back: '后退',
       forward: '前进',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1891,6 +1891,9 @@ export interface TranslationDict {
     startHere: string;
     terminalProcessExited: string;
     terminalStartFailed: string;
+    terminalCopy: string;
+    terminalPaste: string;
+    terminalSelectAll: string;
     browser: {
       back: string;
       forward: string;


### PR DESCRIPTION
## 问题

工作区终端里「无法复制文字」，也没有其他区域已有的划词添加到对话能力。

## 根因

xterm 默认 `selectionBackground` 是 `rgba(255,255,255,0.3)`（白色 30%），在浅色主题近白的终端背景上**选区完全不可见** —— 用户拖选后看不到任何反馈，因此认为复制坏了。同时终端缺系统终端的右键菜单，Windows 侧 Ctrl+C 只发 SIGINT 无法复制。

## 改动

- **选区可见**：终端主题显式设置 `selectionBackground: var(--abu-clay-20)`，与应用 `::selection` 同款陶土橙，深浅主题均可见
- **右键菜单**：复制（无选区置灰）/ 粘贴 / 全选，样式复用 TabStrip 菜单模式
- **键盘约定**（对齐 VS Code / Windows Terminal）：全平台 Ctrl+Shift+C/V；Windows/Linux Ctrl+C 有选区时复制并清除选区（下一次 Ctrl+C 恢复 SIGINT）；macOS ⌘C/⌘V 走原生菜单路径不受影响
- **划词添加到对话**：复用 `SelectionToolbar`（添加到对话 / 评论到对话），由 xterm 自己的 selection API 驱动（`window.getSelection()` 看不到 xterm 选区）；引用以 `terminal://<tabId>` 为 source 进入 composer chip
- `SelectionToolbar` 新增 `enableKeyboard` prop（默认 true）：终端里禁用文档级 Enter/⌘J 快捷键，避免劫持 shell 输入

## 验证

- `npm run verify` 退出码 0（lint + typecheck + 全量测试 + 覆盖率）
- TerminalTab 单测 12/12（主题选区色、键盘 copy/paste 分支、右键菜单、划词→引用入 store）
- 真实 Electron 壳手动走查通过（用户实测）：拖选高亮可见、⌘C 复制、右键菜单复制/粘贴、划词工具栏→引用 chip→随消息发送

🤖 Generated with [Claude Code](https://claude.com/claude-code)