### PR TITLE
fix(preview): avoid Windows titlebar overlap in fullscreen

### DIFF
--- a/src/components/panel/PreviewPanel.fullscreen.test.tsx
+++ b/src/components/panel/PreviewPanel.fullscreen.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PreviewPanel from './PreviewPanel';
+
+const testPlatform = vi.hoisted(() => ({ current: 'windows' }));
+
+vi.mock('@/utils/platform', () => ({
+  isWindows: () => testPlatform.current === 'windows',
+  isMacOS: () => testPlatform.current === 'macos',
+}));
+
+function renderImagePreview() {
+  return render(
+    <PreviewPanel
+      filePath="data:image/png;base64,iVBORw0KGgo="
+      tabId="preview-test"
+      embedded
+    />,
+  );
+}
+
+describe('PreviewPanel fullscreen layout', () => {
+  beforeEach(() => {
+    testPlatform.current = 'windows';
+  });
+
+  it('keeps the Windows native title bar above the maximized content', () => {
+    const { container } = renderImagePreview();
+
+    fireEvent.click(screen.getByTitle(/全屏|Fullscreen/i));
+
+    expect(container.firstElementChild).toHaveClass('fixed', 'inset-0');
+    expect(container.firstElementChild).toHaveStyle({
+      top: 'calc(env(titlebar-area-y, 0px) + env(titlebar-area-height, 36px))',
+    });
+  });
+
+  it('leaves the existing macOS fullscreen geometry unchanged', () => {
+    testPlatform.current = 'macos';
+    const { container } = renderImagePreview();
+
+    fireEvent.click(screen.getByTitle(/全屏|Fullscreen/i));
+
+    expect(container.firstElementChild).toHaveClass('fixed', 'inset-0');
+    expect(container.firstElementChild).not.toHaveAttribute('style');
+    expect(container.querySelector('.pl-20')).not.toBeNull();
+  });
+});

--- a/src/components/panel/PreviewPanel.tsx
+++ b/src/components/panel/PreviewPanel.tsx
@@ -21,7 +21,7 @@ import { Check, Loader2, X, FolderOpen, Code, Eye, SquareArrowOutUpRight, Histor
 import { Button } from '@/components/ui/button';
 import { DocSelectionLayer } from '@/features/reference/DocSelectionLayer';
 import { cn } from '@/lib/utils';
-import { isMacOS } from '@/utils/platform';
+import { isMacOS, isWindows } from '@/utils/platform';
 import { getToolbarButtons } from './previewToolbarConfig';
 import { openWithDefaultApp } from '@/utils/openWithDefaultApp';
 import { createDomElementReference, type BrowserElementPayload } from '@/types/chatReference';
@@ -664,10 +664,21 @@ export default function PreviewPanel({
   if (!previewFilePath) return null;
 
   return (
-    <div data-electron-no-drag className={cn(
-      'flex flex-col',
-      isFullscreen ? 'fixed inset-0 z-50 bg-[var(--abu-bg-base)]' : 'h-full',
-    )}>
+    <div
+      data-electron-no-drag
+      style={isFullscreen && isWindows() ? {
+        // Window Controls Overlay stays native and always paints above the
+        // renderer. Keep "fullscreen" as a content-area maximize on Windows,
+        // matching the shell layout and leaving caption controls unobstructed.
+        // The 36px fallback matches WindowTitleBar's legacy Windows toolbar;
+        // WCO-capable builds resolve the real 30px height from the env value.
+        top: 'calc(env(titlebar-area-y, 0px) + env(titlebar-area-height, 36px))',
+      } : undefined}
+      className={cn(
+        'flex flex-col',
+        isFullscreen ? 'fixed inset-0 z-50 bg-[var(--abu-bg-base)]' : 'h-full',
+      )}
+    >
       {/* Content-first preview toolbar: identity stays anchored on the left,
           common reading/AI actions on the right, filesystem actions in More. */}
       <div className={cn(


### PR DESCRIPTION
## Summary

- keep preview fullscreen content below the native Windows caption controls
- use Window Controls Overlay environment values with the existing 36px legacy fallback
- leave the macOS fullscreen layout unchanged
- add regression coverage for both Windows and macOS geometry

## Test plan

- `npx vitest run src/components/panel/PreviewPanel.fullscreen.test.tsx` (2 tests passed)
- manually verified the Windows Electron dev UI and fullscreen preview behavior