### PR TITLE
fix(shell): 输入框原生右键菜单 + 面板收起后点文件重新展开

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -47,6 +47,7 @@ const { isTauriTransitionBuild } = require('./releaseMetadata.cjs');
 const { hideLegacyTauriUninstallEntry } = require('./legacyWindowsInstall.cjs');
 const {
   WINDOW_DRAG_REGION_CSS,
+  attachEditContextMenu,
   configureApplicationMenu,
   mainWindowPlatformOptions,
 } = require('./windowChrome.cjs');
@@ -191,6 +192,9 @@ function createWindow(transitionWindow = null) {
       nodeIntegration: false,
       sandbox: true,
     },
+  });
+  attachEditContextMenu(win, Menu, {
+    isZh: app.getLocale().toLowerCase().startsWith('zh'),
   });
   configureApplicationMenu(win, Menu, {
     platform: process.platform,

--- a/electron/windowChrome.cjs
+++ b/electron/windowChrome.cjs
@@ -145,6 +145,37 @@ function configureApplicationMenu(
   return true;
 }
 
+/**
+ * Native edit context menu for the whole window: right-click in any editable
+ * field shows cut/copy/paste/select-all, and right-click on selected page text
+ * shows copy. Without this Electron shows NOTHING on right-click (unlike a
+ * browser), which read as "copy/paste is broken" in the chat composer.
+ *
+ * Renderer-owned menus stay in charge: a renderer that calls
+ * `event.preventDefault()` on `contextmenu` (e.g. the workspace terminal's
+ * custom menu) suppresses Chromium's context-menu request, so this handler
+ * never fires there. Non-actionable right-clicks (no selection, not editable)
+ * intentionally show no menu.
+ */
+function attachEditContextMenu(win, Menu, { isZh = false } = {}) {
+  const label = (zh, en) => (isZh ? zh : en);
+  win.webContents.on('context-menu', (_event, params) => {
+    const { isEditable, selectionText, editFlags } = params;
+    const hasSelection = !!selectionText && selectionText.trim().length > 0;
+    if (!isEditable && !hasSelection) return;
+    const template = isEditable
+      ? [
+          { role: 'cut', label: label('剪切', 'Cut'), enabled: !!editFlags.canCut },
+          { role: 'copy', label: label('复制', 'Copy'), enabled: !!editFlags.canCopy },
+          { role: 'paste', label: label('粘贴', 'Paste'), enabled: !!editFlags.canPaste },
+          { type: 'separator' },
+          { role: 'selectAll', label: label('全选', 'Select All'), enabled: !!editFlags.canSelectAll },
+        ]
+      : [{ role: 'copy', label: label('复制', 'Copy'), enabled: !!editFlags.canCopy }];
+    Menu.buildFromTemplate(template).popup({ window: win });
+  });
+}
+
 function syncMainWindowChromeTheme(win, dark, platform = process.platform) {
   if (!win || win.isDestroyed?.()) return false;
   const colors = chromeColors(dark);
@@ -194,6 +225,7 @@ module.exports = {
   WINDOWS_OVERLAY_BACKGROUND,
   WINDOW_DRAG_REGION_CSS,
   WINDOWS_MENU_IDS,
+  attachEditContextMenu,
   buildWindowsMenuTemplate,
   configureApplicationMenu,
   mainWindowPlatformOptions,

--- a/electron/windowChrome.test.cjs
+++ b/electron/windowChrome.test.cjs
@@ -14,7 +14,29 @@ const {
   mainWindowPlatformOptions,
   popupWindowsMenu,
   syncMainWindowChromeTheme,
+  attachEditContextMenu,
 } = require('./windowChrome.cjs');
+
+/** Fake win/Menu pair capturing the context-menu handler and built templates. */
+function contextMenuHarness() {
+  const handlers = {};
+  const built = [];
+  const popups = [];
+  const win = {
+    webContents: {
+      on: (event, handler) => {
+        handlers[event] = handler;
+      },
+    },
+  };
+  const Menu = {
+    buildFromTemplate: (template) => {
+      built.push(template);
+      return { popup: (opts) => popups.push(opts) };
+    },
+  };
+  return { win, Menu, handlers, built, popups };
+}
 
 test('Windows overlays native caption buttons and removes the second menu-bar row', () => {
   assert.deepEqual(mainWindowPlatformOptions('win32', false), {
@@ -188,4 +210,47 @@ test('portaled popper layers subtract themselves from the drag lanes', () => {
     WINDOW_DRAG_REGION_CSS,
     /\[data-radix-popper-content-wrapper\],\[data-radix-popper-content-wrapper\] \*\{-webkit-app-region:no-drag\}/,
   );
+});
+
+test('edit context menu: editable fields get cut/copy/paste/select-all with editFlags-driven enabling', () => {
+  const { win, Menu, handlers, built, popups } = contextMenuHarness();
+  attachEditContextMenu(win, Menu, { isZh: true });
+  handlers['context-menu'](null, {
+    isEditable: true,
+    selectionText: '',
+    editFlags: { canCut: false, canCopy: false, canPaste: true, canSelectAll: true },
+  });
+  assert.equal(built.length, 1);
+  assert.deepEqual(
+    built[0].map((item) => item.role ?? item.type),
+    ['cut', 'copy', 'paste', 'separator', 'selectAll'],
+  );
+  assert.deepEqual(
+    built[0].filter((item) => item.role).map((item) => item.enabled),
+    [false, false, true, true],
+  );
+  assert.equal(built[0][0].label, '剪切');
+  assert.equal(popups.length, 1);
+});
+
+test('edit context menu: selected non-editable text gets a copy-only menu', () => {
+  const { win, Menu, handlers, built, popups } = contextMenuHarness();
+  attachEditContextMenu(win, Menu, { isZh: false });
+  handlers['context-menu'](null, {
+    isEditable: false,
+    selectionText: 'quoted reply',
+    editFlags: { canCopy: true },
+  });
+  assert.equal(built.length, 1);
+  assert.deepEqual(built[0].map((item) => item.role), ['copy']);
+  assert.equal(built[0][0].label, 'Copy');
+  assert.equal(popups.length, 1);
+});
+
+test('edit context menu: non-actionable right-clicks (no selection, not editable) show nothing', () => {
+  const { win, Menu, handlers, built, popups } = contextMenuHarness();
+  attachEditContextMenu(win, Menu, {});
+  handlers['context-menu'](null, { isEditable: false, selectionText: '  ', editFlags: {} });
+  assert.equal(built.length, 0);
+  assert.equal(popups.length, 0);
 });

--- a/src/stores/previewStore.test.ts
+++ b/src/stores/previewStore.test.ts
@@ -303,4 +303,35 @@ describe('previewStore', () => {
       expect(usePreviewStore.getState().tabs[0]).toMatchObject({ filePath: '/proj/a.md' });
     });
   });
+
+  describe('right-panel expansion on open intent', () => {
+    // Regression: with the panel collapsed but the tab still open, re-clicking
+    // a chat file card changed no previewStore state, so RightPanel's
+    // hasWideContent effect never re-fired and the panel stayed hidden.
+    it('openPreview un-collapses the right panel even when the tab already exists and is active', async () => {
+      const { useSettingsStore } = await import('./settingsStore');
+      usePreviewStore.getState().openPreview('/proj/report.html');
+      useSettingsStore.setState({ rightPanelCollapsed: true });
+      usePreviewStore.getState().openPreview('/proj/report.html');
+      expect(useSettingsStore.getState().rightPanelCollapsed).toBe(false);
+    });
+
+    it('openTerminal and user-invoked openBrowser un-collapse the right panel', async () => {
+      const { useSettingsStore } = await import('./settingsStore');
+      useSettingsStore.setState({ rightPanelCollapsed: true });
+      usePreviewStore.getState().openTerminal();
+      expect(useSettingsStore.getState().rightPanelCollapsed).toBe(false);
+
+      useSettingsStore.setState({ rightPanelCollapsed: true });
+      usePreviewStore.getState().openBrowser('https://example.com');
+      expect(useSettingsStore.getState().rightPanelCollapsed).toBe(false);
+    });
+
+    it('agent browser-view adoption (openBrowser with requestedId) keeps the collapse state', async () => {
+      const { useSettingsStore } = await import('./settingsStore');
+      useSettingsStore.setState({ rightPanelCollapsed: true });
+      usePreviewStore.getState().openBrowser('about:blank', '__abu-browser-automation__x');
+      expect(useSettingsStore.getState().rightPanelCollapsed).toBe(true);
+    });
+  });
 });

--- a/src/stores/previewStore.ts
+++ b/src/stores/previewStore.ts
@@ -1,4 +1,16 @@
 import { create } from 'zustand';
+import { useSettingsStore } from './settingsStore';
+
+/**
+ * Opening workspace content is an explicit "show me this" intent, so it must
+ * also un-collapse the right panel. RightPanel's own auto-expand effect only
+ * fires when `hasWideContent` flips false→true — with the panel collapsed but
+ * tabs still open, re-clicking a file card changed no state at all and the
+ * panel silently stayed hidden.
+ */
+function expandRightPanel(): void {
+  useSettingsStore.getState().setRightPanelCollapsed(false);
+}
 
 /**
  * A single tab in the right-panel workspace. `preview` is today's single
@@ -135,11 +147,13 @@ export const usePreviewStore = create<PreviewState>((set, get) => ({
     const existing = tabs.find((t) => t.kind === 'preview' && t.filePath === filePath);
     if (existing) {
       set({ activeTabId: existing.id, previewFilePath: filePath });
+      expandRightPanel();
       return;
     }
     const id = genId();
     const nextTabs: WorkspaceTab[] = [...tabs, { id, kind: 'preview', filePath }];
     set({ tabs: nextTabs, activeTabId: id, previewFilePath: filePath });
+    expandRightPanel();
   },
 
   openBrowser: (url = '', requestedId) => {
@@ -161,11 +175,15 @@ export const usePreviewStore = create<PreviewState>((set, get) => ({
     const existing = tabs.find((t) => t.kind === 'browser' && t.url === url);
     if (existing) {
       set({ activeTabId: existing.id, previewFilePath: null });
+      expandRightPanel();
       return existing.id;
     }
     const id = genId();
     const nextTabs: WorkspaceTab[] = [...tabs, { id, kind: 'browser', url }];
     set({ tabs: nextTabs, activeTabId: id, previewFilePath: null });
+    // User-invoked only: the `requestedId` branch above (agent browser-view
+    // adoption) intentionally keeps the current collapse state.
+    expandRightPanel();
     return id;
   },
 
@@ -174,6 +192,7 @@ export const usePreviewStore = create<PreviewState>((set, get) => ({
     const id = genId();
     const nextTabs: WorkspaceTab[] = [...tabs, { id, kind: 'terminal' }];
     set({ tabs: nextTabs, activeTabId: id, previewFilePath: null });
+    expandRightPanel();
   },
 
   activateTab: (id) => {


### PR DESCRIPTION
## 问题

1. 在聊天输入框（及选中消息文字）右键没有任何菜单 —— Electron 默认不提供右键菜单，应用也从未注册过。
2. 预览文件时把右侧面板收起后，再点对话里的文件卡片面板不会重新展开。

## 根因与修复

**Bug 1**：主进程新增 `attachEditContextMenu`（windowChrome.cjs），挂在 webContents 的 `context-menu` 事件上：可编辑区域出 剪切/复制/粘贴/全选（按 `editFlags` 置灰），选中页面文字出 复制。工作区终端不受影响——其渲染层 `preventDefault()` 会抑制 Chromium 的菜单请求，原生 handler 不触发（真实壳实测无双菜单）。

**Bug 2**：`RightPanel` 的自动展开 effect 只在 `hasWideContent` 从 false→true 翻转时触发；面板收起但 tab 仍在时，再点文件卡片走「激活已有 tab」分支，状态零变化，effect 不再触发。现在 `previewStore.openPreview / openTerminal / 用户发起的 openBrowser` 直接展开面板（agent 浏览器视图接管的 `requestedId` 分支保持原状）。

## 验证

- `npm run electron:test` + `npm run verify` 均退出码 0
- windowChrome 10/10（新增 3 个右键菜单用例）、previewStore 32/32（新增 3 个面板展开回归用例）
- 真实 Electron 壳驱动 4/4：composer 右键触发 isEditable 事件、终端右键无双菜单
- 用户真机手动走查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)