### PR TITLE
fix(window): keep conversations out of titlebar hit testing

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -244,11 +244,10 @@ function createWindow(transitionWindow = null) {
   // window is dragged via CSS `-webkit-app-region`. Map them so the top bar
   // moves the window (interactive children stay clickable via no-drag).
   win.webContents.on('did-finish-load', () => {
-    // Only the drag region's OWN empty space moves the window; EVERY descendant
-    // is no-drag so it stays clickable. Tauri's data-tauri-drag-region behaves
-    // this way (interactive children keep working) — the previous version only
-    // excluded button/input/a, so the workspace TABS (plain divs) inherited the
-    // drag region and showed the window-move cursor / were hard to click.
+    // Map the renderer's explicit drag/no-drag surfaces into Chromium's native
+    // app-region geometry. The shared CSS deliberately avoids marking every
+    // descendant of a no-drag card: scrolled conversation descendants can have
+    // un-clipped layout rectangles that cross the Windows title bar.
     void win.webContents.insertCSS(WINDOW_DRAG_REGION_CSS);
   });
   const hasFrontend = fs.existsSync(FRONTEND_INDEX);

--- a/electron/windowChrome.cjs
+++ b/electron/windowChrome.cjs
@@ -28,12 +28,15 @@ const windowsMenus = new WeakMap();
 const WINDOW_DRAG_REGION_CSS = [
   '[data-tauri-drag],[data-tauri-drag-region]{-webkit-app-region:drag;-webkit-user-select:none;user-select:none}',
   '[data-electron-drag]{-webkit-app-region:drag;-webkit-user-select:none;user-select:none}',
-  '[data-electron-no-drag],[data-electron-no-drag] *:not([data-electron-drag]){-webkit-app-region:no-drag}',
+  // Keep no-drag on the marked surface itself. Applying it to every descendant
+  // lets a tall, scrolled conversation contribute un-clipped native geometry
+  // over the Windows title bar after Chromium recomputes the app regions.
+  '[data-electron-no-drag],[data-electron-drag] *:not([data-electron-drag]){-webkit-app-region:no-drag}',
   '[data-tauri-drag] :where(button,a,input,textarea,select,[role="button"],[contenteditable]),'
     + '[data-tauri-drag-region] :where(button,a,input,textarea,select,[role="button"],[contenteditable]),'
     + '[data-electron-drag] :where(button,a,input,textarea,select,[role="button"],[contenteditable])'
     + '{-webkit-app-region:no-drag}',
-  '[data-radix-popper-content-wrapper],[data-radix-popper-content-wrapper] *{-webkit-app-region:no-drag}',
+  '[data-radix-popper-content-wrapper]{-webkit-app-region:no-drag}',
 ].join('');
 
 function chromeColors(dark) {

--- a/electron/windowChrome.test.cjs
+++ b/electron/windowChrome.test.cjs
@@ -200,6 +200,7 @@ test('Electron maps both historical and current Tauri drag attributes', () => {
   assert.match(WINDOW_DRAG_REGION_CSS, /data-tauri-drag-region\]/);
   assert.match(WINDOW_DRAG_REGION_CSS, /data-electron-no-drag/);
   assert.match(WINDOW_DRAG_REGION_CSS, /no-drag/);
+  assert.doesNotMatch(WINDOW_DRAG_REGION_CSS, /\[data-electron-no-drag\] \*/);
 });
 
 test('portaled popper layers subtract themselves from the drag lanes', () => {
@@ -208,7 +209,7 @@ test('portaled popper layers subtract themselves from the drag lanes', () => {
   // over the 72px Windows chrome band has every click eaten by the drag lane.
   assert.match(
     WINDOW_DRAG_REGION_CSS,
-    /\[data-radix-popper-content-wrapper\],\[data-radix-popper-content-wrapper\] \*\{-webkit-app-region:no-drag\}/,
+    /\[data-radix-popper-content-wrapper\]\{-webkit-app-region:no-drag\}/,
   );
 });
 

--- a/src/__tests__/overlayDragRegions.test.ts
+++ b/src/__tests__/overlayDragRegions.test.ts
@@ -17,9 +17,9 @@
  * The fix this test guards: every layer that paints above the chrome declares
  * `data-electron-no-drag` on its root, which `src/styles/index.css` (and the
  * identical main-process `insertCSS` in `electron/windowChrome.cjs`) turns into
- * `-webkit-app-region: no-drag !important` for the root AND every descendant.
- * That subtracts the overlay's rectangle from the lane, so the OS hands the
- * clicks back to the page.
+ * `-webkit-app-region: no-drag !important` for the marked surface itself. That
+ * subtracts the overlay's rectangle from the lane, so the OS hands the clicks
+ * back to the page without leaking descendant geometry across scroll clips.
  *
  * Relying on DOM ancestry instead is not safe: `<main>` carries the marker, so
  * overlays rendered inside it inherit no-drag by accident, but anything rendered
@@ -178,26 +178,23 @@ describe('overlay layers opt out of the OS drag lanes', () => {
 describe('the stylesheet turns the marker into a no-drag region', () => {
   const css = fs.readFileSync(path.join(SRC_DIR, 'styles', 'index.css'), 'utf8');
 
-  it('applies no-drag to marked roots and all of their descendants', () => {
-    // The descendant selector is what makes a single marker on the scrim enough
-    // to hand every button inside the dialog back to the renderer.
+  it('applies no-drag to the marked surface without leaking through scroll clips', () => {
     expect(css).toMatch(
-      /\[data-electron-no-drag\],\s*\[data-electron-no-drag\] \*:not\(\[data-electron-drag\]\)\s*\{[^}]*-webkit-app-region:\s*no-drag !important/,
+      /\[data-electron-no-drag\],\s*\[data-electron-drag\] \*:not\(\[data-electron-drag\]\)\s*\{[^}]*-webkit-app-region:\s*no-drag !important/,
     );
+    expect(css).not.toContain('[data-electron-no-drag] *');
   });
 
   it('keeps the drag-row escape valve immune to source order', () => {
-    // `[data-electron-drag]` and `[data-electron-no-drag] *` both weigh (0,1,0)
-    // with !important, so without the `:not()` the winner would come down to
-    // which rule appears last in the file — and a macOS title row inside a card
-    // would silently stop being draggable the next time this file is reordered.
-    expect(css).toContain('[data-electron-no-drag] *:not([data-electron-drag])');
+    // The row re-opens a macOS drag lane inside a no-drag card while its own
+    // contents stay clickable. Nested drag rows are excluded from subtraction.
+    expect(css).toContain('[data-electron-drag] *:not([data-electron-drag])');
     expect(css).toMatch(/\[data-electron-drag\]\s*\{[^}]*-webkit-app-region:\s*drag !important/);
   });
 
   it('never lets an interactive element inside a drag region become draggable', () => {
-    // Backstop for drag rows that sit outside a no-drag card, where the
-    // descendant rule above does not reach.
+    // Backstop for Tauri drag rows and other drag surfaces without the macOS
+    // data-electron-drag child rule.
     expect(css).toMatch(
       /\[data-electron-drag\] :where\(button, a, input, textarea, select, \[role="button"\], \[contenteditable\]\)/,
     );
@@ -205,7 +202,7 @@ describe('the stylesheet turns the marker into a no-drag region', () => {
 
   it('covers portaled popper layers that have no ancestor to inherit from', () => {
     expect(css).toMatch(
-      /\[data-radix-popper-content-wrapper\],\s*\[data-radix-popper-content-wrapper\] \*\s*\{[^}]*-webkit-app-region:\s*no-drag !important/,
+      /\[data-radix-popper-content-wrapper\]\s*\{[^}]*-webkit-app-region:\s*no-drag !important/,
     );
   });
 });

--- a/src/components/window/WindowTitleBar.test.tsx
+++ b/src/components/window/WindowTitleBar.test.tsx
@@ -56,6 +56,7 @@ describe('WindowTitleBar', () => {
     dragRegions.forEach((region) => {
       expect(region).toHaveAttribute('data-tauri-drag-region');
       expect(region).not.toHaveAttribute('data-electron-no-drag');
+      expect(region).toHaveClass('pointer-events-none', 'absolute', 'inset-0');
     });
     expect(menus).toHaveLength(3);
     menus.forEach((menu) => {

--- a/src/components/window/WindowTitleBar.tsx
+++ b/src/components/window/WindowTitleBar.tsx
@@ -251,9 +251,17 @@ export default function WindowTitleBar({
                 width: 'env(titlebar-area-width, calc(100% - 138px))',
               }}
             >
+              {/* Keep the native drag geometry independent of the flex items
+                  above the workspace. Menus subtract their own no-drag island
+                  from this full safe-area plane. */}
               <div
+                data-abu-windows-drag-region="titlebar"
                 data-tauri-drag-region
-                className="pointer-events-none flex h-full items-center gap-1.5 pl-2 pr-1.5"
+                className="pointer-events-none absolute inset-0"
+                aria-hidden="true"
+              />
+              <div
+                className="relative flex h-full items-center gap-1.5 pl-2 pr-1.5"
               >
                 <img src={abuAvatar} alt="" className="h-4 w-4 rounded-[4px]" draggable={false} />
                 <span className="text-minor font-medium text-[var(--abu-text-primary)]">
@@ -263,7 +271,7 @@ export default function WindowTitleBar({
               <div
                 data-electron-no-drag
                 data-abu-window-menu-group
-                className="flex h-full items-center"
+                className="relative flex h-full items-center"
               >
                 {([
                   ['edit', labels.editMenu],
@@ -288,12 +296,6 @@ export default function WindowTitleBar({
                   </button>
                 ))}
               </div>
-              <div
-                data-abu-windows-drag-region="titlebar"
-                data-tauri-drag-region
-                className="h-full min-w-8 flex-1"
-                aria-hidden="true"
-              />
             </div>
           </div>
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -35,8 +35,15 @@
   user-select: none;
 }
 
+/* A no-drag root's own rectangle is enough to hand its surface back to the
+   renderer. Do NOT stamp no-drag onto every descendant: Chromium includes the
+   descendants' un-clipped layout rectangles in native app-region geometry, so
+   a tall conversation scrolled underneath an overflow-hidden card can reach
+   back into the title bar and turn HTCAPTION into HTCLIENT. macOS drag rows are
+   the narrow exception; their descendants must remain clickable after the row
+   opts back into drag. */
 [data-electron-no-drag],
-[data-electron-no-drag] *:not([data-electron-drag]) {
+[data-electron-drag] *:not([data-electron-drag]) {
   -webkit-app-region: no-drag !important;
 }
 
@@ -57,8 +64,7 @@
    in the top chrome band is simply dead. Overlays we author declare
    `data-electron-no-drag` on their root; these selectors cover the layers that
    escape the React tree into `document.body`, where no ancestor can mark them. */
-[data-radix-popper-content-wrapper],
-[data-radix-popper-content-wrapper] * {
+[data-radix-popper-content-wrapper] {
   -webkit-app-region: no-drag !important;
 }
 

--- a/tests/e2e/windows-titlebar-drag.spec.ts
+++ b/tests/e2e/windows-titlebar-drag.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * Real-Electron guard for the Windows title-bar lane being clipped when the
+ * chat shares the window with a wide workspace panel. The drag geometry must
+ * cover the whole Window Controls Overlay safe area rather than a flex item's
+ * leftover width. Win32 WM_NCHITTEST then verifies the OS sees HTCAPTION across
+ * both the chat and preview columns.
+ */
+import { expect, test } from '@playwright/test';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { ElectronApplication, Page } from 'playwright';
+import {
+  appRegionAt,
+  closeAbuElectron,
+  createElectronDataRoot,
+  launchAbuElectron,
+  removeElectronDataRoot,
+  type ElectronDataRoot,
+} from './electronHelpers';
+
+const READY_TIMEOUT = 45_000;
+const CHAT_PLACEHOLDER = '想让阿布帮你做点什么？';
+
+function nativeHitTest(x: number, y: number): { point: number; root: number } {
+  const script = `
+Add-Type @'
+using System;
+using System.Runtime.InteropServices;
+public static class AbuHitTest {
+  [StructLayout(LayoutKind.Sequential)] public struct POINT { public int X; public int Y; }
+  [DllImport("user32.dll")] public static extern IntPtr WindowFromPoint(POINT point);
+  [DllImport("user32.dll")] public static extern IntPtr GetAncestor(IntPtr hwnd, uint flags);
+  [DllImport("user32.dll")] public static extern IntPtr SendMessage(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam);
+}
+'@
+$point = New-Object AbuHitTest+POINT
+$point.X = ${Math.round(x)}
+$point.Y = ${Math.round(y)}
+$hwnd = [AbuHitTest]::WindowFromPoint($point)
+$root = [AbuHitTest]::GetAncestor($hwnd, 2)
+$packed = [IntPtr](($point.Y -shl 16) -bor ($point.X -band 0xffff))
+$pointResult = [AbuHitTest]::SendMessage($hwnd, 0x84, [IntPtr]::Zero, $packed).ToInt64()
+$rootResult = [AbuHitTest]::SendMessage($root, 0x84, [IntPtr]::Zero, $packed).ToInt64()
+[Console]::Write((@{ point = $pointResult; root = $rootResult } | ConvertTo-Json -Compress))
+`;
+  const result = spawnSync('powershell.exe', ['-NoProfile', '-Command', script], {
+    encoding: 'utf8',
+    timeout: 10_000,
+  });
+  if (result.status !== 0) throw new Error(result.stderr || 'native hit test failed');
+  return JSON.parse(result.stdout) as { point: number; root: number };
+}
+
+async function waitForApp(page: Page): Promise<void> {
+  await page.waitForLoadState('domcontentloaded');
+  await expect(page.getByPlaceholder(CHAT_PLACEHOLDER)).toBeVisible({ timeout: READY_TIMEOUT });
+}
+
+async function dismissFirstRunOverlays(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const raw = window.localStorage.getItem('abu-settings');
+    if (!raw) throw new Error('abu-settings was not initialized before E2E configuration');
+    const persisted = JSON.parse(raw) as { state: Record<string, unknown>; version: number };
+    Object.assign(persisted.state, {
+      guideShown: true,
+      guideOpen: false,
+      hasAcknowledgedDisclaimer: true,
+      hasRunSensitiveAudit_v015: true,
+    });
+    window.localStorage.setItem('abu-settings', JSON.stringify(persisted));
+  });
+  await page.reload();
+  await waitForApp(page);
+}
+
+async function configureLocalProvider(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const raw = window.localStorage.getItem('abu-settings');
+    if (!raw) throw new Error('abu-settings was not initialized before E2E configuration');
+    const persisted = JSON.parse(raw) as { state: Record<string, unknown>; version: number };
+    persisted.state.providers = [{
+      id: 'windows-titlebar-e2e',
+      source: 'custom',
+      name: 'Windows titlebar E2E',
+      enabled: true,
+      apiFormat: 'openai-compatible',
+      baseUrl: 'http://127.0.0.1:1/v1',
+      apiKey: 'not-a-real-secret',
+      models: [{ id: 'e2e-model', label: 'E2E model', isCustom: true }],
+      defaultModelId: 'e2e-model',
+      status: 'verified',
+      sortOrder: 0,
+      userAdded: true,
+    }];
+    persisted.state.activeModel = { providerId: 'windows-titlebar-e2e', modelId: 'e2e-model' };
+    window.localStorage.setItem('abu-settings', JSON.stringify(persisted));
+  });
+  await page.reload();
+  await waitForApp(page);
+}
+
+async function openHtmlPreview(page: Page, filePath: string): Promise<void> {
+  const normalizedPath = filePath.replace(/\\/g, '/');
+  const fileName = path.basename(filePath);
+  const input = page.getByPlaceholder(CHAT_PLACEHOLDER);
+  await input.fill(`[Attachment: \`${normalizedPath}\`]`);
+  await input.press('Enter');
+  const attachment = page.getByText(fileName, { exact: true }).first();
+  await expect(attachment).toBeVisible({ timeout: READY_TIMEOUT });
+  await attachment.click();
+  await expect(page.locator('[data-abu-right-panel]')).toBeVisible({ timeout: READY_TIMEOUT });
+}
+
+let app: ElectronApplication | undefined;
+let dataRoot: ElectronDataRoot | undefined;
+
+test.describe.serial('Electron Windows title-bar drag lane', () => {
+  test.afterEach(async () => {
+    if (app) {
+      await closeAbuElectron(app);
+      app = undefined;
+    }
+    if (dataRoot) {
+      removeElectronDataRoot(dataRoot);
+      dataRoot = undefined;
+    }
+  });
+
+  test('the lane remains natively draggable over the wide workspace column', async () => {
+    test.skip(process.platform !== 'win32', 'the Window Controls Overlay lane only exists on Windows');
+
+    dataRoot = createElectronDataRoot();
+    const launched = await launchAbuElectron(dataRoot);
+    app = launched.app;
+    const page = await app.firstWindow({ timeout: READY_TIMEOUT });
+    await waitForApp(page);
+    await dismissFirstRunOverlays(page);
+    await configureLocalProvider(page);
+
+    await app.evaluate(({ BrowserWindow }) => {
+      const [mainWindow] = BrowserWindow.getAllWindows();
+      if (!mainWindow) throw new Error('main window missing');
+      if (mainWindow.isMaximized()) mainWindow.unmaximize();
+      mainWindow.setContentSize(1200, 800);
+    });
+    const chromeBeforeSplit = await page.evaluate(() => {
+      const lane = document.querySelector('[data-abu-windows-drag-region="titlebar"]');
+      const safeArea = document.querySelector('[data-abu-windows-titlebar-safe-area]');
+      if (!lane || !safeArea) throw new Error('Windows title-bar geometry is incomplete');
+      const laneRect = lane.getBoundingClientRect();
+      const safeRect = safeArea.getBoundingClientRect();
+      return {
+        laneLeft: laneRect.left,
+        laneRight: laneRect.right,
+        safeLeft: safeRect.left,
+        safeRight: safeRect.right,
+      };
+    });
+    const reportPath = path.join(dataRoot.rootDir, 'windows-titlebar-report.html');
+    fs.writeFileSync(reportPath, '<!doctype html><title>Windows titlebar E2E</title>');
+    await openHtmlPreview(page, reportPath);
+
+    const sample = await page.evaluate(() => {
+      const lane = document.querySelector('[data-abu-windows-drag-region="titlebar"]');
+      const safeArea = document.querySelector('[data-abu-windows-titlebar-safe-area]');
+      const panel = document.querySelector('[data-abu-right-panel]');
+      if (!lane || !safeArea || !panel) throw new Error('Windows split layout is incomplete');
+      const laneRect = lane.getBoundingClientRect();
+      const safeRect = safeArea.getBoundingClientRect();
+      const panelRect = panel.getBoundingClientRect();
+      const x = Math.min(laneRect.right - 24, panelRect.left + panelRect.width / 2);
+      if (x <= panelRect.left || x >= panelRect.right) {
+        throw new Error('the drag sample is not horizontally inside the workspace panel');
+      }
+      return {
+        x,
+        y: laneRect.top + laneRect.height / 2,
+        laneWidth: laneRect.width,
+        laneLeft: laneRect.left,
+        laneRight: laneRect.right,
+        panelLeft: panelRect.left,
+        safeLeft: safeRect.left,
+        safeRight: safeRect.right,
+      };
+    });
+
+    expect(chromeBeforeSplit.laneLeft).toBeCloseTo(chromeBeforeSplit.safeLeft, 0);
+    expect(chromeBeforeSplit.laneRight).toBeCloseTo(chromeBeforeSplit.safeRight, 0);
+    expect(sample.laneLeft).toBeCloseTo(sample.safeLeft, 0);
+    expect(sample.laneRight).toBeCloseTo(sample.safeRight, 0);
+    expect(sample.laneWidth).toBeCloseTo(sample.safeRight - sample.safeLeft, 0);
+    expect(await appRegionAt(page, sample.x, sample.y)).toBe('drag');
+
+    // Reproduce the real failure mode: after entering a long conversation, a
+    // scrolled message descendant retains a large un-clipped layout rectangle.
+    // A blanket `[data-electron-no-drag] *` selector lets that rectangle subtract
+    // the native title bar even though the card clips it visually.
+    const clippedProbe = await page.evaluate(({ x, y }) => {
+      const card = document.querySelector('main[data-electron-no-drag]');
+      if (!(card instanceof HTMLElement)) throw new Error('conversation card missing');
+      const cardRect = card.getBoundingClientRect();
+      const probe = document.createElement('div');
+      probe.dataset.abuE2eClippedConversationProbe = 'true';
+      Object.assign(probe.style, {
+        position: 'absolute',
+        left: `${Math.max(0, x - cardRect.left - 40)}px`,
+        top: `${y - cardRect.top - 40}px`,
+        width: '80px',
+        height: '80px',
+      });
+      card.appendChild(probe);
+      const rect = probe.getBoundingClientRect();
+      return {
+        region: getComputedStyle(probe).webkitAppRegion,
+        coversSample: x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom,
+      };
+    }, { x: sample.x, y: sample.y });
+    expect(clippedProbe.coversSample).toBe(true);
+    expect(clippedProbe.region).toBe('none');
+    expect(await appRegionAt(page, sample.x, sample.y)).toBe('drag');
+
+    const windowPlan = await app.evaluate(({ BrowserWindow }) => {
+      const [mainWindow] = BrowserWindow.getAllWindows();
+      if (!mainWindow) throw new Error('main window missing');
+      const contentBounds = mainWindow.getContentBounds();
+      mainWindow.focus();
+      mainWindow.moveTop();
+      return {
+        contentX: contentBounds.x,
+        contentY: contentBounds.y,
+      };
+    });
+    const sampleXs = [
+      sample.laneLeft + 20,
+      sample.panelLeft - 20,
+      sample.panelLeft + 20,
+      sample.x,
+      sample.laneRight - 20,
+    ];
+    for (const x of sampleXs) {
+      const hitTest = nativeHitTest(
+        windowPlan.contentX + x,
+        windowPlan.contentY + sample.y,
+      );
+      expect([hitTest.point, hitTest.root], `x=${x}: ${JSON.stringify(hitTest)}`).toContain(2);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- keep the Windows Window Controls Overlay drag plane independent of workspace flex layout
- prevent scrolled conversation descendants from leaking `no-drag` geometry into the title bar
- add a real-Electron Windows regression test covering split preview and clipped conversation content

## Testing

- targeted Vitest: 12 passed
- Electron window chrome tests: 10 passed
- Windows real-Electron titlebar E2E: passed
- TypeScript/Vite Electron renderer build: passed
- ESLint: passed