### PR TITLE
fix(setup): setup:electron-dev 补跑 copy-resources，新 worktree 首次 verify 不再误报 STALE

### DIFF
--- a/scripts/electron-dev-scripts.test.mjs
+++ b/scripts/electron-dev-scripts.test.mjs
@@ -20,3 +20,22 @@ test('enterprise Electron dev launch rebuilds the enterprise sidecar and native 
     'npm run electron:dev:check && ABU_BUILD_TARGET=enterprise npm run build:sidecar && npm run build:native-helper && ABU_BUILD_TARGET=enterprise npm run build:electron:renderer',
   );
 });
+
+test('setup:electron-dev runs copy-resources so every browser-artifact digest gets stamped', () => {
+  // check:browser-artifacts 校验 4 个产物戳，setup 的构建步骤只写其中 3 个；
+  // src-tauri/browser-extension 的戳只有 copy-resources 写，缺了它新 worktree
+  // 首次 verify 必报 STALE。
+  const setupScript = readFileSync(path.join(repoRoot, 'scripts', 'setup-electron-dev.mjs'), 'utf8');
+  const browserRuntimeAt = setupScript.indexOf("'build:electron-browser-runtime'");
+  const sidecarAt = setupScript.indexOf("'build:sidecar'");
+  const copyResourcesAt = setupScript.indexOf("'copy-resources'");
+  assert.notEqual(copyResourcesAt, -1, 'setup:electron-dev must run copy-resources');
+  assert.ok(
+    copyResourcesAt > browserRuntimeAt && browserRuntimeAt !== -1,
+    'copy-resources needs abu-chrome-extension/dist built first',
+  );
+  assert.ok(
+    copyResourcesAt > sidecarAt && sidecarAt !== -1,
+    'copy-resources needs sidecar/index.mjs built first',
+  );
+});

--- a/scripts/setup-electron-dev.mjs
+++ b/scripts/setup-electron-dev.mjs
@@ -55,6 +55,10 @@ run(npmArgs('run', 'setup:electron-runtimes'), '准备内置 Node 和 Python');
 run(npmArgs('run', 'verify:electron-runtimes'), '校验内置运行时');
 run(npmArgs('run', 'build:electron-browser-runtime'), '构建浏览器能力');
 run(npmArgs('run', 'build:sidecar'), '构建 Agent sidecar');
+// src-tauri/browser-extension 的摘要戳只有 copy-resources 会写（.artifact-digests/
+// 不入 git），缺了它新 worktree 首次 verify 会在 check:browser-artifacts 报 STALE。
+// 须排在 sidecar 构建之后：copy-resources 还要同步 sidecar/index.mjs。
+run(npmArgs('run', 'copy-resources'), '同步 src-tauri 资源副本');
 run(npmArgs('run', 'build:native-helper'), '构建电脑操控辅助程序');
 run(npmArgs('run', 'build:sandbox-launcher'), '构建沙箱启动器');
 run(npmArgs('run', 'build:electron:renderer'), '构建 Electron 前端');


### PR DESCRIPTION
## 问题

新 worktree / 新 clone 执行 `npm run setup:electron-dev` 之后，首次 `npm run verify` 必在 `check:browser-artifacts` 步骤失败，报 `STALE src-tauri/browser-extension/content.js`（2026-08-23 实测复现），需手动补跑一次 `npm run copy-resources` 才能通过。

## 根因

`check:browser-artifacts` 校验 4 个产物摘要戳，但 setup 流程的三个 build 步骤只写其中 3 个：`src-tauri/browser-extension/content.js` 的戳只有 `copy-resources` 会写，而戳目录 `.artifact-digests/` 不入 git——所以任何全新环境都会命中。实测补跑后零 tracked 文件漂移，纯属戳缺失误报。

## 修复

- `scripts/setup-electron-dev.mjs`：在 `build:sidecar` 之后补跑 `copy-resources`（排在 sidecar 构建后是因为它还要同步 `sidecar/index.mjs`）。OSS 与 enterprise 变体共用此脚本，一处修复覆盖两者。
- `scripts/electron-dev-scripts.test.mjs`：新增测试钉住该步骤存在及其顺序（须在 extension 构建和 sidecar 构建之后），防止步骤被删或挪错位置。

## 验证

在干净新 worktree（无 node_modules）端到端实测：

- `npm run setup:electron-dev` 退出码 0；跑完 `.artifact-digests/` 4 个戳齐全，`git status` 零 tracked 漂移
- 紧接首次 `npm run verify` 退出码 0：`check:browser-artifacts` up to date，404 个测试文件 5882 用例全过，覆盖率门禁通过
- `node --test scripts/electron-dev-preflight.test.mjs scripts/electron-dev-scripts.test.mjs` 8/8 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)