### PR TITLE
fix(chat): 章节 rail 溢出裁切、短会话噪音、预览卡出界

### DIFF
--- a/src/components/chat/ChapterRail.test.tsx
+++ b/src/components/chat/ChapterRail.test.tsx
@@ -81,6 +81,31 @@ describe('ChapterRail', () => {
     expect(screen.getByRole('navigation').querySelectorAll('.line-clamp-3')).toHaveLength(0);
   });
 
+  it('caps its own height so a long conversation cannot clip the end ticks', () => {
+    // 10px per tick means 150 chapters overflow a chat pane, and because the
+    // rail is centred the overflow is cut off at BOTH ends — the oldest and
+    // newest ticks would be unreachable without this cap.
+    const many = Array.from({ length: 150 }, (_, i) => chapter(i, `第 ${i + 1} 段`));
+    render(<ChapterRail chapters={many} currentIndex={0} onJump={() => {}} />);
+
+    const list = screen.getAllByRole('button')[0].parentElement;
+    expect(list?.className).toContain('max-h-[60vh]');
+    expect(list?.className).toContain('overflow-y-auto');
+  });
+
+  it('brings the current tick into view when it changes', () => {
+    const many = Array.from({ length: 60 }, (_, i) => chapter(i, `第 ${i + 1} 段`));
+    const spy = vi.fn();
+    // happy-dom has no layout, so scrollIntoView is a stub — assert we asked.
+    Element.prototype.scrollIntoView = spy;
+
+    const { rerender } = render(<ChapterRail chapters={many} currentIndex={0} onJump={() => {}} />);
+    spy.mockClear();
+    rerender(<ChapterRail chapters={many} currentIndex={59} onJump={() => {}} />);
+
+    expect(spy).toHaveBeenCalledWith({ block: 'nearest' });
+  });
+
   it('condenses only the middle ticks once the rail gets long', () => {
     const many = Array.from({ length: 14 }, (_, i) => chapter(i, `第 ${i + 1} 段`));
     render(<ChapterRail chapters={many} currentIndex={0} onJump={() => {}} />);

--- a/src/components/chat/ChapterRail.tsx
+++ b/src/components/chat/ChapterRail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useI18n, format } from '@/i18n';
 import { cn } from '@/lib/utils';
 import { CONDENSE_THRESHOLD, type Chapter } from './chapters';
@@ -35,6 +35,9 @@ const TICK_CONDENSED = 'h-[6px]';
 
 const TICK_CURRENT = 'before:bg-[var(--abu-clay)] before:opacity-100';
 
+/** Breathing room kept between the preview card and the window edge. */
+const VIEWPORT_GUTTER = 16;
+
 export default function ChapterRail({
   chapters,
   currentIndex,
@@ -46,7 +49,14 @@ export default function ChapterRail({
 }) {
   const { t } = useI18n();
   const [peeked, setPeeked] = useState<{ index: number; top: number } | null>(null);
+  // Pixels to lift the preview card by so it stays inside the window. Measured
+  // rather than estimated: the card is one line or two depending on whether the
+  // chapter has a summary yet, so any hard-coded height would be wrong half the
+  // time.
+  const [peekShift, setPeekShift] = useState(0);
   const tickRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const ticksRef = useRef<HTMLDivElement>(null);
+  const peekRef = useRef<HTMLDivElement>(null);
 
   // The preview card is aligned to the tick under the cursor, so it is measured
   // from the live element rather than computed from an index: the condensed
@@ -55,8 +65,26 @@ export default function ChapterRail({
   const showPeek = useCallback((index: number) => {
     const tick = tickRefs.current[index];
     if (!tick) return;
+    setPeekShift(0);
     setPeeked({ index, top: tick.offsetTop - 10 });
   }, []);
+
+  // Keep the card on screen. It is anchored to a tick, and ticks near the foot
+  // of a long rail sit close enough to the composer that a two-line card would
+  // hang off the bottom of the window.
+  useLayoutEffect(() => {
+    if (!peeked) return;
+    const card = peekRef.current;
+    if (!card) return;
+    const overflow = card.getBoundingClientRect().bottom - (window.innerHeight - VIEWPORT_GUTTER);
+    if (overflow > 0) setPeekShift((current) => current + overflow);
+  }, [peeked]);
+
+  // Once the rail scrolls, the current tick can fall outside it — most visibly
+  // on open, which lands on the newest chapter at the very bottom of the list.
+  useEffect(() => {
+    tickRefs.current[currentIndex]?.scrollIntoView({ block: 'nearest' });
+  }, [currentIndex, chapters.length]);
 
   if (chapters.length === 0) return null;
 
@@ -84,7 +112,19 @@ export default function ChapterRail({
           className="absolute left-1 -translate-y-1/2 py-1.5 px-1"
           onMouseLeave={() => setPeeked(null)}
         >
-          <div className="flex flex-col items-start">
+          {/* The rail's height is 10px per chapter (6px condensed), so it grows
+              without limit: 150 chapters already exceed a chat pane, and since
+              the rail is centred the overflow is clipped at BOTH ends — the
+              oldest and newest ticks silently become unreachable. Cap it and
+              let the excess scroll instead. The scrollbar is hidden because a
+              second one beside the transcript reads as chrome, not navigation;
+              the effect below keeps the current tick in view, which is what the
+              scrollbar would otherwise be for. */}
+          <div
+            ref={ticksRef}
+            className="flex flex-col items-start max-h-[60vh] overflow-y-auto
+                       [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          >
             {chapters.map((chapter, index) => (
               <button
                 key={chapter.messageId}
@@ -110,9 +150,10 @@ export default function ChapterRail({
 
           {preview && peeked && (
             <div
+              ref={peekRef}
               className="absolute left-[calc(100%+10px)] w-[300px] flex flex-col gap-1 px-3 py-2.5 pointer-events-none
                          rounded-xl bg-[var(--abu-bg-base)] border border-[var(--abu-border)] shadow-lg"
-              style={{ top: peeked.top }}
+              style={{ top: peeked.top - peekShift }}
             >
               <span className="text-h-xs text-[var(--abu-text-primary)] truncate">{preview.title}</span>
               {preview.summary && (

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -14,7 +14,7 @@ import MessageGroup from './MessageGroup';
 import CompactDivider from './CompactDivider';
 import ChapterRail from './ChapterRail';
 import ChapterMenu from './ChapterMenu';
-import { activeChapterIndex, deriveChapters, topVisibleGroup, type Chapter, type RowPosition } from './chapters';
+import { activeChapterIndex, deriveChapters, shouldShowRail, topVisibleGroup, type Chapter, type RowPosition } from './chapters';
 import { isCompactBoundary } from '@/core/context/compactBoundary';
 import { getMessageText } from '@/core/context/contextUtils';
 import { compactConversationManually } from '@/core/context/compactionService';
@@ -537,6 +537,8 @@ export default function ChatView({
   // unmemoized for the same reason.
   const chapters = deriveChapters(messageGroups, t.chat.chapters.sessionStart);
   const currentChapter = activeChapterIndex(chapters, firstVisibleGroup);
+  // One or two ticks navigate nothing — the conversation is already on screen.
+  const chapterNavVisible = shouldShowRail(chapters);
 
   // Same landing behaviour as a search hit: release the bottom lock (so a late
   // height measurement cannot yank the view back down) and flash the target so
@@ -716,7 +718,7 @@ export default function ChatView({
         )}
         {/* Chapter navigation moves into the header exactly when the gutter can
             no longer hold the rail, so the two never appear at once. */}
-        {!railFits && (
+        {chapterNavVisible && !railFits && (
           <ChapterMenu chapters={chapters} currentIndex={currentChapter} onJump={jumpToChapter} />
         )}
       </div>
@@ -776,7 +778,7 @@ export default function ChatView({
           shift the content. Both were lost in the Virtuoso-list merge — do not
           drop them again. */}
       <div className="relative flex-1 min-h-0 overflow-y-scroll overlay-scroll" ref={setScrollParentEl}>
-        {railFits && (
+        {chapterNavVisible && railFits && (
           <ChapterRail chapters={chapters} currentIndex={currentChapter} onJump={jumpToChapter} />
         )}
         <div className="w-full max-w-4xl mx-auto px-6 md:px-10 pt-5 pb-16 overflow-hidden">

--- a/src/components/chat/chapters.test.ts
+++ b/src/components/chat/chapters.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { Message } from '@/types';
 import { COMPACT_BOUNDARY_ID_PREFIX } from '@/core/context/compactBoundary';
-import { activeChapterIndex, deriveChapters, topVisibleGroup, type Chapter } from './chapters';
+import { activeChapterIndex, deriveChapters, shouldShowRail, topVisibleGroup, type Chapter } from './chapters';
 
 const FALLBACK = '会话开始';
 
@@ -234,5 +234,23 @@ describe('topVisibleGroup', () => {
 
   it('falls back to the first chapter when nothing is rendered', () => {
     expect(topVisibleGroup([])).toBe(0);
+  });
+});
+
+describe('shouldShowRail', () => {
+  function chapters(n: number): Chapter[] {
+    return Array.from({ length: n }, (_, i) => ({ groupIndex: i, messageId: `m${i}`, title: `第 ${i}`, summary: '' }));
+  }
+
+  it('stays out of the way until scrubbing beats scrolling', () => {
+    expect(shouldShowRail(chapters(0))).toBe(false);
+    // A brand-new conversation: one turn, one tick, nothing to navigate.
+    expect(shouldShowRail(chapters(1))).toBe(false);
+    expect(shouldShowRail(chapters(2))).toBe(false);
+  });
+
+  it('appears from the third chapter on', () => {
+    expect(shouldShowRail(chapters(3))).toBe(true);
+    expect(shouldShowRail(chapters(40))).toBe(true);
   });
 });

--- a/src/components/chat/chapters.ts
+++ b/src/components/chat/chapters.ts
@@ -174,6 +174,20 @@ export function topVisibleGroup(
 }
 
 /**
+ * Below this many chapters the rail is not worth drawing.
+ *
+ * One or two ticks navigate nothing — the whole conversation is already on
+ * screen — so the rail would be pure ornament next to the text. Three is the
+ * first count where scrubbing beats scrolling.
+ */
+export const MIN_CHAPTERS_FOR_RAIL = 3;
+
+/** Whether a conversation has enough chapters for the rail to earn its place. */
+export function shouldShowRail(chapters: Chapter[]): boolean {
+  return chapters.length >= MIN_CHAPTERS_FOR_RAIL;
+}
+
+/**
  * Above this many chapters the rail switches to its condensed pitch: the ticks
  * keep their length and only the row spacing tightens, so the rail's height
  * stops growing with the conversation instead of turning into a scrollbar of


### PR DESCRIPTION
批一（#261）上线后我回头审了 rail 自己的边界条件，不是来自审查意见。三个缺陷，都在真实使用中会遇到。

## 1. rail 高度没有上限，长会话首尾刻度被裁掉 🔴

每章 10px（收敛后 6px），高度一路长上去：

| 章节数 | rail 高度 |
|---|---|
| 50 | 308px |
| 100 | 608px |
| **150** | **908px** |

聊天区高度撑死七八百 px，而 rail 是**垂直居中**的，所以溢出是**上下两头一起被裁** —— 最老和最新的刻度既看不见也点不到，正好跟导航件该干的事相反。

我之前在注释和 PR 里写的「rail 高度封顶，不滚动」**是错的**，因为只在 22 章的规模验过。

**修法**：封顶 `max-h-[60vh]`，超出部分可滚但**隐藏滚动条**（正文旁边再来一条滚动条会像 chrome 不像导航），并在当前章节变化时把它 `scrollIntoView({block:'nearest'})`。最后这条覆盖了最常见的情形：打开会话落在最新一章，而它在长 rail 的最底部。

## 2. 一轮对话也画一根孤零零的刻度

新开会话说完第一句，左边就冒出一根刻度。它导航不了任何东西 —— 整个会话本来就在屏幕上 —— 纯噪音。

**修法**：抽出 `shouldShowRail()`，**少于 3 章时 rail 和窄窗菜单都不出现**。三是「刷刻度比滚动划算」的第一个数。

## 3. 预览卡会探出窗口下沿

卡片锚在刻度上，rail 底部那几根离输入框很近，两行的卡片会挂到窗口外面。

**修法**：布局后实测再上移。**实测而非估算** —— 卡片是一行还是两行取决于该章有没有回复，写死高度必错一半。

## 验证

- `npm run verify` 退出码 0（5886 用例）
- 新增用例：150 章时刻度容器必须带高度上限和溢出滚动；当前刻度变化时必须请求 `scrollIntoView`；少于 3 章不显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)
