### PR TITLE
feat(chat): 章节 rail 的 fisheye 悬停

### DIFF
--- a/src/components/chat/ChapterRail.test.tsx
+++ b/src/components/chat/ChapterRail.test.tsx
@@ -106,6 +106,42 @@ describe('ChapterRail', () => {
     expect(spy).toHaveBeenCalledWith({ block: 'nearest' });
   });
 
+  it('swells the hovered tick and its neighbours by distance, colouring only the hovered one', () => {
+    const many = Array.from({ length: 9 }, (_, i) => chapter(i, `第 ${i + 1} 段`));
+    render(<ChapterRail chapters={many} currentIndex={0} onJump={() => {}} />);
+    const ticks = screen.getAllByRole('button');
+
+    fireEvent.mouseEnter(ticks[4]);
+
+    // Hovered: longest, and the accent — never near-black, which read as a
+    // different kind of state next to the accent-coloured current chapter.
+    expect(ticks[4].className).toContain('before:w-[24px]');
+    expect(ticks[4].className).toContain('before:bg-[var(--abu-clay)]');
+    expect(ticks[4].className).not.toContain('var(--abu-text-primary)');
+    // Neighbours fall off with distance, so the column reads as one wave — but
+    // by LENGTH only. Colour stays exclusive to the tick under the pointer (and
+    // to the current chapter), or the rail reads as three states at once.
+    for (const [tick, width] of [[ticks[3], '16px'], [ticks[5], '16px'], [ticks[2], '10px']] as const) {
+      expect(tick.className).toContain(`before:w-[${width}]`);
+      expect(tick.className).toContain('before:bg-[var(--abu-text-placeholder)]');
+      expect(tick.className).not.toContain('before:bg-[var(--abu-clay)]');
+    }
+    // Far enough away, nothing moves.
+    expect(ticks[0].className).not.toContain('before:w-[10px]');
+  });
+
+  it('keeps the current chapter in the accent colour while a neighbour is hovered', () => {
+    const many = Array.from({ length: 5 }, (_, i) => chapter(i, `第 ${i + 1} 段`));
+    render(<ChapterRail chapters={many} currentIndex={0} onJump={() => {}} />);
+    const ticks = screen.getAllByRole('button');
+
+    fireEvent.mouseEnter(ticks[1]);
+
+    // Ramped in size by proximity, but still the chapter being read.
+    expect(ticks[0].className).toContain('before:w-[16px]');
+    expect(ticks[0].className).toContain('before:bg-[var(--abu-clay)]');
+  });
+
   it('condenses only the middle ticks once the rail gets long', () => {
     const many = Array.from({ length: 14 }, (_, i) => chapter(i, `第 ${i + 1} 段`));
     render(<ChapterRail chapters={many} currentIndex={0} onJump={() => {}} />);

--- a/src/components/chat/ChapterRail.tsx
+++ b/src/components/chat/ChapterRail.tsx
@@ -22,17 +22,47 @@ import { CONDENSE_THRESHOLD, type Chapter } from './chapters';
  *  rail reads as an even scale rather than a ragged bar chart. State is carried
  *  by colour (current) and weight (hover) instead. */
 const TICK_BASE =
-  'relative block w-[22px] h-[10px] border-0 p-0 bg-transparent cursor-pointer ' +
+  'relative block w-[28px] h-[10px] border-0 p-0 bg-transparent cursor-pointer ' +
   "before:content-[''] before:absolute before:left-0 before:top-1/2 before:-translate-y-1/2 " +
   'before:w-[5px] before:h-[2px] before:rounded-[1px] before:bg-[var(--abu-text-placeholder)] ' +
-  'before:opacity-75 before:transition-all before:duration-150 ' +
-  'hover:before:w-[10px] hover:before:h-[3px] hover:before:bg-[var(--abu-text-primary)] hover:before:opacity-100 ' +
+  'before:opacity-75 before:transition-all before:duration-150 before:ease-out ' +
   'focus-visible:outline-2 focus-visible:outline-[var(--abu-clay)] focus-visible:outline-offset-2';
 
 /** Condensed rows tighten the pitch only — the tick keeps its length, so a long
  *  conversation still reads as the same scale, just a denser one. */
 const TICK_CONDENSED = 'h-[6px]';
 
+/**
+ * Fisheye ramp, indexed by distance from the tick under the pointer.
+ *
+ * A single tick lighting up on hover makes a 5x2px target feel like a dare: you
+ * get no feedback until you are already on it. Letting the neighbours swell by
+ * proximity — the macOS dock trick ChatGPT uses on the same control — turns the
+ * rail into something that reacts as the pointer approaches, so the eye leads
+ * the cursor onto the right one. The transition on every tick is what makes the
+ * whole column read as one soft wave rather than five independent flickers.
+ *
+ * Only the tick under the pointer takes colour. Tinting the neighbours too
+ * reads as three separate states rather than one target with a run-up, and it
+ * competes with the accent that means "the chapter you are reading". The
+ * neighbours carry the wave through length alone.
+ *
+ * The resting 5px is deliberately tiny — the rail has to sit beside the text
+ * without competing with it. That makes the swell do double duty: it is both
+ * the "you are on this one" signal and the target itself, so it goes to 24px,
+ * near five times the resting length. The button is 28px wide throughout, so
+ * the whole of the swollen line is clickable rather than just its first 5px.
+ *
+ * Distances past the end of this ramp keep the resting size.
+ */
+const TICK_RAMP = [
+  'before:w-[24px] before:h-[3px] before:bg-[var(--abu-clay)] before:opacity-100',
+  'before:w-[16px]',
+  'before:w-[10px]',
+];
+
+/** The chapter being read. Colour only — the ramp above owns the sizes, so a
+ *  current tick under the pointer still swells like any other. */
 const TICK_CURRENT = 'before:bg-[var(--abu-clay)] before:opacity-100';
 
 /** Breathing room kept between the preview card and the window edge. */
@@ -138,6 +168,9 @@ export default function ChapterRail({
                   // ends of the scale, and condensing them would make the rail's
                   // top and bottom drift as the conversation grows.
                   condensed && index > 0 && index < chapters.length - 1 && TICK_CONDENSED,
+                  peeked && TICK_RAMP[Math.abs(index - peeked.index)],
+                  // After the ramp, so the chapter being read keeps its colour
+                  // even while a neighbour is hovered.
                   index === currentIndex && TICK_CURRENT,
                 )}
                 onMouseEnter={() => showPeek(index)}


### PR DESCRIPTION
5×2px 的刻度**在你压上去之前不给任何反馈**，这让 rail 用起来像在赌，而不像一个控件。改成光标下那根鼓起、邻居按距离衰减 —— ChatGPT 和 Codex 在同一个控件上用的都是这套 dock 手法 —— 光标还在靠近时 rail 就有反应，眼睛能提前把它带到正确那根上。

| 距离 | 线宽 |
|---|---|
| 悬停 | 5px → **24px**，且加粗 2px → 3px |
| ±1 | 16px |
| ±2 | 10px |
| 更远 | 不变 |

## 两个决定它是「一道波」还是「一团噪音」的细节

- **只有悬停那根上色。** 邻居也上色的话，rail 上同时出现三种状态，并且跟已经表示「你正在读这一章」的 clay 抢意思。邻居只用长度承载波浪。
- **按钮同步加宽到 28px**，让鼓到 24px 的整根线都可点。否则视觉目标和真实目标对不上 —— 那比一个诚实的小目标更糟。

## 顺带修掉一个配色错误

悬停态原本是近黑色，紧挨着 clay 的「当前章节」，看着像另一种状态。现在统一成 clay，两者靠**长度**区分：悬停的最长。

## 实现说明

波浪由 hover **状态**驱动，不是 CSS `:hover` 伪类 —— 衰减需要「与悬停项的距离」，这是 CSS 表达不了的。

## 验证

- `npm run verify` 退出码 0（5888 用例）
- 真实 Electron 壳里由用户确认手感
- 新增用例：悬停项 24px 且为 clay、明确断言**不是** `--abu-text-primary`；邻居 16/10px 且**保持静息色**；当前章节被邻居波及时尺寸跟着变、颜色仍是 clay

🤖 Generated with [Claude Code](https://claude.com/claude-code)
