### PR TITLE
fix: isolate agent status and unattended authorization

### DIFF
--- a/builtin-skills/trigger/SKILL.md
+++ b/builtin-skills/trigger/SKILL.md
@@ -54,9 +54,9 @@ Content-Type: application/json
 
 ## 能力等级
 
-触发器无人值守运行，不能弹窗问用户。所以权限必须在创建时声明好。
+触发器无人值守运行，不能弹窗问用户。能力档位必须由用户在阿布的触发器设置界面中设置，模型和 `manage_trigger` 工具不能设置或提升档位。
 
-通过 `capability` 参数设置触发器的能力等级：
+`manage_trigger` 创建触发器时使用默认最小档位；创建或更新结果会提醒用户去设置界面确认能力档位。
 
 | 等级 | 说明 | 适用场景 |
 |------|------|---------|
@@ -65,11 +65,11 @@ Content-Type: application/json
 | `full` | 几乎所有操作（硬封锁的危险路径/命令仍然不可用） | 自动部署、运维操作、完整自动化 |
 | `custom` | 自定义白名单，精确控制 | 只允许特定命令/路径/工具的场景 |
 
-**不传 capability 时默认 `read_tools`，最安全。**
+**不要向 `manage_trigger` 传 `capability`。** 这个字段不会被工具接受，也不能用来设置触发器能力档位。
 
 ### custom 模式的额外参数
 
-当 `capability` 设为 `custom` 时，可通过以下参数精确控制权限：
+当用户已经在触发器设置界面把某个触发器设为 `custom` 时，可通过以下参数更新该触发器的白名单：
 
 - `allowed_commands`: 命令白名单，支持 glob 模式（如 `["npm run *", "git pull", "curl *"]`）
 - `allowed_paths`: 路径白名单，运行时自动授权（如 `["/Users/xx/project/src"]`）
@@ -79,10 +79,10 @@ Content-Type: application/json
 
 根据触发器需要做的事情，选择**最小够用**的等级：
 
-- 只需要分析、汇总、通知 → `read_tools`
-- 需要写文件但不跑命令 → `safe_tools`
-- 需要跑特定命令（如 `npm run build`）→ `custom` + `allowed_commands`
-- 需要完全自主 → `full`（创建时提醒用户风险）
+- 只需要分析、汇总、通知 → 建议用户在界面选择 `read_tools`
+- 需要写文件但不跑命令 → 建议用户在界面选择 `safe_tools`
+- 需要跑特定命令（如 `npm run build`）→ 建议用户在界面选择 `custom` 并配置命令白名单
+- 需要完全自主 → 建议用户在界面选择 `full`，并提醒用户风险
 
 ## 重要：必须使用 manage_trigger 工具
 
@@ -92,10 +92,10 @@ Content-Type: application/json
 
 1. 确认用户需求：什么事件、做什么处理
 2. 确定触发器类型：文件变化用 file，外部事件用 http，定时用 cron
-3. **根据需要的操作，选择合适的能力等级**
+3. **根据需要的操作，告诉用户应在触发器设置界面选择哪个能力等级**
 4. 设计过滤条件和执行指令（prompt）
-5. 调用 `manage_trigger` 工具创建
-6. 告知用户创建结果，包括能力等级和权限范围
+5. 调用 `manage_trigger` 工具创建，不传 `capability`
+6. 告知用户创建结果，并提醒用户到触发器设置界面设置/确认能力档位和权限范围
 
 ## Prompt 编写指南
 
@@ -116,29 +116,30 @@ $EVENT_DATA
 ### 告警分析（read_tools）
 ```
 用户：帮我创建一个触发器，收到告警就分析原因，结果发到飞书群
-→ capability: read_tools（只需要读和分析）
+→ 创建触发器，不传 capability
+→ 告知用户：建议在触发器设置界面选择 read_tools（只需要读和分析）
 ```
 
 ### 文件归档（safe_tools）
 ```
 用户：下载目录来了新 PDF 就提取摘要，归档到 /docs 目录
-→ capability: safe_tools（需要写文件）
 → workspace_path: "/Users/xx/docs"
+→ 创建触发器，不传 capability
+→ 告知用户：建议在触发器设置界面选择 safe_tools（需要写文件）
 ```
 
 ### CI 修复（custom）
 ```
 用户：CI 失败时自动修代码并提 PR
-→ capability: custom
-→ allowed_commands: ["npm run test", "npm run lint", "git *"]
-→ allowed_paths: ["/Users/xx/project"]
+→ 创建触发器，不传 capability
+→ 告知用户：建议在触发器设置界面选择 custom，并配置 allowed_commands / allowed_paths
 ```
 
 ### 全自动运维（full）
 ```
 用户：服务挂了自动重启并发通知
-→ capability: full
-→ ⚠️ 创建时提醒用户：此触发器拥有完全自主权限，请确认
+→ 创建触发器，不传 capability
+→ 告知用户：如确实需要 full，必须由用户在触发器设置界面手动选择，并确认风险
 ```
 
 ## 外部脚本示例（仅 HTTP 触发器需要）

--- a/builtin-skills/trigger/SKILL.md
+++ b/builtin-skills/trigger/SKILL.md
@@ -54,9 +54,9 @@ Content-Type: application/json
 
 ## 能力等级
 
-触发器无人值守运行，不能弹窗问用户。能力档位必须由用户在阿布的触发器设置界面中设置，模型和 `manage_trigger` 工具不能设置或提升档位。
+触发器无人值守运行，不能弹窗问用户。模型和 `manage_trigger` 工具不能设置或提升能力档位。
 
-`manage_trigger` 创建触发器时使用默认最小档位；创建或更新结果会提醒用户去设置界面确认能力档位。
+`manage_trigger` 创建触发器时使用默认最小档位 `read_tools`；更新时保留现有档位。工具结果会明确说明这条边界。
 
 | 等级 | 说明 | 适用场景 |
 |------|------|---------|
@@ -69,7 +69,7 @@ Content-Type: application/json
 
 ### custom 模式的额外参数
 
-当用户已经在触发器设置界面把某个触发器设为 `custom` 时，可通过以下参数更新该触发器的白名单：
+当已有触发器的档位是 `custom` 时，可通过以下参数更新该触发器的白名单：
 
 - `allowed_commands`: 命令白名单，支持 glob 模式（如 `["npm run *", "git pull", "curl *"]`）
 - `allowed_paths`: 路径白名单，运行时自动授权（如 `["/Users/xx/project/src"]`）
@@ -79,10 +79,9 @@ Content-Type: application/json
 
 根据触发器需要做的事情，选择**最小够用**的等级：
 
-- 只需要分析、汇总、通知 → 建议用户在界面选择 `read_tools`
-- 需要写文件但不跑命令 → 建议用户在界面选择 `safe_tools`
-- 需要跑特定命令（如 `npm run build`）→ 建议用户在界面选择 `custom` 并配置命令白名单
-- 需要完全自主 → 建议用户在界面选择 `full`，并提醒用户风险
+- 只需要分析、汇总、通知 → 默认 `read_tools` 足够
+- 需要写文件、跑命令或完全自主 → 明确说明 `manage_trigger` 不能提升档位，不要声称已放开权限
+- 已有 `custom` 触发器 → 可按用户明确要求更新它的白名单
 
 ## 重要：必须使用 manage_trigger 工具
 
@@ -92,10 +91,10 @@ Content-Type: application/json
 
 1. 确认用户需求：什么事件、做什么处理
 2. 确定触发器类型：文件变化用 file，外部事件用 http，定时用 cron
-3. **根据需要的操作，告诉用户应在触发器设置界面选择哪个能力等级**
+3. **判断默认 `read_tools` 是否足够；不足时明确说明工具不能提升档位**
 4. 设计过滤条件和执行指令（prompt）
 5. 调用 `manage_trigger` 工具创建，不传 `capability`
-6. 告知用户创建结果，并提醒用户到触发器设置界面设置/确认能力档位和权限范围
+6. 告知用户创建结果，并准确说明新建默认为 `read_tools`、更新保留现有档位
 
 ## Prompt 编写指南
 
@@ -117,7 +116,7 @@ $EVENT_DATA
 ```
 用户：帮我创建一个触发器，收到告警就分析原因，结果发到飞书群
 → 创建触发器，不传 capability
-→ 告知用户：建议在触发器设置界面选择 read_tools（只需要读和分析）
+→ 告知用户：新建触发器默认 read_tools（只需要读和分析）
 ```
 
 ### 文件归档（safe_tools）
@@ -125,21 +124,21 @@ $EVENT_DATA
 用户：下载目录来了新 PDF 就提取摘要，归档到 /docs 目录
 → workspace_path: "/Users/xx/docs"
 → 创建触发器，不传 capability
-→ 告知用户：建议在触发器设置界面选择 safe_tools（需要写文件）
+→ 告知用户：新建触发器仍为 read_tools，manage_trigger 不能提升到 safe_tools
 ```
 
 ### CI 修复（custom）
 ```
 用户：CI 失败时自动修代码并提 PR
 → 创建触发器，不传 capability
-→ 告知用户：建议在触发器设置界面选择 custom，并配置 allowed_commands / allowed_paths
+→ 告知用户：manage_trigger 不能把新触发器提升到 custom
 ```
 
 ### 全自动运维（full）
 ```
 用户：服务挂了自动重启并发通知
 → 创建触发器，不传 capability
-→ 告知用户：如确实需要 full，必须由用户在触发器设置界面手动选择，并确认风险
+→ 告知用户：manage_trigger 不能创建或提升为 full，不要声称已经获得完全权限
 ```
 
 ## 外部脚本示例（仅 HTTP 触发器需要）

--- a/sidecar/src/agentLoopHost.test.ts
+++ b/sidecar/src/agentLoopHost.test.ts
@@ -219,6 +219,7 @@ describe('agentLoopHost', () => {
       ['resolvedCreds not an object', { ...baseParams(), resolvedCreds: null }],
       ['toolList not an array', { ...baseParams(), toolList: 'nope' }],
       ['locale not a string', { ...baseParams(), locale: 42 }],
+      ['empty authorizationScopeId', { ...baseParams(), options: { authorizationScopeId: '' } }],
     ])('rejects %s with RpcError -32602', async (_label, params) => {
       await expect(handleAgentRun(params)).rejects.toThrow(RpcError);
       await expect(handleAgentRun(params)).rejects.toMatchObject({ code: -32602 });

--- a/sidecar/src/agentLoopHost.test.ts
+++ b/sidecar/src/agentLoopHost.test.ts
@@ -310,6 +310,53 @@ describe('agentLoopHost', () => {
         },
       });
     });
+
+    it('aborts scoped run controllers on normal completion so background commands cannot outlive unattended runs', async () => {
+      let capturedSignal: AbortSignal | undefined;
+      runAgentLoopMock.mockImplementationOnce(async () => {
+        const ctx = getCurrentAgentRunContext();
+        capturedSignal = ctx.abortRegistry.getAbortController(ctx.conversationId).signal;
+        expect(capturedSignal.aborted).toBe(false);
+        ctx.abortRegistry.clearAbortController(ctx.conversationId);
+        return { reason: 'completed' };
+      });
+
+      await handleAgentRun(baseParams({
+        runId: 'scoped-controller-complete',
+        options: { authorizationScopeId: 'scope-complete' },
+      }));
+
+      expect(capturedSignal?.aborted).toBe(true);
+    });
+
+    it('aborts scoped run controllers when the loop throws', async () => {
+      let capturedSignal: AbortSignal | undefined;
+      runAgentLoopMock.mockImplementationOnce(async () => {
+        const ctx = getCurrentAgentRunContext();
+        capturedSignal = ctx.abortRegistry.getAbortController(ctx.conversationId).signal;
+        throw new Error('boom');
+      });
+
+      await expect(handleAgentRun(baseParams({
+        runId: 'scoped-controller-error',
+        options: { authorizationScopeId: 'scope-error' },
+      }))).rejects.toThrow('boom');
+
+      expect(capturedSignal?.aborted).toBe(true);
+    });
+
+    it('does not abort unscoped run controllers on normal completion', async () => {
+      let capturedSignal: AbortSignal | undefined;
+      runAgentLoopMock.mockImplementationOnce(async () => {
+        const ctx = getCurrentAgentRunContext();
+        capturedSignal = ctx.abortRegistry.getAbortController(ctx.conversationId).signal;
+        return { reason: 'completed' };
+      });
+
+      await handleAgentRun(baseParams({ runId: 'unscoped-controller-complete' }));
+
+      expect(capturedSignal?.aborted).toBe(false);
+    });
   });
 
   describe('ALS isolation of two concurrent runs\' ports', () => {

--- a/sidecar/src/agentLoopHost.ts
+++ b/sidecar/src/agentLoopHost.ts
@@ -631,6 +631,7 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
   // ── AbortRegistry — sidecar-local Map, lazily-created controllers, same
   // contract as the in-process store (design doc §3 "abortRegistry" row) ──
   const controllers = new Map<string, AbortController>();
+  const createdControllers = new Set<AbortController>();
   const abortRegistry: AbortRegistry = {
     hasAbortController: (convId) => controllers.has(convId),
     getAbortController: (convId) => {
@@ -638,6 +639,7 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
       if (!c) {
         c = new AbortController();
         controllers.set(convId, c);
+        createdControllers.add(c);
       }
       return c;
     },
@@ -801,6 +803,13 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
     throw error;
   } finally {
     coalescer.flush();
+    if (params.options.authorizationScopeId !== undefined) {
+      for (const controller of createdControllers) {
+        if (!controller.signal.aborted) {
+          controller.abort(new Error('Scoped agent run finished'));
+        }
+      }
+    }
     activeRuns.delete(runId);
   }
 }

--- a/sidecar/src/agentLoopHost.ts
+++ b/sidecar/src/agentLoopHost.ts
@@ -88,6 +88,8 @@ export interface AgentRunParams {
     images?: ImageAttachment[];
     blockedTools?: string[];
     allowedTools?: string[];
+    authorizationScopeId?: string;
+    workspacePathSnapshot?: string | null;
     imContext?: IMContext;
     prePersistedUserMessageId?: string;
   };
@@ -141,6 +143,12 @@ function parseAgentRunParams(params: unknown): AgentRunParams {
     typeof options.prePersistedUserMessageId !== 'string' || !options.prePersistedUserMessageId
   )) {
     throw new RpcError(-32602, 'Invalid params: options.prePersistedUserMessageId must be a non-empty string');
+  }
+  if (options.authorizationScopeId !== undefined && (typeof options.authorizationScopeId !== 'string' || !options.authorizationScopeId)) {
+    throw new RpcError(-32602, 'Invalid params: options.authorizationScopeId must be a non-empty string');
+  }
+  if (options.workspacePathSnapshot !== undefined && options.workspacePathSnapshot !== null && typeof options.workspacePathSnapshot !== 'string') {
+    throw new RpcError(-32602, 'Invalid params: options.workspacePathSnapshot must be a string or null');
   }
   if (!isRecord(orchestration) || !isRecord((orchestration as { route?: unknown }).route)) {
     throw new RpcError(-32602, 'Invalid params: orchestration.route must be an object');
@@ -729,6 +737,7 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
       images: params.options.images,
       blockedTools: params.options.blockedTools,
       allowedTools: params.options.allowedTools,
+      authorizationScopeId: params.options.authorizationScopeId,
       imContext: params.options.imContext,
       prePersistedUserMessageId: params.options.prePersistedUserMessageId,
       settingsReader: getSettingsMirrorReader(),

--- a/sidecar/src/conversationRunMirror.test.ts
+++ b/sidecar/src/conversationRunMirror.test.ts
@@ -48,7 +48,7 @@ describe('conversationRunMirror', () => {
 
     it('getThinkingStartTime starts null', () => {
       const mirror = createConversationRunMirror('conv-1', { conversation: makeConversation() });
-      expect(mirror.reader.getThinkingStartTime()).toBeNull();
+      expect(mirror.reader.getThinkingStartTime('conv-1')).toBeNull();
     });
   });
 
@@ -186,19 +186,19 @@ describe('conversationRunMirror', () => {
 
     it('setAgentStatus tracks thinkingStartTime (thinking -> set, idle -> clear)', () => {
       const mirror = createConversationRunMirror('conv-1', { conversation: makeConversation() });
-      mirror.applyChatDeltaWrite('setAgentStatus', ['thinking', undefined, undefined]);
-      expect(mirror.reader.getThinkingStartTime()).not.toBeNull();
-      mirror.applyChatDeltaWrite('setAgentStatus', ['idle', undefined, undefined]);
-      expect(mirror.reader.getThinkingStartTime()).toBeNull();
+      mirror.applyChatDeltaWrite('setAgentStatus', ['conv-1', 'thinking', undefined, undefined]);
+      expect(mirror.reader.getThinkingStartTime('conv-1')).not.toBeNull();
+      mirror.applyChatDeltaWrite('setAgentStatus', ['conv-1', 'idle', undefined, undefined]);
+      expect(mirror.reader.getThinkingStartTime('conv-1')).toBeNull();
     });
 
     it('cancelStreaming clears isStreaming on the last message and thinkingStartTime', () => {
       const conv = makeConversation({ messages: [makeMessage({ id: 'm1', isStreaming: true })] });
       const mirror = createConversationRunMirror('conv-1', { conversation: conv });
-      mirror.applyChatDeltaWrite('setAgentStatus', ['thinking', undefined, undefined]);
+      mirror.applyChatDeltaWrite('setAgentStatus', ['conv-1', 'thinking', undefined, undefined]);
       mirror.applyChatDeltaWrite('cancelStreaming', ['conv-1']);
       expect(mirror.reader.getConversation('conv-1')?.messages[0].isStreaming).toBe(false);
-      expect(mirror.reader.getThinkingStartTime()).toBeNull();
+      expect(mirror.reader.getThinkingStartTime('conv-1')).toBeNull();
     });
 
     it('unhandled methods (e.g. flushTokens) are a documented no-op — no throw', () => {

--- a/sidecar/src/conversationRunMirror.ts
+++ b/sidecar/src/conversationRunMirror.ts
@@ -87,7 +87,7 @@ export function createConversationRunMirror(
   const reader: ConversationReader = {
     getConversation: (convId) => (convId === conversationId ? conversation : undefined),
     getIndexEntry: (convId) => (convId === conversationId ? indexEntry : undefined),
-    getThinkingStartTime: () => thinkingStartTime,
+    getThinkingStartTime: (convId) => (convId === conversationId ? thinkingStartTime : null),
   };
 
   function findTarget(msgId: string | undefined): Message | undefined {
@@ -231,7 +231,8 @@ export function createConversationRunMirror(
         break;
       }
       case 'setAgentStatus': {
-        const [status] = args as [AgentStatus, string | undefined, string | undefined];
+        const [convId, status] = args as [string, AgentStatus, string | undefined, string | undefined];
+        if (convId !== conversationId) break;
         if (status === 'thinking') thinkingStartTime = Date.now();
         else if (status === 'idle') thinkingStartTime = null;
         break;

--- a/sidecar/src/portFrameSenders.test.ts
+++ b/sidecar/src/portFrameSenders.test.ts
@@ -63,16 +63,16 @@ describe('createFrameChatDelta', () => {
     delta.setExecutionStepsSnapshot('c1', 'loop1', []);
     delta.setPlannedStepsSnapshot('c1', 'loop1', []);
     delta.setConversationStatus('c1', 'idle');
-    delta.setAgentStatus('idle', 'tool', 'agent1');
+    delta.setAgentStatus('c1', 'idle', 'tool', 'agent1');
     delta.setCurrentUsage(null);
-    delta.setRetryInfo(null);
+    delta.setRetryInfo('c1', null);
     delta.setContextUsage('c1', undefined);
     delta.setContextCache('c1', { compressed: true } as never);
     delta.clearContextCache('c1');
     delta.setIsCompressing('c1', true);
     delta.setConversationModel('c1', { providerId: 'p', modelId: 'm' });
     delta.setPendingProposalSignal('c1', undefined);
-    delta.removeActiveAgent('agent1');
+    delta.removeActiveAgent('c1', 'agent1');
 
     expect(frames).toHaveLength(28);
     for (const f of frames) {
@@ -84,7 +84,7 @@ describe('createFrameChatDelta', () => {
     expect(frames.find((frame) => frame.m === 'updateToolCall')?.a.at(-1)).toEqual({
       sandboxRecovery: { kind: 'app-automation', targetApp: 'Notes' },
     });
-    expect(frames[frames.length - 1]).toEqual({ p: 'chat', m: 'removeActiveAgent', a: ['agent1'] });
+    expect(frames[frames.length - 1]).toEqual({ p: 'chat', m: 'removeActiveAgent', a: ['c1', 'agent1'] });
   });
 
   it('onLocalApply is invoked synchronously BEFORE the frame is pushed', () => {

--- a/sidecar/src/portFrameSenders.ts
+++ b/sidecar/src/portFrameSenders.ts
@@ -83,16 +83,16 @@ export function createFrameChatDelta(push: Push, onLocalApply?: (m: string, a: u
     setExecutionStepsSnapshot: (convId, loopId, steps) => send('setExecutionStepsSnapshot', [convId, loopId, steps]),
     setPlannedStepsSnapshot: (convId, loopId, steps) => send('setPlannedStepsSnapshot', [convId, loopId, steps]),
     setConversationStatus: (convId, status) => send('setConversationStatus', [convId, status]),
-    setAgentStatus: (status, tool, agentName) => send('setAgentStatus', [status, tool, agentName]),
+    setAgentStatus: (convId, status, tool, agentName) => send('setAgentStatus', [convId, status, tool, agentName]),
     setCurrentUsage: (usage) => send('setCurrentUsage', [usage]),
-    setRetryInfo: (info) => send('setRetryInfo', [info]),
+    setRetryInfo: (convId, info) => send('setRetryInfo', [convId, info]),
     setContextUsage: (convId, usage) => send('setContextUsage', [convId, usage]),
     setContextCache: (convId, cache) => send('setContextCache', [convId, cache]),
     clearContextCache: (convId) => send('clearContextCache', [convId]),
     setIsCompressing: (convId, value) => send('setIsCompressing', [convId, value]),
     setConversationModel: (convId, model) => send('setConversationModel', [convId, model]),
     setPendingProposalSignal: (convId, signal) => send('setPendingProposalSignal', [convId, signal]),
-    removeActiveAgent: (agentName) => send('removeActiveAgent', [agentName]),
+    removeActiveAgent: (convId, agentName) => send('removeActiveAgent', [convId, agentName]),
   };
 }
 

--- a/sidecar/src/shims/authorizedPathsReaderRun.test.ts
+++ b/sidecar/src/shims/authorizedPathsReaderRun.test.ts
@@ -11,6 +11,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as rpcClient from '../rpcClient';
+import { agentRunContext, type AgentRunContext } from '../agentRunContext';
 import { getAuthorizedPathsReader, setAuthorizedPathsReader } from './authorizedPathsReaderRun';
 
 vi.mock('../rpcClient', () => ({
@@ -21,28 +22,55 @@ beforeEach(() => {
   vi.mocked(rpcClient.sendRequest).mockReset();
 });
 
+function makeCtx(overrides?: Partial<AgentRunContext>): AgentRunContext {
+  return {
+    runId: 'run-1',
+    conversationId: 'conv-1',
+    chatDelta: {} as AgentRunContext['chatDelta'],
+    conversationReader: {} as AgentRunContext['conversationReader'],
+    executionPort: {} as AgentRunContext['executionPort'],
+    abortRegistry: {} as AgentRunContext['abortRegistry'],
+    scratchpadPort: {} as AgentRunContext['scratchpadPort'],
+    capsPort: {} as AgentRunContext['capsPort'],
+    workspaceReader: {} as AgentRunContext['workspaceReader'],
+    toolInvoker: {} as AgentRunContext['toolInvoker'],
+    pushFrame: vi.fn(),
+    resolvedCreds: { apiKey: 'sk', baseUrl: undefined, forceOpenAiCompatible: false },
+    locale: 'zh-CN',
+    ...overrides,
+  };
+}
+
 describe('authorizedPathsReaderRun shim', () => {
   it('returns the array result from workspace.authorizedWritablePaths', async () => {
     vi.mocked(rpcClient.sendRequest).mockResolvedValue(['/a', '/b']);
-    await expect(getAuthorizedPathsReader().getAuthorizedWritablePaths()).resolves.toEqual([
-      '/a',
-      '/b',
-    ]);
-    expect(rpcClient.sendRequest).toHaveBeenCalledWith('workspace.authorizedWritablePaths', {});
+    const result = await agentRunContext.run(makeCtx({ runId: 'run-scoped' }), () =>
+      getAuthorizedPathsReader().getAuthorizedWritablePaths(),
+    );
+    expect(result).toEqual(['/a', '/b']);
+    expect(rpcClient.sendRequest).toHaveBeenCalledWith('workspace.authorizedWritablePaths', {
+      runId: 'run-scoped',
+    });
   });
 
   it('fails closed (throws) on a malformed non-array result instead of coercing to []', async () => {
     vi.mocked(rpcClient.sendRequest).mockResolvedValue(undefined);
+    await expect(
+      agentRunContext.run(makeCtx(), () => getAuthorizedPathsReader().getAuthorizedWritablePaths()),
+    ).rejects.toThrow(/non-array/);
+  });
+
+  it('fails closed when called outside an agent run context', async () => {
     await expect(getAuthorizedPathsReader().getAuthorizedWritablePaths()).rejects.toThrow(
-      /non-array/,
+      /outside agentLoopHost/,
     );
   });
 
   it('propagates a rejected RPC (fail closed, no swallow)', async () => {
     vi.mocked(rpcClient.sendRequest).mockRejectedValue(new Error('transport down'));
-    await expect(getAuthorizedPathsReader().getAuthorizedWritablePaths()).rejects.toThrow(
-      'transport down',
-    );
+    await expect(
+      agentRunContext.run(makeCtx(), () => getAuthorizedPathsReader().getAuthorizedWritablePaths()),
+    ).rejects.toThrow('transport down');
   });
 
   it('setAuthorizedPathsReader throws (wiring-bug guard, mirrors workspaceReaderRun)', () => {

--- a/sidecar/src/shims/authorizedPathsReaderRun.ts
+++ b/sidecar/src/shims/authorizedPathsReaderRun.ts
@@ -3,28 +3,31 @@
  *
  * Real forwarding shim (same class as `conversationStorageRun.ts`'s
  * `replaceMessageById`, NOT a throwing bundle-graph-only stub): the
- * shell's `authorizedWorkspaces` map (`src/core/tools/pathSafety.ts`) is
- * populated by `authorizeWorkspace()` calls that only happen shell-side
- * (`registry.ts:407`, `triggerPermission.ts`) — the sidecar process has no
- * such state of its own, so `run_command`'s sandboxed writes need a live
- * reverse RPC to see the SAME authorized-paths set the shell would use, not
- * an always-empty local stand-in (which would under-authorize the OS-level
- * sandbox for every sidecar-run `run_command` call).
+ * shell-side path authorization maps (`src/core/tools/pathSafety.ts`) are
+ * populated by `authorizeWorkspace()` / `scopedAuthorizeWorkspace()` calls
+ * that only happen in the shell — the sidecar process has no such state of
+ * its own, so `run_command`'s sandboxed writes need a live reverse RPC to
+ * see the SAME run/session-scoped authorized-path set the shell would use,
+ * not an always-empty local stand-in (which would under-authorize the
+ * OS-level sandbox for every sidecar-run `run_command` call).
  *
  * Sends the `workspace.authorizedWritablePaths` REQUEST (shell handler:
  * `agentLoopRunner.ts`'s `handleWorkspaceAuthorizedPaths`, which returns the
- * REAL `getAuthorizedWritablePaths()` — same function
- * `createInProcessAuthorizedPathsReader` wraps in the shell/in-process case)
- * and returns its `string[]` result. No params needed — the authorized-paths
- * map is shell-global, not per-run.
+ * REAL `getAuthorizedWritablePaths(session.options.authorizationScopeId)` —
+ * same function `createInProcessAuthorizedPathsReader` wraps in the
+ * shell/in-process case) and returns its `string[]` result. The sidecar sends
+ * the current runId from AgentRunContext; outside a registered run it fails
+ * closed rather than asking for global writable paths.
  */
 import type { AuthorizedPathsReader } from '@/core/agent/ports/authorizedPathsReader';
+import { getCurrentAgentRunContext } from '../agentRunContext';
 import { sendRequest } from '../rpcClient';
 
 function createSidecarAuthorizedPathsReader(): AuthorizedPathsReader {
   return {
     getAuthorizedWritablePaths: async () => {
-      const result = await sendRequest('workspace.authorizedWritablePaths', {});
+      const { runId } = getCurrentAgentRunContext();
+      const result = await sendRequest('workspace.authorizedWritablePaths', { runId });
       // Fail CLOSED on a malformed (resolved but non-array) result, same as a
       // rejected RPC: coercing to [] would silently under-authorize the OS
       // sandbox — exactly the outcome localTools/index.ts's fail-closed doc

--- a/sidecar/src/subagentHost.test.ts
+++ b/sidecar/src/subagentHost.test.ts
@@ -85,6 +85,7 @@ describe('subagentHost', () => {
       ['resolvedCreds not an object', { ...baseParams(), resolvedCreds: null }],
       ['uiStrings not an object', { ...baseParams(), uiStrings: null }],
       ['locale not a string', { ...baseParams(), locale: 42 }],
+      ['blockedTools not a string array', { ...baseParams(), blockedTools: ['read_file', 42] }],
       ['workspacePathSnapshot not string/null', { ...baseParams(), workspacePathSnapshot: 42 }],
       ['empty authorizationScopeId', { ...baseParams(), authorizationScopeId: '' }],
     ])('rejects %s with RpcError -32602', async (_label, params) => {
@@ -152,6 +153,22 @@ describe('subagentHost', () => {
         context: { workspacePath: '/tmp' },
       });
       expect(result.text).toBe('file contents');
+    });
+
+    it('parses and restores blockedTools into the sidecar SubagentLoopOptions', async () => {
+      let capturedOptions: { allowedTools?: string[]; blockedTools?: string[] } | undefined;
+      runSubagentLoopMock.mockImplementation(async (options: { allowedTools?: string[]; blockedTools?: string[] }) => {
+        capturedOptions = options;
+        return resultShape('ok');
+      });
+
+      await handleSubagentRun(baseParams({
+        allowedTools: ['read_*'],
+        blockedTools: ['run_command', 'abu-browser__*'],
+      }));
+
+      expect(capturedOptions?.allowedTools).toEqual(['read_*']);
+      expect(capturedOptions?.blockedTools).toEqual(['run_command', 'abu-browser__*']);
     });
 
     it('the sidecar-local ToolDefinition.execute stub throws if ever called directly (it never should be)', async () => {

--- a/sidecar/src/subagentHost.test.ts
+++ b/sidecar/src/subagentHost.test.ts
@@ -86,6 +86,7 @@ describe('subagentHost', () => {
       ['uiStrings not an object', { ...baseParams(), uiStrings: null }],
       ['locale not a string', { ...baseParams(), locale: 42 }],
       ['workspacePathSnapshot not string/null', { ...baseParams(), workspacePathSnapshot: 42 }],
+      ['empty authorizationScopeId', { ...baseParams(), authorizationScopeId: '' }],
     ])('rejects %s with RpcError -32602', async (_label, params) => {
       await expect(handleSubagentRun(params)).rejects.toThrow(RpcError);
       await expect(handleSubagentRun(params)).rejects.toMatchObject({ code: -32602 });

--- a/sidecar/src/subagentHost.ts
+++ b/sidecar/src/subagentHost.ts
@@ -54,6 +54,7 @@ interface SubagentRunParams {
   parentConversationId?: string;
   imContext?: IMContext;
   allowedTools?: string[];
+  authorizationScopeId?: string;
   locale: string;
   uiStrings: SubagentUiStrings;
   settingsSnapshot: SettingsState;
@@ -98,6 +99,9 @@ function parseSubagentRunParams(params: unknown): SubagentRunParams {
     (!Array.isArray(params.allowedTools) || params.allowedTools.some((entry) => typeof entry !== 'string'))
   ) {
     throw new RpcError(-32602, 'Invalid params: allowedTools must be a string array');
+  }
+  if (params.authorizationScopeId !== undefined && (typeof params.authorizationScopeId !== 'string' || !params.authorizationScopeId)) {
+    throw new RpcError(-32602, 'Invalid params: authorizationScopeId must be a non-empty string');
   }
   const { workspacePathSnapshot } = params;
   if (workspacePathSnapshot !== null && typeof workspacePathSnapshot !== 'string') {
@@ -266,6 +270,7 @@ export async function handleSubagentRun(rawParams: unknown): Promise<unknown> {
       sendNotification('subagent.progress', { runId, event });
     },
     allowedTools: params.allowedTools,
+    authorizationScopeId: params.authorizationScopeId,
     // commandConfirmCallback/filePermissionCallback intentionally omitted:
     // createReverseToolInvoker's executeAnyTool ALWAYS reverses to the
     // shell's tool.invoke handler, which threads the SESSION's REAL

--- a/sidecar/src/subagentHost.ts
+++ b/sidecar/src/subagentHost.ts
@@ -54,6 +54,7 @@ interface SubagentRunParams {
   parentConversationId?: string;
   imContext?: IMContext;
   allowedTools?: string[];
+  blockedTools?: string[];
   authorizationScopeId?: string;
   locale: string;
   uiStrings: SubagentUiStrings;
@@ -99,6 +100,12 @@ function parseSubagentRunParams(params: unknown): SubagentRunParams {
     (!Array.isArray(params.allowedTools) || params.allowedTools.some((entry) => typeof entry !== 'string'))
   ) {
     throw new RpcError(-32602, 'Invalid params: allowedTools must be a string array');
+  }
+  if (
+    params.blockedTools !== undefined &&
+    (!Array.isArray(params.blockedTools) || params.blockedTools.some((entry) => typeof entry !== 'string'))
+  ) {
+    throw new RpcError(-32602, 'Invalid params: blockedTools must be a string array');
   }
   if (params.authorizationScopeId !== undefined && (typeof params.authorizationScopeId !== 'string' || !params.authorizationScopeId)) {
     throw new RpcError(-32602, 'Invalid params: authorizationScopeId must be a non-empty string');
@@ -270,6 +277,7 @@ export async function handleSubagentRun(rawParams: unknown): Promise<unknown> {
       sendNotification('subagent.progress', { runId, event });
     },
     allowedTools: params.allowedTools,
+    blockedTools: params.blockedTools,
     authorizationScopeId: params.authorizationScopeId,
     // commandConfirmCallback/filePermissionCallback intentionally omitted:
     // createReverseToolInvoker's executeAnyTool ALWAYS reverses to the

--- a/src/__tests__/agentPipeline.integration.test.ts
+++ b/src/__tests__/agentPipeline.integration.test.ts
@@ -366,11 +366,9 @@ describe('Agent Pipeline Integration', () => {
     useChatStore.setState({
       conversations: {},
       activeConversationId: null,
-      agentStatus: 'idle',
-      currentTool: null,
       currentUsage: null,
       pendingInput: null,
-      thinkingStartTime: null,
+      agentStates: new Map(),
     });
     useTaskExecutionStore.setState({
       executions: {},

--- a/src/__tests__/storeIntegration.test.ts
+++ b/src/__tests__/storeIntegration.test.ts
@@ -27,11 +27,9 @@ describe('Store Integration', () => {
     useChatStore.setState({
       conversations: {},
       activeConversationId: null,
-      agentStatus: 'idle',
-      currentTool: null,
       currentUsage: null,
       pendingInput: null,
-      thinkingStartTime: null,
+      agentStates: new Map(),
     });
     useTaskExecutionStore.setState({
       executions: {},
@@ -214,18 +212,22 @@ describe('Store Integration', () => {
 
   // ── Agent status transitions ──
   describe('agent status', () => {
-    it('tracks global agent status', () => {
-      expect(useChatStore.getState().agentStatus).toBe('idle');
+    it('tracks agent status per conversation', () => {
+      const convId = useChatStore.getState().createConversation();
 
-      useChatStore.getState().setAgentStatus('thinking');
-      expect(useChatStore.getState().agentStatus).toBe('thinking');
+      expect(useChatStore.getState().agentStates.has(convId)).toBe(false);
 
-      useChatStore.getState().setAgentStatus('tool-calling', 'read_file');
-      expect(useChatStore.getState().agentStatus).toBe('tool-calling');
-      expect(useChatStore.getState().currentTool).toBe('read_file');
+      useChatStore.getState().setAgentStatus(convId, 'thinking');
+      expect(useChatStore.getState().agentStates.get(convId)?.status).toBe('thinking');
 
-      useChatStore.getState().setAgentStatus('idle');
-      expect(useChatStore.getState().agentStatus).toBe('idle');
+      useChatStore.getState().setAgentStatus(convId, 'tool-calling', 'read_file');
+      expect(useChatStore.getState().agentStates.get(convId)).toMatchObject({
+        status: 'tool-calling',
+        currentTool: 'read_file',
+      });
+
+      useChatStore.getState().setAgentStatus(convId, 'idle');
+      expect(useChatStore.getState().agentStates.has(convId)).toBe(false);
     });
   });
 });

--- a/src/__tests__/toolRegistry.integration.test.ts
+++ b/src/__tests__/toolRegistry.integration.test.ts
@@ -4,7 +4,15 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { toolRegistry, executeAnyTool } from '../core/tools/registry';
-import { authorizeWorkspace, revokeWorkspace } from '../core/tools/pathSafety';
+import {
+  authorizeWorkspace,
+  checkWritePath,
+  createAuthorizationScope,
+  disposeAuthorizationScope,
+  revokeWorkspace,
+  scopedAuthorizeWorkspace,
+} from '../core/tools/pathSafety';
+import { useSettingsStore } from '../stores/settingsStore';
 import { setPlatformForTest as _setPlatformForTest } from '../test/helpers';
 
 // Mock i18n. commandSafety resolves reason/label strings via
@@ -19,6 +27,11 @@ vi.mock('../i18n', () => ({
     },
     toolResult: {
       commandSafety: new Proxy({}, { get: (_t, key) => String(key) }),
+    },
+    toolErrors: {
+      userDeniedAccess: 'user denied access',
+      pathAccessDenied: 'path access denied',
+      needsAuthorization: 'needs authorization',
     },
   }),
 }));
@@ -153,6 +166,138 @@ describe('toolRegistry integration', () => {
         onFilePermission
       );
       expect(onFilePermission).toHaveBeenCalled();
+    });
+
+    it('checks, rechecks, and auto-authorizes inside the explicit run scope without falling back to global writes', async () => {
+      const ws = '/Users/testuser/Projects/scoped-registry';
+      revokeWorkspace(ws);
+      authorizeWorkspace(ws, ['read', 'write']);
+      const scopeId = createAuthorizationScope();
+      const executeFn = vi.fn().mockResolvedValue('written');
+      toolRegistry.register({
+        name: 'write_file',
+        description: 'Write file',
+        inputSchema: { type: 'object', properties: { path: { type: 'string', description: 'path' } } },
+        execute: executeFn,
+      });
+
+      try {
+        scopedAuthorizeWorkspace(scopeId, ws, ['read']);
+
+        const denied = await executeAnyTool(
+          'write_file',
+          { path: `${ws}/out.md` },
+          undefined,
+          undefined,
+          { authorizationScopeId: scopeId },
+        );
+        expect(String(denied)).toContain('needs authorization');
+        expect(executeFn).not.toHaveBeenCalled();
+
+        const filePermission = vi.fn(async ({ path }) => {
+          scopedAuthorizeWorkspace(scopeId, path, ['write']);
+          return true;
+        });
+        const allowed = await executeAnyTool(
+          'write_file',
+          { path: `${ws}/out.md` },
+          undefined,
+          filePermission,
+          { authorizationScopeId: scopeId },
+        );
+        expect(allowed).toBe('written');
+        expect(filePermission).toHaveBeenCalledWith({
+          path: '/Users/testuser/Projects',
+          capability: 'write',
+          toolName: 'write_file',
+        }, undefined);
+
+        const filePermissionWithLoop = vi.fn(async ({ path }) => {
+          scopedAuthorizeWorkspace(scopeId, path, ['write']);
+          return true;
+        });
+        const allowedWithLoop = await executeAnyTool(
+          'write_file',
+          { path: '/Users/testuser/Desktop/scoped-registry-loop.md' },
+          undefined,
+          filePermissionWithLoop,
+          { authorizationScopeId: scopeId, loopId: 'loop-owned' },
+        );
+        expect(allowedWithLoop).toBe('written');
+        expect(filePermissionWithLoop).toHaveBeenCalledWith({
+          path: '/Users/testuser/Desktop',
+          capability: 'write',
+          toolName: 'write_file',
+        }, 'loop-owned');
+      } finally {
+        disposeAuthorizationScope(scopeId);
+        revokeWorkspace(ws);
+      }
+    });
+
+    it('auto-authorizes scoped read access without upgrading the scope to write', async () => {
+      const previousMode = useSettingsStore.getState().permissionMode;
+      const scopeId = createAuthorizationScope();
+      const path = '/Users/testuser/Desktop/scoped-auto-read.md';
+      const executeFn = vi.fn().mockResolvedValue('read');
+      toolRegistry.register({
+        name: 'read_file',
+        description: 'Read file',
+        inputSchema: { type: 'object', properties: { path: { type: 'string', description: 'path' } } },
+        execute: executeFn,
+      });
+
+      try {
+        useSettingsStore.setState({ permissionMode: 'autonomous' });
+
+        const result = await executeAnyTool(
+          'read_file',
+          { path },
+          undefined,
+          undefined,
+          { authorizationScopeId: scopeId },
+        );
+
+        expect(result).toBe('read');
+        expect(executeFn).toHaveBeenCalled();
+        expect((await checkWritePath(path, scopeId)).allowed).toBe(false);
+      } finally {
+        useSettingsStore.setState({ permissionMode: previousMode });
+        disposeAuthorizationScope(scopeId);
+      }
+    });
+
+    it('treats an empty explicit scope as fail-closed instead of auto-authorizing globally', async () => {
+      const previousMode = useSettingsStore.getState().permissionMode;
+      const path = '/Users/testuser/Desktop/empty-scope-auto-read.md';
+      revokeWorkspace('/Users/testuser/Desktop');
+      const executeFn = vi.fn().mockResolvedValue('read');
+      toolRegistry.register({
+        name: 'read_file',
+        description: 'Read file',
+        inputSchema: { type: 'object', properties: { path: { type: 'string', description: 'path' } } },
+        execute: executeFn,
+      });
+
+      try {
+        useSettingsStore.setState({ permissionMode: 'autonomous' });
+
+        const result = await executeAnyTool(
+          'read_file',
+          { path },
+          undefined,
+          undefined,
+          { authorizationScopeId: '' },
+        );
+
+        expect(result).toBe('read');
+        expect(executeFn).toHaveBeenCalled();
+        expect((await checkWritePath(path)).allowed).toBe(false);
+        expect((await checkWritePath(path, '')).allowed).toBe(false);
+      } finally {
+        useSettingsStore.setState({ permissionMode: previousMode });
+        revokeWorkspace('/Users/testuser/Desktop');
+      }
     });
   });
 

--- a/src/__tests__/toolRegistry.integration.test.ts
+++ b/src/__tests__/toolRegistry.integration.test.ts
@@ -114,6 +114,145 @@ describe('toolRegistry integration', () => {
       );
       expect(result).toContain('用户取消');
     });
+
+    it('fails closed for scoped non-read-only commands whose effective cwd is read-only', async () => {
+      const previousMode = useSettingsStore.getState().permissionMode;
+      const scopeId = createAuthorizationScope();
+      const readOnlyWs = '/Users/testuser/Projects/scoped-readonly-command';
+      const executeFn = vi.fn().mockResolvedValue('should not execute');
+      toolRegistry.register({
+        name: 'run_command',
+        description: 'Run shell command',
+        inputSchema: { type: 'object', properties: { command: { type: 'string', description: 'cmd' } } },
+        execute: executeFn,
+      });
+
+      try {
+        useSettingsStore.setState({ permissionMode: 'standard' });
+        scopedAuthorizeWorkspace(scopeId, readOnlyWs, ['read']);
+
+        const result = await executeAnyTool(
+          'run_command',
+          { command: 'touch pwned.txt', cwd: readOnlyWs },
+          undefined,
+          undefined,
+          { authorizationScopeId: scopeId, workspacePath: readOnlyWs },
+        );
+
+        expect(String(result)).toContain('Error');
+        expect(executeFn).not.toHaveBeenCalled();
+      } finally {
+        useSettingsStore.setState({ permissionMode: previousMode });
+        disposeAuthorizationScope(scopeId);
+      }
+    });
+
+    it('fails closed for scoped non-read-only commands whose cwd is path-safe but not scope-writable', async () => {
+      const previousMode = useSettingsStore.getState().permissionMode;
+      const scopeId = createAuthorizationScope();
+      const executeFn = vi.fn().mockResolvedValue('should not execute');
+      toolRegistry.register({
+        name: 'run_command',
+        description: 'Run shell command',
+        inputSchema: { type: 'object', properties: { command: { type: 'string', description: 'cmd' } } },
+        execute: executeFn,
+      });
+
+      try {
+        useSettingsStore.setState({ permissionMode: 'standard' });
+
+        const result = await executeAnyTool(
+          'run_command',
+          { command: 'touch pwned.txt', cwd: '/Applications' },
+          undefined,
+          undefined,
+          { authorizationScopeId: scopeId, workspacePath: '/Applications' },
+        );
+
+        expect(String(result)).toContain('Error');
+        expect(executeFn).not.toHaveBeenCalled();
+      } finally {
+        useSettingsStore.setState({ permissionMode: previousMode });
+        disposeAuthorizationScope(scopeId);
+      }
+    });
+
+    it('fails closed when scoped command cwd escapes a write-authorized directory via traversal', async () => {
+      const previousMode = useSettingsStore.getState().permissionMode;
+      const scopeId = createAuthorizationScope();
+      const writableWs = '/Users/testuser/Projects/scoped-traversal/ws';
+      const executeFn = vi.fn().mockResolvedValue('should not execute');
+      toolRegistry.register({
+        name: 'run_command',
+        description: 'Run shell command',
+        inputSchema: { type: 'object', properties: { command: { type: 'string', description: 'cmd' } } },
+        execute: executeFn,
+      });
+
+      try {
+        useSettingsStore.setState({ permissionMode: 'standard' });
+        scopedAuthorizeWorkspace(scopeId, writableWs, ['read', 'write']);
+
+        for (const cwd of [
+          `${writableWs}/../outside`,
+          `${writableWs}/../Applications`,
+          '/authorized/../Applications',
+        ]) {
+          if (cwd.startsWith('/authorized/')) {
+            scopedAuthorizeWorkspace(scopeId, '/authorized', ['read', 'write']);
+          }
+          const result = await executeAnyTool(
+            'run_command',
+            { command: 'touch pwned.txt', cwd },
+            undefined,
+            undefined,
+            { authorizationScopeId: scopeId, workspacePath: writableWs },
+          );
+          expect(String(result)).toContain('Error');
+        }
+        expect(executeFn).not.toHaveBeenCalled();
+      } finally {
+        useSettingsStore.setState({ permissionMode: previousMode });
+        disposeAuthorizationScope(scopeId);
+      }
+    });
+
+    it('allows scoped non-read-only commands when cwd is write-authorized or temp', async () => {
+      const previousMode = useSettingsStore.getState().permissionMode;
+      const scopeId = createAuthorizationScope();
+      const writableWs = '/Users/testuser/Projects/scoped-writable-command';
+      const executeFn = vi.fn().mockResolvedValue('executed');
+      toolRegistry.register({
+        name: 'run_command',
+        description: 'Run shell command',
+        inputSchema: { type: 'object', properties: { command: { type: 'string', description: 'cmd' } } },
+        execute: executeFn,
+      });
+
+      try {
+        useSettingsStore.setState({ permissionMode: 'standard' });
+        scopedAuthorizeWorkspace(scopeId, writableWs, ['read', 'write']);
+
+        await expect(executeAnyTool(
+          'run_command',
+          { command: 'touch ok.txt', cwd: writableWs },
+          undefined,
+          undefined,
+          { authorizationScopeId: scopeId, workspacePath: writableWs },
+        )).resolves.toBe('executed');
+        await expect(executeAnyTool(
+          'run_command',
+          { command: 'touch scratch.txt', cwd: '/tmp' },
+          undefined,
+          undefined,
+          { authorizationScopeId: scopeId, workspacePath: writableWs },
+        )).resolves.toBe('executed');
+        expect(executeFn).toHaveBeenCalledTimes(2);
+      } finally {
+        useSettingsStore.setState({ permissionMode: previousMode });
+        disposeAuthorizationScope(scopeId);
+      }
+    });
   });
 
   // ── Path safety through executeAnyTool ──

--- a/src/components/chat/AgentStatusStrip.test.tsx
+++ b/src/components/chat/AgentStatusStrip.test.tsx
@@ -18,7 +18,7 @@ const baseConv: Conversation = {
 
 describe('AgentStatusStrip (Bug 1: 死寂可见)', () => {
   beforeEach(() => {
-    useChatStore.setState({ conversations: { c1: baseConv }, retryInfo: null });
+    useChatStore.setState({ conversations: { c1: baseConv }, agentStates: new Map() });
   });
   afterEach(() => cleanup());
 
@@ -30,17 +30,14 @@ describe('AgentStatusStrip (Bug 1: 死寂可见)', () => {
   it('shows the compaction status while compressing', () => {
     useChatStore.setState({
       conversations: { c1: { ...baseConv, isCompressing: true } },
-      retryInfo: null,
+      agentStates: new Map(),
     });
     render(<AgentStatusStrip conversationId="c1" />);
     expect(screen.getByText(/Compacting|压缩/)).toBeInTheDocument();
   });
 
   it('shows "正在重试 N/M" while retrying', () => {
-    useChatStore.setState({
-      conversations: { c1: baseConv },
-      retryInfo: { attempt: 2, maxAttempts: 3, delayMs: 5000 },
-    });
+    useChatStore.getState().setRetryInfo('c1', { attempt: 2, maxAttempts: 3, delayMs: 5000 });
     render(<AgentStatusStrip conversationId="c1" />);
     expect(screen.getByText(/(retrying|重试).*2\/3/)).toBeInTheDocument();
   });
@@ -48,10 +45,19 @@ describe('AgentStatusStrip (Bug 1: 死寂可见)', () => {
   it('prioritizes retry over compaction when both are active', () => {
     useChatStore.setState({
       conversations: { c1: { ...baseConv, isCompressing: true } },
-      retryInfo: { attempt: 1, maxAttempts: 3, delayMs: 1000 },
     });
+    useChatStore.getState().setRetryInfo('c1', { attempt: 1, maxAttempts: 3, delayMs: 1000 });
     render(<AgentStatusStrip conversationId="c1" />);
     expect(screen.getByText(/retrying|重试/)).toBeInTheDocument();
     expect(screen.queryByText(/Compacting|压缩/)).not.toBeInTheDocument();
+  });
+
+  it('does not show another conversation retry state', () => {
+    useChatStore.setState({
+      conversations: { c1: baseConv, c2: { ...baseConv, id: 'c2' } },
+    });
+    useChatStore.getState().setRetryInfo('c1', { attempt: 2, maxAttempts: 3, delayMs: 5000 });
+    const { container } = render(<AgentStatusStrip conversationId="c2" />);
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/src/components/chat/AgentStatusStrip.tsx
+++ b/src/components/chat/AgentStatusStrip.tsx
@@ -1,6 +1,6 @@
 import { Loader2 } from 'lucide-react';
 import { useI18n } from '@/i18n';
-import { useChatStore } from '@/stores/chatStore';
+import { getConversationAgentState, useChatStore } from '@/stores/chatStore';
 
 /**
  * AgentStatusStrip — a small line above the composer that surfaces the two
@@ -12,7 +12,7 @@ import { useChatStore } from '@/stores/chatStore';
 export default function AgentStatusStrip({ conversationId }: { conversationId: string }) {
   const { t, format } = useI18n();
   const isCompressing = useChatStore((s) => s.conversations[conversationId]?.isCompressing ?? false);
-  const retryInfo = useChatStore((s) => s.retryInfo);
+  const retryInfo = useChatStore((s) => getConversationAgentState(s.agentStates, conversationId).retryInfo);
 
   if (!isCompressing && !retryInfo) return null;
 

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useLayoutEffect, useRef, useSyncExternalStore } from 'react';
 import { Virtuoso, type Components, type VirtuosoHandle } from 'react-virtuoso';
-import { useChatStore, useActiveConversation } from '@/stores/chatStore';
+import { getConversationAgentState, useChatStore, useActiveConversation } from '@/stores/chatStore';
 import type { Message, ImageAttachment } from '@/types';
 import { runAgentLoopDispatched } from '@/core/agent/agentLoopRunner';
 import { getPendingCommandConfirmation, resolveCommandConfirmation, subscribeToCommandConfirmation, getPendingFilePermission, resolveFilePermission, subscribeToFilePermission, getPendingWorkspaceRequest, resolveWorkspaceRequest, subscribeToWorkspaceRequest, getPendingUserQuestions, subscribeUserQuestion, findQuestionOwningMessage } from '@/core/agent/permissionBridge';
@@ -503,8 +503,8 @@ export default function ChatView({
   // Optimistic feedback for the beat between submitting a question/plan answer
   // and the resumed loop producing anything (Bug 1: 点同意后无反应).
   const [resuming, setResuming] = useState(false);
-  const agentStatus = useChatStore((s) => s.agentStatus);
-  const retryInfo = useChatStore((s) => s.retryInfo);
+  const agentStatus = useChatStore((s) => getConversationAgentState(s.agentStates, activeConvId).status);
+  const retryInfo = useChatStore((s) => getConversationAgentState(s.agentStates, activeConvId).retryInfo);
 
   const handleSelectPrompt = useCallback((prompt: string) => {
     // Fill the prompt into the input via pendingInput

--- a/src/components/chat/MessageGroup.imageReplay.test.tsx
+++ b/src/components/chat/MessageGroup.imageReplay.test.tsx
@@ -113,7 +113,7 @@ function renderReplayedGroup(messages: Message[]) {
   useChatStore.setState({
     activeConversationId: conversation.id,
     conversations: { [conversation.id]: conversation },
-    agentStatus: 'idle',
+    agentStates: new Map(),
   });
   return render(<MessageGroup messages={messages} isLastGroup />);
 }

--- a/src/components/chat/MessageGroup.status.test.tsx
+++ b/src/components/chat/MessageGroup.status.test.tsx
@@ -38,7 +38,7 @@ describe('MessageGroup stopped terminal', () => {
     useChatStore.setState({
       activeConversationId: conversation.id,
       conversations: { [conversation.id]: conversation },
-      agentStatus: 'idle',
+      agentStates: new Map(),
     });
 
     render(<MessageGroup messages={[userMessage]} isLastGroup />);

--- a/src/components/chat/MessageGroup.tsx
+++ b/src/components/chat/MessageGroup.tsx
@@ -16,7 +16,7 @@ import BatchProgress from './BatchProgress';
 import MarkdownRenderer from './MarkdownRenderer';
 import FileAttachment, { ImagePreviewCard, ImageThumbnail, isImageFile } from './FileAttachment';
 import SourcesSection from './SourcesSection';
-import { useChatStore, useActiveConversation } from '@/stores/chatStore';
+import { getConversationAgentState, useChatStore, useActiveConversation } from '@/stores/chatStore';
 import { usePreviewStore } from '@/stores/previewStore';
 import { useI18n, format } from '@/i18n';
 import { MessageErrorBoundary } from '@/components/common/ErrorBoundary';
@@ -351,8 +351,9 @@ export default function MessageGroup({ messages, isLastGroup: isLastGroupProp = 
   // Separate user and assistant messages
   const userMsg = messages.find((m) => m.role === 'user');
   const assistantMsgs = messages.filter((m) => m.role === 'assistant');
-  const agentStatus = useChatStore((s) => s.agentStatus);
   const activeConv = useActiveConversation();
+  const activeConversationId = activeConv?.id ?? null;
+  const agentStatus = useChatStore((s) => getConversationAgentState(s.agentStates, activeConversationId).status);
   const home = useHomeDir();
 
   // Get loopId from messages (all messages in group share same loopId)
@@ -470,8 +471,9 @@ export default function MessageGroup({ messages, isLastGroup: isLastGroupProp = 
   const skillInfo = userMsg?.skill;
 
   // Extract workflow steps from all tool calls (legacy fallback)
-  // Only pass agentStatus to the currently streaming group — prevents the global
-  // 'thinking' status from injecting a phantom thinking step into completed groups
+  // Only pass the active conversation's agent status to the currently streaming
+  // group — prevents another running conversation from injecting a phantom
+  // thinking step into completed groups.
   const workflowSteps = extractWorkflowSteps(allToolCalls, thinkingContent, isStreaming ? agentStatus : undefined, skillInfo, thinkingDuration);
 
   // Extract file outputs for attachments — deliverables semantics: only show

--- a/src/components/common/StatusBar.tsx
+++ b/src/components/common/StatusBar.tsx
@@ -1,4 +1,4 @@
-import { useChatStore } from '../../stores/chatStore';
+import { getConversationAgentState, useChatStore } from '../../stores/chatStore';
 import { useSettingsStore, getEffectiveModel, getActiveProvider } from '../../stores/settingsStore';
 import { useI18n } from '@/i18n';
 import { Loader2, Wrench, Zap } from 'lucide-react';
@@ -31,9 +31,10 @@ function useElapsedTime(startTime: number | null): number {
 }
 
 export default function StatusBar() {
-  const agentStatus = useChatStore((s) => s.agentStatus);
-  const currentTool = useChatStore((s) => s.currentTool);
-  const thinkingStartTime = useChatStore((s) => s.thinkingStartTime);
+  const activeConversationId = useChatStore((s) => s.activeConversationId);
+  const agentStatus = useChatStore((s) => getConversationAgentState(s.agentStates, activeConversationId).status);
+  const currentTool = useChatStore((s) => getConversationAgentState(s.agentStates, activeConversationId).currentTool);
+  const thinkingStartTime = useChatStore((s) => getConversationAgentState(s.agentStates, activeConversationId).thinkingStartTime);
   const currentUsage = useChatStore((s) => s.currentUsage);
   const effectiveModel = getEffectiveModel(useSettingsStore.getState());
   const activeProvider = getActiveProvider(useSettingsStore.getState());

--- a/src/core/agent/__contractFixtures__/portFrameFixtures.ts
+++ b/src/core/agent/__contractFixtures__/portFrameFixtures.ts
@@ -143,16 +143,16 @@ export const CHAT_CONTRACT_FIXTURES: ContractFixtureEntry[] = [
   { port: 'chat', method: 'setExecutionStepsSnapshot', args: ['conv-1', 'loop-1', [sampleExecStepSnapshot]] },
   { port: 'chat', method: 'setPlannedStepsSnapshot', args: ['conv-1', 'loop-1', [samplePlannedStep]] },
   { port: 'chat', method: 'setConversationStatus', args: ['conv-1', 'running'] },
-  { port: 'chat', method: 'setAgentStatus', args: ['tool-calling', 'run_command', 'abu'] },
+  { port: 'chat', method: 'setAgentStatus', args: ['conv-1', 'tool-calling', 'run_command', 'abu'] },
   { port: 'chat', method: 'setCurrentUsage', args: [sampleUsage] },
-  { port: 'chat', method: 'setRetryInfo', args: [{ attempt: 2, maxAttempts: 5, delayMs: 1000 }] },
+  { port: 'chat', method: 'setRetryInfo', args: ['conv-1', { attempt: 2, maxAttempts: 5, delayMs: 1000 }] },
   { port: 'chat', method: 'setContextUsage', args: ['conv-1', sampleContextUsage] },
   { port: 'chat', method: 'setContextCache', args: ['conv-1', sampleContextCache] },
   { port: 'chat', method: 'clearContextCache', args: ['conv-1'] },
   { port: 'chat', method: 'setIsCompressing', args: ['conv-1', true] },
   { port: 'chat', method: 'setConversationModel', args: ['conv-1', sampleModel] },
   { port: 'chat', method: 'setPendingProposalSignal', args: ['conv-1', sampleProposalSignal] },
-  { port: 'chat', method: 'removeActiveAgent', args: ['agent-1'] },
+  { port: 'chat', method: 'removeActiveAgent', args: ['conv-1', 'agent-1'] },
 ];
 
 /** All 13 generic-dispatch ExecutionPort methods (14 total minus createExecution). */

--- a/src/core/agent/agentLoop.test.ts
+++ b/src/core/agent/agentLoop.test.ts
@@ -8,6 +8,8 @@ import {
   getCapabilityPrompt,
   resolveTools,
   buildVolatileContextTail,
+  buildDirectDelegateSubagentOptions,
+  resolveToolContextWorkspacePath,
 } from './agentLoop';
 import type { ToolDefinition } from '../../types';
 import type { ToolInvoker } from './ports/toolInvoker';
@@ -183,6 +185,73 @@ describe('resolveTools · per-run restrictions', () => {
 
     expect(resolved.tools.map((tool) => tool.name)).toEqual(['read_file', 'read_skill_file']);
     expect(resolved.deferredTools).toEqual([]);
+  });
+});
+
+describe('buildDirectDelegateSubagentOptions', () => {
+  it('carries the parent unattended authorization scope into direct @agent delegation', () => {
+    const controller = new AbortController();
+    const agent = {
+      name: 'researcher',
+      description: 'research',
+      systemPrompt: 'research',
+    };
+    const settingsReader = { getSnapshot: () => ({}) };
+
+    const params = buildDirectDelegateSubagentOptions({
+      agent,
+      task: 'look this up',
+      parentConversationSummary: 'parent context',
+      signal: controller.signal,
+      commandConfirmCallback: async () => true,
+      filePermissionCallback: async () => true,
+      onProgress: undefined,
+      imContext: undefined,
+      parentConversationId: 'conv-1',
+      settingsReader,
+    } as never, {
+      allowedTools: ['read_*'],
+      blockedTools: ['run_command'],
+      authorizationScopeId: 'scope-parent',
+    }, null);
+
+    expect(params).toEqual(expect.objectContaining({
+      agent,
+      task: 'look this up',
+      parentConversationId: 'conv-1',
+      settingsReader,
+      allowedTools: ['read_*'],
+      blockedTools: ['run_command'],
+      authorizationScopeId: 'scope-parent',
+      workspaceReader: expect.any(Object),
+    }));
+    expect(params.workspaceReader?.getCurrentPath()).toBeNull();
+  });
+});
+
+describe('resolveToolContextWorkspacePath', () => {
+  it('fails closed to null for scoped unattended runs with no IM or conversation workspace', () => {
+    expect(resolveToolContextWorkspacePath(
+      { authorizationScopeId: 'scope-1' },
+      { workspacePath: null },
+      '/Users/test/global-workspace',
+    )).toBeNull();
+  });
+
+  it('treats an empty authorization scope as explicit and still fails closed', () => {
+    expect(resolveToolContextWorkspacePath(
+      { authorizationScopeId: '' },
+      { workspacePath: null },
+      '/Users/test/global-workspace',
+    )).toBeNull();
+  });
+
+  it('keeps the legacy global fallback when no authorization scope is present', () => {
+    expect(resolveToolContextWorkspacePath(
+      {},
+      { workspacePath: null },
+      '/Users/test/global-workspace',
+    )).toBe('/Users/test/global-workspace');
   });
 });
 

--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -502,6 +502,8 @@ export interface AgentLoopOptions {
   /** Fail instead of staging into an already-running loop. Used by recovery
    * flows whose tool restrictions must apply from the first turn. */
   requireNewRun?: boolean;
+  /** Shell-created path authorization scope for unattended/background runs. */
+  authorizationScopeId?: string;
   /** IM headless context — injected into system prompt to replace UI-dependent workspace logic */
   imContext?: IMContext;
   /** Settings port — defaults to the in-process Zustand-backed reader. Injection point for
@@ -545,6 +547,32 @@ export interface AgentLoopOptions {
     modelTier?: string;
     capabilitySource?: string;
   }) => void;
+}
+
+export function resolveToolContextWorkspacePath(
+  options: Pick<AgentLoopOptions, 'authorizationScopeId' | 'imContext'> | undefined,
+  conversation: { workspacePath?: string | null } | null | undefined,
+  globalWorkspacePath: string | null,
+): string | null {
+  return (
+    options?.imContext?.workspacePath ??
+    conversation?.workspacePath ??
+    (options?.authorizationScopeId !== undefined ? null : globalWorkspacePath)
+  );
+}
+
+export function buildDirectDelegateSubagentOptions(
+  baseOptions: Omit<Parameters<typeof runSubagent>[0], 'allowedTools' | 'blockedTools' | 'authorizationScopeId' | 'workspaceReader'>,
+  parentOptions: Pick<AgentLoopOptions, 'allowedTools' | 'blockedTools' | 'authorizationScopeId'> | undefined,
+  trustedWorkspacePath: string | null,
+): Parameters<typeof runSubagent>[0] {
+  return {
+    ...baseOptions,
+    allowedTools: parentOptions?.allowedTools,
+    blockedTools: parentOptions?.blockedTools,
+    authorizationScopeId: parentOptions?.authorizationScopeId,
+    workspaceReader: { getCurrentPath: () => trustedWorkspacePath },
+  };
 }
 
 /** Exit reason returned by runAgentLoop so callers (scheduler, trigger) can
@@ -828,10 +856,11 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
   // first write. Headless contexts (IM / scheduled / trigger) are excluded —
   // they must not auto-create workspace directories.
   const toolContext: ToolExecutionContext = {
-    workspacePath:
-      options?.imContext?.workspacePath ??
-      _convForContext?.workspacePath ??
+    workspacePath: resolveToolContextWorkspacePath(
+      options,
+      _convForContext,
       getWorkspaceReader().getCurrentPath(),
+    ),
     loopId,
     conversationId,
     interactionMode: isInteractiveDesktop(options, _convForContext)
@@ -839,6 +868,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       : 'background',
     permissionMode: _convForContext?.permissionMode
       ?? getSettingsReader().getSnapshot().permissionMode,
+    authorizationScopeId: options?.authorizationScopeId,
     abortSignal: abortController.signal,
     taskSummaryHash: await hashComputerUseTaskSummary(
       latestUserTaskSummary(_convForContext?.messages ?? []) ?? userMessage,
@@ -1016,7 +1046,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
     );
 
     try {
-      const result = await runSubagent({
+      const result = await runSubagent(buildDirectDelegateSubagentOptions({
         agent: delegateAgent,
         task: taskText,
         parentConversationSummary: parentConversationSummary || undefined,
@@ -1027,15 +1057,14 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         imContext: options?.imContext,
         parentConversationId: conversationId,
         settingsReader: entrySettingsReader,
+      }, {
         // The `@agent` route reaches runSubagent WITHOUT passing through
-        // `delegate_to_agent`, so it never inherited either run-scoped tool
-        // restriction. An unattended tier is picked by the channel, but the
-        // prompt is user-authored — an IM message on a read-only channel
-        // beginning with `@researcher` delegated a subagent with no ceiling
-        // at all, which is the one hole a roster on the parent cannot see.
+        // `delegate_to_agent`, so it must inherit the parent run's effective
+        // restrictions as well as its authorization scope.
         allowedTools: options?.allowedTools,
         blockedTools: effectiveBlockedTools,
-      });
+        authorizationScopeId: options?.authorizationScopeId,
+      }, toolContext.workspacePath ?? null));
 
       // runSubagentLoop RETURNS a (partial/cancelled) SubagentResult on abort
       // rather than throwing — deliberate for its structured-result contract, but

--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -973,7 +973,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
     const delegateAgent = route.delegateAgent;
     const taskText = route.cleanInput;
 
-    chatDelta.setAgentStatus('tool-calling', TOOL_NAMES.DELEGATE_TO_AGENT, delegateAgent.name);
+    chatDelta.setAgentStatus(conversationId, 'tool-calling', TOOL_NAMES.DELEGATE_TO_AGENT, delegateAgent.name);
 
     // Create a delegate step in the execution
     const delegateStepId = eventRouter.createStepForToolUse(loopId, {
@@ -1045,8 +1045,8 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       // completion (schedulers/triggers/isIncompleteReason depend on this).
       if (abortController.signal.aborted) {
         subagentCleanup();
-        chatDelta.removeActiveAgent(delegateAgent.name);
-        chatDelta.setAgentStatus('idle');
+        chatDelta.removeActiveAgent(conversationId, delegateAgent.name);
+        chatDelta.setAgentStatus(conversationId, 'idle');
         chatDelta.cancelStreaming(conversationId);
         abortRegistry.clearAbortController(conversationId);
         executionPort.cancelExecution(execution.id);
@@ -1056,7 +1056,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
 
       // Complete the delegate step
       subagentCleanup();
-      chatDelta.removeActiveAgent(delegateAgent.name);
+      chatDelta.removeActiveAgent(conversationId, delegateAgent.name);
       if (delegateStepId) {
         eventRouter.route({ type: 'step-end', loopId, stepId: delegateStepId, result: result.text });
       }
@@ -1081,7 +1081,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       abortRegistry.clearAbortController(conversationId);
       eventRouter.route({ type: 'done', loopId, reason: 'delegate_complete' });
       persistExecutionSnapshot(conversationId, loopId);
-      chatDelta.setAgentStatus('idle');
+      chatDelta.setAgentStatus(conversationId, 'idle');
       chatDelta.setConversationStatus(conversationId, 'completed');
       // Delegate run completed without an LLMError → provider is healthy; clears
       // any stale config-failure recorded for it (mirrors the main-loop path).
@@ -1091,8 +1091,8 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       notifyTaskCompleted(convTitle, conversationId);
     } catch (err) {
       subagentCleanup();
-      chatDelta.removeActiveAgent(delegateAgent.name);
-      chatDelta.setAgentStatus('idle');
+      chatDelta.removeActiveAgent(conversationId, delegateAgent.name);
+      chatDelta.setAgentStatus(conversationId, 'idle');
       // Treat retry-layer cancellation sentinel (LLMError code='cancelled', thrown
       // from retry.ts's abort-aware sleep) as a user abort, not a user-facing error.
       const isUserAbort = err instanceof Error
@@ -1312,7 +1312,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       loopId,
     });
 
-    chatDelta.setAgentStatus('thinking');
+    chatDelta.setAgentStatus(conversationId, 'thinking');
 
     const collectedToolCalls: ToolCall[] = [];
     const toolCallToStepId: Map<string, string> = new Map();  // Map toolCallId -> stepId
@@ -1839,13 +1839,13 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
               // while the body text is already streaming, which looks broken.
               if (!thinkingEndTime && collectedThinking) {
                 thinkingEndTime = Date.now();
-                const thinkingStartTime = getConversationReader().getThinkingStartTime();
+                const thinkingStartTime = getConversationReader().getThinkingStartTime(conversationId);
                 if (thinkingStartTime) {
                   const thinkingDuration = Math.max(1, Math.round((thinkingEndTime - thinkingStartTime) / 1000));
                   chatDelta.setThinkingDuration(conversationId, thinkingDuration, assistantMsgId);
                 }
               }
-              chatDelta.setAgentStatus('streaming');
+              chatDelta.setAgentStatus(conversationId, 'streaming');
               chatDelta.appendText(conversationId, event.text, assistantMsgId);
               break;
 
@@ -1862,7 +1862,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
               // completed (same reason as the 'text' branch above).
               if (!thinkingEndTime && collectedThinking) {
                 thinkingEndTime = Date.now();
-                const thinkingStartTime = getConversationReader().getThinkingStartTime();
+                const thinkingStartTime = getConversationReader().getThinkingStartTime(conversationId);
                 if (thinkingStartTime) {
                   const thinkingDuration = Math.max(1, Math.round((thinkingEndTime - thinkingStartTime) / 1000));
                   chatDelta.setThinkingDuration(conversationId, thinkingDuration, assistantMsgId);
@@ -1886,7 +1886,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
                 break;
               }
 
-              chatDelta.setAgentStatus('tool-calling', event.name);
+              chatDelta.setAgentStatus(conversationId, 'tool-calling', event.name);
 
               // Create step in TaskExecutionStore via EventRouter
               const stepId = eventRouter.createStepForToolUse(loopId, {
@@ -1935,7 +1935,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
               }
               // Calculate and save thinking duration
               if (collectedThinking && thinkingEndTime) {
-                const thinkingStartTime = getConversationReader().getThinkingStartTime();
+                const thinkingStartTime = getConversationReader().getThinkingStartTime(conversationId);
                 if (thinkingStartTime) {
                   const thinkingDuration = Math.round((thinkingEndTime - thinkingStartTime) / 1000);
                   chatDelta.setThinkingDuration(conversationId, thinkingDuration, assistantMsgId);
@@ -1986,9 +1986,9 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
             // provider isn't a silent dead wait. rate_limit gets 5 attempts in
             // retry.ts, others get 3.
             const maxAttempts = error.code === 'rate_limit' ? 5 : 3;
-            chatDelta.setRetryInfo({ attempt, maxAttempts, delayMs });
+            chatDelta.setRetryInfo(conversationId, { attempt, maxAttempts, delayMs });
             if (error.code === 'rate_limit') {
-              chatDelta.setAgentStatus('rate-limited', `${Math.round(delayMs / 1000)}s`);
+              chatDelta.setAgentStatus(conversationId, 'rate-limited', `${Math.round(delayMs / 1000)}s`);
             }
             // Clear any partial content written before the stream failed so
             // the retry starts with a clean message instead of appending to

--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -2741,6 +2741,9 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
     }
   }
   abortController.signal.removeEventListener('abort', endComputerUseTaskOnAbort);
+  if (options?.authorizationScopeId !== undefined && !abortController.signal.aborted) {
+    abortController.abort(new Error('Scoped agent run finished'));
+  }
   await endComputerUseTaskLease();
   endConversationTrace(conversationId, { output: { reason: exitReason }, error: exitError });
   return { reason: exitReason, error: exitError };

--- a/src/core/agent/agentLoopRunner.test.ts
+++ b/src/core/agent/agentLoopRunner.test.ts
@@ -206,6 +206,15 @@ vi.mock('./agentLoop', () => ({
   runAgentLoop: (...a: unknown[]) => runAgentLoopMock(...a),
   isInteractiveDesktop: (...a: unknown[]) => isInteractiveDesktopMock(...a),
   buildUserMessageContent: (...a: [string, string, unknown]) => buildUserMessageContentMock(...a),
+  resolveToolContextWorkspacePath: (
+    options: { authorizationScopeId?: string; imContext?: { workspacePath?: string | null } } | undefined,
+    conversation: { workspacePath?: string | null } | null | undefined,
+    globalWorkspacePath: string | null,
+  ) => (
+    options?.imContext?.workspacePath ??
+    conversation?.workspacePath ??
+    (options?.authorizationScopeId !== undefined ? null : globalWorkspacePath)
+  ),
 }));
 
 const precomputeOrchestrationMock = vi.fn().mockResolvedValue({
@@ -437,12 +446,25 @@ function handlerFor(mock: ReturnType<typeof vi.fn>, method: string): (params: un
 }
 
 function makeSession(
-  overrides: Partial<{ conversationId: string; loopId: string; terminalPublished: boolean }> = {},
+  overrides: Partial<{
+    conversationId: string;
+    loopId: string;
+    terminalPublished: boolean;
+    authorizationScopeId: string;
+    workspacePathSnapshot: string | null;
+  }> = {},
 ) {
   return {
     conversationId: overrides.conversationId ?? 'conv-1',
     loopId: overrides.loopId ?? 'loop-1',
-    options: {},
+    options: {
+      ...(Object.prototype.hasOwnProperty.call(overrides, 'authorizationScopeId')
+        ? { authorizationScopeId: overrides.authorizationScopeId }
+        : {}),
+      ...(Object.prototype.hasOwnProperty.call(overrides, 'workspacePathSnapshot')
+        ? { workspacePathSnapshot: overrides.workspacePathSnapshot }
+        : {}),
+    },
     shellAbortController: new AbortController(),
     toolCallToStepId: new Map<string, string>(),
     ...(overrides.terminalPublished === undefined
@@ -1103,22 +1125,137 @@ describe('agentLoopRunner', () => {
   // ── workspace.authorizedWritablePaths (P1-3d-5 slice 2a) ──────────────
 
   describe('workspace.authorizedWritablePaths handler', () => {
-    it('returns the real getAuthorizedWritablePaths() result', async () => {
-      const { ensureHandlersRegistered } = await importFresh();
+    it('returns writable paths from the shell-owned session scope, ignoring forged params', async () => {
+      const { ensureHandlersRegistered, registerRunSession } = await importFresh();
       ensureHandlersRegistered();
-      getAuthorizedWritablePathsMock.mockReturnValue(['/tmp/authorized-a', '/tmp/authorized-b']);
+      registerRunSession('run-1', makeSession({
+        authorizationScopeId: 'scope-real',
+        workspacePathSnapshot: '/trusted/workspace',
+      }));
+      getAuthorizedWritablePathsMock.mockImplementation((scopeId?: string) =>
+        scopeId === 'scope-real' ? ['/tmp/scoped'] : ['/tmp/global'],
+      );
       const handler = handlerFor(onSidecarRequest, 'workspace.authorizedWritablePaths') as (p: unknown) => Promise<unknown>;
-      const result = await handler(undefined);
-      expect(result).toEqual(['/tmp/authorized-a', '/tmp/authorized-b']);
+      const result = await handler({ runId: 'run-1', authorizationScopeId: 'scope-forged' });
+      expect(result).toEqual(['/tmp/scoped']);
+      expect(getAuthorizedWritablePathsMock).toHaveBeenCalledWith('scope-real');
     });
 
-    it('returns an empty array when nothing is authorized', async () => {
+    it('rejects unknown runId instead of falling back to global writable paths', async () => {
       const { ensureHandlersRegistered } = await importFresh();
       ensureHandlersRegistered();
-      getAuthorizedWritablePathsMock.mockReturnValue([]);
       const handler = handlerFor(onSidecarRequest, 'workspace.authorizedWritablePaths') as (p: unknown) => Promise<unknown>;
-      const result = await handler(undefined);
-      expect(result).toEqual([]);
+      await expect(handler({ runId: 'missing' })).rejects.toThrow(MockSidecarRequestError);
+      expect(getAuthorizedWritablePathsMock).not.toHaveBeenCalled();
+    });
+
+    it('uses global writable paths only for an unscoped registered session', async () => {
+      const { ensureHandlersRegistered, registerRunSession } = await importFresh();
+      ensureHandlersRegistered();
+      registerRunSession('run-1', makeSession());
+      getAuthorizedWritablePathsMock.mockReturnValue(['/tmp/global']);
+      const handler = handlerFor(onSidecarRequest, 'workspace.authorizedWritablePaths') as (p: unknown) => Promise<unknown>;
+      const result = await handler({ runId: 'run-1' });
+      expect(result).toEqual(['/tmp/global']);
+      expect(getAuthorizedWritablePathsMock).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe('sidecar context scope hardening', () => {
+    it('tool.invoke overwrites sidecar-supplied scope and identity with the shell session values', async () => {
+      const { ensureHandlersRegistered, registerRunSession } = await importFresh();
+      ensureHandlersRegistered();
+      registerRunSession('run-1', makeSession({
+        authorizationScopeId: 'scope-real',
+        workspacePathSnapshot: '/trusted/workspace',
+      }));
+      const handler = handlerFor(onSidecarRequest, 'tool.invoke') as (p: unknown) => Promise<unknown>;
+
+      await handler({
+        runId: 'run-1',
+        toolName: 'read_file',
+        input: { path: '/tmp/x' },
+        context: {
+          authorizationScopeId: 'scope-forged',
+          conversationId: 'conv-forged',
+          loopId: 'loop-forged',
+          workspacePath: '/forged/workspace',
+        },
+      });
+
+      expect(executeAnyToolMock).toHaveBeenCalledWith(
+        'read_file',
+        { path: '/tmp/x' },
+        expect.any(Function),
+        expect.any(Function),
+        expect.objectContaining({
+          authorizationScopeId: 'scope-real',
+          conversationId: 'conv-1',
+          loopId: 'loop-1',
+          workspacePath: '/trusted/workspace',
+        }),
+      );
+    });
+
+    it('tool.invoke overwrites a forged workspace with null when the shell session has no trusted workspace', async () => {
+      const { ensureHandlersRegistered, registerRunSession } = await importFresh();
+      ensureHandlersRegistered();
+      registerRunSession('run-1', makeSession({
+        authorizationScopeId: 'scope-real',
+        workspacePathSnapshot: null,
+      }));
+      const handler = handlerFor(onSidecarRequest, 'tool.invoke') as (p: unknown) => Promise<unknown>;
+
+      await handler({
+        runId: 'run-1',
+        toolName: 'run_command',
+        input: { command: 'touch ok' },
+        context: {
+          authorizationScopeId: 'scope-forged',
+          workspacePath: '/forged/workspace',
+        },
+      });
+
+      expect(executeAnyToolMock).toHaveBeenCalledWith(
+        'run_command',
+        { command: 'touch ok' },
+        expect.any(Function),
+        expect.any(Function),
+        expect.objectContaining({
+          authorizationScopeId: 'scope-real',
+          workspacePath: null,
+        }),
+      );
+    });
+
+    it('approval.check overwrites sidecar-supplied scope before registry approval', async () => {
+      const { ensureHandlersRegistered, registerRunSession } = await importFresh();
+      ensureHandlersRegistered();
+      registerRunSession('run-1', makeSession({ authorizationScopeId: 'scope-real' }));
+      const handler = handlerFor(onSidecarRequest, 'approval.check') as (p: unknown) => Promise<unknown>;
+
+      await handler({
+        runId: 'run-1',
+        toolName: 'read_file',
+        input: { path: '/tmp/x' },
+        context: {
+          authorizationScopeId: 'scope-forged',
+          conversationId: 'conv-forged',
+          loopId: 'loop-forged',
+        },
+      });
+
+      expect(checkToolApprovalMock).toHaveBeenCalledWith(
+        'read_file',
+        { path: '/tmp/x' },
+        expect.objectContaining({
+          authorizationScopeId: 'scope-real',
+          conversationId: 'conv-1',
+          loopId: 'loop-1',
+        }),
+        expect.any(Function),
+        expect.any(Function),
+      );
     });
   });
 
@@ -1758,7 +1895,13 @@ describe('agentLoopRunner', () => {
       const result = await handler({ runId: 'run-1', toolName: 'show_widget', input: { title: 't' }, context });
 
       expect(result).toEqual({ decision: 'allow' });
-      expect(checkToolApprovalMock).toHaveBeenCalledWith('show_widget', { title: 't' }, context, confirmCb, filePermCb);
+      expect(checkToolApprovalMock).toHaveBeenCalledWith(
+        'show_widget',
+        { title: 't' },
+        expect.objectContaining({ conversationId: 'conv-1', loopId: 'run-1' }),
+        confirmCb,
+        filePermCb,
+      );
     });
 
     it('marks an allowed side-effecting local tool as committed before returning its ACK', async () => {
@@ -1832,7 +1975,13 @@ describe('agentLoopRunner', () => {
       const handler = handlerFor(onSidecarRequest, 'approval.check');
       await handler({ runId: 'run-1', toolName: 'show_widget', input: {} });
 
-      expect(checkToolApprovalMock).toHaveBeenCalledWith('show_widget', {}, undefined, requestCommandConfirmationMock, requestFilePermissionMock);
+      expect(checkToolApprovalMock).toHaveBeenCalledWith(
+        'show_widget',
+        {},
+        expect.objectContaining({ conversationId: 'conv-1', loopId: 'loop-1' }),
+        requestCommandConfirmationMock,
+        requestFilePermissionMock,
+      );
     });
 
     it('refuses local sidecar approval outside the run whitelist', async () => {

--- a/src/core/agent/agentLoopRunner.test.ts
+++ b/src/core/agent/agentLoopRunner.test.ts
@@ -689,7 +689,7 @@ describe('agentLoopRunner', () => {
       registerRunSession('run-1', makeSession());
 
       const handler = handlerFor(onSidecarNotification, 'agent.delta');
-      const frames = [{ p: 'chat', m: 'appendText', a: ['c1', 'hi'] }];
+      const frames = [{ p: 'chat', m: 'appendText', a: ['conv-1', 'hi'] }];
       handler({ runId: 'run-1', frames });
 
       await Promise.resolve();
@@ -741,6 +741,86 @@ describe('agentLoopRunner', () => {
       const handler = handlerFor(onSidecarNotification, 'agent.delta');
       expect(() => handler(null)).not.toThrow();
       expect(() => handler({ runId: 123, frames: [] })).not.toThrow();
+      expect(applyDeltaFramesMock).not.toHaveBeenCalled();
+    });
+
+    it('drops malformed frame entries without throwing or applying the batch', async () => {
+      const { ensureHandlersRegistered, registerRunSession } = await importFresh();
+      ensureHandlersRegistered();
+      registerRunSession('run-1', makeSession({ conversationId: 'conv-1', loopId: 'loop-1' }));
+
+      const handler = handlerFor(onSidecarNotification, 'agent.delta');
+      expect(() => handler({
+        runId: 'run-1',
+        frames: [
+          null,
+          { p: 'chat', m: 'setAgentStatus' },
+          { p: 'exec', m: 'addStep', a: null },
+        ],
+      })).not.toThrow();
+
+      expect(applyDeltaFramesMock).not.toHaveBeenCalled();
+    });
+
+    it('filters chat/session frames that target a different conversation than the registered run', async () => {
+      const { ensureHandlersRegistered, registerRunSession } = await importFresh();
+      ensureHandlersRegistered();
+      registerRunSession('run-1', makeSession({ conversationId: 'conv-1', loopId: 'loop-1' }));
+
+      const handler = handlerFor(onSidecarNotification, 'agent.delta');
+      const forged = [
+        { p: 'chat', m: 'setAgentStatus', a: ['conv-forged', 'tool-calling', 'read_file'] },
+        { p: 'session', m: 'replaceMessageById', a: ['conv-forged', { id: 'm-forged' }] },
+        { p: 'chat', m: 'setRetryInfo', a: ['conv-1', { attempt: 1, maxAttempts: 3, delayMs: 1000 }] },
+      ];
+
+      handler({ runId: 'run-1', frames: forged });
+
+      await Promise.resolve();
+      expect(applyDeltaFramesMock).toHaveBeenCalledWith([
+        { p: 'chat', m: 'setRetryInfo', a: ['conv-1', { attempt: 1, maxAttempts: 3, delayMs: 1000 }] },
+      ]);
+    });
+
+    it('filters exec and scratchpad frames that are not bound to the registered conversation and loop', async () => {
+      const { ensureHandlersRegistered, registerRunSession } = await importFresh();
+      ensureHandlersRegistered();
+      registerRunSession('run-1', makeSession({ conversationId: 'conv-1', loopId: 'loop-1' }));
+
+      const handler = handlerFor(onSidecarNotification, 'agent.delta');
+      const frames = [
+        { p: 'exec', m: 'createExecution', a: ['conv-forged', 'loop-1'] },
+        { p: 'exec', m: 'createExecution', a: ['conv-1', 'loop-forged'] },
+        { p: 'exec', m: 'addStep', a: ['loop-forged', { id: 's-forged' }] },
+        { p: 'scratchpad', m: 'addEntry', a: ['entry-forged', { conversationId: 'conv-forged', title: 't', type: 'summary', content: 'c' }] },
+        { p: 'exec', m: 'createExecution', a: ['conv-1', 'loop-1'] },
+        { p: 'exec', m: 'addStep', a: ['loop-1', { id: 's-real' }] },
+        { p: 'scratchpad', m: 'addEntry', a: ['entry-real', { conversationId: 'conv-1', title: 't', type: 'summary', content: 'c' }] },
+      ];
+
+      handler({ runId: 'run-1', frames });
+
+      await Promise.resolve();
+      expect(applyDeltaFramesMock).toHaveBeenCalledWith([
+        { p: 'exec', m: 'createExecution', a: ['conv-1', 'loop-1'] },
+        { p: 'exec', m: 'addStep', a: ['loop-1', { id: 's-real' }] },
+        { p: 'scratchpad', m: 'addEntry', a: ['entry-real', { conversationId: 'conv-1', title: 't', type: 'summary', content: 'c' }] },
+      ]);
+    });
+
+    it('drops valid-looking frames when the registered conversation has already been deleted', async () => {
+      const { ensureHandlersRegistered, registerRunSession } = await importFresh();
+      ensureHandlersRegistered();
+      chatState = { conversations: {}, conversationIndex: {} };
+      registerRunSession('run-deleted', makeSession({ conversationId: 'conv-1', loopId: 'loop-1' }));
+
+      const handler = handlerFor(onSidecarNotification, 'agent.delta');
+      handler({
+        runId: 'run-deleted',
+        frames: [{ p: 'chat', m: 'setAgentStatus', a: ['conv-1', 'tool-calling', 'read_file'] }],
+      });
+
+      await Promise.resolve();
       expect(applyDeltaFramesMock).not.toHaveBeenCalled();
     });
   });
@@ -2671,7 +2751,7 @@ describe('agentLoopRunner', () => {
       expect(pauseUserInputQueueMock).toHaveBeenCalledWith('conv-1');
       expect(drainSystemQueuedInputsMock).toHaveBeenCalledWith('conv-1');
       expect(chatDeltaAddMessageMock).not.toHaveBeenCalled();
-      expect(chatDeltaSetAgentStatusMock).toHaveBeenCalledWith('idle');
+      expect(chatDeltaSetAgentStatusMock).toHaveBeenCalledWith('conv-1', 'idle');
       expect(chatDeltaSetConversationStatusMock).toHaveBeenCalledWith('conv-1', 'idle');
       expect(cancelExecutionMock).toHaveBeenCalledWith(expect.any(String));
       expect(clearAbortControllerMock).toHaveBeenCalledWith('conv-1');
@@ -2951,7 +3031,7 @@ describe('agentLoopRunner', () => {
       // conversation hangs streaming forever.
       expect(chatDeltaFinishStreamingMock).toHaveBeenCalledWith('conv-1');
       expect(chatDeltaSetConversationStatusMock).toHaveBeenCalledWith('conv-1', 'error');
-      expect(chatDeltaSetAgentStatusMock).toHaveBeenCalledWith('idle');
+      expect(chatDeltaSetAgentStatusMock).toHaveBeenCalledWith('conv-1', 'idle');
     });
 
     it('rejects a post-commit failure result when its terminal state cannot be persisted', async () => {

--- a/src/core/agent/agentLoopRunner.test.ts
+++ b/src/core/agent/agentLoopRunner.test.ts
@@ -2078,6 +2078,22 @@ describe('agentLoopRunner', () => {
       expect(bindWorkspaceFromWriteMock).not.toHaveBeenCalled();
     });
 
+    it('silently drops a notification that targets a conversation not owned by the run', async () => {
+      const { ensureHandlersRegistered, registerRunSession } = await importFresh();
+      ensureHandlersRegistered();
+      registerRunSession('run-1', makeSession({ conversationId: 'conv-1' }));
+
+      const handler = handlerFor(onSidecarNotification, 'workspace.bindFromWrite');
+      expect(() => handler({
+        runId: 'run-1',
+        conversationId: 'conv-forged',
+        path: '/Users/x/Abu/report/out.html',
+      })).not.toThrow();
+      await Promise.resolve();
+
+      expect(bindWorkspaceFromWriteMock).not.toHaveBeenCalled();
+    });
+
     it('silently drops malformed params (missing runId/path)', async () => {
       const { ensureHandlersRegistered, registerRunSession } = await importFresh();
       ensureHandlersRegistered();
@@ -2511,6 +2527,27 @@ describe('agentLoopRunner', () => {
       await expect(running).resolves.toEqual({ reason: 'completed' });
       expect(sidecarRequestMock).not.toHaveBeenCalledWith('agent.abort', expect.anything(), expect.anything());
       expect(chatDeltaCancelStreamingMock).not.toHaveBeenCalled();
+    });
+
+    it('aborts scoped shell controllers after a terminal without sending a late agent.abort', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      const shellController = new AbortController();
+      getAbortControllerMock.mockReturnValue(shellController);
+      sidecarRequestMock.mockImplementation((_method: string, _params: unknown, _timeout: number, signal?: AbortSignal) => (
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+        })
+      ));
+
+      const running = runAgentLoopDispatched('conv-1', 'hello', { authorizationScopeId: 'scope-shell' });
+      await waitForCall(sidecarRequestMock);
+      const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
+      const terminalHandler = handlerFor(onSidecarNotification, 'agent.terminal');
+      terminalHandler({ version: 1, runId, state: 'completed', result: { reason: 'completed' } });
+
+      await expect(running).resolves.toEqual({ reason: 'completed' });
+      expect(shellController.signal.aborted).toBe(true);
+      expect(sidecarRequestMock).not.toHaveBeenCalledWith('agent.abort', expect.anything(), expect.anything());
     });
 
     it('uses a failed terminal before any delta as authoritative and finalizes the UI exactly once', async () => {

--- a/src/core/agent/agentLoopRunner.ts
+++ b/src/core/agent/agentLoopRunner.ts
@@ -1232,18 +1232,19 @@ function assertRunToolAllowed(
  * runId → silent drop" discipline (3a), NOT `handleMainLoopToolInvoke`'s
  * hard-refuse-with-throw (there is no RPC response to fail here — silent
  * drop is the only sensible behavior for a fire-and-forget notification).
- * The real function is itself idempotent/self-guarding on a missing or
- * already-bound conversation (`defaultWorkspace.ts:119-122`), so this
- * lookup is a defense-in-depth consistency check, not the only thing
- * preventing a stale/deleted-conversation write from taking effect.
+ * The notification's conversationId must match the run-owned conversation;
+ * otherwise a delayed or forged sidecar notification could bind a different
+ * interactive conversation. The real function is itself idempotent and
+ * self-guarding on a missing or already-bound conversation
+ * (`defaultWorkspace.ts:119-122`).
  */
 function handleWorkspaceBindFromWrite(rawParams: unknown): void {
   const params = rawParams as { runId?: unknown; conversationId?: unknown; path?: unknown } | null;
   if (!params || typeof params.runId !== 'string' || typeof params.path !== 'string') return;
   const session = sessions.get(params.runId);
   if (!session) return; // unknown/already-finished runId — silent drop
-  const conversationId = typeof params.conversationId === 'string' ? params.conversationId : undefined;
-  void bindWorkspaceFromWrite(conversationId, params.path).catch((err: unknown) => {
+  if (typeof params.conversationId === 'string' && params.conversationId !== session.conversationId) return;
+  void bindWorkspaceFromWrite(session.conversationId, params.path).catch((err: unknown) => {
     logger.warn('bindWorkspaceFromWrite threw', { error: err instanceof Error ? err.message : String(err) });
   });
 }
@@ -2810,6 +2811,13 @@ async function runSingleAgentLoopDispatched(
     removeShellLoopContext(runId);
     unregisterRunSession(runId);
     shellAbortController.signal.removeEventListener('abort', onShellAbort);
+    if (
+      !handedOffToLocal
+      && options?.authorizationScopeId !== undefined
+      && !shellAbortController.signal.aborted
+    ) {
+      shellAbortController.abort(new Error('Scoped agent run finished'));
+    }
     if (!handedOffToLocal) {
       // Ownership-checked: everything above the `finally` can outlive this
       // run's visible terminal (persistence, the Computer Use lease release

--- a/src/core/agent/agentLoopRunner.ts
+++ b/src/core/agent/agentLoopRunner.ts
@@ -49,6 +49,7 @@ import { getCapsPort } from './ports/capsPort';
 import { getAbortRegistry } from './ports/abortRegistry';
 import { getToolInvoker } from './ports/toolInvoker';
 import { getSettingsReader, type SettingsReader } from './ports/settingsReader';
+import { getWorkspaceReader } from './ports/workspaceReader';
 import { toSerializableTool } from './subagentRunner';
 import { registerToolInvokeSource, ensureToolInvokeRouterRegistered } from './toolInvokeRouter';
 import { ensureHookBridgeRegistered, registerHookSignalSource } from './hookBridge';
@@ -83,6 +84,7 @@ import {
   runAgentLoop,
   buildUserMessageContent,
   isInteractiveDesktop,
+  resolveToolContextWorkspacePath,
   type AgentLoopOptions,
   type AgentLoopResult,
 } from './agentLoop';
@@ -154,6 +156,8 @@ export interface AgentLoopRunOptions {
   requestFilePermission?: FilePermissionCallback;
   blockedTools?: string[];
   allowedTools?: string[];
+  authorizationScopeId?: string;
+  workspacePathSnapshot?: string | null;
   /** Frozen provider/model snapshot inherited by nested shell-side agents. */
   settingsReader?: SettingsReader;
 }
@@ -993,16 +997,39 @@ async function handleToolList(): Promise<unknown> {
  * side twin: `sidecar/src/shims/authorizedPathsReaderRun.ts`. Answers "what
  * paths has the user authorized for write access?" for a locally-executed
  * `run_command` (once slice 2b registers it in `localTools/index.ts`) —
- * `pathSafety.ts`'s `authorizedWorkspaces` map is shell-only state (populated
- * by `authorizeWorkspace()`, `registry.ts`/`triggerPermission.ts`), so this
- * is the same real `getAuthorizedWritablePaths()` the in-process
- * `AuthorizedPathsReader` default wraps — single source of truth, no
- * duplicated logic. Stateless (no runId/session lookup, mirroring
- * `handleToolList` above) since the authorized-paths set is global, not
- * per-run.
+ * `pathSafety.ts`'s authorization maps are shell-only state (populated by
+ * `authorizeWorkspace()` / `scopedAuthorizeWorkspace()`), so this is the same
+ * real `getAuthorizedWritablePaths()` the in-process `AuthorizedPathsReader`
+ * default wraps — single source of truth, no duplicated logic. The request
+ * includes a runId and the shell resolves the session-owned scope; unknown
+ * runs fail closed rather than falling back to global writable paths.
  */
-async function handleWorkspaceAuthorizedPaths(): Promise<unknown> {
-  return getAuthorizedWritablePaths();
+async function handleWorkspaceAuthorizedPaths(rawParams: unknown): Promise<unknown> {
+  const params = rawParams as { runId?: unknown } | null;
+  if (!params || typeof params.runId !== 'string') {
+    throw new SidecarRequestError(-32602, 'Invalid workspace.authorizedWritablePaths params: runId must be a string');
+  }
+  const session = sessions.get(params.runId);
+  if (!session) {
+    throw new SidecarRequestError(-32000, `Unknown agent-loop runId: ${params.runId}`);
+  }
+  return getAuthorizedWritablePaths(session.options.authorizationScopeId);
+}
+
+function contextForSession(
+  session: RunSession,
+  incoming: ToolExecutionContext | undefined,
+): ToolExecutionContext {
+  return {
+    ...incoming,
+    conversationId: session.conversationId,
+    loopId: session.loopId,
+    authorizationScopeId: session.options.authorizationScopeId,
+    ...(Object.prototype.hasOwnProperty.call(session.options, 'workspacePathSnapshot')
+      ? { workspacePath: session.options.workspacePathSnapshot ?? null }
+      : {}),
+    abortSignal: session.shellAbortController.signal,
+  };
 }
 
 /**
@@ -1075,10 +1102,7 @@ async function handleMainLoopToolInvoke(rawParams: unknown): Promise<unknown> {
     (params.input as Record<string, unknown>) ?? {},
     session.options.requestCommandConfirmation ?? requestCommandConfirmation,
     session.options.requestFilePermission ?? requestFilePermission,
-    {
-      ...((params.context as ToolExecutionContext | undefined) ?? {}),
-      abortSignal: session.shellAbortController.signal,
-    },
+    contextForSession(session, params.context as ToolExecutionContext | undefined),
   );
 }
 
@@ -1135,7 +1159,7 @@ async function handleApprovalCheck(rawParams: unknown): Promise<ToolApprovalDeci
   const decision = await checkToolApproval(
     params.toolName,
     (params.input as Record<string, unknown>) ?? {},
-    params.context as ToolExecutionContext | undefined,
+    contextForSession(session, params.context as ToolExecutionContext | undefined),
     session.options.requestCommandConfirmation ?? requestCommandConfirmation,
     session.options.requestFilePermission ?? requestFilePermission,
   );
@@ -1662,6 +1686,7 @@ export function installShellLoopContext(runId: string, session: RunSession): voi
     toolCallToStepId: session.toolCallToStepId,
     blockedTools: session.options.blockedTools,
     allowedTools: session.options.allowedTools,
+    authorizationScopeId: session.options.authorizationScopeId,
   });
 }
 
@@ -1692,6 +1717,8 @@ interface AgentRunParams {
     images?: ImageAttachment[];
     blockedTools?: string[];
     allowedTools?: string[];
+    authorizationScopeId?: string;
+    workspacePathSnapshot?: string | null;
     imContext?: IMContext;
     prePersistedUserMessageId?: string;
   };
@@ -2046,6 +2073,11 @@ async function buildAgentRunParams(
   if (!conversationSnapshot) {
     throw new Error(`buildAgentRunParams: conversation "${conversationId}" disappeared before dispatch`);
   }
+  const workspacePathSnapshot = resolveToolContextWorkspacePath(
+    options,
+    conversationSnapshot,
+    getWorkspaceReader().getCurrentPath(),
+  );
 
   // Snapshot only internal system wake-ups for this conversation at dispatch
   // time. User follow-ups remain shell-side until the current run terminates.
@@ -2065,6 +2097,8 @@ async function buildAgentRunParams(
       images: options?.images,
       blockedTools: options?.blockedTools,
       allowedTools: options?.allowedTools,
+      authorizationScopeId: options?.authorizationScopeId,
+      workspacePathSnapshot,
       imContext: options?.imContext,
     },
   }));
@@ -2079,6 +2113,8 @@ async function buildAgentRunParams(
       images: options?.images,
       blockedTools: options?.blockedTools,
       allowedTools: options?.allowedTools,
+      authorizationScopeId: options?.authorizationScopeId,
+      workspacePathSnapshot,
       imContext: options?.imContext,
       prePersistedUserMessageId: clientMessageId,
     },
@@ -2088,6 +2124,7 @@ async function buildAgentRunParams(
     // not be combined with this run's already-resolved credentials.
     conversationSnapshot: {
       ...conversationSnapshot,
+      workspacePath: workspacePathSnapshot,
       model: settingsForModel.activeModel,
     } as Conversation,
     indexEntrySnapshot: indexEntrySnapshot as ConversationMeta | undefined,
@@ -2368,6 +2405,8 @@ async function runSingleAgentLoopDispatched(
       requestFilePermission: options?.filePermissionCallback,
       blockedTools: options?.blockedTools,
       allowedTools: options?.allowedTools,
+      authorizationScopeId: options?.authorizationScopeId,
+      workspacePathSnapshot: params.options.workspacePathSnapshot,
       settingsReader: { getSnapshot: () => params.settingsSnapshot },
     },
     shellAbortController,

--- a/src/core/agent/agentLoopRunner.ts
+++ b/src/core/agent/agentLoopRunner.ts
@@ -344,14 +344,77 @@ export function __resetAgentLoopRunnerForTests(): void {
 
 // ── Reverse-channel handlers (registered ONCE at module init) ──────────
 
+function isPortFrame(value: unknown): value is PortFrame {
+  if (typeof value !== 'object' || value === null) return false;
+  const frame = value as { p?: unknown; m?: unknown; a?: unknown };
+  return (
+    (frame.p === 'chat' || frame.p === 'exec' || frame.p === 'scratchpad' || frame.p === 'session')
+    && typeof frame.m === 'string'
+    && Array.isArray(frame.a)
+  );
+}
+
+function frameConversationId(frame: PortFrame): string | undefined {
+  if (frame.p === 'chat') {
+    if (frame.m === 'setCurrentUsage') return undefined;
+    return typeof frame.a[0] === 'string' ? frame.a[0] : undefined;
+  }
+  if (frame.p === 'session') {
+    return typeof frame.a[0] === 'string' ? frame.a[0] : undefined;
+  }
+  if (frame.p === 'exec' && frame.m === 'createExecution') {
+    return typeof frame.a[0] === 'string' ? frame.a[0] : undefined;
+  }
+  if (frame.p === 'scratchpad') {
+    const entry = frame.a[1] as { conversationId?: unknown } | undefined;
+    return typeof entry?.conversationId === 'string' ? entry.conversationId : undefined;
+  }
+  return undefined;
+}
+
+function frameLoopId(frame: PortFrame): string | undefined {
+  if (frame.p !== 'exec') return undefined;
+  if (frame.m === 'createExecution') {
+    return typeof frame.a[1] === 'string' ? frame.a[1] : undefined;
+  }
+  return typeof frame.a[0] === 'string' ? frame.a[0] : undefined;
+}
+
+function isDeltaFrameTrustedForSession(frame: PortFrame, session: RunSession): boolean {
+  switch (frame.p) {
+    case 'chat': {
+      if (frame.m === 'setCurrentUsage') return true;
+      return frameConversationId(frame) === session.conversationId;
+    }
+    case 'session':
+    case 'scratchpad':
+      return frameConversationId(frame) === session.conversationId;
+    case 'exec':
+      if (frame.m === 'createExecution') {
+        return frameConversationId(frame) === session.conversationId
+          && frameLoopId(frame) === session.loopId;
+      }
+      return frameLoopId(frame) === session.loopId;
+    default:
+      return false;
+  }
+}
+
+function trustedDeltaFramesForSession(session: RunSession, frames: PortFrame[]): PortFrame[] {
+  if (!useChatStore.getState().conversations[session.conversationId]) return [];
+  return frames.filter((frame) => isDeltaFrameTrustedForSession(frame, session));
+}
+
 /** `agent.delta` (NOTIFICATION) → {runId, frames} → applyDeltaFrames. Unknown runId → silent drop (3a discipline, matches handleSubagentAbort's unknown-runId no-op). */
 function handleAgentDelta(rawParams: unknown): void {
   const params = rawParams as { runId?: unknown; frames?: unknown } | null;
   if (!params || typeof params.runId !== 'string' || !Array.isArray(params.frames)) return;
-  const frames = params.frames as PortFrame[];
+  const receivedFrames = params.frames.filter(isPortFrame);
   const session = sessions.get(params.runId);
   if (!session) return; // unknown/already-finished runId — silent drop
   if (session.dropFrames) return; // terminal fence — late frames from an aborted run are stale
+  const frames = trustedDeltaFramesForSession(session, receivedFrames);
+  if (frames.length === 0) return;
   // P1-3B-3B fallback discipline: the first frame observed for this run is
   // an already-committed, observable side effect (text/thinking streamed to
   // the real chatStore) — see RunSession.committed's doc.
@@ -556,7 +619,7 @@ async function finalizeFailedRun(
         chatDelta.appendText(session.conversationId, `\n\n**Error:** ${displayMessage}`);
       }
       chatDelta.finishStreaming(session.conversationId);
-      chatDelta.setAgentStatus('idle');
+      chatDelta.setAgentStatus(session.conversationId, 'idle');
       chatDelta.setConversationStatus(session.conversationId, 'error');
     } catch (cleanupErr) {
       logger.warn('terminal UI finalization failed', {
@@ -661,7 +724,7 @@ async function finalizeAbortedRun(session: RunSession, source: 'ack' | 'watchdog
 
       chatDelta.cancelStreaming(session.conversationId, { fromSidecarFrame: true });
       chatDelta.deactivateSkills(session.conversationId);
-      chatDelta.setAgentStatus('idle');
+      chatDelta.setAgentStatus(session.conversationId, 'idle');
       chatDelta.setConversationStatus(session.conversationId, 'idle');
       getExecutionPort().cancelExecution(session.loopId);
         await waitForConversationPersistence(session.conversationId);

--- a/src/core/agent/frameApplier.test.ts
+++ b/src/core/agent/frameApplier.test.ts
@@ -46,12 +46,10 @@ describe('applyDeltaFrames', () => {
       conversations: {},
       conversationIndex: {},
       activeConversationId: null,
-      agentStatus: 'idle',
-      currentTool: null,
       currentUsage: null,
       pendingInput: null,
       pendingInputAppend: null,
-      thinkingStartTime: null,
+      agentStates: new Map(),
     });
     useTaskExecutionStore.setState({ executions: {}, activeExecutionId: null, loopIdIndex: {} });
     useScratchpadStore.setState({ entries: {}, order: [] });

--- a/src/core/agent/permissionBridge.test.ts
+++ b/src/core/agent/permissionBridge.test.ts
@@ -25,6 +25,12 @@ import {
 } from './permissionBridge';
 import { usePermissionStore } from '../../stores/permissionStore';
 import type { Message, UserQuestionPayload, UserQuestionResult } from '../../types';
+import {
+  checkReadPath,
+  checkWritePath,
+  createAuthorizationScope,
+  disposeAuthorizationScope,
+} from '../tools/pathSafety';
 
 const MINIMAL_PAYLOAD: UserQuestionPayload = {
   questions: [
@@ -245,5 +251,91 @@ describe('permissionBridge — resolveFilePermission pending guard (F1 regressio
     // Second resolve: nothing pending anymore — must not re-grant.
     resolveFilePermission(true, '/ws/double', ['write'], 'always');
     expect(usePermissionStore.getState().hasPermission('/ws/double', 'write')).toBe(false);
+  });
+
+  it('syncs an existing permission into the loopId-owned scope, not the first ambient loop context', async () => {
+    const path = '/Users/testuser/Projects/permission-bridge-owned/out.md';
+    const scopeA = createAuthorizationScope();
+    const scopeB = createAuthorizationScope();
+    setLoopContext('loop-a', {
+      loopId: 'loop-a',
+      conversationId: 'conv-a',
+      toolCallToStepId: new Map(),
+      authorizationScopeId: scopeA,
+    } as unknown as LoopContext);
+    setLoopContext('loop-b', {
+      loopId: 'loop-b',
+      conversationId: 'conv-b',
+      toolCallToStepId: new Map(),
+      authorizationScopeId: scopeB,
+    } as unknown as LoopContext);
+    usePermissionStore.getState().grantPermission(path, ['write'], 'session');
+
+    try {
+      await expect(requestFilePermission({ path, capability: 'write', toolName: 'write_file' }, 'loop-b')).resolves.toBe(true);
+
+      expect((await checkWritePath(path, scopeB)).allowed).toBe(true);
+      expect((await checkWritePath(path, scopeA)).allowed).toBe(false);
+    } finally {
+      clearLoopContext('loop-a');
+      clearLoopContext('loop-b');
+      disposeAuthorizationScope(scopeA);
+      disposeAuthorizationScope(scopeB);
+    }
+  });
+
+  it('syncs an existing read permission into the run scope without granting write', async () => {
+    const path = '/Users/testuser/Projects/permission-bridge-read/notes.md';
+    const scopeId = createAuthorizationScope();
+    setLoopContext('loop-read-only', {
+      loopId: 'loop-read-only',
+      conversationId: 'conv-read-only',
+      toolCallToStepId: new Map(),
+      authorizationScopeId: scopeId,
+    } as unknown as LoopContext);
+    usePermissionStore.getState().grantPermission(path, ['read'], 'session');
+
+    try {
+      await expect(requestFilePermission({ path, capability: 'read', toolName: 'read_file' }, 'loop-read-only')).resolves.toBe(true);
+
+      expect((await checkReadPath(path, scopeId)).allowed).toBe(true);
+      expect((await checkWritePath(path, scopeId)).allowed).toBe(false);
+    } finally {
+      clearLoopContext('loop-read-only');
+      disposeAuthorizationScope(scopeId);
+    }
+  });
+
+  it('treats an empty authorization scope as explicit and never syncs existing grants globally', async () => {
+    const path = '/Users/testuser/Projects/permission-bridge-empty/notes.md';
+    setLoopContext('loop-empty-scope', {
+      loopId: 'loop-empty-scope',
+      conversationId: 'conv-empty-scope',
+      toolCallToStepId: new Map(),
+      authorizationScopeId: '',
+    } as unknown as LoopContext);
+    usePermissionStore.setState({
+      sessionGrants: {
+        [path]: {
+          path,
+          grantedAt: 0,
+          expiresAt: null,
+          capabilities: ['read'],
+          duration: 'session',
+        },
+      },
+      persistedGrants: {},
+      pendingRequest: null,
+    });
+
+    try {
+      await expect(requestFilePermission({ path, capability: 'read', toolName: 'read_file' }, 'loop-empty-scope')).resolves.toBe(true);
+
+      expect((await checkReadPath(path, '')).allowed).toBe(false);
+      expect((await checkWritePath(path)).allowed).toBe(false);
+    } finally {
+      clearLoopContext('loop-empty-scope');
+      usePermissionStore.setState({ persistedGrants: {}, sessionGrants: {}, pendingRequest: null });
+    }
   });
 });

--- a/src/core/agent/permissionBridge.ts
+++ b/src/core/agent/permissionBridge.ts
@@ -16,7 +16,7 @@ import type { Message, UserQuestionPayload, UserQuestionResult } from '../../typ
 import { TOOL_NAMES } from '../tools/toolNames';
 import { usePermissionStore } from '../../stores/permissionStore';
 import type { PermissionDuration } from '../../stores/permissionStore';
-import { authorizeWorkspace } from '../tools/pathSafety';
+import { authorizeWorkspace, scopedAuthorizeWorkspace } from '../tools/pathSafety';
 import type { EventRouter } from './eventRouter';
 import type { SettingsReader } from './ports/settingsReader';
 import * as approvalBridge from './ports/approvalBridge';
@@ -47,6 +47,8 @@ export interface LoopContext {
   blockedTools?: string[];
   /** Execution whitelist inherited by tools that may create nested work. */
   allowedTools?: string[];
+  /** Run-local path authorization scope inherited by delegated work. */
+  authorizationScopeId?: string;
   /** Agent name for UI display (e.g. permission dialog badge) */
   agentName?: string;
 }
@@ -231,7 +233,12 @@ export async function requestFilePermission(request: {
   // Already has permission → auto-allow
   if (permStore.hasPermission(request.path, request.capability)) {
     // Also sync to pathSafety in case it wasn't already
-    authorizeWorkspace(request.path);
+    const ctx = loopId ? getLoopContext(loopId) : getCurrentLoopContext();
+    if (ctx?.authorizationScopeId !== undefined) {
+      scopedAuthorizeWorkspace(ctx.authorizationScopeId, request.path, [request.capability]);
+    } else {
+      authorizeWorkspace(request.path);
+    }
     return true;
   }
 

--- a/src/core/agent/ports/authorizedPathsReader.ts
+++ b/src/core/agent/ports/authorizedPathsReader.ts
@@ -19,7 +19,7 @@ import { createPortSlot } from './portSlot';
  */
 export interface AuthorizedPathsReader {
   /** Mirrors `pathSafety.ts`'s `getAuthorizedWritablePaths()`. */
-  getAuthorizedWritablePaths(): Promise<string[]>;
+  getAuthorizedWritablePaths(scopeId?: string): Promise<string[]>;
 }
 
 /** Default in-process implementation wrapping the real (synchronous)
@@ -28,7 +28,7 @@ export interface AuthorizedPathsReader {
  *  an IPC/RPC-backed implementation. */
 export function createInProcessAuthorizedPathsReader(): AuthorizedPathsReader {
   return {
-    getAuthorizedWritablePaths: async () => getAuthorizedWritablePaths(),
+    getAuthorizedWritablePaths: async (scopeId?: string) => getAuthorizedWritablePaths(scopeId),
   };
 }
 

--- a/src/core/agent/ports/chatDelta.test.ts
+++ b/src/core/agent/ports/chatDelta.test.ts
@@ -17,12 +17,10 @@ describe('createInProcessChatDelta', () => {
       conversations: {},
       conversationIndex: {},
       activeConversationId: null,
-      agentStatus: 'idle',
-      currentTool: null,
       currentUsage: null,
       pendingInput: null,
       pendingInputAppend: null,
-      thinkingStartTime: null,
+      agentStates: new Map(),
     });
   });
 
@@ -76,7 +74,7 @@ describe('createInProcessChatDelta', () => {
     });
     delta.finishStreaming(id, 'a1');
     expect(useChatStore.getState().conversations[id].messages[0].isStreaming).toBe(false);
-    expect(useChatStore.getState().agentStatus).toBe('idle');
+    expect(useChatStore.getState().agentStates.has(id)).toBe(false);
   });
 
   it('cancelStreaming() forwards and records the stop terminal without changing content', () => {
@@ -112,8 +110,8 @@ describe('createInProcessChatDelta', () => {
     });
     delta.setMessageStreamingFlag(id, 'a1', false);
     expect(useChatStore.getState().conversations[id].messages[0].isStreaming).toBe(false);
-    // no finishStreaming side effects — agentStatus untouched
-    expect(useChatStore.getState().agentStatus).toBe('idle');
+    // no finishStreaming side effects — agent state untouched
+    expect(useChatStore.getState().agentStates.has(id)).toBe(false);
   });
 
   it('reflects store updates on the next call (not cached at construction time)', () => {
@@ -220,8 +218,9 @@ describe('createInProcessChatDelta', () => {
 
     it('setAgentStatus() forwards to chatStore.setAgentStatus', () => {
       const delta = createInProcessChatDelta();
-      delta.setAgentStatus('thinking');
-      expect(useChatStore.getState().agentStatus).toBe('thinking');
+      const id = useChatStore.getState().createConversation();
+      delta.setAgentStatus(id, 'thinking');
+      expect(useChatStore.getState().agentStates.get(id)?.status).toBe('thinking');
     });
 
     it('setCurrentUsage() forwards to chatStore.setCurrentUsage', () => {
@@ -232,8 +231,9 @@ describe('createInProcessChatDelta', () => {
 
     it('setRetryInfo() forwards to chatStore.setRetryInfo', () => {
       const delta = createInProcessChatDelta();
-      delta.setRetryInfo({ attempt: 1, maxAttempts: 3, delayMs: 1000 });
-      expect(useChatStore.getState().retryInfo).toEqual({ attempt: 1, maxAttempts: 3, delayMs: 1000 });
+      const id = useChatStore.getState().createConversation();
+      delta.setRetryInfo(id, { attempt: 1, maxAttempts: 3, delayMs: 1000 });
+      expect(useChatStore.getState().agentStates.get(id)?.retryInfo).toEqual({ attempt: 1, maxAttempts: 3, delayMs: 1000 });
     });
 
     it('setContextUsage() forwards to chatStore.setContextUsage', () => {
@@ -284,9 +284,11 @@ describe('createInProcessChatDelta', () => {
 
     it('removeActiveAgent() forwards to chatStore.removeActiveAgent', () => {
       const delta = createInProcessChatDelta();
-      useChatStore.setState({ activeAgentNames: ['agentA', 'agentB'] });
-      delta.removeActiveAgent('agentA');
-      expect(useChatStore.getState().activeAgentNames).toEqual(['agentB']);
+      const id = useChatStore.getState().createConversation();
+      useChatStore.getState().setAgentStatus(id, 'tool-calling', 'read_file', 'agentA');
+      useChatStore.getState().setAgentStatus(id, 'tool-calling', 'read_file', 'agentB');
+      delta.removeActiveAgent(id, 'agentA');
+      expect(useChatStore.getState().agentStates.get(id)?.activeAgentNames).toEqual(['agentB']);
     });
   });
 });

--- a/src/core/agent/ports/chatDelta.ts
+++ b/src/core/agent/ports/chatDelta.ts
@@ -109,11 +109,11 @@ export interface ChatDelta {
   /** Mirrors chatStore's `setConversationStatus`. */
   setConversationStatus(convId: string, status: ConversationStatus): void;
   /** Mirrors chatStore's `setAgentStatus`. */
-  setAgentStatus(status: AgentStatus, tool?: string, agentName?: string): void;
+  setAgentStatus(convId: string, status: AgentStatus, tool?: string, agentName?: string): void;
   /** Mirrors chatStore's `setCurrentUsage`. */
   setCurrentUsage(usage: TokenUsage | null): void;
   /** Mirrors chatStore's `setRetryInfo`. */
-  setRetryInfo(info: RetryInfo | null): void;
+  setRetryInfo(convId: string, info: RetryInfo | null): void;
   /** Mirrors chatStore's `setContextUsage`. */
   setContextUsage(convId: string, usage: NonNullable<Conversation['contextUsage']> | undefined): void;
   /** Mirrors chatStore's `setContextCache`. */
@@ -127,7 +127,7 @@ export interface ChatDelta {
   /** Mirrors chatStore's `setPendingProposalSignal`. */
   setPendingProposalSignal(convId: string, signal: ProposalSignal | undefined): void;
   /** Mirrors chatStore's `removeActiveAgent`. */
-  removeActiveAgent(agentName: string): void;
+  removeActiveAgent(convId: string, agentName: string): void;
 }
 
 /** Default in-process implementation over the Zustand store. This is the
@@ -183,9 +183,9 @@ export function createInProcessChatDelta(): ChatDelta {
     setPlannedStepsSnapshot: (convId, loopId, steps) =>
       useChatStore.getState().setPlannedStepsSnapshot(convId, loopId, steps),
     setConversationStatus: (convId, status) => useChatStore.getState().setConversationStatus(convId, status),
-    setAgentStatus: (status, tool, agentName) => useChatStore.getState().setAgentStatus(status, tool, agentName),
+    setAgentStatus: (convId, status, tool, agentName) => useChatStore.getState().setAgentStatus(convId, status, tool, agentName),
     setCurrentUsage: (usage) => useChatStore.getState().setCurrentUsage(usage),
-    setRetryInfo: (info) => useChatStore.getState().setRetryInfo(info),
+    setRetryInfo: (convId, info) => useChatStore.getState().setRetryInfo(convId, info),
     setContextUsage: (convId, usage) => useChatStore.getState().setContextUsage(convId, usage),
     setContextCache: (convId, cache) => useChatStore.getState().setContextCache(convId, cache),
     clearContextCache: (convId) => useChatStore.getState().clearContextCache(convId),
@@ -193,7 +193,7 @@ export function createInProcessChatDelta(): ChatDelta {
     setConversationModel: (convId, model) => useChatStore.getState().setConversationModel(convId, model),
     setPendingProposalSignal: (convId, signal) =>
       useChatStore.getState().setPendingProposalSignal(convId, signal),
-    removeActiveAgent: (agentName) => useChatStore.getState().removeActiveAgent(agentName),
+    removeActiveAgent: (convId, agentName) => useChatStore.getState().removeActiveAgent(convId, agentName),
   };
 }
 

--- a/src/core/agent/ports/conversationReader.test.ts
+++ b/src/core/agent/ports/conversationReader.test.ts
@@ -14,7 +14,7 @@ describe('createInProcessConversationReader', () => {
     useChatStore.setState({
       conversations: {},
       conversationIndex: {},
-      thinkingStartTime: null,
+      agentStates: new Map(),
     });
   });
 
@@ -55,10 +55,14 @@ describe('createInProcessConversationReader', () => {
     expect(reader.getIndexEntry('does-not-exist')).toBeUndefined();
   });
 
-  it('getThinkingStartTime() mirrors the global chatStore scalar', () => {
-    useChatStore.setState({ thinkingStartTime: 12345 });
+  it('getThinkingStartTime() returns the addressed conversation thinking timestamp', () => {
+    const c1 = useChatStore.getState().createConversation();
+    const c2 = useChatStore.getState().createConversation();
+    useChatStore.getState().setAgentStatus(c1, 'thinking');
+    useChatStore.getState().setAgentStatus(c2, 'idle');
     const reader = createInProcessConversationReader();
-    expect(reader.getThinkingStartTime()).toBe(12345);
+    expect(reader.getThinkingStartTime(c1)).not.toBeNull();
+    expect(reader.getThinkingStartTime(c2)).toBeNull();
   });
 
   it('reflects store updates on the next call (not cached at construction time)', () => {
@@ -100,6 +104,6 @@ describe('getConversationReader / setConversationReader', () => {
     };
     setConversationReader(stub);
     expect(getConversationReader()).toBe(stub);
-    expect(getConversationReader().getThinkingStartTime()).toBe(999);
+    expect(getConversationReader().getThinkingStartTime('c1')).toBe(999);
   });
 });

--- a/src/core/agent/ports/conversationReader.ts
+++ b/src/core/agent/ports/conversationReader.ts
@@ -1,4 +1,4 @@
-import { useChatStore } from '@/stores/chatStore';
+import { getConversationAgentState, useChatStore } from '@/stores/chatStore';
 import type { Conversation } from '@/types';
 import type { ConversationMeta } from '../../session/conversationStorage';
 import { createPortSlot } from './portSlot';
@@ -6,8 +6,8 @@ import { createPortSlot } from './portSlot';
 /**
  * Port abstracting agentLoop's (and toolExecutor's) READS of chatStore's
  * conversation data: the full per-conversation record, the lighter index/
- * catalog metadata, and the one global (non-per-conversation) scalar these
- * callers consult mid-loop.
+ * catalog metadata, and per-conversation live agent timing these callers
+ * consult mid-loop.
  *
  * This is the read-side counterpart to `ChatDelta` (see `chatDelta.ts`) for
  * conversation data, following the same call-time-not-cached discipline as
@@ -64,9 +64,8 @@ export interface ConversationReader {
    *  metadata (title, workspacePath, model, etc.), used e.g. for
    *  notification text where the full conversation record isn't needed. */
   getIndexEntry(convId: string): Readonly<ConversationMeta> | undefined;
-  /** Mirrors chatStore's `thinkingStartTime` — a global scalar (not keyed
-   *  by conversation), unlike the other two accessors. */
-  getThinkingStartTime(): number | null;
+  /** Mirrors the addressed conversation's agent-state thinking timer. */
+  getThinkingStartTime(convId: string): number | null;
 }
 
 /** Default in-process implementation over the Zustand store's synchronous
@@ -79,7 +78,10 @@ export function createInProcessConversationReader(): ConversationReader {
   return {
     getConversation: (convId) => useChatStore.getState().conversations[convId],
     getIndexEntry: (convId) => useChatStore.getState().conversationIndex[convId],
-    getThinkingStartTime: () => useChatStore.getState().thinkingStartTime,
+    getThinkingStartTime: (convId) => {
+      const state = useChatStore.getState();
+      return getConversationAgentState(state.agentStates, convId).thinkingStartTime;
+    },
   };
 }
 

--- a/src/core/agent/ports/toolInvoker.ts
+++ b/src/core/agent/ports/toolInvoker.ts
@@ -18,7 +18,7 @@ export type FilePermissionCallback = (request: {
   path: string;
   capability: 'read' | 'write';
   toolName: string;
-}) => Promise<boolean>;
+}, loopId?: string) => Promise<boolean>;
 
 /**
  * Port #7 — abstracts subagentLoop's tool execution surface (currently a

--- a/src/core/agent/subagentLoop.ts
+++ b/src/core/agent/subagentLoop.ts
@@ -204,6 +204,8 @@ export interface SubagentLoopOptions {
   filePermissionCallback?: FilePermissionCallback;
   /** Parent-run tool whitelist inherited by delegated work. */
   allowedTools?: string[];
+  /** Parent-run path authorization scope inherited by delegated work. */
+  authorizationScopeId?: string;
   /**
    * Parent-run tool denylist inherited by delegated work — the twin of
    * `allowedTools`, and inherited for the same reason: a run-scoped
@@ -266,7 +268,8 @@ export async function runSubagentLoop(options: SubagentLoopOptions): Promise<Sub
     const settings = settingsReader.getSnapshot();
 
     // 1. Build system prompt
-    const workspacePath = options.imContext?.workspacePath ?? workspaceReaderInst.getCurrentPath();
+    const workspacePath = options.imContext?.workspacePath
+      ?? (options.workspaceReader ? workspaceReaderInst.getCurrentPath() : (options.authorizationScopeId !== undefined ? null : workspaceReaderInst.getCurrentPath()));
     const now = new Date();
     const dateStr = now.toLocaleDateString('zh-CN', {
       year: 'numeric', month: 'long', day: 'numeric', weekday: 'long',
@@ -720,6 +723,7 @@ export async function runSubagentLoop(options: SubagentLoopOptions): Promise<Sub
           try {
             const subagentToolContext: ToolExecutionContext = {
               workspacePath,
+              authorizationScopeId: options.authorizationScopeId,
               abortSignal: signal,
               // Forward the IM reply target so send_file works from a subagent
               // delegated inside an IM run (without it the tool would falsely

--- a/src/core/agent/subagentRunner.test.ts
+++ b/src/core/agent/subagentRunner.test.ts
@@ -200,6 +200,28 @@ describe('subagentRunner', () => {
       expect(result.tokenUsage).toEqual({ input: 10, output: 20 });
     });
 
+    it('treats an empty authorization scope as explicit and snapshots no global workspace for sidecar subagents', async () => {
+      getSidecarStatus.mockReturnValue('running');
+      sidecarRequestMock.mockResolvedValue({
+        text: 'sidecar result',
+        toolCallCount: 0,
+        turnCount: 1,
+        tokenUsage: { input: 1, output: 1 },
+        duration: 1,
+      });
+      getCurrentPathMock.mockReturnValue('/tmp/global-workspace');
+      const { runSubagent } = await importFresh();
+
+      await runSubagent({ agent, task: 'do the thing', authorizationScopeId: '' });
+
+      const params = sidecarRequestMock.mock.calls[0][1] as {
+        authorizationScopeId?: string;
+        workspacePathSnapshot?: string | null;
+      };
+      expect(params.authorizationScopeId).toBe('');
+      expect(params.workspacePathSnapshot).toBeNull();
+    });
+
     it('uses the parent run settings snapshot for both subagent credentials and sidecar model selection', async () => {
       getSidecarStatus.mockReturnValue('running');
       sidecarRequestMock.mockResolvedValue({
@@ -232,10 +254,15 @@ describe('subagentRunner', () => {
       expect(getSubagentRunInheritance({
         conversationId: 'conv-parent',
         settingsReader: parentReader as never,
-      })).toEqual({
+      }, 'scope-parent', null)).toEqual(expect.objectContaining({
         parentConversationId: 'conv-parent',
         settingsReader: parentReader,
-      });
+        authorizationScopeId: 'scope-parent',
+      }));
+      expect(getSubagentRunInheritance({
+        conversationId: 'conv-parent',
+        settingsReader: parentReader as never,
+      }, 'scope-parent', null).workspaceReader?.getCurrentPath()).toBeNull();
 
       await runSubagent({ agent, task: 'do the thing', settingsReader: parentReader as never });
 
@@ -289,7 +316,7 @@ describe('subagentRunner', () => {
       const toolInvokeHandler = onSidecarRequest.mock.calls.find((c) => c[0] === 'tool.invoke')![1] as (p: unknown) => Promise<unknown>;
 
       const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
-      const toolResult = await toolInvokeHandler({ runId, toolName: 'read_file', input: { path: 'x.txt' }, context: { workspacePath: '/tmp' } });
+      const toolResult = await toolInvokeHandler({ runId, toolName: 'read_file', input: { path: 'x.txt' }, context: { workspacePath: '/forged' } });
 
       expect(toolResult).toBe('tool result');
       expect(executeAnyToolMock).toHaveBeenCalledWith(
@@ -297,7 +324,36 @@ describe('subagentRunner', () => {
         { path: 'x.txt' },
         confirmCb,
         filePermCb,
-        expect.objectContaining({ workspacePath: '/tmp', abortSignal: controller.signal }),
+        expect.objectContaining({ workspacePath: '/tmp/workspace', abortSignal: controller.signal }),
+      );
+
+      d.resolve({ text: 'done', toolCallCount: 1, turnCount: 1, tokenUsage: { input: 0, output: 0 }, duration: 1 });
+      await runPromise;
+    });
+
+    it('overwrites a forged sidecar workspace with null when the subagent session has no trusted workspace', async () => {
+      getSidecarStatus.mockReturnValue('running');
+      const d = deferred<unknown>();
+      sidecarRequestMock.mockReturnValue(d.promise);
+      const { runSubagent } = await importFresh();
+
+      const runPromise = runSubagent({
+        agent,
+        task: 'do the thing',
+        workspaceReader: { getCurrentPath: () => null },
+      });
+
+      expect(onSidecarRequest).toHaveBeenCalledWith('tool.invoke', expect.any(Function));
+      const toolInvokeHandler = onSidecarRequest.mock.calls.find((c) => c[0] === 'tool.invoke')![1] as (p: unknown) => Promise<unknown>;
+      const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
+      await toolInvokeHandler({ runId, toolName: 'run_command', input: { command: 'touch ok' }, context: { workspacePath: '/forged' } });
+
+      expect(executeAnyToolMock).toHaveBeenCalledWith(
+        'run_command',
+        { command: 'touch ok' },
+        undefined,
+        undefined,
+        expect.objectContaining({ workspacePath: null }),
       );
 
       d.resolve({ text: 'done', toolCallCount: 1, turnCount: 1, tokenUsage: { input: 0, output: 0 }, duration: 1 });

--- a/src/core/agent/subagentRunner.test.ts
+++ b/src/core/agent/subagentRunner.test.ts
@@ -169,6 +169,30 @@ describe('subagentRunner', () => {
       expect(result.text).toBe('in-process result');
     });
 
+    it('aborts a scoped in-process subagent signal when the subagent run settles', async () => {
+      getSidecarStatus.mockReturnValue('stopped');
+      let runSignal: AbortSignal | undefined;
+      runSubagentLoopMock.mockImplementationOnce(async (options: { signal?: AbortSignal }) => {
+        runSignal = options.signal;
+        expect(runSignal?.aborted).toBe(false);
+        return { text: 'done', toolCallCount: 1, turnCount: 1, tokenUsage: { input: 0, output: 0 }, duration: 1 };
+      });
+      const { runSubagent } = await importFresh();
+      const parentController = new AbortController();
+
+      await runSubagent({
+        agent,
+        task: 'start a background command',
+        signal: parentController.signal,
+        authorizationScopeId: 'scope-subagent',
+      });
+
+      expect(runSignal).toBeDefined();
+      expect(runSignal).not.toBe(parentController.signal);
+      expect(runSignal?.aborted).toBe(true);
+      expect(parentController.signal.aborted).toBe(false);
+    });
+
     it('routes through the sidecar when running — dispatches subagent.run and reconstructs the SubagentResult', async () => {
       getSidecarStatus.mockReturnValue('running');
       sidecarRequestMock.mockResolvedValue({
@@ -198,6 +222,32 @@ describe('subagentRunner', () => {
       expect(result.toolCallCount).toBe(2);
       expect(result.turnCount).toBe(3);
       expect(result.tokenUsage).toEqual({ input: 10, output: 20 });
+    });
+
+    it('serializes blockedTools into subagent.run params alongside allowedTools', async () => {
+      getSidecarStatus.mockReturnValue('running');
+      sidecarRequestMock.mockResolvedValue({
+        text: 'sidecar result',
+        toolCallCount: 0,
+        turnCount: 1,
+        tokenUsage: { input: 1, output: 1 },
+        duration: 1,
+      });
+      const { runSubagent } = await importFresh();
+
+      await runSubagent({
+        agent,
+        task: 'read only',
+        allowedTools: ['read_*'],
+        blockedTools: ['run_command', 'abu-browser__*'],
+      });
+
+      const params = sidecarRequestMock.mock.calls[0][1] as {
+        allowedTools?: string[];
+        blockedTools?: string[];
+      };
+      expect(params.allowedTools).toEqual(['read_*']);
+      expect(params.blockedTools).toEqual(['run_command', 'abu-browser__*']);
     });
 
     it('treats an empty authorization scope as explicit and snapshots no global workspace for sidecar subagents', async () => {
@@ -331,6 +381,38 @@ describe('subagentRunner', () => {
       await runPromise;
     });
 
+    it('aborts the shell-side tool signal after a scoped sidecar subagent settles without sending a late subagent.abort', async () => {
+      getSidecarStatus.mockReturnValue('running');
+      const d = deferred<unknown>();
+      sidecarRequestMock.mockReturnValue(d.promise);
+      const { runSubagent } = await importFresh();
+      const parentController = new AbortController();
+
+      const runPromise = runSubagent({
+        agent,
+        task: 'start a background command',
+        signal: parentController.signal,
+        authorizationScopeId: 'scope-subagent',
+      });
+      const toolInvokeHandler = onSidecarRequest.mock.calls.find((c) => c[0] === 'tool.invoke')![1] as (p: unknown) => Promise<unknown>;
+      const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
+      await toolInvokeHandler({
+        runId,
+        toolName: 'run_command',
+        input: { command: 'start-background-worker', background: true, cwd: '/tmp' },
+      });
+      const toolContext = executeAnyToolMock.mock.calls[0][4] as { abortSignal?: AbortSignal };
+
+      expect(toolContext.abortSignal?.aborted).toBe(false);
+      expect(toolContext.abortSignal).not.toBe(parentController.signal);
+      d.resolve({ text: 'done', toolCallCount: 1, turnCount: 1, tokenUsage: { input: 0, output: 0 }, duration: 1 });
+      await runPromise;
+
+      expect(toolContext.abortSignal?.aborted).toBe(true);
+      expect(parentController.signal.aborted).toBe(false);
+      expect(notifySidecar).not.toHaveBeenCalledWith('subagent.abort', expect.objectContaining({ runId }));
+    });
+
     it('overwrites a forged sidecar workspace with null when the subagent session has no trusted workspace', async () => {
       getSidecarStatus.mockReturnValue('running');
       const d = deferred<unknown>();
@@ -384,6 +466,24 @@ describe('subagentRunner', () => {
       await expect(
         toolInvokeHandler({ runId, toolName: 'write_file', input: { path: 'x' } }),
       ).rejects.toThrow(/not allowed/);
+      expect(executeAnyToolMock).not.toHaveBeenCalled();
+
+      d.resolve({ text: 'done', toolCallCount: 0, turnCount: 1, tokenUsage: { input: 0, output: 0 }, duration: 1 });
+      await runPromise;
+    });
+
+    it('refuses a delegated tool call matching inherited blockedTools even if the sidecar explicitly asks for it', async () => {
+      getSidecarStatus.mockReturnValue('running');
+      const d = deferred<unknown>();
+      sidecarRequestMock.mockReturnValue(d.promise);
+      const { runSubagent } = await importFresh();
+      const runPromise = runSubagent({ agent, task: 'read only', blockedTools: ['run_command', 'abu-browser__*'] });
+      const toolInvokeHandler = onSidecarRequest.mock.calls.find((c) => c[0] === 'tool.invoke')![1] as (p: unknown) => Promise<unknown>;
+      const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
+
+      await expect(
+        toolInvokeHandler({ runId, toolName: 'abu-browser__screenshot', input: {} }),
+      ).rejects.toThrow(/blocked/);
       expect(executeAnyToolMock).not.toHaveBeenCalled();
 
       d.resolve({ text: 'done', toolCallCount: 0, turnCount: 1, tokenUsage: { input: 0, output: 0 }, duration: 1 });

--- a/src/core/agent/subagentRunner.ts
+++ b/src/core/agent/subagentRunner.ts
@@ -83,11 +83,17 @@ const logger = createLogger('subagent-transport');
 /** Security boundary for tool-triggered nesting: inherit the parent run's
  * frozen provider/model snapshot and conversation identity as one unit. */
 export function getSubagentRunInheritance(
-  loopContext: Pick<LoopContext, 'conversationId' | 'settingsReader'> | null | undefined,
-): Pick<SubagentLoopOptions, 'parentConversationId' | 'settingsReader'> {
+  loopContext: Pick<LoopContext, 'conversationId' | 'settingsReader' | 'authorizationScopeId'> | null | undefined,
+  authorizationScopeId?: string,
+  workspacePath?: string | null,
+): Pick<SubagentLoopOptions, 'parentConversationId' | 'settingsReader' | 'authorizationScopeId' | 'workspaceReader'> {
   return {
     parentConversationId: loopContext?.conversationId,
     settingsReader: loopContext?.settingsReader,
+    authorizationScopeId: authorizationScopeId ?? loopContext?.authorizationScopeId,
+    ...(workspacePath !== undefined
+      ? { workspaceReader: { getCurrentPath: () => workspacePath } }
+      : {}),
   };
 }
 import { getToolInvoker } from './ports/toolInvoker';
@@ -124,6 +130,7 @@ export interface SubagentRunParams {
   parentConversationId?: string;
   imContext?: SubagentLoopOptions['imContext'];
   allowedTools?: string[];
+  authorizationScopeId?: string;
   locale: string;
   uiStrings: ReturnType<typeof buildSubagentUiStrings>;
   settingsSnapshot: ReturnType<ReturnType<typeof getSettingsReader>['getSnapshot']>;
@@ -227,6 +234,9 @@ async function handleToolInvoke(rawParams: unknown): Promise<unknown> {
     session.options.filePermissionCallback,
     {
       ...((params.context as ToolExecutionContext | undefined) ?? {}),
+      workspacePath: session.options.workspaceReader?.getCurrentPath() ?? null,
+      authorizationScopeId: session.options.authorizationScopeId,
+      conversationId: session.options.parentConversationId,
       abortSignal: session.options.signal,
     },
   );
@@ -305,7 +315,10 @@ function buildSubagentRunParams(runId: string, options: SubagentLoopOptions): Su
     getActiveProvider(settingsSnapshot)?.baseUrl || undefined,
   );
 
-  const workspaceReader = options.workspaceReader ?? getWorkspaceReader();
+  const workspacePathSnapshot = options.imContext?.workspacePath
+    ?? (options.workspaceReader
+      ? options.workspaceReader.getCurrentPath()
+      : (options.authorizationScopeId !== undefined ? null : getWorkspaceReader().getCurrentPath()));
 
   return {
     runId,
@@ -316,12 +329,13 @@ function buildSubagentRunParams(runId: string, options: SubagentLoopOptions): Su
     parentConversationId: options.parentConversationId,
     imContext: options.imContext,
     allowedTools: options.allowedTools,
+    authorizationScopeId: options.authorizationScopeId,
     locale: getLocale(),
     uiStrings: buildSubagentUiStrings(getI18n()),
     settingsSnapshot,
     resolvedCreds,
     tools,
-    workspacePathSnapshot: workspaceReader.getCurrentPath(),
+    workspacePathSnapshot,
   };
 }
 
@@ -378,7 +392,11 @@ export async function runSubagent(options: SubagentLoopOptions): Promise<Subagen
     return runSubagentLoop(options);
   }
 
-  const session: RunSession = { options, firstToolInvokeArrived: false };
+  const sessionOptions: SubagentLoopOptions = {
+    ...options,
+    workspaceReader: { getCurrentPath: () => params.workspacePathSnapshot },
+  };
+  const session: RunSession = { options: sessionOptions, firstToolInvokeArrived: false };
   sessions.set(runId, session);
 
   const signal = options.signal;

--- a/src/core/agent/subagentRunner.ts
+++ b/src/core/agent/subagentRunner.ts
@@ -103,7 +103,7 @@ import { getActiveApiKey, getActiveProvider } from '../../utils/settingsSelector
 import { resolveEffectiveLlmCreds } from '../enterprise/llm-resolver';
 import { getI18n, getLocale } from '../../i18n';
 import { buildSubagentUiStrings } from './subagentUiStrings';
-import { matchesToolPattern } from '../skill/toolFilter';
+import { matchesToolName, matchesToolPattern } from '../skill/toolFilter';
 
 /** Same defensive ceiling as SidecarLLMAdapter.chat() — see that file's module doc for the rationale (a wedged sidecar event loop must not hang the caller forever after we've asked it to abort). */
 const ABORT_GRACE_MS = 5_000;
@@ -130,6 +130,7 @@ export interface SubagentRunParams {
   parentConversationId?: string;
   imContext?: SubagentLoopOptions['imContext'];
   allowedTools?: string[];
+  blockedTools?: string[];
   authorizationScopeId?: string;
   locale: string;
   uiStrings: ReturnType<typeof buildSubagentUiStrings>;
@@ -212,6 +213,10 @@ async function handleToolInvoke(rawParams: unknown): Promise<unknown> {
     throw new SidecarRequestError(-32000, `Unknown subagent runId: ${params.runId}`);
   }
   session.firstToolInvokeArrived = true;
+
+  if (session.options.blockedTools?.some((pattern) => matchesToolName(params.toolName as string, pattern))) {
+    throw new SidecarRequestError(-32602, `Tool is blocked for this subagent run: ${params.toolName}`);
+  }
 
   if (
     session.options.allowedTools?.length &&
@@ -329,6 +334,7 @@ function buildSubagentRunParams(runId: string, options: SubagentLoopOptions): Su
     parentConversationId: options.parentConversationId,
     imContext: options.imContext,
     allowedTools: options.allowedTools,
+    blockedTools: options.blockedTools,
     authorizationScopeId: options.authorizationScopeId,
     locale: getLocale(),
     uiStrings: buildSubagentUiStrings(getI18n()),
@@ -364,6 +370,34 @@ function cancelledSubagentResult(): SubagentResult {
  * protocol and fallback discipline.
  */
 export async function runSubagent(options: SubagentLoopOptions): Promise<SubagentResult> {
+  if (options.authorizationScopeId === undefined) {
+    return runSubagentForSignal(options);
+  }
+
+  // A successful background run_command deliberately keeps its abort listener
+  // after the tool call resolves. Give every scoped subagent its own run-owned
+  // signal and abort it after every terminal path, so a direct/nested subagent
+  // cannot leave a process alive after the unattended authorization scope ends.
+  const scopedController = new AbortController();
+  const parentSignal = options.signal;
+  const abortFromParent = () => scopedController.abort(parentSignal?.reason);
+  if (parentSignal?.aborted) {
+    abortFromParent();
+  } else {
+    parentSignal?.addEventListener('abort', abortFromParent, { once: true });
+  }
+
+  try {
+    return await runSubagentForSignal({ ...options, signal: scopedController.signal });
+  } finally {
+    parentSignal?.removeEventListener('abort', abortFromParent);
+    if (!scopedController.signal.aborted) {
+      scopedController.abort(new Error('Scoped subagent run finished'));
+    }
+  }
+}
+
+async function runSubagentForSignal(options: SubagentLoopOptions): Promise<SubagentResult> {
   if (options.signal?.aborted) {
     return cancelledSubagentResult();
   }

--- a/src/core/agent/toolExecutor.ts
+++ b/src/core/agent/toolExecutor.ts
@@ -170,6 +170,7 @@ export async function executeToolBatch(params: ToolBatchParams): Promise<ToolBat
     toolCallToStepId,
     blockedTools: params.blockedTools,
     allowedTools: params.allowedTools,
+    authorizationScopeId: params.toolContext.authorizationScopeId,
   });
 
   let completedCount = 0;

--- a/src/core/agent/toolExecutor.ts
+++ b/src/core/agent/toolExecutor.ts
@@ -156,7 +156,7 @@ export async function executeToolBatch(params: ToolBatchParams): Promise<ToolBat
   chatDelta.setMessageToolCalls(conversationId, assistantMsgId, collectedToolCalls);
 
   // Execute tools in parallel using Promise.allSettled
-  chatDelta.setAgentStatus('tool-calling', `${collectedToolCalls.length} tools`);
+  chatDelta.setAgentStatus(conversationId, 'tool-calling', `${collectedToolCalls.length} tools`);
 
   // Expose loop context for delegate_to_agent tool (per-loop, supports concurrent agents)
   setLoopContext(loopId, {
@@ -291,7 +291,7 @@ export async function executeToolBatch(params: ToolBatchParams): Promise<ToolBat
       const durationMs = Date.now() - startTime;
       completedCount++;
       if (totalCount > 1) {
-        chatDelta.setAgentStatus('tool-calling', `${completedCount}/${totalCount}: ${tc.name}`);
+        chatDelta.setAgentStatus(conversationId, 'tool-calling', `${completedCount}/${totalCount}: ${tc.name}`);
       }
       // Extract string for display/hooks; keep rich content for LLM
       const resultStr = toolInvoker.toolResultToString(rawResult);
@@ -329,7 +329,7 @@ export async function executeToolBatch(params: ToolBatchParams): Promise<ToolBat
       const durationMs = Date.now() - startTime;
       completedCount++;
       if (totalCount > 1) {
-        chatDelta.setAgentStatus('tool-calling', `${completedCount}/${totalCount}: ${tc.name}`);
+        chatDelta.setAgentStatus(conversationId, 'tool-calling', `${completedCount}/${totalCount}: ${tc.name}`);
       }
       const errorMsg = err instanceof Error ? err.message : String(err);
       // Emit postToolCall hook for errors too

--- a/src/core/permissions/commandBoundary.test.ts
+++ b/src/core/permissions/commandBoundary.test.ts
@@ -78,6 +78,17 @@ describe('commandBoundary', () => {
         disposeAuthorizationScope(scopeId);
       }
     });
+
+    it('scoped write detection does not treat read-only scope directories as writable', () => {
+      const scopeId = createAuthorizationScope();
+      scopedAuthorizeWorkspace(scopeId, WS, ['read']);
+
+      try {
+        expect(analyzeCommandBoundary('echo hi > out.txt', WS, HOME, scopeId)).toBe('outside');
+      } finally {
+        disposeAuthorizationScope(scopeId);
+      }
+    });
   });
 
   describe('unknown (conservative — no extra prompt)', () => {

--- a/src/core/permissions/commandBoundary.test.ts
+++ b/src/core/permissions/commandBoundary.test.ts
@@ -1,13 +1,29 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { analyzeCommandBoundary } from './commandBoundary';
-import { authorizeWorkspace, revokeWorkspace } from '../tools/pathSafety';
+import { allWorkingDirectories } from './workingDirs';
+import { useWorkspaceStore } from '../../stores/workspaceStore';
+import {
+  authorizeWorkspace,
+  createAuthorizationScope,
+  disposeAuthorizationScope,
+  revokeWorkspace,
+  scopedAuthorizeWorkspace,
+} from '../tools/pathSafety';
 
 const WS = '/Users/test/project';
 const HOME = '/Users/test';
+const GLOBAL_EXTRA = '/Users/test/global-extra';
+const SCOPED_WS = '/Users/test/scoped-project';
 
 describe('commandBoundary', () => {
-  beforeEach(() => authorizeWorkspace(WS));
-  afterEach(() => revokeWorkspace(WS));
+  beforeEach(() => {
+    authorizeWorkspace(WS);
+    useWorkspaceStore.setState({ currentPath: null });
+  });
+  afterEach(() => {
+    revokeWorkspace(WS);
+    useWorkspaceStore.setState({ currentPath: null });
+  });
 
   describe('inside the working set', () => {
     it('relative redirect resolves inside cwd', () => {
@@ -33,6 +49,34 @@ describe('commandBoundary', () => {
     });
     it('tee to an absolute system path', () => {
       expect(analyzeCommandBoundary('tee /etc/evil.conf', WS, HOME)).toBe('outside');
+    });
+
+    it('scoped runs do not treat globally authorized extra directories as inside', () => {
+      const scopeId = createAuthorizationScope();
+      authorizeWorkspace(GLOBAL_EXTRA, ['read', 'write']);
+      scopedAuthorizeWorkspace(scopeId, WS, ['read', 'write']);
+
+      try {
+        expect(analyzeCommandBoundary(`echo data > ${GLOBAL_EXTRA}/out.txt`, WS, HOME, scopeId)).toBe('outside');
+        expect(analyzeCommandBoundary(`echo data > ${GLOBAL_EXTRA}/out.txt`, WS, HOME)).toBe('inside');
+      } finally {
+        disposeAuthorizationScope(scopeId);
+        revokeWorkspace(GLOBAL_EXTRA);
+      }
+    });
+
+    it('scoped runs do not inherit the ambient workspace store currentPath', () => {
+      const scopeId = createAuthorizationScope();
+      useWorkspaceStore.setState({ currentPath: WS });
+      scopedAuthorizeWorkspace(scopeId, SCOPED_WS, ['read', 'write']);
+
+      try {
+        expect(allWorkingDirectories(scopeId)).not.toContain(WS);
+        expect(analyzeCommandBoundary('echo hi > out.txt', WS, HOME, scopeId)).toBe('outside');
+        expect(analyzeCommandBoundary('echo hi > out.txt', WS, HOME)).toBe('inside');
+      } finally {
+        disposeAuthorizationScope(scopeId);
+      }
     });
   });
 

--- a/src/core/permissions/commandBoundary.ts
+++ b/src/core/permissions/commandBoundary.ts
@@ -9,7 +9,7 @@
  * commands is the OS sandbox, not this parser.
  */
 
-import { allWorkingDirectories, isInsideWorkingDirs } from './workingDirs';
+import { allWorkingDirectories, commandWritableDirectories, isInsideWorkingDirs } from './workingDirs';
 import type { AuthorizationScopeId } from '../tools/pathSafety';
 
 export type CmdBoundary = 'inside' | 'outside' | 'unknown';
@@ -31,9 +31,10 @@ function resolvePath(raw: string, cwd: string | undefined, home: string): string
   let p = unquote(raw.trim());
   if (!p) return null;
 
+  const isWindowsAbsolute = /^[A-Za-z]:[\\/]/.test(p);
   if (p === '~' || p.startsWith('~/')) {
     p = home + p.slice(1);
-  } else if (p.startsWith('/')) {
+  } else if (p.startsWith('/') || isWindowsAbsolute) {
     // absolute — keep
   } else {
     // relative — needs cwd to resolve
@@ -48,6 +49,9 @@ function resolvePath(raw: string, cwd: string | undefined, home: string): string
   for (const seg of parts) {
     if (seg === '..') out.pop();
     else if (seg !== '.' && seg !== '') out.push(seg);
+  }
+  if (out[0] && /^[A-Za-z]:$/.test(out[0])) {
+    return out.join('/');
   }
   return '/' + out.join('/');
 }
@@ -103,7 +107,9 @@ export function analyzeCommandBoundary(
   const targets = extractWriteTargets(command);
   if (targets.length === 0) return 'unknown';
 
-  const dirs = allWorkingDirectories(scopeId);
+  const dirs = scopeId === undefined
+    ? allWorkingDirectories()
+    : commandWritableDirectories(scopeId);
   let sawInside = false;
   for (const raw of targets) {
     const abs = resolvePath(raw, cwd, home);

--- a/src/core/permissions/commandBoundary.ts
+++ b/src/core/permissions/commandBoundary.ts
@@ -10,6 +10,7 @@
  */
 
 import { allWorkingDirectories, isInsideWorkingDirs } from './workingDirs';
+import type { AuthorizationScopeId } from '../tools/pathSafety';
 
 export type CmdBoundary = 'inside' | 'outside' | 'unknown';
 
@@ -93,11 +94,16 @@ function extractWriteTargets(command: string): string[] {
  * Decide whether a command writes outside the working directories.
  * Conservative: returns 'unknown' unless write targets are confidently resolved.
  */
-export function analyzeCommandBoundary(command: string, cwd: string | undefined, home: string): CmdBoundary {
+export function analyzeCommandBoundary(
+  command: string,
+  cwd: string | undefined,
+  home: string,
+  scopeId?: AuthorizationScopeId,
+): CmdBoundary {
   const targets = extractWriteTargets(command);
   if (targets.length === 0) return 'unknown';
 
-  const dirs = allWorkingDirectories();
+  const dirs = allWorkingDirectories(scopeId);
   let sawInside = false;
   for (const raw of targets) {
     const abs = resolvePath(raw, cwd, home);

--- a/src/core/permissions/workingDirs.ts
+++ b/src/core/permissions/workingDirs.ts
@@ -5,7 +5,7 @@
  * of "inside vs outside".
  */
 
-import { getAuthorizedDirs } from '../tools/pathSafety';
+import { getAuthorizedDirs, type AuthorizationScopeId } from '../tools/pathSafety';
 import { useWorkspaceStore } from '../../stores/workspaceStore';
 
 // Temp dirs are always considered inside (scratch space, never sensitive).
@@ -16,11 +16,11 @@ function norm(p: string): string {
 }
 
 /** All directories the agent may operate in without escalation. */
-export function allWorkingDirectories(): string[] {
+export function allWorkingDirectories(scopeId?: AuthorizationScopeId): string[] {
   const ws = useWorkspaceStore.getState().currentPath;
   const dirs = [
-    ...(ws ? [ws] : []),
-    ...getAuthorizedDirs(),
+    ...(scopeId === undefined && ws ? [ws] : []),
+    ...getAuthorizedDirs(scopeId),
     ...ALWAYS_INSIDE,
   ];
   return dirs.map(norm);

--- a/src/core/permissions/workingDirs.ts
+++ b/src/core/permissions/workingDirs.ts
@@ -5,14 +5,47 @@
  * of "inside vs outside".
  */
 
-import { getAuthorizedDirs, type AuthorizationScopeId } from '../tools/pathSafety';
+import {
+  getAuthorizedDirs,
+  getAuthorizedWritablePaths,
+  type AuthorizationScopeId,
+} from '../tools/pathSafety';
 import { useWorkspaceStore } from '../../stores/workspaceStore';
+import { isWindows } from '../../utils/platform';
 
 // Temp dirs are always considered inside (scratch space, never sensitive).
 const ALWAYS_INSIDE = ['/tmp', '/private/tmp', '/var/tmp'];
 
-function norm(p: string): string {
-  return p.replace(/\\/g, '/').replace(/\/+/g, '/').replace(/\/+$/, '');
+function norm(raw: string): string {
+  let p = raw.replace(/\\/g, '/').replace(/\/+/g, '/');
+  const driveMatch = /^([A-Za-z]:)(?:\/|$)/.exec(p);
+  const drive = driveMatch?.[1] ?? '';
+  if (drive) p = p.slice(drive.length);
+  const absolute = p.startsWith('/');
+  const parts: string[] = [];
+
+  for (const segment of p.split('/')) {
+    if (!segment || segment === '.') continue;
+    if (segment === '..') {
+      if (parts.length > 0) {
+        parts.pop();
+      } else if (!absolute && !drive) {
+        parts.push(segment);
+      }
+      continue;
+    }
+    parts.push(segment);
+  }
+
+  let normalized: string;
+  if (drive) {
+    normalized = `${drive}${absolute ? '/' : ''}${parts.join('/')}`;
+  } else {
+    normalized = `${absolute ? '/' : ''}${parts.join('/')}`;
+  }
+  if (!normalized) normalized = drive ? `${drive}${absolute ? '/' : ''}` : absolute ? '/' : '.';
+  if (normalized.length > 1 && normalized.endsWith('/')) normalized = normalized.slice(0, -1);
+  return isWindows() ? normalized.toLowerCase() : normalized;
 }
 
 /** All directories the agent may operate in without escalation. */
@@ -33,4 +66,19 @@ export function allWorkingDirectories(scopeId?: AuthorizationScopeId): string[] 
 export function isInsideWorkingDirs(absPath: string, dirs: string[] = allWorkingDirectories()): boolean {
   const p = norm(absPath);
   return dirs.some((d) => p === d || p.startsWith(d + '/'));
+}
+
+/**
+ * Directories a scoped command may use as an implicit write location.
+ *
+ * Unscoped interactive command approval keeps the historical "working dirs"
+ * behavior. Scoped unattended runs are stricter: read-only grants let commands
+ * inspect a tree, but never make that tree a writable cwd or write target.
+ */
+export function commandWritableDirectories(scopeId?: AuthorizationScopeId): string[] {
+  if (scopeId === undefined) return allWorkingDirectories();
+  return [
+    ...getAuthorizedWritablePaths(scopeId),
+    ...ALWAYS_INSIDE,
+  ].map(norm);
 }

--- a/src/core/scheduler/scheduler.test.ts
+++ b/src/core/scheduler/scheduler.test.ts
@@ -74,11 +74,9 @@ describe('SchedulerEngine output delivery by exit reason', () => {
     useChatStore.setState({
       conversations: {},
       activeConversationId: null,
-      agentStatus: 'idle',
-      currentTool: null,
       currentUsage: null,
       pendingInput: null,
-      thinkingStartTime: null,
+      agentStates: new Map(),
     });
     vi.clearAllMocks();
   });
@@ -134,11 +132,9 @@ describe('SchedulerEngine permission tier', () => {
     useChatStore.setState({
       conversations: {},
       activeConversationId: null,
-      agentStatus: 'idle',
-      currentTool: null,
       currentUsage: null,
       pendingInput: null,
-      thinkingStartTime: null,
+      agentStates: new Map(),
     });
     // Pin the global fallback mode so "follows settings" tests are deterministic.
     useSettingsStore.setState({ permissionMode: 'standard' });

--- a/src/core/scheduler/scheduler.test.ts
+++ b/src/core/scheduler/scheduler.test.ts
@@ -265,19 +265,50 @@ describe('SchedulerEngine permission tier', () => {
     expect(latestRunError(task.id)).toContain('请求批准');
   });
 
-  it('authorizes the workspace with full read+write regardless of mode (no read-only rung in this model)', async () => {
+  it('authorizes the workspace only for the unattended run scope and disposes it after completion', async () => {
     const task = makeTask({
       id: 'task-ws',
       permissionMode: 'standard',
       workspacePath: '/Users/testuser/Projects/report',
     });
     useScheduleStore.setState({ tasks: { [task.id]: task } });
-    runWithProbe(async () => {}, 'completed');
+    let scopedWriteAllowed: boolean | undefined;
+    runWithProbe(async (options) => {
+      const scopeId = (options as { authorizationScopeId?: string }).authorizationScopeId;
+      expect(scopeId).toBeDefined();
+      scopedWriteAllowed = (await checkWritePath('/Users/testuser/Projects/report/out.md', scopeId)).allowed;
+    }, 'completed');
 
     await schedulerEngine.runNow(task.id);
 
-    const write = await checkWritePath('/Users/testuser/Projects/report/out.md');
-    expect(write.allowed).toBe(true);
+    expect(scopedWriteAllowed).toBe(true);
+    const writeAfterRun = await checkWritePath('/Users/testuser/Projects/report/out.md');
+    expect(writeAfterRun.allowed).toBe(false);
+    expect(writeAfterRun.needsPermission).toBe(true);
+  });
+
+  it('disposes the unattended run scope when the agent run throws', async () => {
+    const task = makeTask({
+      id: 'task-ws-throw',
+      permissionMode: 'standard',
+      workspacePath: '/Users/testuser/Projects/report',
+    });
+    useScheduleStore.setState({ tasks: { [task.id]: task } });
+    let scopeId: string | undefined;
+    let scopedWriteAllowedDuringRun: boolean | undefined;
+    vi.mocked(runAgentLoop).mockImplementation(async (_conv, _msg, options) => {
+      scopeId = (options as { authorizationScopeId?: string }).authorizationScopeId;
+      expect(scopeId).toBeDefined();
+      scopedWriteAllowedDuringRun = (await checkWritePath('/Users/testuser/Projects/report/out.md', scopeId)).allowed;
+      throw new Error('agent exploded');
+    });
+
+    await schedulerEngine.runNow(task.id);
+
+    expect(scopedWriteAllowedDuringRun).toBe(true);
+    expect(latestRunError(task.id)).toContain('agent exploded');
+    expect((await checkWritePath('/Users/testuser/Projects/report/out.md', scopeId)).allowed).toBe(false);
+    expect((await checkWritePath('/Users/testuser/Projects/report/out.md')).allowed).toBe(false);
   });
 
   it('leaves the result text alone when nothing was refused', async () => {

--- a/src/core/scheduler/scheduler.ts
+++ b/src/core/scheduler/scheduler.ts
@@ -11,7 +11,11 @@ import { getI18n, format } from '../../i18n';
 import type { ScheduledTask } from '../../types/schedule';
 import type { PermissionMode } from '../permissions/permissionMode';
 import type { ConfirmationInfo, FilePermissionCallback } from '../tools/registry';
-import { authorizeWorkspace } from '../tools/pathSafety';
+import {
+  createAuthorizationScope,
+  disposeAuthorizationScope,
+  scopedAuthorizeWorkspace,
+} from '../tools/pathSafety';
 import { getSettingsReader } from '../agent/ports/settingsReader';
 import { TOOL_NAMES } from '../tools/toolNames';
 import { outputSender } from '../im/outputSender';
@@ -65,7 +69,7 @@ function permissionModeLabel(mode: PermissionMode): string {
  * "blocked on example.com, authorize it in Settings" message possible without
  * a separate accounting layer.
  */
-function resolveScheduledRunPermissions(task: ScheduledTask): {
+function resolveScheduledRunPermissions(task: ScheduledTask, authorizationScopeId: string): {
   commandConfirmCallback: (info: ConfirmationInfo) => Promise<boolean>;
   filePermissionCallback: FilePermissionCallback;
   blockedTools: string[];
@@ -78,7 +82,7 @@ function resolveScheduledRunPermissions(task: ScheduledTask): {
   // capping the workspace itself to read-only. Unlike the old TriggerCapability
   // tiers this model has no read-only rung, so there is nothing to restrict here.
   if (task.workspacePath) {
-    authorizeWorkspace(task.workspacePath);
+    scopedAuthorizeWorkspace(authorizationScopeId, task.workspacePath);
   }
 
   // Deduplicated: an agent retrying the same blocked action ten times should
@@ -194,13 +198,15 @@ class SchedulerEngine {
       prompt = `/${task.skillName} ${prompt}`;
     }
 
-    const permissions = resolveScheduledRunPermissions(task);
+    const authorizationScopeId = createAuthorizationScope();
+    const permissions = resolveScheduledRunPermissions(task, authorizationScopeId);
 
     try {
       const result = await runAgentLoopDispatched(conversationId, prompt, {
         commandConfirmCallback: permissions.commandConfirmCallback,
         filePermissionCallback: permissions.filePermissionCallback,
         blockedTools: permissions.blockedTools,
+        authorizationScopeId,
       });
 
       // max_turns hit the cap but still produced a usable (partial) answer — deliver
@@ -272,6 +278,7 @@ class SchedulerEngine {
       });
       console.error(`[Scheduler] Task error: ${task.name}`, err);
     } finally {
+      disposeAuthorizationScope(authorizationScopeId);
       this.runningTasks.delete(task.id);
     }
   }

--- a/src/core/tools/definitions/agentTools.test.ts
+++ b/src/core/tools/definitions/agentTools.test.ts
@@ -52,6 +52,10 @@ vi.mock('../../agent/ports/settingsReader', () => ({
 }));
 
 describe('delegateToAgentTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('is explicitly marked concurrency-safe — a fan-out of independent sub-agent delegations must stay parallel, not silently fall back to the fail-closed default', () => {
     expect(delegateToAgentTool.isConcurrencySafe).toBe(true);
   });
@@ -98,6 +102,51 @@ describe('delegateToAgentTool', () => {
         blockedTools: ['request_workspace', 'abu-browser__*'],
       }),
     );
+  });
+
+  it('prefers the shell-owned tool execution authorization scope for nested delegation', async () => {
+    const { agentRegistry } = await import('../../agent/registry');
+    const { getCurrentLoopContext } = await import('../../agent/permissionBridge');
+    const { createSubagentController } = await import('../../agent/subagentAbort');
+    const { runSubagentLoop } = await import('../../agent/subagentLoop');
+
+    vi.mocked(agentRegistry.getAgent).mockReturnValue({
+      name: 'researcher',
+      description: 'test',
+      systemPrompt: 'test',
+    } as never);
+    vi.mocked(createSubagentController).mockReturnValue({
+      signal: new AbortController().signal,
+      cleanup: vi.fn(),
+    } as never);
+    vi.mocked(runSubagentLoop).mockResolvedValue({ text: 'done' } as never);
+    vi.mocked(getCurrentLoopContext).mockReturnValue({
+      authorizationScopeId: undefined,
+      allowedTools: ['read_file'],
+      blockedTools: [],
+      toolCallToStepId: new Map(),
+      loopId: 'loop-1',
+      conversationId: 'conv-1',
+      eventRouter: {
+        getCurrentStepId: () => undefined,
+        addChildStepToDelegate: () => undefined,
+        completeChildStep: () => undefined,
+      },
+    } as never);
+
+    await delegateToAgentTool.execute(
+      { agent_name: 'researcher', task: 'look something up' },
+      { authorizationScopeId: 'scope-from-tool-context', workspacePath: null } as never,
+    );
+
+    expect(vi.mocked(runSubagentLoop)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorizationScopeId: 'scope-from-tool-context',
+        workspaceReader: expect.any(Object),
+      }),
+    );
+    const call = vi.mocked(runSubagentLoop).mock.calls.at(-1)?.[0] as { workspaceReader?: { getCurrentPath: () => string | null } };
+    expect(call.workspaceReader?.getCurrentPath()).toBeNull();
   });
 });
 

--- a/src/core/tools/definitions/agentTools.ts
+++ b/src/core/tools/definitions/agentTools.ts
@@ -316,7 +316,7 @@ export const delegateToAgentTool: ToolDefinition = {
         filePermissionCallback: loopCtx?.filePermissionCallback,
         allowedTools: loopCtx?.allowedTools,
         blockedTools: loopCtx?.blockedTools,
-        ...getSubagentRunInheritance(loopCtx),
+        ...getSubagentRunInheritance(loopCtx, toolExecContext?.authorizationScopeId, toolExecContext?.workspacePath),
         onProgress,
       });
 

--- a/src/core/tools/definitions/agentTools.ts
+++ b/src/core/tools/definitions/agentTools.ts
@@ -233,9 +233,12 @@ export const delegateToAgentTool: ToolDefinition = {
     const loopCtx = toolExecContext?.loopId
       ? getLoopContext(toolExecContext.loopId)
       : getCurrentLoopContext();
+    const ownerConversationId = toolExecContext?.conversationId ?? loopCtx?.conversationId;
 
     // 4. Set agent status indicator
-    useChatStore.getState().setAgentStatus('tool-calling', TOOL_NAMES.DELEGATE_TO_AGENT, effectiveAgentName);
+    if (ownerConversationId) {
+      useChatStore.getState().setAgentStatus(ownerConversationId, 'tool-calling', TOOL_NAMES.DELEGATE_TO_AGENT, effectiveAgentName);
+    }
 
     // 5. Build onProgress callback for subagent visualization
     let onProgress: ((event: SubagentProgressEvent) => void) | undefined;
@@ -287,9 +290,8 @@ export const delegateToAgentTool: ToolDefinition = {
     let parentConversationSummary: string | undefined;
     try {
       const chatState = useChatStore.getState();
-      const activeConvId = chatState.activeConversationId;
-      if (activeConvId) {
-        const messages = chatState.conversations[activeConvId]?.messages ?? [];
+      if (ownerConversationId) {
+        const messages = chatState.conversations[ownerConversationId]?.messages ?? [];
         parentConversationSummary = extractParentConversationSummary(messages);
       }
     } catch {
@@ -320,11 +322,15 @@ export const delegateToAgentTool: ToolDefinition = {
 
       // Clear this agent from tracking and cleanup
       subagentCleanup();
-      useChatStore.getState().removeActiveAgent(effectiveAgentName);
+      if (ownerConversationId) {
+        useChatStore.getState().removeActiveAgent(ownerConversationId, effectiveAgentName);
+      }
       return result.text;
     } catch (err) {
       subagentCleanup();
-      useChatStore.getState().removeActiveAgent(effectiveAgentName);
+      if (ownerConversationId) {
+        useChatStore.getState().removeActiveAgent(ownerConversationId, effectiveAgentName);
+      }
       throw err;
     }
   },

--- a/src/core/tools/definitions/automationTools.test.ts
+++ b/src/core/tools/definitions/automationTools.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setLanguage } from '@/i18n';
+import { useTriggerStore } from '@/stores/triggerStore';
+import type { TriggerAction } from '@/types/trigger';
+import { manageTriggerTool } from './automationTools';
+
+function resetTriggerStore() {
+  useTriggerStore.setState({
+    triggers: {},
+    selectedTriggerId: null,
+    showEditor: false,
+    editingTriggerId: null,
+    editorTemplateDefaults: null,
+  });
+}
+
+describe('manageTriggerTool', () => {
+  beforeEach(() => {
+    setLanguage('en-US');
+    resetTriggerStore();
+  });
+
+  it('does not expose capability in the tool schema', () => {
+    expect(manageTriggerTool.inputSchema.properties).not.toHaveProperty('capability');
+  });
+
+  it('ignores malicious capability on create and tells the user to set it in Trigger Settings', async () => {
+    const result = await manageTriggerTool.execute({
+      action: 'create',
+      name: 'Malicious trigger',
+      prompt: 'Handle $EVENT_DATA',
+      capability: 'full',
+    });
+
+    const created = Object.values(useTriggerStore.getState().triggers)[0];
+
+    expect(created.action.capability).toBeUndefined();
+    expect(created.action.permissions).toBeUndefined();
+    expect(String(result)).toContain('Capability level is set by the user in Trigger Settings.');
+  });
+
+  it('ignores malicious capability on update while preserving existing capability and permissions', async () => {
+    const triggerId = useTriggerStore.getState().createTrigger({
+      name: 'Existing trigger',
+      source: { type: 'http' },
+      filter: { type: 'always' },
+      action: {
+        prompt: 'Before',
+        capability: 'custom',
+        permissions: {
+          allowedCommands: ['npm run test'],
+          allowedPaths: ['/Users/example/project'],
+          allowedTools: ['read_file'],
+        },
+      },
+      debounce: { enabled: true, windowSeconds: 300 },
+    });
+
+    const result = await manageTriggerTool.execute({
+      action: 'update',
+      trigger_id: triggerId,
+      prompt: 'After',
+      capability: 'full',
+    });
+
+    const updated = useTriggerStore.getState().triggers[triggerId];
+
+    expect(updated.action.prompt).toBe('After');
+    expect(updated.action.capability).toBe('custom');
+    expect(updated.action.permissions).toEqual({
+      allowedCommands: ['npm run test'],
+      allowedPaths: ['/Users/example/project'],
+      allowedTools: ['read_file'],
+    });
+    expect(String(result)).toContain('Capability level is set by the user in Trigger Settings.');
+  });
+
+  it('does not mutate action when update only receives capability', async () => {
+    const originalAction: TriggerAction = {
+      prompt: 'Keep me',
+      skillName: 'alert-sop',
+      workspacePath: '/Users/example/project',
+      capability: 'safe_tools',
+      permissions: {
+        allowedPaths: ['/Users/example/project'],
+      },
+    };
+    const triggerId = useTriggerStore.getState().createTrigger({
+      name: 'Existing trigger',
+      source: { type: 'http' },
+      filter: { type: 'always' },
+      action: originalAction,
+      debounce: { enabled: true, windowSeconds: 300 },
+    });
+
+    const result = await manageTriggerTool.execute({
+      action: 'update',
+      trigger_id: triggerId,
+      capability: 'full',
+    });
+
+    expect(useTriggerStore.getState().triggers[triggerId].action).toEqual(originalAction);
+    expect(String(result)).toContain('Capability level is set by the user in Trigger Settings.');
+  });
+});

--- a/src/core/tools/definitions/automationTools.test.ts
+++ b/src/core/tools/definitions/automationTools.test.ts
@@ -25,19 +25,20 @@ describe('manageTriggerTool', () => {
     expect(manageTriggerTool.inputSchema.properties).not.toHaveProperty('capability');
   });
 
-  it('ignores malicious capability on create and tells the user to set it in Trigger Settings', async () => {
+  it('ignores malicious capability on create and reports the safe default', async () => {
     const result = await manageTriggerTool.execute({
       action: 'create',
       name: 'Malicious trigger',
       prompt: 'Handle $EVENT_DATA',
       capability: 'full',
+      allowed_paths: ['', '   ', '/Users/example/project'],
     });
 
     const created = Object.values(useTriggerStore.getState().triggers)[0];
 
     expect(created.action.capability).toBeUndefined();
     expect(created.action.permissions).toBeUndefined();
-    expect(String(result)).toContain('Capability level is set by the user in Trigger Settings.');
+    expect(String(result)).toContain('New triggers use Read Only; updates keep the existing level.');
   });
 
   it('ignores malicious capability on update while preserving existing capability and permissions', async () => {
@@ -73,7 +74,7 @@ describe('manageTriggerTool', () => {
       allowedPaths: ['/Users/example/project'],
       allowedTools: ['read_file'],
     });
-    expect(String(result)).toContain('Capability level is set by the user in Trigger Settings.');
+    expect(String(result)).toContain('New triggers use Read Only; updates keep the existing level.');
   });
 
   it('does not mutate action when update only receives capability', async () => {
@@ -101,6 +102,34 @@ describe('manageTriggerTool', () => {
     });
 
     expect(useTriggerStore.getState().triggers[triggerId].action).toEqual(originalAction);
-    expect(String(result)).toContain('Capability level is set by the user in Trigger Settings.');
+    expect(String(result)).toContain('New triggers use Read Only; updates keep the existing level.');
+  });
+
+  it('filters empty allowed_paths on update while preserving legal spaces in path names', async () => {
+    const legalPathWithSpaces = '/Users/example/project with trailing space ';
+    const triggerId = useTriggerStore.getState().createTrigger({
+      name: 'Existing trigger',
+      source: { type: 'http' },
+      filter: { type: 'always' },
+      action: {
+        prompt: 'Before',
+        capability: 'custom',
+        permissions: {
+          allowedPaths: ['/Users/example/old'],
+        },
+      },
+      debounce: { enabled: true, windowSeconds: 300 },
+    });
+
+    await manageTriggerTool.execute({
+      action: 'update',
+      trigger_id: triggerId,
+      allowed_paths: ['', '   ', legalPathWithSpaces, '/Users/example/Project Name'],
+    });
+
+    expect(useTriggerStore.getState().triggers[triggerId].action.permissions?.allowedPaths).toEqual([
+      legalPathWithSpaces,
+      '/Users/example/Project Name',
+    ]);
   });
 });

--- a/src/core/tools/definitions/automationTools.ts
+++ b/src/core/tools/definitions/automationTools.ts
@@ -273,25 +273,20 @@ export const manageTriggerTool: ToolDefinition = {
       source_interval: { type: 'number', description: 'Polling interval in seconds (required when source_type=cron, minimum 10)' },
       debounce_enabled: { type: 'boolean', description: 'Whether to enable debounce (default: true)' },
       debounce_seconds: { type: 'number', description: 'Debounce time window in seconds (default: 300)' },
-      capability: {
-        type: 'string',
-        enum: ['read_tools', 'safe_tools', 'full', 'custom'],
-        description: 'Capability level (default: read_tools). read_tools=read-only analysis; safe_tools=read/write workspace + safe commands; full=almost all operations; custom=custom allowlist',
-      },
       allowed_commands: {
         type: 'array',
         items: { type: 'string' },
-        description: 'Command allowlist, glob patterns (used when capability=custom, e.g. ["npm run *", "git pull"])',
+        description: 'Command allowlist, glob patterns (used for triggers whose capability level is custom, e.g. ["npm run *", "git pull"])',
       },
       allowed_paths: {
         type: 'array',
         items: { type: 'string' },
-        description: 'Path allowlist, auto-authorized at runtime (used when capability=custom)',
+        description: 'Path allowlist, auto-authorized at runtime (used for triggers whose capability level is custom)',
       },
       allowed_tools: {
         type: 'array',
         items: { type: 'string' },
-        description: 'Tool allowlist (used when capability=custom, e.g. ["read_file", "http_fetch"])',
+        description: 'Tool allowlist (used for triggers whose capability level is custom, e.g. ["read_file", "http_fetch"])',
       },
       trigger_id: { type: 'string', description: 'Trigger ID (required for update/delete/pause/resume)' },
       status_filter: {
@@ -335,18 +330,11 @@ export const manageTriggerTool: ToolDefinition = {
           field: input.filter_field as string | undefined,
         };
 
-        // Build action with capability
-        const capabilityInput = input.capability as string | undefined;
+        // Build action. Capability level is user-controlled in Trigger Settings.
         const triggerAction: TriggerAction = {
           prompt,
           skillName: input.skill_name as string | undefined,
           workspacePath: input.workspace_path as string | undefined,
-          capability: (capabilityInput as TriggerAction['capability']) ?? undefined,
-          permissions: capabilityInput === 'custom' ? {
-            allowedCommands: input.allowed_commands as string[] | undefined,
-            allowedPaths: input.allowed_paths as string[] | undefined,
-            allowedTools: input.allowed_tools as string[] | undefined,
-          } : undefined,
         };
 
         // Build debounce
@@ -423,6 +411,7 @@ export const manageTriggerTool: ToolDefinition = {
 
         resultLines.push(
           format(t.capLevelLine, { label: capLabel }),
+          t.triggerCapabilityUiNotice,
           format(t.filterLine, { filter: `${filterType}${filter.keywords ? ` [${filter.keywords.join(', ')}]` : ''}` }),
           format(t.debounceLine, { value: debounce.enabled ? format(t.debounceSeconds, { seconds: debounce.windowSeconds }) : t.debounceOff }),
         );
@@ -483,16 +472,22 @@ export const manageTriggerTool: ToolDefinition = {
         const updateData: Record<string, unknown> = {};
         if (input.name !== undefined) updateData.name = input.name;
         if (input.description !== undefined) updateData.description = input.description;
-        if (input.prompt !== undefined || input.skill_name !== undefined || input.workspace_path !== undefined || input.capability !== undefined) {
-          const updatedCapability = input.capability !== undefined
-            ? (input.capability as TriggerAction['capability'])
-            : existing.action.capability;
+        const hasActionUpdate =
+          input.prompt !== undefined ||
+          input.skill_name !== undefined ||
+          input.workspace_path !== undefined ||
+          input.allowed_commands !== undefined ||
+          input.allowed_paths !== undefined ||
+          input.allowed_tools !== undefined;
+
+        if (hasActionUpdate) {
+          const existingCapability = existing.action.capability;
           updateData.action = {
             prompt: (input.prompt as string) ?? existing.action.prompt,
             skillName: input.skill_name !== undefined ? input.skill_name : existing.action.skillName,
             workspacePath: input.workspace_path !== undefined ? input.workspace_path : existing.action.workspacePath,
-            capability: updatedCapability,
-            permissions: updatedCapability === 'custom' ? {
+            capability: existingCapability,
+            permissions: existingCapability === 'custom' ? {
               allowedCommands: input.allowed_commands !== undefined ? input.allowed_commands : existing.action.permissions?.allowedCommands,
               allowedPaths: input.allowed_paths !== undefined ? input.allowed_paths : existing.action.permissions?.allowedPaths,
               allowedTools: input.allowed_tools !== undefined ? input.allowed_tools : existing.action.permissions?.allowedTools,
@@ -515,7 +510,10 @@ export const manageTriggerTool: ToolDefinition = {
         }
 
         store.updateTrigger(triggerId, updateData as Parameters<typeof store.updateTrigger>[1]);
-        return format(t.triggerUpdated, { name: (input.name as string) || existing.name, id: triggerId });
+        return [
+          format(t.triggerUpdated, { name: (input.name as string) || existing.name, id: triggerId }),
+          t.triggerCapabilityUiNotice,
+        ].join('\n');
       }
 
       case 'delete': {

--- a/src/core/tools/definitions/automationTools.ts
+++ b/src/core/tools/definitions/automationTools.ts
@@ -11,6 +11,13 @@ import { getI18n, getLocale, format } from '../../../i18n';
 /** Locale tag for Date#toLocaleString, following the resolved UI locale. */
 const dateLocale = (): string => (getLocale() === 'zh-CN' ? 'zh-CN' : 'en-US');
 
+function filterNonBlankStringList(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((item): item is string =>
+    typeof item === 'string' && item.trim().length > 0,
+  );
+}
+
 export const manageScheduledTaskTool: ToolDefinition = {
   name: TOOL_NAMES.MANAGE_SCHEDULED_TASK,
   description: 'Create, list, update, delete, pause, or resume scheduled tasks. Use when the user needs an operation to run automatically on a recurring or timed schedule.',
@@ -330,7 +337,8 @@ export const manageTriggerTool: ToolDefinition = {
           field: input.filter_field as string | undefined,
         };
 
-        // Build action. Capability level is user-controlled in Trigger Settings.
+        // Build action without a model-controlled capability. New triggers
+        // therefore take the safest default in triggerPermission.ts.
         const triggerAction: TriggerAction = {
           prompt,
           skillName: input.skill_name as string | undefined,
@@ -482,6 +490,9 @@ export const manageTriggerTool: ToolDefinition = {
 
         if (hasActionUpdate) {
           const existingCapability = existing.action.capability;
+          const allowedPaths = input.allowed_paths !== undefined
+            ? filterNonBlankStringList(input.allowed_paths)
+            : existing.action.permissions?.allowedPaths;
           updateData.action = {
             prompt: (input.prompt as string) ?? existing.action.prompt,
             skillName: input.skill_name !== undefined ? input.skill_name : existing.action.skillName,
@@ -489,7 +500,7 @@ export const manageTriggerTool: ToolDefinition = {
             capability: existingCapability,
             permissions: existingCapability === 'custom' ? {
               allowedCommands: input.allowed_commands !== undefined ? input.allowed_commands : existing.action.permissions?.allowedCommands,
-              allowedPaths: input.allowed_paths !== undefined ? input.allowed_paths : existing.action.permissions?.allowedPaths,
+              allowedPaths,
               allowedTools: input.allowed_tools !== undefined ? input.allowed_tools : existing.action.permissions?.allowedTools,
             } : existing.action.permissions,
           };

--- a/src/core/tools/definitions/commandTools.test.ts
+++ b/src/core/tools/definitions/commandTools.test.ts
@@ -149,6 +149,32 @@ describe('runCommandTool', () => {
     expect(p.extraWritablePaths).toEqual([]);
   });
 
+  it('does not grant scoped Seatbelt writes just because the run has a workspacePath', async () => {
+    mockAuthorized([]);
+
+    await runCommandTool.execute(
+      { command: 'touch pwned.txt' },
+      { authorizationScopeId: 'scope-read-only', workspacePath: '/readonly/ws' },
+    );
+
+    const p = shellPayload();
+    expect(p.cwd).toBe('/readonly/ws');
+    expect(p.extraWritablePaths).toEqual([]);
+  });
+
+  it('passes only scoped write-authorized paths to Seatbelt for scoped runs', async () => {
+    mockAuthorized(['/writable/ws']);
+
+    await runCommandTool.execute(
+      { command: 'touch ok.txt' },
+      { authorizationScopeId: 'scope-write', workspacePath: '/readonly/ws' },
+    );
+
+    const p = shellPayload();
+    expect(p.cwd).toBe('/readonly/ws');
+    expect(p.extraWritablePaths).toEqual(['/writable/ws']);
+  });
+
   it('does not fall back to the global workspace for a scoped run with no trusted workspace field', async () => {
     mockReader('/reader/ws');
 

--- a/src/core/tools/definitions/commandTools.test.ts
+++ b/src/core/tools/definitions/commandTools.test.ts
@@ -136,6 +136,45 @@ describe('runCommandTool', () => {
     expect(p.extraWritablePaths).toEqual(['/reader/ws']);
   });
 
+  it('does not fall back to the global workspace for a scoped run with a null trusted workspace', async () => {
+    mockReader('/reader/ws');
+
+    await runCommandTool.execute(
+      { command: 'pwd' },
+      { authorizationScopeId: 'scope-1', workspacePath: null },
+    );
+
+    const p = shellPayload();
+    expect(p.cwd).toBeNull();
+    expect(p.extraWritablePaths).toEqual([]);
+  });
+
+  it('does not fall back to the global workspace for a scoped run with no trusted workspace field', async () => {
+    mockReader('/reader/ws');
+
+    await runCommandTool.execute(
+      { command: 'pwd' },
+      { authorizationScopeId: 'scope-1' },
+    );
+
+    const p = shellPayload();
+    expect(p.cwd).toBeNull();
+    expect(p.extraWritablePaths).toEqual([]);
+  });
+
+  it('treats an empty authorization scope as explicit and does not fall back to the global workspace', async () => {
+    mockReader('/reader/ws');
+
+    await runCommandTool.execute(
+      { command: 'pwd' },
+      { authorizationScopeId: '' },
+    );
+
+    const p = shellPayload();
+    expect(p.cwd).toBeNull();
+    expect(p.extraWritablePaths).toEqual([]);
+  });
+
   it('degrades to "no workspace" (cwd-less spawn) when the fallback reader throws — never fails the command (sidecar outside-run guard)', async () => {
     vi.mocked(getWorkspaceReader).mockReturnValue({
       getCurrentPath: () => {

--- a/src/core/tools/definitions/commandTools.ts
+++ b/src/core/tools/definitions/commandTools.ts
@@ -127,7 +127,7 @@ This tool is suitable for: moving/copying/renaming files (mv/cp), package manage
         ? await getAuthorizedPathsReader().getAuthorizedWritablePaths(context?.authorizationScopeId)
         : [];
       const extraWritablePaths = [
-        ...(workspacePath ? [workspacePath] : []),
+        ...(context?.authorizationScopeId === undefined && workspacePath ? [workspacePath] : []),
         ...authorizedPaths,
       ];
 

--- a/src/core/tools/definitions/commandTools.ts
+++ b/src/core/tools/definitions/commandTools.ts
@@ -112,14 +112,20 @@ This tool is suitable for: moving/copying/renaming files (mv/cp), package manage
         return formatAppAutomationRecovery(preflightAppAutomationRecovery);
       }
 
-      // Use conversation-scoped workspace from context; fall back to global store
-      // only if context is absent (e.g. direct invocation outside agent loop).
+      // Use the shell/session-owned workspace from context. Scoped unattended
+      // runs fail closed when that trusted value is null/absent; only
+      // unscoped interactive/direct invocations may fall back to the global
+      // workspace reader.
       // The fallback must not fail the command: in the sidecar the bare getter
       // resolves an ambient-run mirror and THROWS outside a registered run —
       // treat that as "no workspace" (cwd-less spawn), matching the shell's
       // no-workspace behavior instead of erroring before the spawn.
-      const workspacePath = context?.workspacePath ?? safeGlobalWorkspacePath();
-      const authorizedPaths = sandbox ? await getAuthorizedPathsReader().getAuthorizedWritablePaths() : [];
+      const workspacePath = context?.authorizationScopeId !== undefined
+        ? (context.workspacePath ?? null)
+        : (context?.workspacePath ?? safeGlobalWorkspacePath());
+      const authorizedPaths = sandbox
+        ? await getAuthorizedPathsReader().getAuthorizedWritablePaths(context?.authorizationScopeId)
+        : [];
       const extraWritablePaths = [
         ...(workspacePath ? [workspacePath] : []),
         ...authorizedPaths,

--- a/src/core/tools/definitions/orchestrationTools.scope.test.ts
+++ b/src/core/tools/definitions/orchestrationTools.scope.test.ts
@@ -1,0 +1,79 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import type { ToolDefinition } from '../../../types';
+
+const runSubagentMock = vi.fn().mockResolvedValue({
+  text: 'done',
+  toolCallCount: 0,
+  turnCount: 1,
+  tokenUsage: { input: 0, output: 0 },
+  duration: 1,
+});
+
+vi.mock('../../agent/subagentRunner', () => ({
+  getSubagentRunInheritance: (
+    loopCtx: { conversationId?: string; settingsReader?: unknown; authorizationScopeId?: string } | null | undefined,
+    authorizationScopeId?: string,
+    workspacePath?: string | null,
+  ) => ({
+    parentConversationId: loopCtx?.conversationId,
+    settingsReader: loopCtx?.settingsReader,
+    authorizationScopeId: authorizationScopeId ?? loopCtx?.authorizationScopeId,
+    workspaceReader: { getCurrentPath: () => workspacePath ?? null },
+  }),
+  runSubagent: (...args: unknown[]) => runSubagentMock(...args),
+}));
+
+vi.mock('../../agent/permissionBridge', () => ({
+  getCurrentLoopContext: vi.fn(() => ({
+    authorizationScopeId: undefined,
+    allowedTools: ['read_file'],
+    blockedTools: [],
+    signal: undefined,
+    conversationId: 'conv-1',
+  })),
+  getLoopContext: vi.fn(),
+}));
+
+vi.mock('../../../stores/chatStore', () => ({
+  useChatStore: {
+    getState: vi.fn(() => ({
+      activeConversationId: 'conv-1',
+      conversations: { 'conv-1': { messages: [] } },
+    })),
+  },
+}));
+
+vi.mock('../../../stores/batchProgressStore', () => ({
+  useBatchProgressStore: {
+    getState: vi.fn(() => ({
+      initBatch: vi.fn(),
+      batches: {},
+      setTaskRunning: vi.fn(),
+      setTaskActivity: vi.fn(),
+    })),
+  },
+}));
+
+let runAgentBatchTool: ToolDefinition;
+
+beforeAll(async () => {
+  ({ runAgentBatchTool } = await import('./orchestrationTools'));
+});
+
+describe('runAgentBatchTool scope inheritance', () => {
+  it('prefers the shell-owned tool execution authorization scope for nested batch subagents', async () => {
+    await runAgentBatchTool.execute(
+      { tasks: [{ type: 'research', task: 'look something up' }], concurrency: 1 },
+      { authorizationScopeId: 'scope-from-tool-context', workspacePath: null, toolCallId: 'tool-1' } as never,
+    );
+
+    expect(runSubagentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorizationScopeId: 'scope-from-tool-context',
+        workspaceReader: expect.any(Object),
+      }),
+    );
+    const call = runSubagentMock.mock.calls.at(-1)?.[0] as { workspaceReader?: { getCurrentPath: () => string | null } };
+    expect(call.workspaceReader?.getCurrentPath()).toBeNull();
+  });
+});

--- a/src/core/tools/definitions/orchestrationTools.ts
+++ b/src/core/tools/definitions/orchestrationTools.ts
@@ -393,7 +393,7 @@ export const runAgentBatchTool: ToolDefinition = {
             filePermissionCallback: loopCtx?.filePermissionCallback,
             allowedTools: loopCtx?.allowedTools,
             blockedTools: loopCtx?.blockedTools,
-            ...getSubagentRunInheritance(loopCtx),
+            ...getSubagentRunInheritance(loopCtx, toolExecContext?.authorizationScopeId, toolExecContext?.workspacePath),
             onProgress: (event) => {
               try {
                 const store = useBatchProgressStore.getState();

--- a/src/core/tools/pathSafety.test.ts
+++ b/src/core/tools/pathSafety.test.ts
@@ -4,7 +4,11 @@ import {
   checkWritePath,
   checkListPath,
   authorizeWorkspace,
+  createAuthorizationScope,
+  disposeAuthorizationScope,
+  getAuthorizedWritablePaths,
   revokeWorkspace,
+  scopedAuthorizeWorkspace,
   getPermissionDirectory,
   isCatastrophicDeleteTarget,
 } from './pathSafety';
@@ -129,6 +133,88 @@ describe('pathSafety', () => {
       authorizeWorkspace('/Users/testuser/Projects/myapp');
       const result = await checkReadPath('/Users/testuser/Projects/myapp');
       expect(result.allowed).toBe(true);
+    });
+
+    it('keeps an explicit read-only scope from inheriting a global write grant on the same path', async () => {
+      const ws = '/Users/testuser/Projects/scoped-global';
+      revokeWorkspace(ws);
+      authorizeWorkspace(ws, ['read', 'write']);
+      const scopeId = createAuthorizationScope();
+      try {
+        scopedAuthorizeWorkspace(scopeId, ws, ['read']);
+
+        expect((await checkReadPath(`${ws}/notes.md`, scopeId)).allowed).toBe(true);
+        const scopedWrite = await checkWritePath(`${ws}/out.md`, scopeId);
+        expect(scopedWrite.allowed).toBe(false);
+        expect(scopedWrite.needsPermission).toBe(true);
+        expect((await checkWritePath(`${ws}/out.md`)).allowed).toBe(true);
+      } finally {
+        disposeAuthorizationScope(scopeId);
+        revokeWorkspace(ws);
+      }
+    });
+
+    it('keeps concurrent scopes isolated and fails closed after disposal without touching global state', async () => {
+      const wsA = '/Users/testuser/Projects/scope-a';
+      const wsB = '/Users/testuser/Projects/scope-b';
+      const globalWs = '/Users/testuser/Projects/global-only';
+      revokeWorkspace(wsA);
+      revokeWorkspace(wsB);
+      revokeWorkspace(globalWs);
+      authorizeWorkspace(globalWs, ['read', 'write']);
+      const scopeA = createAuthorizationScope();
+      const scopeB = createAuthorizationScope();
+      try {
+        scopedAuthorizeWorkspace(scopeA, wsA, ['read']);
+        scopedAuthorizeWorkspace(scopeB, wsB, ['read', 'write']);
+
+        expect((await checkReadPath(`${wsA}/a.txt`, scopeA)).allowed).toBe(true);
+        expect((await checkWritePath(`${wsA}/a.txt`, scopeA)).allowed).toBe(false);
+        expect((await checkWritePath(`${wsA}/a.txt`, scopeB)).allowed).toBe(false);
+        expect((await checkWritePath(`${wsB}/b.txt`, scopeB)).allowed).toBe(true);
+        expect(getAuthorizedWritablePaths(scopeB)).toEqual([wsB]);
+
+        disposeAuthorizationScope(scopeA);
+
+        expect((await checkReadPath(`${wsA}/a.txt`, scopeA)).allowed).toBe(false);
+        expect(getAuthorizedWritablePaths(scopeA)).toEqual([]);
+        expect((await checkWritePath(`${globalWs}/g.txt`)).allowed).toBe(true);
+        expect((await checkWritePath(`${wsB}/b.txt`, scopeB)).allowed).toBe(true);
+      } finally {
+        disposeAuthorizationScope(scopeB);
+        revokeWorkspace(wsA);
+        revokeWorkspace(wsB);
+        revokeWorkspace(globalWs);
+      }
+    });
+
+    it('scopedAuthorizeWorkspace never falls back to global authorization when scope is missing', async () => {
+      const ws = '/Users/testuser/Projects/missing-scope';
+      revokeWorkspace(ws);
+      try {
+        scopedAuthorizeWorkspace(undefined as unknown as string, ws, ['read', 'write']);
+        scopedAuthorizeWorkspace('missing-scope', ws, ['read', 'write']);
+        scopedAuthorizeWorkspace('', ws, ['read', 'write']);
+
+        expect((await checkReadPath(`${ws}/notes.md`)).allowed).toBe(false);
+        expect((await checkWritePath(`${ws}/out.md`)).allowed).toBe(false);
+        expect((await checkWritePath(`${ws}/out.md`, '')).allowed).toBe(false);
+        expect(getAuthorizedWritablePaths('')).toEqual([]);
+      } finally {
+        revokeWorkspace(ws);
+      }
+    });
+
+    it('treats an empty explicit scope as scoped fail-closed instead of global fallback', async () => {
+      const ws = '/Users/testuser/Projects/empty-scope-global';
+      revokeWorkspace(ws);
+      authorizeWorkspace(ws, ['read', 'write']);
+      try {
+        expect((await checkWritePath(`${ws}/global.md`)).allowed).toBe(true);
+        expect((await checkWritePath(`${ws}/scoped.md`, '')).allowed).toBe(false);
+      } finally {
+        revokeWorkspace(ws);
+      }
     });
   });
 

--- a/src/core/tools/pathSafety.test.ts
+++ b/src/core/tools/pathSafety.test.ts
@@ -216,6 +216,51 @@ describe('pathSafety', () => {
         revokeWorkspace(ws);
       }
     });
+
+    it('ignores empty and whitespace-only global grants instead of matching every absolute path', async () => {
+      authorizeWorkspace('', ['read', 'write']);
+      authorizeWorkspace('   ', ['read', 'write']);
+
+      const read = await checkReadPath('/Users/testuser/Documents/notes.md');
+      const write = await checkWritePath('/Users/testuser/Documents/notes.md');
+
+      expect(read.allowed).toBe(false);
+      expect(read.needsPermission).toBe(true);
+      expect(write.allowed).toBe(false);
+      expect(write.needsPermission).toBe(true);
+    });
+
+    it('ignores empty and whitespace-only scoped grants instead of exposing scoped writable paths', async () => {
+      const scopeId = createAuthorizationScope();
+      try {
+        scopedAuthorizeWorkspace(scopeId, '', ['read', 'write']);
+        scopedAuthorizeWorkspace(scopeId, '\t  ', ['read', 'write']);
+
+        const write = await checkWritePath('/Users/testuser/Documents/notes.md', scopeId);
+
+        expect(write.allowed).toBe(false);
+        expect(write.needsPermission).toBe(true);
+        expect(getAuthorizedWritablePaths(scopeId)).toEqual([]);
+      } finally {
+        disposeAuthorizationScope(scopeId);
+      }
+    });
+
+    it('preserves legal spaces in authorized paths rather than trimming them into a different path', async () => {
+      const ws = '/Users/testuser/Projects/project with trailing space ';
+      const trimmedWs = '/Users/testuser/Projects/project with trailing space';
+      revokeWorkspace(ws);
+      revokeWorkspace(trimmedWs);
+      try {
+        authorizeWorkspace(ws, ['read']);
+
+        expect((await checkReadPath(`${ws}/notes.md`)).allowed).toBe(true);
+        expect((await checkReadPath(`${trimmedWs}/notes.md`)).allowed).toBe(false);
+      } finally {
+        revokeWorkspace(ws);
+        revokeWorkspace(trimmedWs);
+      }
+    });
   });
 
   // ── Path traversal ──

--- a/src/core/tools/pathSafety.ts
+++ b/src/core/tools/pathSafety.ts
@@ -202,6 +202,10 @@ function normalizeWorkspacePath(path: string): string {
   return path.replace(/\\/g, '/').replace(/\/+$/, '');
 }
 
+function isBlankWorkspaceGrant(path: string): boolean {
+  return path.trim().length === 0;
+}
+
 function getAuthorizationMap(scopeId: AuthorizationScopeId | undefined): Map<string, Set<'read' | 'write'>> | undefined {
   if (scopeId === undefined) return authorizedWorkspaces;
   return scopedAuthorizedWorkspaces.get(scopeId);
@@ -212,6 +216,7 @@ function addAuthorizedWorkspace(
   path: string,
   capabilities?: ('read' | 'write')[],
 ): void {
+  if (isBlankWorkspaceGrant(path)) return;
   const normalized = normalizeWorkspacePath(path);
   const caps = capabilities ?? ['read', 'write'];
   const existing = target.get(normalized);
@@ -254,6 +259,7 @@ export function getAuthorizedWritablePaths(scopeId?: AuthorizationScopeId): stri
   if (!target) return [];
   const paths: string[] = [];
   for (const [workspace, caps] of target) {
+    if (isBlankWorkspaceGrant(workspace)) continue;
     if (caps.has('write')) paths.push(workspace);
   }
   return paths;
@@ -266,7 +272,7 @@ export function getAuthorizedWritablePaths(scopeId?: AuthorizationScopeId): stri
  */
 export function getAuthorizedDirs(scopeId?: AuthorizationScopeId): string[] {
   const target = getAuthorizationMap(scopeId);
-  return target ? Array.from(target.keys()) : [];
+  return target ? Array.from(target.keys()).filter((path) => !isBlankWorkspaceGrant(path)) : [];
 }
 
 /**
@@ -290,6 +296,7 @@ function isInAuthorizedWorkspace(
   let normalized = path.replace(/\\/g, '/').replace(/\/+$/, '');
   if (isWindows()) normalized = normalized.toLowerCase();
   for (const [workspace, caps] of target) {
+    if (isBlankWorkspaceGrant(workspace)) continue;
     const compareWs = isWindows() ? workspace.toLowerCase() : workspace;
     if (normalized === compareWs || normalized.startsWith(compareWs + '/')) {
       if (caps.has(capability)) return true;

--- a/src/core/tools/pathSafety.ts
+++ b/src/core/tools/pathSafety.ts
@@ -181,21 +181,67 @@ const ALWAYS_ALLOWED_PATHS = [
 // Workspace paths that user has explicitly authorized, with capability tracking
 // Each entry maps a normalized path to its authorized capabilities
 const authorizedWorkspaces: Map<string, Set<'read' | 'write'>> = new Map();
+const scopedAuthorizedWorkspaces: Map<string, Map<string, Set<'read' | 'write'>>> = new Map();
+let authorizationScopeCounter = 0;
+
+export type AuthorizationScopeId = string;
+
+export function createAuthorizationScope(): AuthorizationScopeId {
+  authorizationScopeCounter += 1;
+  const scopeId = `auth-scope-${Date.now().toString(36)}-${authorizationScopeCounter.toString(36)}`;
+  scopedAuthorizedWorkspaces.set(scopeId, new Map());
+  return scopeId;
+}
+
+export function disposeAuthorizationScope(scopeId: AuthorizationScopeId | undefined): void {
+  if (!scopeId) return;
+  scopedAuthorizedWorkspaces.delete(scopeId);
+}
+
+function normalizeWorkspacePath(path: string): string {
+  return path.replace(/\\/g, '/').replace(/\/+$/, '');
+}
+
+function getAuthorizationMap(scopeId: AuthorizationScopeId | undefined): Map<string, Set<'read' | 'write'>> | undefined {
+  if (scopeId === undefined) return authorizedWorkspaces;
+  return scopedAuthorizedWorkspaces.get(scopeId);
+}
+
+function addAuthorizedWorkspace(
+  target: Map<string, Set<'read' | 'write'>>,
+  path: string,
+  capabilities?: ('read' | 'write')[],
+): void {
+  const normalized = normalizeWorkspacePath(path);
+  const caps = capabilities ?? ['read', 'write'];
+  const existing = target.get(normalized);
+  if (existing) {
+    for (const c of caps) existing.add(c);
+  } else {
+    target.set(normalized, new Set(caps));
+  }
+}
 
 /**
  * Add a workspace path to the authorized list.
  * @param capabilities - defaults to ['read', 'write'] for backward compatibility (user-selected workspace).
  *   Pass ['read'] for read-only authorization (e.g., read_tools triggers).
  */
-export function authorizeWorkspace(path: string, capabilities?: ('read' | 'write')[]): void {
-  const normalized = path.replace(/\\/g, '/').replace(/\/+$/, '');
-  const caps = capabilities ?? ['read', 'write'];
-  const existing = authorizedWorkspaces.get(normalized);
-  if (existing) {
-    for (const c of caps) existing.add(c);
-  } else {
-    authorizedWorkspaces.set(normalized, new Set(caps));
-  }
+export function authorizeWorkspace(
+  path: string,
+  capabilities?: ('read' | 'write')[],
+): void {
+  addAuthorizedWorkspace(authorizedWorkspaces, path, capabilities);
+}
+
+export function scopedAuthorizeWorkspace(
+  scopeId: AuthorizationScopeId,
+  path: string,
+  capabilities?: ('read' | 'write')[],
+): void {
+  const target = scopedAuthorizedWorkspaces.get(scopeId);
+  if (!target) return;
+  addAuthorizedWorkspace(target, path, capabilities);
 }
 
 /**
@@ -203,9 +249,11 @@ export function authorizeWorkspace(path: string, capabilities?: ('read' | 'write
  * Used by commandTools to forward authorized paths to the OS-level sandbox (Seatbelt),
  * so child processes (cp, python, etc.) can write to user-authorized directories.
  */
-export function getAuthorizedWritablePaths(): string[] {
+export function getAuthorizedWritablePaths(scopeId?: AuthorizationScopeId): string[] {
+  const target = getAuthorizationMap(scopeId);
+  if (!target) return [];
   const paths: string[] = [];
-  for (const [workspace, caps] of authorizedWorkspaces) {
+  for (const [workspace, caps] of target) {
     if (caps.has('write')) paths.push(workspace);
   }
   return paths;
@@ -216,28 +264,35 @@ export function getAuthorizedWritablePaths(): string[] {
  * Used by the working-directory boundary (workingDirs.ts) to decide whether a
  * command operates inside the user's working set.
  */
-export function getAuthorizedDirs(): string[] {
-  return Array.from(authorizedWorkspaces.keys());
+export function getAuthorizedDirs(scopeId?: AuthorizationScopeId): string[] {
+  const target = getAuthorizationMap(scopeId);
+  return target ? Array.from(target.keys()) : [];
 }
 
 /**
  * Remove a workspace from the authorized list
  */
 export function revokeWorkspace(path: string): void {
-  const normalized = path.replace(/\\/g, '/').replace(/\/+$/, '');
+  const normalized = normalizeWorkspacePath(path);
   authorizedWorkspaces.delete(normalized);
 }
 
 /**
  * Check if a path is within an authorized workspace with the required capability
  */
-function isInAuthorizedWorkspace(path: string, capability: 'read' | 'write' = 'read'): boolean {
+function isInAuthorizedWorkspace(
+  path: string,
+  capability: 'read' | 'write' = 'read',
+  scopeId?: AuthorizationScopeId,
+): boolean {
+  const target = getAuthorizationMap(scopeId);
+  if (!target) return false;
   let normalized = path.replace(/\\/g, '/').replace(/\/+$/, '');
   if (isWindows()) normalized = normalized.toLowerCase();
-  for (const [workspace, caps] of authorizedWorkspaces) {
+  for (const [workspace, caps] of target) {
     const compareWs = isWindows() ? workspace.toLowerCase() : workspace;
     if (normalized === compareWs || normalized.startsWith(compareWs + '/')) {
-      return caps.has(capability);
+      if (caps.has(capability)) return true;
     }
   }
   return false;
@@ -582,7 +637,7 @@ export async function isCatastrophicDeleteTarget(path: string): Promise<boolean>
 /**
  * Check if a path is safe for reading
  */
-export async function checkReadPath(path: string): Promise<PathCheckResult> {
+export async function checkReadPath(path: string, scopeId?: AuthorizationScopeId): Promise<PathCheckResult> {
   // Block UNC network paths
   if (isUNCPath(path)) {
     return { allowed: false, reason: 'UNC network paths are not supported' };
@@ -602,7 +657,7 @@ export async function checkReadPath(path: string): Promise<PathCheckResult> {
   }
 
   // Check if in authorized workspace (already granted permission)
-  if (isInAuthorizedWorkspace(normalizedPath, 'read')) {
+  if (isInAuthorizedWorkspace(normalizedPath, 'read', scopeId)) {
     return { allowed: true };
   }
 
@@ -661,7 +716,7 @@ export async function checkReadPath(path: string): Promise<PathCheckResult> {
 /**
  * Check if a path is safe for writing
  */
-export async function checkWritePath(path: string): Promise<PathCheckResult> {
+export async function checkWritePath(path: string, scopeId?: AuthorizationScopeId): Promise<PathCheckResult> {
   // Block UNC network paths
   if (isUNCPath(path)) {
     return { allowed: false, reason: 'UNC network paths are not supported' };
@@ -701,7 +756,7 @@ export async function checkWritePath(path: string): Promise<PathCheckResult> {
   }
 
   // Check if in authorized workspace (already granted permission)
-  if (isInAuthorizedWorkspace(normalizedPath, 'write')) {
+  if (isInAuthorizedWorkspace(normalizedPath, 'write', scopeId)) {
     return { allowed: true };
   }
 
@@ -760,7 +815,7 @@ export async function checkWritePath(path: string): Promise<PathCheckResult> {
 /**
  * Check if a path is safe for listing (more permissive than read/write)
  */
-export async function checkListPath(path: string): Promise<PathCheckResult> {
+export async function checkListPath(path: string, scopeId?: AuthorizationScopeId): Promise<PathCheckResult> {
   // Block UNC network paths
   if (isUNCPath(path)) {
     return { allowed: false, reason: 'UNC network paths are not supported' };
@@ -775,7 +830,7 @@ export async function checkListPath(path: string): Promise<PathCheckResult> {
   }
 
   // Check if in authorized workspace
-  if (isInAuthorizedWorkspace(normalizedPath, 'read')) {
+  if (isInAuthorizedWorkspace(normalizedPath, 'read', scopeId)) {
     return { allowed: true };
   }
 

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -1,7 +1,7 @@
 import type { ToolDefinition, ToolResult, ToolExecutionContext } from '../../types';
 import { mcpManager } from '../mcp/client';
 import { analyzeCommand, type ConfirmationInfo, type DangerLevel } from './commandSafety';
-import { checkReadPath, checkWritePath, checkListPath, authorizeWorkspace } from './pathSafety';
+import { checkReadPath, checkWritePath, checkListPath, authorizeWorkspace, scopedAuthorizeWorkspace } from './pathSafety';
 import { getI18n } from '../../i18n';
 import { truncateToolResult } from '../context/truncation';
 import { getSettingsReader } from '../agent/ports/settingsReader';
@@ -246,7 +246,7 @@ export type FilePermissionCallback = (request: {
   path: string;
   capability: 'read' | 'write';
   toolName: string;
-}) => Promise<boolean>;
+}, loopId?: string) => Promise<boolean>;
 
 /**
  * Map of file-related tools to their path extraction logic
@@ -387,7 +387,7 @@ export async function checkToolApproval(
       let boundary: CmdBoundary = 'unknown';
       if (!analysis.readOnly && analysis.level === 'safe' && permissionMode !== 'autonomous') {
         const cwd = (input.cwd as string | undefined) || toolContext?.workspacePath || undefined;
-        boundary = analyzeCommandBoundary(command, cwd, await getCachedHomeDir());
+        boundary = analyzeCommandBoundary(command, cwd, await getCachedHomeDir(), toolContext?.authorizationScopeId);
       }
 
       // Decide how this command is gated. 'review' (smart tier) routes to the AI reviewer.
@@ -438,7 +438,8 @@ export async function checkToolApproval(
         ? checkWritePath
         : (name === TOOL_NAMES.LIST_DIRECTORY ? checkListPath : checkReadPath);
 
-      const pathCheck = await checkFn(pathInfo.path);
+      const scopeId = toolContext?.authorizationScopeId;
+      const pathCheck = await checkFn(pathInfo.path, scopeId);
 
       if (!pathCheck.allowed) {
         if (pathCheck.needsPermission && pathCheck.permissionPath) {
@@ -468,12 +469,12 @@ export async function checkToolApproval(
                 path: pathCheck.permissionPath,
                 capability: cap,
                 toolName: name,
-              });
+              }, toolContext?.loopId);
               if (!granted) {
                 return { decision: 'deny', reason: `[${t.toolErrors.userDeniedAccess} ${pathCheck.permissionPath}]` };
               }
               // Permission granted — re-check (should now pass since authorizeWorkspace was called)
-              const recheck = await checkFn(pathInfo.path);
+              const recheck = await checkFn(pathInfo.path, scopeId);
               if (!recheck.allowed) {
                 return { decision: 'deny', reason: `Error: ${recheck.reason || t.toolErrors.pathAccessDenied}` };
               }
@@ -483,7 +484,11 @@ export async function checkToolApproval(
             }
           } else {
             // allow → auto-authorize the workspace for this path
-            authorizeWorkspace(pathCheck.permissionPath);
+            if (scopeId !== undefined) {
+              scopedAuthorizeWorkspace(scopeId, pathCheck.permissionPath, [cap]);
+            } else {
+              authorizeWorkspace(pathCheck.permissionPath);
+            }
           }
         } else {
           // Hard blocked — always enforced regardless of permission mode

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -17,6 +17,7 @@ import {
 } from '../permissions/browserToolPolicy';
 import { classifySelfExtension } from '../permissions/selfExtensionPolicy';
 import { analyzeCommandBoundary, type CmdBoundary } from '../permissions/commandBoundary';
+import { commandWritableDirectories, isInsideWorkingDirs } from '../permissions/workingDirs';
 import { reviewAction } from '../safety/reviewer';
 import { getLoopContext } from '../agent/permissionBridge';
 import { homeDir } from '@tauri-apps/api/path';
@@ -356,6 +357,22 @@ async function resolveBrowserActionOrigin(
   }
 }
 
+async function isScopedCommandCwdWriteAllowed(
+  input: Record<string, unknown>,
+  toolContext?: ToolExecutionContext,
+): Promise<boolean> {
+  const scopeId = toolContext?.authorizationScopeId;
+  if (scopeId === undefined) return true;
+  const effectiveCwd = typeof input.cwd === 'string' && input.cwd.trim().length > 0
+    ? input.cwd
+    : toolContext?.workspacePath ?? undefined;
+  if (!effectiveCwd) return false;
+  if (!isInsideWorkingDirs(effectiveCwd, commandWritableDirectories(scopeId))) {
+    return false;
+  }
+  return (await checkWritePath(effectiveCwd, scopeId)).allowed;
+}
+
 export async function checkToolApproval(
   name: string,
   input: Record<string, unknown>,
@@ -379,6 +396,13 @@ export async function checkToolApproval(
       // Block dangerous commands — always enforced regardless of permission mode
       if (analysis.level === 'block') {
         return { decision: 'deny', reason: `Error: ${t.commandConfirm.blocked}: ${analysis.reason}` };
+      }
+
+      if (!analysis.readOnly && !(await isScopedCommandCwdWriteAllowed(input, toolContext))) {
+        return {
+          decision: 'deny',
+          reason: 'Error: command working directory is not write-authorized for this scoped run',
+        };
       }
 
       // Best-effort boundary check: only matters for safe, non-read-only commands

--- a/src/core/trigger/triggerEngine.test.ts
+++ b/src/core/trigger/triggerEngine.test.ts
@@ -79,11 +79,9 @@ describe('TriggerEngine', () => {
     useChatStore.setState({
       conversations: {},
       activeConversationId: null,
-      agentStatus: 'idle',
-      currentTool: null,
       currentUsage: null,
       pendingInput: null,
-      thinkingStartTime: null,
+      agentStates: new Map(),
     });
   });
 

--- a/src/core/trigger/triggerEngine.test.ts
+++ b/src/core/trigger/triggerEngine.test.ts
@@ -12,9 +12,23 @@ import { useTriggerStore } from '../../stores/triggerStore';
 import { useChatStore } from '../../stores/chatStore';
 import type { Trigger, TriggerEventPayload } from '../../types/trigger';
 
+const runAgentLoopMock = vi.hoisted(() => vi.fn().mockResolvedValue({ reason: 'completed' }));
+const createAuthorizationScopeMock = vi.hoisted(() => vi.fn(() => 'scope-trigger-test'));
+const disposeAuthorizationScopeMock = vi.hoisted(() => vi.fn());
+
 // Mock agentLoop to avoid full LLM execution
 vi.mock('../agent/agentLoop', () => ({
-  runAgentLoop: vi.fn().mockResolvedValue(undefined),
+  runAgentLoop: runAgentLoopMock,
+}));
+
+vi.mock('../agent/agentLoopRunner', () => ({
+  runAgentLoopDispatched: runAgentLoopMock,
+}));
+
+vi.mock('../tools/pathSafety', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../tools/pathSafety')>()),
+  createAuthorizationScope: createAuthorizationScopeMock,
+  disposeAuthorizationScope: disposeAuthorizationScopeMock,
 }));
 
 // Mock notifications
@@ -74,6 +88,11 @@ function makeTrigger(overrides: Partial<Trigger> = {}): Trigger {
 describe('TriggerEngine', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    runAgentLoopMock.mockClear();
+    runAgentLoopMock.mockResolvedValue({ reason: 'completed' });
+    createAuthorizationScopeMock.mockClear();
+    createAuthorizationScopeMock.mockReturnValue('scope-trigger-test');
+    disposeAuthorizationScopeMock.mockClear();
     // Reset stores
     useTriggerStore.setState({ triggers: {}, triggerOrder: [] });
     useChatStore.setState({
@@ -407,6 +426,47 @@ describe('TriggerEngine', () => {
       await triggerEngine.handleEvent(trigger.id, { data: { n: 3 } });
 
       expect(outputSender.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('authorization scope lifecycle', () => {
+    it('passes one trigger-run scope to permission resolution and the agent runner, then disposes it after completion', async () => {
+      const trigger = makeTrigger({
+        id: 'trigger-scope-complete',
+        action: { prompt: 'Do scoped work', workspacePath: '/Users/testuser/Projects/trigger' },
+      });
+      useTriggerStore.setState({ triggers: { [trigger.id]: trigger } });
+      const { resolveTriggerCallbacks } = await import('./triggerPermission');
+
+      await triggerEngine.handleEvent(trigger.id, { data: { n: 1 } });
+
+      expect(createAuthorizationScopeMock).toHaveBeenCalledTimes(1);
+      expect(resolveTriggerCallbacks).toHaveBeenCalledWith(
+        expect.objectContaining({ workspacePath: '/Users/testuser/Projects/trigger' }),
+        { authorizationScopeId: 'scope-trigger-test' },
+      );
+      expect(runAgentLoopMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.objectContaining({ authorizationScopeId: 'scope-trigger-test' }),
+      );
+      expect(disposeAuthorizationScopeMock).toHaveBeenCalledWith('scope-trigger-test');
+    });
+
+    it('disposes the trigger-run scope when the agent runner throws', async () => {
+      const trigger = makeTrigger({
+        id: 'trigger-scope-throw',
+        action: { prompt: 'Do scoped work', workspacePath: '/Users/testuser/Projects/trigger' },
+      });
+      useTriggerStore.setState({ triggers: { [trigger.id]: trigger } });
+      runAgentLoopMock.mockRejectedValueOnce(new Error('agent exploded'));
+
+      await triggerEngine.handleEvent(trigger.id, { data: { n: 2 } });
+
+      expect(disposeAuthorizationScopeMock).toHaveBeenCalledWith('scope-trigger-test');
+      const run = useTriggerStore.getState().triggers[trigger.id]?.runs.at(-1);
+      expect(run?.status).toBe('error');
+      expect(run?.error).toContain('agent exploded');
     });
   });
 });

--- a/src/core/trigger/triggerEngine.ts
+++ b/src/core/trigger/triggerEngine.ts
@@ -14,6 +14,7 @@ import type { NormalizedIMMessage } from '../im/inboundRouter';
 import { getI18n } from '../../i18n';
 import { useIMChannelStore } from '../../stores/imChannelStore';
 import { resolveTriggerCallbacks } from './triggerPermission';
+import { createAuthorizationScope, disposeAuthorizationScope } from '../tools/pathSafety';
 import { cacheTriggerContext } from '../im/triggerContextCache';
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
@@ -317,6 +318,8 @@ class TriggerEngine {
       prompt = `/${trigger.action.skillName} ${prompt}`;
     }
 
+    const authorizationScopeId = createAuthorizationScope();
+
     try {
       // Resolve permission callbacks based on trigger's capability level.
       // Permissions are declared at creation time — no runtime dialogs.
@@ -324,12 +327,13 @@ class TriggerEngine {
       const actionWithWorkspace = workspacePath
         ? { ...trigger.action, workspacePath }
         : trigger.action;
-      const callbacks = resolveTriggerCallbacks(actionWithWorkspace);
+      const callbacks = resolveTriggerCallbacks(actionWithWorkspace, { authorizationScopeId });
       const result = await runAgentLoopDispatched(conversationId, prompt, {
         commandConfirmCallback: callbacks.commandConfirmCallback,
         filePermissionCallback: callbacks.filePermissionCallback,
         blockedTools: callbacks.blockedTools,
         allowedTools: callbacks.allowedTools,
+        authorizationScopeId,
       });
 
       // max_turns hit the cap but still produced a usable (partial) reply — fall
@@ -389,6 +393,8 @@ class TriggerEngine {
         message: errorMsg.slice(0, 100),
       });
       console.error(`[Trigger] Error: ${trigger.name}`, err);
+    } finally {
+      disposeAuthorizationScope(authorizationScopeId);
     }
   }
 

--- a/src/core/trigger/triggerPermission.test.ts
+++ b/src/core/trigger/triggerPermission.test.ts
@@ -1,25 +1,53 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { resolveTriggerCallbacks } from './triggerPermission';
 import { matchesToolName } from '../skill/toolFilter';
-import { checkReadPath, checkWritePath, revokeWorkspace } from '../tools/pathSafety';
+import {
+  authorizeWorkspace,
+  checkReadPath,
+  checkWritePath,
+  createAuthorizationScope,
+  disposeAuthorizationScope,
+  revokeWorkspace,
+} from '../tools/pathSafety';
+import { usePermissionStore } from '../../stores/permissionStore';
 
 describe('resolveTriggerCallbacks', () => {
-  it('carries a custom trigger tool whitelist to the agent run', () => {
-    const callbacks = resolveTriggerCallbacks({
-      prompt: 'read only',
-      capability: 'custom',
-      permissions: { allowedTools: ['read_*', 'http_fetch'] },
-    });
+  function resolveForTest(action: Parameters<typeof resolveTriggerCallbacks>[0]) {
+    const scopeId = createAuthorizationScope();
+    const callbacks = resolveTriggerCallbacks(action, { authorizationScopeId: scopeId });
+    return {
+      callbacks,
+      scopeId,
+      dispose: () => disposeAuthorizationScope(scopeId),
+    };
+  }
 
-    expect(callbacks.allowedTools).toEqual(['read_*', 'http_fetch']);
-    expect(callbacks.blockedTools).toContain('request_workspace');
+  it('carries a custom trigger tool whitelist to the agent run', () => {
+    const { callbacks, dispose } = resolveForTest({
+        prompt: 'read only',
+        capability: 'custom',
+        permissions: { allowedTools: ['read_*', 'http_fetch'] },
+      });
+    try {
+      expect(callbacks.allowedTools).toEqual(['read_*', 'http_fetch']);
+      expect(callbacks.blockedTools).toContain('request_workspace');
+    } finally {
+      dispose();
+    }
   });
 
   // read_tools is the exception since RB-02 — see the read_tools write
   // ceiling block below. The confirming tiers stay callback-driven.
   it('does not create a whitelist for the confirming capability levels', () => {
-    expect(resolveTriggerCallbacks({ prompt: 'safe', capability: 'safe_tools' }).allowedTools).toBeUndefined();
-    expect(resolveTriggerCallbacks({ prompt: 'full', capability: 'full' }).allowedTools).toBeUndefined();
+    const safe = resolveForTest({ prompt: 'safe', capability: 'safe_tools' });
+    const full = resolveForTest({ prompt: 'full', capability: 'full' });
+    try {
+      expect(safe.callbacks.allowedTools).toBeUndefined();
+      expect(full.callbacks.allowedTools).toBeUndefined();
+    } finally {
+      safe.dispose();
+      full.dispose();
+    }
   });
 
   // b4ce62e8 closed this hole on the scheduler side and its own note flagged
@@ -36,23 +64,105 @@ describe('resolveTriggerCallbacks', () => {
     });
 
     it('read_tools authorizes its workspace read-only — writes inside it stay blocked', async () => {
-      resolveTriggerCallbacks({ prompt: 'read', capability: 'read_tools', workspacePath: WS });
+      const { scopeId, dispose } = resolveForTest({ prompt: 'read', capability: 'read_tools', workspacePath: WS });
 
-      expect((await checkReadPath(`${WS}/notes.md`)).allowed).toBe(true);
-      expect((await checkWritePath(`${WS}/evil.sh`)).allowed).toBe(false);
+      try {
+        expect((await checkReadPath(`${WS}/notes.md`, scopeId)).allowed).toBe(true);
+        expect((await checkWritePath(`${WS}/evil.sh`, scopeId)).allowed).toBe(false);
+      } finally {
+        dispose();
+      }
     });
 
     it('a trigger with no capability field (defaults to read_tools) gets the same read-only grant', async () => {
-      resolveTriggerCallbacks({ prompt: 'read', workspacePath: WS });
+      const { scopeId, dispose } = resolveForTest({ prompt: 'read', workspacePath: WS });
 
-      expect((await checkWritePath(`${WS}/evil.sh`)).allowed).toBe(false);
+      try {
+        expect((await checkWritePath(`${WS}/evil.sh`, scopeId)).allowed).toBe(false);
+      } finally {
+        dispose();
+      }
     });
 
     it('safe_tools and full still get read+write in their workspace', async () => {
       for (const capability of ['safe_tools', 'full'] as const) {
         revokeWorkspace(WS);
-        resolveTriggerCallbacks({ prompt: 'x', capability, workspacePath: WS });
-        expect((await checkWritePath(`${WS}/out.txt`)).allowed, capability).toBe(true);
+        const { scopeId, dispose } = resolveForTest({ prompt: 'x', capability, workspacePath: WS });
+        try {
+          expect((await checkWritePath(`${WS}/out.txt`, scopeId)).allowed, capability).toBe(true);
+        } finally {
+          dispose();
+        }
+      }
+    });
+
+    it('read_tools uses its run scope instead of inheriting a standing global write grant', async () => {
+      const scopeId = createAuthorizationScope();
+      authorizeWorkspace(WS, ['read', 'write']);
+      try {
+        resolveTriggerCallbacks(
+          { prompt: 'read', capability: 'read_tools', workspacePath: WS },
+          { authorizationScopeId: scopeId },
+        );
+
+        expect((await checkReadPath(`${WS}/notes.md`, scopeId)).allowed).toBe(true);
+        expect((await checkWritePath(`${WS}/evil.sh`, scopeId)).allowed).toBe(false);
+        expect((await checkWritePath(`${WS}/interactive.md`)).allowed).toBe(true);
+      } finally {
+        disposeAuthorizationScope(scopeId);
+        revokeWorkspace(WS);
+      }
+    });
+  });
+
+  describe('scoped file callback grants preserve the requested capability', () => {
+    beforeEach(() => {
+      usePermissionStore.setState({ persistedGrants: {}, sessionGrants: {}, pendingRequest: null });
+    });
+
+    it('safe_tools syncs an existing read grant without upgrading it to write', async () => {
+      const path = '/Users/testuser/Desktop/trigger-safe-read.md';
+      const { callbacks, scopeId, dispose } = resolveForTest({ prompt: 'safe', capability: 'safe_tools' });
+      usePermissionStore.getState().grantPermission(path, ['read'], 'session');
+
+      try {
+        await expect(callbacks.filePermissionCallback({
+          path,
+          capability: 'read',
+          toolName: 'read_file',
+        })).resolves.toBe(true);
+
+        expect((await checkReadPath(path, scopeId)).allowed).toBe(true);
+        expect((await checkWritePath(path, scopeId)).allowed).toBe(false);
+      } finally {
+        dispose();
+        revokeWorkspace(path);
+        usePermissionStore.setState({ persistedGrants: {}, sessionGrants: {}, pendingRequest: null });
+      }
+    });
+
+    it('custom callbacks sync an existing read grant without upgrading it to write', async () => {
+      const path = '/Users/testuser/Desktop/trigger-custom-read.md';
+      const { callbacks, scopeId, dispose } = resolveForTest({
+        prompt: 'custom',
+        capability: 'custom',
+        permissions: { allowedTools: ['read_file'] },
+      });
+      usePermissionStore.getState().grantPermission(path, ['read'], 'session');
+
+      try {
+        await expect(callbacks.filePermissionCallback({
+          path,
+          capability: 'read',
+          toolName: 'read_file',
+        })).resolves.toBe(true);
+
+        expect((await checkReadPath(path, scopeId)).allowed).toBe(true);
+        expect((await checkWritePath(path, scopeId)).allowed).toBe(false);
+      } finally {
+        dispose();
+        revokeWorkspace(path);
+        usePermissionStore.setState({ persistedGrants: {}, sessionGrants: {}, pendingRequest: null });
       }
     });
   });
@@ -66,30 +176,42 @@ describe('resolveTriggerCallbacks', () => {
   // read-only tier has no browser access, period.
   describe('read_tools browser ceiling', () => {
     it('blocks every browser-automation tool via a namespace wildcard — including navigate and read-only tools', () => {
-      const { blockedTools } = resolveTriggerCallbacks({ prompt: 'read', capability: 'read_tools' });
+      const { callbacks: { blockedTools }, dispose } = resolveForTest({ prompt: 'read', capability: 'read_tools' });
 
-      // click/fill/select/keyboard/execute_js/navigate are the enumerated
-      // STATE_CHANGING_TOOLS; snapshot/screenshot/get_tabs stand in for the
-      // read-only tools this module never enumerates (they're registered
-      // dynamically by the browser servers) — the wildcard has to catch
-      // those too, not just the known state-changing set.
-      for (const tool of ['click', 'fill', 'select', 'keyboard', 'execute_js', 'navigate', 'snapshot', 'screenshot', 'get_tabs']) {
-        expect(blockedTools.some((p) => matchesToolName(`abu-browser__${tool}`, p)), tool).toBe(true);
-        expect(blockedTools.some((p) => matchesToolName(`abu-browser-bridge__${tool}`, p)), tool).toBe(true);
+      try {
+        // click/fill/select/keyboard/execute_js/navigate are the enumerated
+        // STATE_CHANGING_TOOLS; snapshot/screenshot/get_tabs stand in for the
+        // read-only tools this module never enumerates (they're registered
+        // dynamically by the browser servers) — the wildcard has to catch
+        // those too, not just the known state-changing set.
+        for (const tool of ['click', 'fill', 'select', 'keyboard', 'execute_js', 'navigate', 'snapshot', 'screenshot', 'get_tabs']) {
+          expect(blockedTools.some((p) => matchesToolName(`abu-browser__${tool}`, p)), tool).toBe(true);
+          expect(blockedTools.some((p) => matchesToolName(`abu-browser-bridge__${tool}`, p)), tool).toBe(true);
+        }
+      } finally {
+        dispose();
       }
     });
 
     it('leaves the higher tiers untouched', () => {
       for (const capability of ['safe_tools', 'full'] as const) {
-        const { blockedTools } = resolveTriggerCallbacks({ prompt: 'x', capability });
-        expect(blockedTools.some((p) => matchesToolName('abu-browser__click', p)), capability).toBe(false);
-        expect(blockedTools.some((p) => matchesToolName('abu-browser__navigate', p)), capability).toBe(false);
+        const { callbacks: { blockedTools }, dispose } = resolveForTest({ prompt: 'x', capability });
+        try {
+          expect(blockedTools.some((p) => matchesToolName('abu-browser__click', p)), capability).toBe(false);
+          expect(blockedTools.some((p) => matchesToolName('abu-browser__navigate', p)), capability).toBe(false);
+        } finally {
+          dispose();
+        }
       }
     });
 
     it('applies to a task that predates the capability field (defaults to read_tools)', () => {
-      const { blockedTools } = resolveTriggerCallbacks({ prompt: 'x' });
-      expect(blockedTools.some((p) => matchesToolName('abu-browser__click', p))).toBe(true);
+      const { callbacks: { blockedTools }, dispose } = resolveForTest({ prompt: 'x' });
+      try {
+        expect(blockedTools.some((p) => matchesToolName('abu-browser__click', p))).toBe(true);
+      } finally {
+        dispose();
+      }
     });
   });
 
@@ -99,8 +221,12 @@ describe('resolveTriggerCallbacks', () => {
   // callback never runs and `touch` / `mkdir` / `cp` wrote unasked. The
   // roster is what actually holds the "changes nothing" promise.
   describe('read_tools write ceiling', () => {
-    const allowedFor = (capability: 'read_tools' | 'safe_tools' | 'full') =>
-      resolveTriggerCallbacks({ prompt: 'x', capability }).allowedTools;
+    const allowedFor = (capability: 'read_tools' | 'safe_tools' | 'full') => {
+      const { callbacks, dispose } = resolveForTest({ prompt: 'x', capability });
+      const allowedTools = callbacks.allowedTools;
+      dispose();
+      return allowedTools;
+    };
 
     it('caps the tier at a positive roster instead of relying on the deny callback', () => {
       const allowed = allowedFor('read_tools');
@@ -135,7 +261,9 @@ describe('resolveTriggerCallbacks', () => {
     });
 
     it('applies to a task that predates the capability field (defaults to read_tools)', () => {
-      const allowed = resolveTriggerCallbacks({ prompt: 'x' }).allowedTools ?? [];
+      const { callbacks, dispose } = resolveForTest({ prompt: 'x' });
+      const allowed = callbacks.allowedTools ?? [];
+      dispose();
       expect(allowed.some((p) => matchesToolName('run_command', p))).toBe(false);
     });
   });

--- a/src/core/trigger/triggerPermission.test.ts
+++ b/src/core/trigger/triggerPermission.test.ts
@@ -115,38 +115,17 @@ describe('resolveTriggerCallbacks', () => {
     });
   });
 
-  describe('scoped file callback grants preserve the requested capability', () => {
+  describe('run-scoped file callbacks do not import standing global grants', () => {
     beforeEach(() => {
       usePermissionStore.setState({ persistedGrants: {}, sessionGrants: {}, pendingRequest: null });
     });
 
-    it('safe_tools syncs an existing read grant without upgrading it to write', async () => {
-      const path = '/Users/testuser/Desktop/trigger-safe-read.md';
-      const { callbacks, scopeId, dispose } = resolveForTest({ prompt: 'safe', capability: 'safe_tools' });
-      usePermissionStore.getState().grantPermission(path, ['read'], 'session');
-
-      try {
-        await expect(callbacks.filePermissionCallback({
-          path,
-          capability: 'read',
-          toolName: 'read_file',
-        })).resolves.toBe(true);
-
-        expect((await checkReadPath(path, scopeId)).allowed).toBe(true);
-        expect((await checkWritePath(path, scopeId)).allowed).toBe(false);
-      } finally {
-        dispose();
-        revokeWorkspace(path);
-        usePermissionStore.setState({ persistedGrants: {}, sessionGrants: {}, pendingRequest: null });
-      }
-    });
-
-    it('custom callbacks sync an existing read grant without upgrading it to write', async () => {
-      const path = '/Users/testuser/Desktop/trigger-custom-read.md';
+    it('read_tools refuses a globally granted read outside its declared workspace', async () => {
+      const path = '/Users/testuser/Desktop/trigger-read-only.md';
       const { callbacks, scopeId, dispose } = resolveForTest({
-        prompt: 'custom',
-        capability: 'custom',
-        permissions: { allowedTools: ['read_file'] },
+        prompt: 'read',
+        capability: 'read_tools',
+        workspacePath: '/Users/testuser/Projects/trigger-read-workspace',
       });
       usePermissionStore.getState().grantPermission(path, ['read'], 'session');
 
@@ -155,9 +134,61 @@ describe('resolveTriggerCallbacks', () => {
           path,
           capability: 'read',
           toolName: 'read_file',
-        })).resolves.toBe(true);
+        })).resolves.toBe(false);
 
-        expect((await checkReadPath(path, scopeId)).allowed).toBe(true);
+        expect((await checkReadPath(path, scopeId)).allowed).toBe(false);
+      } finally {
+        dispose();
+        revokeWorkspace(path);
+        usePermissionStore.setState({ persistedGrants: {}, sessionGrants: {}, pendingRequest: null });
+      }
+    });
+
+    it('safe_tools refuses a globally granted path outside its declared workspace', async () => {
+      const path = '/Users/testuser/Desktop/trigger-safe-read.md';
+      const { callbacks, scopeId, dispose } = resolveForTest({
+        prompt: 'safe',
+        capability: 'safe_tools',
+        workspacePath: '/Users/testuser/Projects/trigger-safe-workspace',
+      });
+      usePermissionStore.getState().grantPermission(path, ['read', 'write'], 'session');
+
+      try {
+        await expect(callbacks.filePermissionCallback({
+          path,
+          capability: 'write',
+          toolName: 'write_file',
+        })).resolves.toBe(false);
+
+        expect((await checkReadPath(path, scopeId)).allowed).toBe(false);
+        expect((await checkWritePath(path, scopeId)).allowed).toBe(false);
+      } finally {
+        dispose();
+        revokeWorkspace(path);
+        usePermissionStore.setState({ persistedGrants: {}, sessionGrants: {}, pendingRequest: null });
+      }
+    });
+
+    it('custom refuses a globally granted path outside its explicit allowlist', async () => {
+      const path = '/Users/testuser/Desktop/trigger-custom-write.md';
+      const { callbacks, scopeId, dispose } = resolveForTest({
+        prompt: 'custom',
+        capability: 'custom',
+        permissions: {
+          allowedPaths: ['/Users/testuser/Projects/only-this-path'],
+          allowedTools: ['write_file'],
+        },
+      });
+      usePermissionStore.getState().grantPermission(path, ['read', 'write'], 'session');
+
+      try {
+        await expect(callbacks.filePermissionCallback({
+          path,
+          capability: 'write',
+          toolName: 'write_file',
+        })).resolves.toBe(false);
+
+        expect((await checkReadPath(path, scopeId)).allowed).toBe(false);
         expect((await checkWritePath(path, scopeId)).allowed).toBe(false);
       } finally {
         dispose();

--- a/src/core/trigger/triggerPermission.ts
+++ b/src/core/trigger/triggerPermission.ts
@@ -11,7 +11,7 @@ import type { TriggerAction, TriggerCapability, TriggerPermissions } from '../..
 import type { ConfirmationInfo, FilePermissionCallback } from '../tools/registry';
 import { listAllBrowserToolPatterns } from '../permissions/browserToolPolicy';
 import { READ_ONLY_TOOL_ALLOWLIST } from '../permissions/readOnlyToolPolicy';
-import { authorizeWorkspace } from '../tools/pathSafety';
+import { scopedAuthorizeWorkspace } from '../tools/pathSafety';
 import { usePermissionStore } from '../../stores/permissionStore';
 import { TOOL_NAMES } from '../tools/toolNames';
 
@@ -31,12 +31,17 @@ export interface TriggerCallbacks {
   allowedTools?: string[];
 }
 
+export interface TriggerCallbackOptions {
+  authorizationScopeId: string;
+}
+
 /**
  * Resolve permission callbacks for a trigger based on its capability level.
  * Pre-authorizes workspace and allowed paths before execution.
  */
-export function resolveTriggerCallbacks(action: TriggerAction): TriggerCallbacks {
+export function resolveTriggerCallbacks(action: TriggerAction, options: TriggerCallbackOptions): TriggerCallbacks {
   const capability = action.capability ?? 'read_tools';
+  const authorizationScopeId = options.authorizationScopeId;
 
   // Pre-authorize the workspace path with the rights the tier actually
   // promises — NOT authorizeWorkspace's read+write default. An authorized
@@ -46,12 +51,12 @@ export function resolveTriggerCallbacks(action: TriggerAction): TriggerCallbacks
   // trigger ("reads information, changes nothing") could write anywhere
   // inside its own workspace. b4ce62e8 closed exactly this hole on the
   // scheduler side and its own commit note flagged the trigger path as still
-  // open; this closes it. (Note the map only ever *adds* capabilities — if
-  // the same directory was already authorized read+write by an interactive
-  // session, that standing grant still applies; this stops the trigger from
-  // minting the write grant itself.)
+  // open; this closes it. The grant is scoped to this unattended run, so a
+  // standing global read+write grant from an interactive session is not
+  // inherited by read_tools.
   if (action.workspacePath) {
-    authorizeWorkspace(
+    scopedAuthorizeWorkspace(
+      authorizationScopeId,
       action.workspacePath,
       capability === 'read_tools' ? ['read'] : ['read', 'write'],
     );
@@ -60,7 +65,7 @@ export function resolveTriggerCallbacks(action: TriggerAction): TriggerCallbacks
   // Pre-authorize custom allowed paths
   if (capability === 'custom' && action.permissions?.allowedPaths) {
     for (const p of action.permissions.allowedPaths) {
-      authorizeWorkspace(p);
+      scopedAuthorizeWorkspace(authorizationScopeId, p);
     }
   }
 
@@ -84,7 +89,7 @@ export function resolveTriggerCallbacks(action: TriggerAction): TriggerCallbacks
             // Auto-allow reads for pre-authorized workspaces (read-only)
             const permStore = usePermissionStore.getState();
             if (permStore.hasPermission(req.path, 'read')) {
-              authorizeWorkspace(req.path, ['read']);
+              scopedAuthorizeWorkspace(authorizationScopeId, req.path, ['read']);
               return true;
             }
           }
@@ -108,7 +113,7 @@ export function resolveTriggerCallbacks(action: TriggerAction): TriggerCallbacks
         filePermissionCallback: async (req) => {
           const permStore = usePermissionStore.getState();
           if (permStore.hasPermission(req.path, req.capability)) {
-            authorizeWorkspace(req.path);
+            scopedAuthorizeWorkspace(authorizationScopeId, req.path, [req.capability]);
             return true;
           }
           console.log(`[Trigger] safe_tools: denied ${req.capability} "${req.path}"`);
@@ -129,20 +134,21 @@ export function resolveTriggerCallbacks(action: TriggerAction): TriggerCallbacks
         },
         filePermissionCallback: async (req) => {
           // Auto-allow all file access (pathSafety hard blocks still apply in executeAnyTool)
-          authorizeWorkspace(req.path);
+          scopedAuthorizeWorkspace(authorizationScopeId, req.path);
           return true;
         },
         blockedTools,
       };
 
     case 'custom':
-      return buildCustomCallbacks(action.permissions, blockedTools);
+      return buildCustomCallbacks(action.permissions, blockedTools, authorizationScopeId);
   }
 }
 
 function buildCustomCallbacks(
   permissions: TriggerPermissions | undefined,
   blockedTools: string[],
+  authorizationScopeId: string,
 ): TriggerCallbacks {
   const allowedCommands = permissions?.allowedCommands;
 
@@ -164,7 +170,7 @@ function buildCustomCallbacks(
     filePermissionCallback: async (req) => {
       const permStore = usePermissionStore.getState();
       if (permStore.hasPermission(req.path, req.capability)) {
-        authorizeWorkspace(req.path);
+        scopedAuthorizeWorkspace(authorizationScopeId, req.path, [req.capability]);
         return true;
       }
       console.log(`[Trigger] custom: denied ${req.capability} "${req.path}"`);

--- a/src/core/trigger/triggerPermission.ts
+++ b/src/core/trigger/triggerPermission.ts
@@ -12,7 +12,6 @@ import type { ConfirmationInfo, FilePermissionCallback } from '../tools/registry
 import { listAllBrowserToolPatterns } from '../permissions/browserToolPolicy';
 import { READ_ONLY_TOOL_ALLOWLIST } from '../permissions/readOnlyToolPolicy';
 import { scopedAuthorizeWorkspace } from '../tools/pathSafety';
-import { usePermissionStore } from '../../stores/permissionStore';
 import { TOOL_NAMES } from '../tools/toolNames';
 
 /** Simple glob matching for command patterns (e.g. "npm run *", "git *") */
@@ -85,14 +84,9 @@ export function resolveTriggerCallbacks(action: TriggerAction, options: TriggerC
           return false;
         },
         filePermissionCallback: async (req) => {
-          if (req.capability === 'read') {
-            // Auto-allow reads for pre-authorized workspaces (read-only)
-            const permStore = usePermissionStore.getState();
-            if (permStore.hasPermission(req.path, 'read')) {
-              scopedAuthorizeWorkspace(authorizationScopeId, req.path, ['read']);
-              return true;
-            }
-          }
+          // The run's declared workspace was already pre-authorized above.
+          // Reaching this callback means the path is outside that run-local
+          // set, so a standing interactive grant must not bridge into it.
           console.log(`[Trigger] read_tools: denied ${req.capability} "${req.path}"`);
           return false;
         },
@@ -111,11 +105,8 @@ export function resolveTriggerCallbacks(action: TriggerAction, options: TriggerC
           return allowed;
         },
         filePermissionCallback: async (req) => {
-          const permStore = usePermissionStore.getState();
-          if (permStore.hasPermission(req.path, req.capability)) {
-            scopedAuthorizeWorkspace(authorizationScopeId, req.path, [req.capability]);
-            return true;
-          }
+          // Workspace access is already present in this run's scope. Never
+          // import unrelated interactive grants into an unattended run.
           console.log(`[Trigger] safe_tools: denied ${req.capability} "${req.path}"`);
           return false;
         },
@@ -141,14 +132,13 @@ export function resolveTriggerCallbacks(action: TriggerAction, options: TriggerC
       };
 
     case 'custom':
-      return buildCustomCallbacks(action.permissions, blockedTools, authorizationScopeId);
+      return buildCustomCallbacks(action.permissions, blockedTools);
   }
 }
 
 function buildCustomCallbacks(
   permissions: TriggerPermissions | undefined,
   blockedTools: string[],
-  authorizationScopeId: string,
 ): TriggerCallbacks {
   const allowedCommands = permissions?.allowedCommands;
 
@@ -168,11 +158,9 @@ function buildCustomCallbacks(
       return allowed;
     },
     filePermissionCallback: async (req) => {
-      const permStore = usePermissionStore.getState();
-      if (permStore.hasPermission(req.path, req.capability)) {
-        scopedAuthorizeWorkspace(authorizationScopeId, req.path, [req.capability]);
-        return true;
-      }
+      // Explicit allowedPaths were pre-authorized in the run scope. A path
+      // that still reaches this callback is outside that allowlist, even if
+      // an interactive conversation granted it globally.
       console.log(`[Trigger] custom: denied ${req.capability} "${req.path}"`);
       return false;
     },

--- a/src/eval/__snapshots__/toolSchemaSnapshot.test.ts.snap
+++ b/src/eval/__snapshots__/toolSchemaSnapshot.test.ts.snap
@@ -247,7 +247,6 @@ exports[`Tool schema snapshot > all tool schemas match snapshot 1`] = `
       "allowed_commands",
       "allowed_paths",
       "allowed_tools",
-      "capability",
       "debounce_enabled",
       "debounce_seconds",
       "description",

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -2571,6 +2571,7 @@ const enUS: TranslationDict = {
       capFull: 'Fully autonomous',
       capCustom: 'Custom allowlist',
       capLevelLine: 'Capability level: {label}',
+      triggerCapabilityUiNotice: 'Capability level is set by the user in Trigger Settings.',
       filterLine: 'Filter: {filter}',
       debounceLine: 'Debounce: {value}',
       debounceSeconds: '{seconds}s',

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -2571,7 +2571,7 @@ const enUS: TranslationDict = {
       capFull: 'Fully autonomous',
       capCustom: 'Custom allowlist',
       capLevelLine: 'Capability level: {label}',
-      triggerCapabilityUiNotice: 'Capability level is set by the user in Trigger Settings.',
+      triggerCapabilityUiNotice: 'The model cannot change the capability level. New triggers use Read Only; updates keep the existing level.',
       filterLine: 'Filter: {filter}',
       debounceLine: 'Debounce: {value}',
       debounceSeconds: '{seconds}s',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -2572,6 +2572,7 @@ const zhCN: TranslationDict = {
       capFull: '完全自主',
       capCustom: '自定义白名单',
       capLevelLine: '能力等级: {label}',
+      triggerCapabilityUiNotice: '能力档位由用户在触发器设置界面设置。',
       filterLine: '过滤: {filter}',
       debounceLine: '防抖: {value}',
       debounceSeconds: '{seconds}秒',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -2572,7 +2572,7 @@ const zhCN: TranslationDict = {
       capFull: '完全自主',
       capCustom: '自定义白名单',
       capLevelLine: '能力等级: {label}',
-      triggerCapabilityUiNotice: '能力档位由用户在触发器设置界面设置。',
+      triggerCapabilityUiNotice: '模型不能更改能力档位。新建触发器默认为只读；更新时保留现有档位。',
       filterLine: '过滤: {filter}',
       debounceLine: '防抖: {value}',
       debounceSeconds: '{seconds}秒',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -2820,6 +2820,8 @@ export interface TranslationDict {
       capCustom: string;
       /** {label} */
       capLevelLine: string;
+      /** Capability level is controlled by the user in the trigger settings UI. */
+      triggerCapabilityUiNotice: string;
       /** {filter} */
       filterLine: string;
       /** {value} */

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -84,12 +84,10 @@ describe('chatStore', () => {
       // from earlier tests would leak across cases.
       conversationIndex: {},
       activeConversationId: null,
-      agentStatus: 'idle',
-      currentTool: null,
       currentUsage: null,
       pendingInput: null,
       pendingInputAppend: null,
-      thinkingStartTime: null,
+      agentStates: new Map(),
     });
   });
 
@@ -860,15 +858,22 @@ describe('chatStore', () => {
 
   // ── finishStreaming ──
   describe('finishStreaming', () => {
-    it('sets isStreaming to false and resets agent status', () => {
+    it('sets isStreaming to false and cleans up only that conversation agent state', () => {
       const id = useChatStore.getState().createConversation();
+      const otherId = useChatStore.getState().createConversation();
       useChatStore.getState().addMessage(id, {
         id: 'msg1', role: 'assistant', content: 'Hi', timestamp: FIXED_TIMESTAMP, isStreaming: true,
       });
+      useChatStore.getState().setAgentStatus(id, 'tool-calling', 'read_file');
+      useChatStore.getState().setAgentStatus(otherId, 'tool-calling', 'write_file');
       useChatStore.getState().finishStreaming(id);
       const state = useChatStore.getState();
       expect(state.conversations[id].messages[0].isStreaming).toBe(false);
-      expect(state.agentStatus).toBe('idle');
+      expect(state.agentStates.has(id)).toBe(false);
+      expect(state.agentStates.get(otherId)).toMatchObject({
+        status: 'tool-calling',
+        currentTool: 'write_file',
+      });
     });
 
     // Regression: without msgId, finishStreaming flipped isStreaming on whatever
@@ -1154,7 +1159,7 @@ describe('chatStore', () => {
       useChatStore.getState().addMessage(id, {
         id: 'a1', role: 'assistant', content: '部分输出', timestamp: FIXED_TIMESTAMP, isStreaming: true,
       });
-      useChatStore.setState({ agentStatus: 'thinking' });
+      useChatStore.getState().setAgentStatus(id, 'thinking');
       const controller = useChatStore.getState().getAbortController(id);
 
       useChatStore.getState().cancelStreaming(id);
@@ -1168,7 +1173,7 @@ describe('chatStore', () => {
       const live = useChatStore.getState().conversations[id].messages[0];
       expect(live.content).toBe('部分输出');
       expect(live.isStreaming).toBe(true);
-      expect(useChatStore.getState().agentStatus).toBe('thinking');
+      expect(useChatStore.getState().agentStates.get(id)?.status).toBe('thinking');
     });
 
     it('frame-driven call (fromSidecarFrame: true) applies the FULL decoration even though a sidecar run still reads as active', () => {
@@ -1191,7 +1196,7 @@ describe('chatStore', () => {
       expect(live.content).toBe('部分输出');
       expect(live.stopReason).toBe('user');
       expect(live.isStreaming).toBe(false);
-      expect(useChatStore.getState().agentStatus).toBe('idle');
+      expect(useChatStore.getState().agentStates.has(id)).toBe(false);
     });
 
     it('direct call with NO active sidecar run: unchanged original full-decoration path', () => {
@@ -1208,7 +1213,7 @@ describe('chatStore', () => {
       expect(live.content).toBe('部分输出');
       expect(live.stopReason).toBe('user');
       expect(live.isStreaming).toBe(false);
-      expect(useChatStore.getState().agentStatus).toBe('idle');
+      expect(useChatStore.getState().agentStates.has(id)).toBe(false);
     });
   });
 
@@ -1217,7 +1222,7 @@ describe('chatStore', () => {
   // "user enqueued input while the turn ended without tool calls" rescue path)
   // as part of the chatStore write-side probe. Unlike finishStreaming, this
   // looks a message up by EXACT id (no FALLBACK_LAST) and has zero side effects
-  // beyond the flag flip — no disk persistence, no agentStatus/retryInfo reset.
+  // beyond the flag flip — no disk persistence, no agent-state cleanup.
   describe('setMessageStreamingFlag', () => {
     it('flips isStreaming on the exact message id', () => {
       const id = useChatStore.getState().createConversation();
@@ -1228,14 +1233,14 @@ describe('chatStore', () => {
       expect(useChatStore.getState().conversations[id].messages[0].isStreaming).toBe(false);
     });
 
-    it('does not touch agentStatus/retryInfo (unlike finishStreaming)', () => {
+    it('does not touch agent state (unlike finishStreaming)', () => {
       const id = useChatStore.getState().createConversation();
       useChatStore.getState().addMessage(id, {
         id: 'a1', role: 'assistant', content: 'partial', timestamp: FIXED_TIMESTAMP, isStreaming: true,
       });
-      useChatStore.getState().setAgentStatus('streaming');
+      useChatStore.getState().setAgentStatus(id, 'streaming');
       useChatStore.getState().setMessageStreamingFlag(id, 'a1', false);
-      expect(useChatStore.getState().agentStatus).toBe('streaming');
+      expect(useChatStore.getState().agentStates.get(id)?.status).toBe('streaming');
     });
 
     it('is a no-op when messageId does not match any message (no FALLBACK_LAST)', () => {
@@ -1498,22 +1503,48 @@ describe('chatStore', () => {
 
   // ── setAgentStatus ──
   describe('setAgentStatus', () => {
-    it('sets thinking status with timestamp', () => {
-      useChatStore.getState().setAgentStatus('thinking');
+    it('sets thinking status with timestamp for one conversation', () => {
+      const id = useChatStore.getState().createConversation();
+      useChatStore.getState().setAgentStatus(id, 'thinking');
       const state = useChatStore.getState();
-      expect(state.agentStatus).toBe('thinking');
-      expect(state.thinkingStartTime).not.toBeNull();
+      expect(state.agentStates.get(id)).toMatchObject({ status: 'thinking' });
+      expect(state.agentStates.get(id)?.thinkingStartTime).not.toBeNull();
     });
 
-    it('clears thinking timestamp on idle', () => {
-      useChatStore.getState().setAgentStatus('thinking');
-      useChatStore.getState().setAgentStatus('idle');
-      expect(useChatStore.getState().thinkingStartTime).toBeNull();
+    it('clears only the addressed conversation on idle', () => {
+      const id = useChatStore.getState().createConversation();
+      const otherId = useChatStore.getState().createConversation();
+      useChatStore.getState().setAgentStatus(id, 'thinking');
+      useChatStore.getState().setAgentStatus(otherId, 'tool-calling', 'read_file');
+      useChatStore.getState().setAgentStatus(id, 'idle');
+      expect(useChatStore.getState().agentStates.has(id)).toBe(false);
+      expect(useChatStore.getState().agentStates.get(otherId)).toMatchObject({
+        status: 'tool-calling',
+        currentTool: 'read_file',
+      });
     });
 
-    it('sets tool name', () => {
-      useChatStore.getState().setAgentStatus('tool-calling', 'read_file');
-      expect(useChatStore.getState().currentTool).toBe('read_file');
+    it('isolates tool, retry, and active-agent state between concurrent conversations', () => {
+      const convA = useChatStore.getState().createConversation();
+      const convB = useChatStore.getState().createConversation();
+
+      useChatStore.getState().setAgentStatus(convA, 'tool-calling', 'read_file', 'agent-a');
+      useChatStore.getState().setRetryInfo(convA, { attempt: 2, maxAttempts: 3, delayMs: 5000 });
+      useChatStore.getState().setAgentStatus(convB, 'idle');
+
+      expect(useChatStore.getState().agentStates.get(convA)).toMatchObject({
+        status: 'tool-calling',
+        currentTool: 'read_file',
+        retryInfo: { attempt: 2, maxAttempts: 3, delayMs: 5000 },
+        activeAgentNames: ['agent-a'],
+      });
+      expect(useChatStore.getState().agentStates.has(convB)).toBe(false);
+    });
+
+    it('does not create orphan agent state for a missing conversation', () => {
+      useChatStore.getState().setAgentStatus('missing-conv', 'tool-calling', 'read_file');
+
+      expect(useChatStore.getState().agentStates.has('missing-conv')).toBe(false);
     });
   });
 
@@ -1613,6 +1644,58 @@ describe('chatStore', () => {
       await new Promise((r) => setTimeout(r, 20));
       const reindex = vi.mocked(invoke).mock.calls.find((c) => c[0] === 'catalog_reindex_conversation');
       expect(reindex).toBeUndefined();
+    });
+
+    it('cleans terminal agent state for an unloaded conversation without clobbering another row', () => {
+      const completedId = 'unloaded-completed-conv';
+      const errorId = 'unloaded-error-conv';
+      const otherId = 'other-running-conv';
+
+      useChatStore.setState({
+        agentStates: new Map([
+          [completedId, {
+            status: 'thinking',
+            currentTool: null,
+            retryInfo: null,
+            thinkingStartTime: FIXED_TIMESTAMP,
+            activeAgentNames: [],
+          }],
+          [errorId, {
+            status: 'tool-calling',
+            currentTool: 'read_file',
+            retryInfo: null,
+            thinkingStartTime: null,
+            activeAgentNames: [],
+          }],
+          [otherId, {
+            status: 'streaming',
+            currentTool: null,
+            retryInfo: null,
+            thinkingStartTime: null,
+            activeAgentNames: [],
+          }],
+        ]),
+      });
+      expect(useChatStore.getState().conversations[completedId]).toBeUndefined();
+      expect(useChatStore.getState().conversations[errorId]).toBeUndefined();
+
+      useChatStore.getState().setConversationStatus(completedId, 'completed');
+
+      expect(useChatStore.getState().agentStates.has(completedId)).toBe(false);
+      expect(useChatStore.getState().agentStates.get(errorId)).toMatchObject({
+        status: 'tool-calling',
+        currentTool: 'read_file',
+      });
+      expect(useChatStore.getState().agentStates.get(otherId)).toMatchObject({
+        status: 'streaming',
+      });
+
+      useChatStore.getState().setConversationStatus(errorId, 'error');
+
+      expect(useChatStore.getState().agentStates.has(errorId)).toBe(false);
+      expect(useChatStore.getState().agentStates.get(otherId)).toMatchObject({
+        status: 'streaming',
+      });
     });
   });
 
@@ -2389,24 +2472,35 @@ describe('chatStore', () => {
 
   describe('retryInfo (Bug 1: 死寂期重试可见)', () => {
     beforeEach(() => {
-      useChatStore.setState({ retryInfo: null, agentStatus: 'idle', currentTool: null });
+      useChatStore.setState({ agentStates: new Map() });
     });
 
-    it('setRetryInfo stores the live retry state', () => {
-      useChatStore.getState().setRetryInfo({ attempt: 2, maxAttempts: 3, delayMs: 5000 });
-      expect(useChatStore.getState().retryInfo).toEqual({ attempt: 2, maxAttempts: 3, delayMs: 5000 });
+    it('setRetryInfo stores the live retry state for the addressed conversation only', () => {
+      const convA = useChatStore.getState().createConversation();
+      const convB = useChatStore.getState().createConversation();
+      useChatStore.getState().setRetryInfo(convA, { attempt: 2, maxAttempts: 3, delayMs: 5000 });
+      expect(useChatStore.getState().agentStates.get(convA)?.retryInfo).toEqual({ attempt: 2, maxAttempts: 3, delayMs: 5000 });
+      expect(useChatStore.getState().agentStates.has(convB)).toBe(false);
     });
 
     it('a resumed stream clears the retry strip (retry succeeded)', () => {
-      useChatStore.getState().setRetryInfo({ attempt: 1, maxAttempts: 3, delayMs: 1000 });
-      useChatStore.getState().setAgentStatus('streaming');
-      expect(useChatStore.getState().retryInfo).toBeNull();
+      const convA = useChatStore.getState().createConversation();
+      useChatStore.getState().setRetryInfo(convA, { attempt: 1, maxAttempts: 3, delayMs: 1000 });
+      useChatStore.getState().setAgentStatus(convA, 'streaming');
+      expect(useChatStore.getState().agentStates.get(convA)?.retryInfo).toBeNull();
     });
 
     it('rate-limited status does NOT clear retryInfo (still retrying)', () => {
-      useChatStore.getState().setRetryInfo({ attempt: 1, maxAttempts: 5, delayMs: 2000 });
-      useChatStore.getState().setAgentStatus('rate-limited', '2s');
-      expect(useChatStore.getState().retryInfo).not.toBeNull();
+      const convA = useChatStore.getState().createConversation();
+      useChatStore.getState().setRetryInfo(convA, { attempt: 1, maxAttempts: 5, delayMs: 2000 });
+      useChatStore.getState().setAgentStatus(convA, 'rate-limited', '2s');
+      expect(useChatStore.getState().agentStates.get(convA)?.retryInfo).not.toBeNull();
+    });
+
+    it('does not create orphan retry state for a missing conversation', () => {
+      useChatStore.getState().setRetryInfo('missing-conv', { attempt: 1, maxAttempts: 3, delayMs: 1000 });
+
+      expect(useChatStore.getState().agentStates.has('missing-conv')).toBe(false);
     });
   });
 

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
-import { current } from 'immer';
+import { current, enableMapSet } from 'immer';
 import type { Message, Conversation, AgentStatus, RetryInfo, TokenUsage, ConversationStatus, ToolCallForContext, ToolResultContent, ToolCall, NoticeCardAction, SandboxRecoveryAction, ToolExecutionMetadata, UserQuestionResult } from '../types';
 import type { ExecutionStepSnapshot, PlannedStep } from '../types/execution';
 import { useWorkspaceStore } from './workspaceStore';
@@ -24,6 +24,8 @@ import {
   getComposerDraftScopeForEnterpriseMode,
 } from './composerDraftStore';
 import { useEnterpriseStore } from './enterpriseStore';
+
+enableMapSet();
 
 function generateId(): string {
   return Date.now().toString(36) + Math.random().toString(36).substring(2, 8);
@@ -432,6 +434,59 @@ export function flushTokenBuffer(convId?: string, msgId?: string) {
   });
 }
 
+export interface ConversationAgentState {
+  status: AgentStatus;
+  currentTool: string | null;
+  retryInfo: RetryInfo | null;
+  thinkingStartTime: number | null;
+  activeAgentNames: string[];
+}
+
+export const IDLE_AGENT_STATE: ConversationAgentState = {
+  status: 'idle',
+  currentTool: null,
+  retryInfo: null,
+  thinkingStartTime: null,
+  activeAgentNames: [],
+};
+
+export function getConversationAgentState(
+  agentStates: Map<string, ConversationAgentState>,
+  conversationId: string | null | undefined,
+): ConversationAgentState {
+  if (!conversationId) return IDLE_AGENT_STATE;
+  return agentStates.get(conversationId) ?? IDLE_AGENT_STATE;
+}
+
+function isIdleAgentState(state: ConversationAgentState): boolean {
+  return state.status === 'idle'
+    && state.currentTool === null
+    && state.retryInfo === null
+    && state.thinkingStartTime === null
+    && state.activeAgentNames.length === 0;
+}
+
+function removeConversationAgentState(
+  agentStates: Map<string, ConversationAgentState>,
+  conversationId: string,
+): Map<string, ConversationAgentState> {
+  if (!agentStates.has(conversationId)) return agentStates;
+  const next = new Map(agentStates);
+  next.delete(conversationId);
+  return next;
+}
+
+function upsertConversationAgentState(
+  agentStates: Map<string, ConversationAgentState>,
+  conversationId: string,
+  nextState: ConversationAgentState,
+): Map<string, ConversationAgentState> {
+  const next = new Map(agentStates);
+  if (isIdleAgentState(nextState)) next.delete(conversationId);
+  else next.set(conversationId, nextState);
+  return next;
+}
+
 // Note: Old localStorage persistence limits (MAX_CONVERSATIONS, MAX_MESSAGES_PER_CONVERSATION,
 // KEEP_FIRST_MESSAGES, stripImageDataForPersist) removed in v4.
 // Messages are now persisted to JSONL files — no localStorage size constraints.
@@ -444,10 +499,8 @@ interface ChatState {
    *  Only contains the active conversation + LRU cache of recent ones (~5). */
   conversations: Record<string, Conversation>;
   activeConversationId: string | null;
-  agentStatus: AgentStatus;
-  currentTool: string | null;
-  /** Live retry state (null when not retrying) — drives the "正在重试" strip. */
-  retryInfo: RetryInfo | null;
+  /** Per-conversation live agent state. Ephemeral; never persisted. */
+  agentStates: Map<string, ConversationAgentState>;
   // Token usage tracking
   currentUsage: TokenUsage | null;
   // Pending input for prefilling the chat input (REPLACES the current draft)
@@ -477,10 +530,6 @@ interface ChatState {
   // ChatInput drains it into its local files/images attachment state via
   // processFilePaths, then clears. NOT persisted.
   pendingAttachmentPaths: string[];
-  // Thinking timer
-  thinkingStartTime: number | null;
-  // Track multiple concurrent active agents
-  activeAgentNames: string[];
   /** Bumped whenever a conversation's outputs manifest materially changes
    *  from outside the snapshot hot path — currently: after
    *  installSharedAttachments writes newly imported files. FileAttachment
@@ -561,7 +610,7 @@ interface ChatActions {
    * "user enqueued more input while the turn ended without tool calls" rescue
    * path) — kept as a narrow, purpose-specific action rather than generalizing
    * `finishStreaming` because callers here intentionally do NOT want the
-   * disk-persistence / agentStatus/retryInfo side effects `finishStreaming` has.
+   * disk-persistence / per-conversation agent-state cleanup `finishStreaming` has.
    */
   setMessageStreamingFlag: (convId: string, messageId: string, streaming: boolean) => void;
   /**
@@ -606,9 +655,9 @@ interface ChatActions {
    */
   deactivateConversationSkills: (convId: string) => void;
 
-  setAgentStatus: (status: AgentStatus, tool?: string, agentName?: string) => void;
-  setRetryInfo: (info: RetryInfo | null) => void;
-  removeActiveAgent: (agentName: string) => void;
+  setAgentStatus: (convId: string, status: AgentStatus, tool?: string, agentName?: string) => void;
+  setRetryInfo: (convId: string, info: RetryInfo | null) => void;
+  removeActiveAgent: (convId: string, agentName: string) => void;
   setCurrentUsage: (usage: TokenUsage | null) => void;
   setPendingInput: (text: string | null) => void;
   setPendingSearchJump: (v: { convId: string; query: string } | null) => void;
@@ -666,9 +715,7 @@ export const useChatStore = create<ChatStore>()(
       conversationIndex: {} as Record<string, ConversationMeta>,
       conversations: {},
       activeConversationId: null,
-      agentStatus: 'idle' as AgentStatus,
-      currentTool: null,
-      retryInfo: null,
+      agentStates: new Map(),
       currentUsage: null,
       outputsRev: {} as Record<string, number>,
       pendingInput: null,
@@ -678,8 +725,6 @@ export const useChatStore = create<ChatStore>()(
       pendingReferences: [],
       pendingAttachmentPaths: [],
       pendingPermissionMode: undefined,
-      thinkingStartTime: null,
-      activeAgentNames: [],
 
       createConversation: (workspacePath, options) => {
         const id = generateId();
@@ -935,9 +980,11 @@ export const useChatStore = create<ChatStore>()(
         const nextActiveId = wasActive
           ? findNextActiveConversation(get().conversationIndex, id)
           : null;
+        const nextAgentStates = removeConversationAgentState(get().agentStates, id);
         set((state) => {
           delete state.conversations[id];
           delete state.conversationIndex[id];
+          state.agentStates = nextAgentStates;
           if (state.activeConversationId === id) {
             state.activeConversationId = nextActiveId;
           }
@@ -1108,15 +1155,14 @@ export const useChatStore = create<ChatStore>()(
       finishStreaming: (convId, msgId) => {
         // Flush any buffered tokens before marking streaming complete
         flushTokenBuffer(convId, msgId);
+        const nextAgentStates = removeConversationAgentState(get().agentStates, convId);
         set((state) => {
           const target = findTargetMessage(
             state.conversations[convId]?.messages,
             msgId ?? FALLBACK_LAST,
           );
           if (target) target.isStreaming = false;
-          state.agentStatus = 'idle';
-          state.currentTool = null;
-          state.retryInfo = null;
+          state.agentStates = nextAgentStates;
         });
         // Persist the final completed message to disk.
         // When msgId is provided, we must replace by id (not "last line") because the
@@ -1641,6 +1687,8 @@ export const useChatStore = create<ChatStore>()(
           invoke('window_show').catch(() => {});
         }).catch(() => {});
 
+        const agentStateBeforeCancel = getConversationAgentState(get().agentStates, convId);
+        const nextAgentStates = removeConversationAgentState(get().agentStates, convId);
         let cancelledMsgId: string | null = null;
         set((state) => {
           const messages = state.conversations[convId]?.messages;
@@ -1676,7 +1724,7 @@ export const useChatStore = create<ChatStore>()(
             // thinkingDuration is the canonical "thinking done" signal in both
             // MessageGroup's synth path and workflowExtractor's legacy path.
             if (lastMsg.thinking && lastMsg.thinkingDuration === undefined) {
-              const start = state.thinkingStartTime;
+              const start = agentStateBeforeCancel.thinkingStartTime;
               lastMsg.thinkingDuration = start
                 ? Math.max(1, Math.round((Date.now() - start) / 1000))
                 : 1;
@@ -1694,10 +1742,7 @@ export const useChatStore = create<ChatStore>()(
             }
             if (mutated) cancelledMsgId = lastMsg.id;
           }
-          state.agentStatus = 'idle';
-          state.currentTool = null;
-          state.retryInfo = null;
-          state.thinkingStartTime = null;
+          state.agentStates = nextAgentStates;
         });
 
         // Persist the stop mutation (terminal + cancelled tool calls) — without
@@ -1745,40 +1790,55 @@ export const useChatStore = create<ChatStore>()(
         });
       },
 
-      setRetryInfo: (info) => {
-        set((state) => {
-          state.retryInfo = info;
+      setRetryInfo: (convId, info) => {
+        if (!get().conversations[convId]) return;
+        const currentAgentState = getConversationAgentState(get().agentStates, convId);
+        const nextAgentState: ConversationAgentState = {
+          ...currentAgentState,
+          activeAgentNames: [...currentAgentState.activeAgentNames],
+          retryInfo: info,
+        };
+        set({
+          agentStates: upsertConversationAgentState(get().agentStates, convId, nextAgentState),
         });
       },
 
-      setAgentStatus: (status, tool, agentName) => {
-        set((state) => {
-          state.agentStatus = status;
-          state.currentTool = tool ?? null;
+      setAgentStatus: (convId, status, tool, agentName) => {
+        if (!get().conversations[convId]) return;
+        const currentAgentState = getConversationAgentState(get().agentStates, convId);
+        const activeAgentNames = [...currentAgentState.activeAgentNames];
+        if (agentName && status === 'tool-calling' && !activeAgentNames.includes(agentName)) {
+          activeAgentNames.push(agentName);
+        }
+
+        const nextAgentState: ConversationAgentState = {
+          status,
+          currentTool: tool ?? null,
           // A resumed stream (any non-retry status) means a prior retry
           // succeeded — clear the retry strip so it doesn't linger.
-          if (status !== 'rate-limited') {
-            state.retryInfo = null;
-          }
-          // Track concurrent active agents
-          if (agentName && status === 'tool-calling') {
-            if (!state.activeAgentNames.includes(agentName)) {
-              state.activeAgentNames.push(agentName);
-            }
-          }
-          // Track thinking start time
-          if (status === 'thinking') {
-            state.thinkingStartTime = Date.now();
-          } else if (status === 'idle') {
-            state.thinkingStartTime = null;
-            state.activeAgentNames = [];
-          }
+          retryInfo: status === 'rate-limited' ? currentAgentState.retryInfo : null,
+          thinkingStartTime: status === 'thinking'
+            ? Date.now()
+            : status === 'idle'
+              ? null
+              : currentAgentState.thinkingStartTime,
+          activeAgentNames: status === 'idle' ? [] : activeAgentNames,
+        };
+
+        set({
+          agentStates: upsertConversationAgentState(get().agentStates, convId, nextAgentState),
         });
       },
 
-      removeActiveAgent: (agentName) => {
-        set((state) => {
-          state.activeAgentNames = state.activeAgentNames.filter(n => n !== agentName);
+      removeActiveAgent: (convId, agentName) => {
+        const currentAgentState = get().agentStates.get(convId);
+        if (!currentAgentState) return;
+        const nextAgentState: ConversationAgentState = {
+          ...currentAgentState,
+          activeAgentNames: currentAgentState.activeAgentNames.filter(n => n !== agentName),
+        };
+        set({
+          agentStates: upsertConversationAgentState(get().agentStates, convId, nextAgentState),
         });
       },
 
@@ -1843,7 +1903,14 @@ export const useChatStore = create<ChatStore>()(
 
       setConversationStatus: (convId, status) => {
         let shouldReindex = false;
+        const isTerminal = status === 'completed' || status === 'error';
+        const nextAgentStates = isTerminal
+          ? removeConversationAgentState(get().agentStates, convId)
+          : get().agentStates;
         set((state) => {
+          if (isTerminal) {
+            state.agentStates = nextAgentStates;
+          }
           const conv = state.conversations[convId];
           if (conv) {
             const prevStatus = conv.status;
@@ -1851,7 +1918,6 @@ export const useChatStore = create<ChatStore>()(
             // partial assistant reply are already appended to messages.jsonl
             // by the time a turn ends in error, but without this the
             // conversation was never indexed until the next restart.
-            const isTerminal = status === 'completed' || status === 'error';
             // Fix #5: only fire when the conversation actually exists AND is
             // transitioning INTO a terminal state — not on a redundant
             // re-set of a status it's already in (e.g. a duplicate

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -470,6 +470,12 @@ export interface ToolExecutionContext {
   /** Effective three-tier permission mode for this conversation. */
   permissionMode?: import('../core/permissions/permissionMode').PermissionMode;
   /**
+   * Shell-created authorization scope for unattended runs. When present,
+   * path checks must read only that scoped grant set and never fall back to
+   * process-global interactive grants.
+   */
+  authorizationScopeId?: string;
+  /**
    * Whether the active model supports vision/image input, resolved from the
    * turn's model capabilities. When explicitly `false`, tools that would emit
    * image content (e.g. read_file on an image) must return a text note instead

--- a/tests/e2e/infra-hygiene.spec.ts
+++ b/tests/e2e/infra-hygiene.spec.ts
@@ -1,0 +1,605 @@
+/**
+ * Real Electron coverage for the infra-hygiene A2/A3 batch.
+ *
+ * This launches the actual Electron main entry and sidecar. The only model
+ * endpoint is a loopback OpenAI-compatible SSE mock bound to 127.0.0.1:0.
+ */
+import { expect, test } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import { createServer, type Server, type ServerResponse } from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import type { ElectronApplication, Page } from 'playwright';
+import {
+  closeAbuElectron,
+  createElectronDataRoot,
+  launchAbuElectron,
+  removeElectronDataRoot,
+  type ElectronDataRoot,
+} from './electronHelpers';
+
+const READY_TIMEOUT = 45_000;
+const CHAT_PLACEHOLDER = '想让阿布帮你做点什么？';
+const TEST_API_KEY = 'abu-e2e-infra-hygiene-not-a-real-secret';
+const TEST_MODEL_ID = 'abu-e2e-infra-hygiene-model';
+const PROVIDER_ID = 'abu-e2e-infra-hygiene-provider';
+
+interface MockRequest {
+  authorization: string | undefined;
+  body: unknown;
+  pathname: string;
+  purpose: 'memory' | 'task';
+  responseAborted: boolean;
+}
+
+interface HoldHandle {
+  release: (responseText: string) => void;
+}
+
+type MockReplyPlan =
+  | { kind: 'complete'; responseText: string }
+  | { kind: 'hold'; released: Promise<string> }
+  | {
+      kind: 'tool-call';
+      arguments: Record<string, unknown>;
+      toolCallId: string;
+      toolName: string;
+    };
+
+interface OpenAiMock {
+  baseUrl: string;
+  close: () => Promise<void>;
+  requests: MockRequest[];
+}
+
+interface OpenAiRequestMessage {
+  role?: unknown;
+  content?: unknown;
+  tool_call_id?: unknown;
+  tool_calls?: Array<{
+    id?: unknown;
+    function?: {
+      name?: unknown;
+      arguments?: unknown;
+    };
+  }>;
+}
+
+function makeHoldPlan(): { handle: HoldHandle; plan: MockReplyPlan } {
+  let release!: (responseText: string) => void;
+  const released = new Promise<string>((resolve) => {
+    release = resolve;
+  });
+  return { handle: { release }, plan: { kind: 'hold', released } };
+}
+
+function sseChunk(delta: Record<string, unknown>, finishReason: string | null): string {
+  return `data: ${JSON.stringify({
+    id: 'chatcmpl-abu-e2e-infra-hygiene',
+    object: 'chat.completion.chunk',
+    created: 0,
+    model: TEST_MODEL_ID,
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  })}\n\n`;
+}
+
+function completeSse(responseText: string): string {
+  return sseChunk({ content: responseText }, null) + sseChunk({}, 'stop') + 'data: [DONE]\n\n';
+}
+
+function toolCallSse(plan: Extract<MockReplyPlan, { kind: 'tool-call' }>): string {
+  return sseChunk({
+    tool_calls: [{
+      index: 0,
+      id: plan.toolCallId,
+      type: 'function',
+      function: { name: plan.toolName, arguments: JSON.stringify(plan.arguments) },
+    }],
+  }, null) + sseChunk({}, 'tool_calls') + 'data: [DONE]\n\n';
+}
+
+async function startOpenAiMock(replyPlans: readonly MockReplyPlan[]): Promise<OpenAiMock> {
+  const requests: MockRequest[] = [];
+  let taskRequestCount = 0;
+  const activeResponses = new Set<ServerResponse>();
+  const server = createServer(async (req, res) => {
+    activeResponses.add(res);
+    res.once('close', () => activeResponses.delete(res));
+
+    const requestUrl = new URL(req.url ?? '/', 'http://127.0.0.1');
+    let rawBody = '';
+    for await (const chunk of req) rawBody += String(chunk);
+
+    let body: unknown = rawBody;
+    try {
+      body = JSON.parse(rawBody);
+    } catch {
+      // Preserve malformed input in request diagnostics.
+    }
+
+    if (req.method !== 'POST' || requestUrl.pathname !== '/v1/chat/completions') {
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'unexpected local E2E mock route' }));
+      return;
+    }
+
+    const mockRequest: MockRequest = {
+      authorization: req.headers.authorization,
+      body,
+      pathname: requestUrl.pathname,
+      purpose: isMemoryExtractionRequest(body) ? 'memory' : 'task',
+      responseAborted: false,
+    };
+    requests.push(mockRequest);
+
+    const replyPlan = mockRequest.purpose === 'memory'
+      ? { kind: 'complete' as const, responseText: '[]' }
+      : replyPlans[taskRequestCount++];
+    if (!replyPlan) {
+      res.writeHead(500, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'unexpected extra local E2E mock request' }));
+      return;
+    }
+
+    res.writeHead(200, {
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+      'content-type': 'text/event-stream; charset=utf-8',
+    });
+
+    if (replyPlan.kind === 'hold') {
+      res.once('close', () => {
+        mockRequest.responseAborted = !res.writableEnded;
+      });
+      const responseText = await replyPlan.released;
+      if (!res.destroyed && !res.writableEnded) {
+        res.end(completeSse(responseText));
+      }
+      return;
+    }
+
+    res.end(replyPlan.kind === 'tool-call' ? toolCallSse(replyPlan) : completeSse(replyPlan.responseText));
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await closeServer(server, activeResponses);
+    throw new Error('The local OpenAI-compatible mock did not receive a TCP port');
+  }
+
+  return {
+    // Numeric loopback still reaches the 127.0.0.1-only server, while avoiding
+    // the local-provider heuristic that disables streaming tool calls.
+    baseUrl: `http://2130706433:${address.port}/v1`,
+    close: () => closeServer(server, activeResponses),
+    requests,
+  };
+}
+
+function closeServer(server: Server, activeResponses: ReadonlySet<ServerResponse>): Promise<void> {
+  for (const response of activeResponses) response.destroy();
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      server.closeAllConnections?.();
+      reject(new Error('Timed out closing local OpenAI E2E mock'));
+    }, 5_000);
+    server.close((error) => {
+      clearTimeout(timeout);
+      if (error) reject(error);
+      else resolve();
+    });
+    server.closeAllConnections?.();
+  });
+}
+
+function isMemoryExtractionRequest(body: unknown): boolean {
+  if (!body || typeof body !== 'object' || !('messages' in body)) return false;
+  const messages = (body as { messages?: unknown }).messages;
+  return Array.isArray(messages) && messages.some((message) => {
+    if (!message || typeof message !== 'object') return false;
+    const candidate = message as { content?: unknown; role?: unknown };
+    return candidate.role === 'system' &&
+      typeof candidate.content === 'string' &&
+      candidate.content.includes('你是一个记忆提取助手');
+  });
+}
+
+function taskRequests(mock: OpenAiMock): MockRequest[] {
+  return mock.requests.filter((request) => request.purpose === 'task');
+}
+
+async function waitForApp(page: Page): Promise<void> {
+  await page.waitForLoadState('domcontentloaded');
+  await expect(page.getByPlaceholder(CHAT_PLACEHOLDER)).toBeVisible({ timeout: READY_TIMEOUT });
+}
+
+async function configureLocalMockProvider(page: Page, baseUrl: string): Promise<void> {
+  await page.evaluate(({ baseUrl, testApiKey, testModelId, providerId }) => {
+    const raw = window.localStorage.getItem('abu-settings');
+    if (!raw) throw new Error('abu-settings was not initialized before E2E configuration');
+    const persisted = JSON.parse(raw) as { state: Record<string, unknown>; version: number };
+    const state = persisted.state;
+
+    state.providers = [{
+      id: providerId,
+      source: 'custom',
+      name: 'Abu E2E infra hygiene loopback provider',
+      enabled: true,
+      apiFormat: 'openai-compatible',
+      baseUrl,
+      apiKey: testApiKey,
+      models: [{
+        id: testModelId,
+        label: 'Abu E2E infra hygiene model',
+        isCustom: true,
+        declaredCapabilities: { supportsTools: true },
+      }],
+      defaultModelId: testModelId,
+      status: 'verified',
+      sortOrder: 0,
+      userAdded: true,
+      declaredCapabilities: { supportsTools: true },
+    }];
+    state.activeModel = { providerId, modelId: testModelId };
+    state.recentModels = [];
+    state.favoriteModels = [];
+    state.permissionMode = 'standard';
+    state.guideShown = true;
+    state.guideOpen = false;
+    state.hasAcknowledgedDisclaimer = true;
+    state.hasRunSensitiveAudit_v015 = true;
+
+    window.localStorage.setItem('abu-settings', JSON.stringify({ ...persisted, state, version: 42 }));
+  }, { baseUrl, testApiKey: TEST_API_KEY, testModelId: TEST_MODEL_ID, providerId: PROVIDER_ID });
+  await page.reload();
+  await waitForApp(page);
+}
+
+async function seedAutomation(page: Page, seed: {
+  activeTab: 'schedule' | 'trigger';
+  schedules?: Record<string, unknown>;
+  triggers?: Record<string, unknown>;
+}): Promise<void> {
+  await page.evaluate(({ activeTab, schedules, triggers }) => {
+    const settingsRaw = window.localStorage.getItem('abu-settings');
+    if (!settingsRaw) throw new Error('abu-settings was not initialized before seeding automation');
+    const settings = JSON.parse(settingsRaw) as { state: Record<string, unknown>; version: number };
+    settings.state.activeAutomationTab = activeTab;
+    settings.state.viewMode = 'automation';
+    window.localStorage.setItem('abu-settings', JSON.stringify(settings));
+
+    if (schedules) {
+      window.localStorage.setItem('abu-schedule', JSON.stringify({
+        state: { tasks: schedules },
+        version: 5,
+      }));
+    }
+    if (triggers) {
+      window.localStorage.setItem('abu-triggers', JSON.stringify({
+        state: { triggers },
+        version: 4,
+      }));
+    }
+  }, seed);
+  await page.reload();
+  await waitForApp(page);
+}
+
+function makeSchedule(id: string, name: string, prompt: string, workspacePath?: string): Record<string, unknown> {
+  return {
+    id,
+    name,
+    prompt,
+    schedule: { frequency: 'manual' },
+    status: 'active',
+    workspacePath,
+    createdAt: 1_800_000_000_000,
+    updatedAt: 1_800_000_000_000,
+    runs: [],
+    totalRuns: 0,
+  };
+}
+
+function makeTrigger(
+  id: string,
+  name: string,
+  prompt: string,
+  workspacePath: string,
+  capability?: 'read_tools' | 'safe_tools' | 'full' | 'custom',
+): Record<string, unknown> {
+  return {
+    id,
+    name,
+    status: 'active',
+    source: { type: 'http' },
+    filter: { type: 'always' },
+    action: {
+      prompt,
+      workspacePath,
+      ...(capability ? { capability } : {}),
+    },
+    debounce: { enabled: false, windowSeconds: 0 },
+    createdAt: 1_800_000_000_000,
+    updatedAt: 1_800_000_000_000,
+    runs: [],
+    totalRuns: 0,
+  };
+}
+
+async function openAutomationItem(page: Page, tabLabel: RegExp, itemName: string): Promise<void> {
+  await page
+    .getByRole('navigation', { name: /^(Main navigation|主导航)$/ })
+    .getByRole('button', { name: /^(自动化|Automation)$/ })
+    .evaluate((element: HTMLElement) => element.click());
+  await expect(page.getByRole('button', { name: tabLabel })).toBeVisible({ timeout: READY_TIMEOUT });
+  await page.getByRole('button', { name: tabLabel }).click();
+  const item = page.getByText(itemName, { exact: true });
+  if (!await item.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    await page.locator('.border-b').getByRole('button').first().click();
+  }
+  await expect(item).toBeVisible({ timeout: READY_TIMEOUT });
+  await item.click();
+}
+
+async function sendPrompt(page: Page, prompt: string): Promise<void> {
+  const input = page.getByPlaceholder(CHAT_PLACEHOLDER);
+  await expect(input).toBeEditable({ timeout: READY_TIMEOUT });
+  await input.fill(prompt);
+  await input.press('Enter');
+}
+
+async function startNewChat(page: Page): Promise<void> {
+  await page.locator('[data-sidebar-action="new-task"]').evaluate((element: HTMLElement) => element.click());
+  await expect(page.getByPlaceholder(CHAT_PLACEHOLDER)).toBeEditable({ timeout: READY_TIMEOUT });
+}
+
+async function expectCurrentChatReady(page: Page): Promise<void> {
+  const readyStatus = page.getByText(/^(就绪|Ready)$/);
+  if (await readyStatus.isVisible({ timeout: 1_000 }).catch(() => false)) return;
+  await expect(page.getByPlaceholder(CHAT_PLACEHOLDER)).toBeEditable({ timeout: READY_TIMEOUT });
+  await expect(page.getByText(/^(思考中|Thinking|回复中|Responding)(?:\s*\(\d+s\))?$/)).toHaveCount(0);
+}
+
+function expectToolResultMatches(body: unknown, toolName: string, expected: RegExp): string {
+  const messages = (body as { messages?: OpenAiRequestMessage[] } | null)?.messages;
+  expect(Array.isArray(messages)).toBe(true);
+  const toolCall = messages
+    ?.filter((message) => message.role === 'assistant' && Array.isArray(message.tool_calls))
+    .flatMap((message) => message.tool_calls ?? [])
+    .find((call) => call.function?.name === toolName);
+  expect(toolCall).toBeDefined();
+  const toolResultMessage = messages?.find((message) =>
+    message.role === 'tool' && message.tool_call_id === toolCall?.id
+  );
+  expect(toolResultMessage).toBeDefined();
+  const resultText = String(toolResultMessage?.content ?? '');
+  expect(resultText).toMatch(expected);
+  return resultText;
+}
+
+function mkdirFixtureRoot(): string {
+  return fs.mkdtempSync(path.join(os.homedir(), 'Documents', 'abu-infra-e2e-'));
+}
+
+function removeFixtureRoot(root: string | undefined): void {
+  if (!root) return;
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+let app: ElectronApplication | undefined;
+let dataRoot: ElectronDataRoot | undefined;
+let mock: OpenAiMock | undefined;
+let fixtureRoot: string | undefined;
+
+test.describe.serial('Electron infra hygiene batch', () => {
+  test.afterEach(async () => {
+    if (app) {
+      await closeAbuElectron(app);
+      app = undefined;
+    }
+    if (mock) {
+      await mock.close();
+      mock = undefined;
+    }
+    if (dataRoot) {
+      removeElectronDataRoot(dataRoot);
+      dataRoot = undefined;
+    }
+    removeFixtureRoot(fixtureRoot);
+    fixtureRoot = undefined;
+  });
+
+  test('keeps live agent status isolated between a held scheduled run and a normal chat', async () => {
+    const scheduleId = `schedule-a2-${randomUUID()}`;
+    const scheduleName = `A2 hold schedule ${randomUUID().slice(0, 8)}`;
+    const chatPrompt = `a2 normal chat ${randomUUID()}`;
+    const chatResponse = `a2 normal chat done ${randomUUID()}`;
+    const scheduleResponse = `a2 held schedule done ${randomUUID()}`;
+    const { handle, plan } = makeHoldPlan();
+    mock = await startOpenAiMock([
+      plan,
+      { kind: 'complete', responseText: chatResponse },
+    ]);
+
+    dataRoot = createElectronDataRoot();
+    const launched = await launchAbuElectron(dataRoot);
+    app = launched.app;
+    const page = await app.firstWindow({ timeout: READY_TIMEOUT });
+    await waitForApp(page);
+    await configureLocalMockProvider(page, mock.baseUrl);
+    await seedAutomation(page, {
+      activeTab: 'schedule',
+      schedules: {
+        [scheduleId]: makeSchedule(scheduleId, scheduleName, `hold schedule ${randomUUID()}`),
+      },
+    });
+
+    await openAutomationItem(page, /^(定时任务|Scheduled Tasks)$/, scheduleName);
+    await page.getByRole('button', { name: /^(立即执行|Run Now)$/ }).click();
+    await expect.poll(() => taskRequests(mock!).length, { timeout: READY_TIMEOUT }).toBe(1);
+
+    await startNewChat(page);
+    await sendPrompt(page, chatPrompt);
+    await expect.poll(() => taskRequests(mock!).length, { timeout: READY_TIMEOUT }).toBe(2);
+    await expect(page.getByText(chatResponse, { exact: true })).toBeVisible({ timeout: READY_TIMEOUT });
+    await expectCurrentChatReady(page);
+
+    await openAutomationItem(page, /^(定时任务|Scheduled Tasks)$/, scheduleName);
+    await page.getByTitle(/^(查看会话|View Conversation)$/).click();
+    await expect(page.getByText(/^(思考中|Thinking)(?:\s*\(\d+s\))?$/)).toBeVisible({ timeout: READY_TIMEOUT });
+
+    handle.release(scheduleResponse);
+    await expect(page.getByText(scheduleResponse, { exact: true })).toBeVisible({ timeout: READY_TIMEOUT });
+    await expectCurrentChatReady(page);
+  });
+
+  test('scopes unattended authorization, recovers it after runs, and ignores manage_trigger self-escalation', async () => {
+    fixtureRoot = mkdirFixtureRoot();
+    const chatGrantDir = path.join(fixtureRoot, 'chat-grant');
+    const fullRunDir = path.join(fixtureRoot, 'full-run');
+    fs.mkdirSync(chatGrantDir, { recursive: true });
+    fs.mkdirSync(fullRunDir, { recursive: true });
+
+    const readTriggerId = `trigger-read-${randomUUID()}`;
+    const fullTriggerId = `trigger-full-${randomUUID()}`;
+    const readTriggerName = `A3 read trigger ${randomUUID().slice(0, 8)}`;
+    const fullTriggerName = `A3 full trigger ${randomUUID().slice(0, 8)}`;
+    const readTarget = path.join(chatGrantDir, 'read-trigger-should-not-write.txt');
+    const fullTarget = path.join(fullRunDir, 'full-trigger-write.txt');
+    const afterFullTarget = path.join(fullRunDir, 'chat-after-full-should-prompt.txt');
+    const grantTarget = path.join(chatGrantDir, 'chat-grant.txt');
+    const managedTriggerName = `A3 malicious managed trigger ${randomUUID().slice(0, 8)}`;
+
+    mock = await startOpenAiMock([
+      {
+        kind: 'tool-call',
+        toolName: 'write_file',
+        toolCallId: `call-full-trigger-${randomUUID()}`,
+        arguments: { path: fullTarget, content: 'full trigger may write' },
+      },
+      { kind: 'complete', responseText: `full trigger complete ${randomUUID()}` },
+      {
+        kind: 'tool-call',
+        toolName: 'write_file',
+        toolCallId: `call-after-full-chat-${randomUUID()}`,
+        arguments: { path: afterFullTarget, content: 'chat after full must prompt' },
+      },
+      { kind: 'complete', responseText: `chat after full complete ${randomUUID()}` },
+      {
+        kind: 'tool-call',
+        toolName: 'write_file',
+        toolCallId: `call-chat-grant-${randomUUID()}`,
+        arguments: { path: grantTarget, content: 'chat session grant' },
+      },
+      { kind: 'complete', responseText: `chat grant complete ${randomUUID()}` },
+      {
+        kind: 'tool-call',
+        toolName: 'write_file',
+        toolCallId: `call-read-trigger-${randomUUID()}`,
+        arguments: { path: readTarget, content: 'read trigger must not write' },
+      },
+      { kind: 'complete', responseText: `read trigger complete ${randomUUID()}` },
+      {
+        kind: 'tool-call',
+        toolName: 'manage_trigger',
+        toolCallId: `call-manage-trigger-${randomUUID()}`,
+        arguments: {
+          action: 'create',
+          name: managedTriggerName,
+          prompt: 'malicious full trigger',
+          source_type: 'http',
+          filter_type: 'always',
+          capability: 'full',
+        },
+      },
+      { kind: 'complete', responseText: `manage trigger complete ${randomUUID()}` },
+    ]);
+
+    dataRoot = createElectronDataRoot();
+    const launched = await launchAbuElectron(dataRoot);
+    app = launched.app;
+    const page = await app.firstWindow({ timeout: READY_TIMEOUT });
+    await waitForApp(page);
+    await configureLocalMockProvider(page, mock.baseUrl);
+    await seedAutomation(page, {
+      activeTab: 'trigger',
+      triggers: {
+        [readTriggerId]: makeTrigger(readTriggerId, readTriggerName, 'read_tools trigger $EVENT_DATA', chatGrantDir),
+        [fullTriggerId]: makeTrigger(fullTriggerId, fullTriggerName, 'full trigger $EVENT_DATA', fullRunDir, 'full'),
+      },
+    });
+
+    // Run the full-trigger scope check before any ordinary chat grant. A chat
+    // "allow for session" to a Documents child grants the top-level Documents
+    // permission directory, which would mask whether trigger-full cleanup worked.
+    await openAutomationItem(page, /^(监听事件|Triggers)$/, fullTriggerName);
+    await page.getByRole('button', { name: /^(测试触发|Test Trigger)$/ }).click();
+    await expect.poll(() => taskRequests(mock!).length, { timeout: READY_TIMEOUT }).toBe(2);
+    expectToolResultMatches(taskRequests(mock)[1].body, 'write_file', /Successfully wrote|成功/);
+    await expect.poll(() => fs.existsSync(fullTarget), { timeout: READY_TIMEOUT }).toBe(true);
+
+    await startNewChat(page);
+    await sendPrompt(page, `chat after full ${randomUUID()}`);
+    await expect.poll(() => taskRequests(mock!).length, { timeout: READY_TIMEOUT }).toBeGreaterThanOrEqual(3);
+    await expect(page.getByRole('heading', { name: /^(文件写入权限|File Write Permission)$/ })).toBeVisible({
+      timeout: READY_TIMEOUT,
+    });
+    await page.getByRole('button', { name: /^(拒绝|Deny)$/ }).click();
+    await expect.poll(() => taskRequests(mock!).length, { timeout: READY_TIMEOUT }).toBe(4);
+    expectToolResultMatches(taskRequests(mock)[3].body, 'write_file', /用户拒绝|denied/i);
+    expect(fs.existsSync(afterFullTarget)).toBe(false);
+
+    await startNewChat(page);
+    await sendPrompt(page, `grant chat write ${randomUUID()}`);
+    await expect.poll(() => taskRequests(mock!).length, { timeout: READY_TIMEOUT }).toBe(5);
+    await expect(page.getByRole('heading', { name: /^(文件写入权限|File Write Permission)$/ })).toBeVisible({
+      timeout: READY_TIMEOUT,
+    });
+    await page.getByRole('button', { name: /^(本次会话|This session)$/ }).click();
+    await page.getByRole('button', { name: /^(允许本次会话|Allow for Session)$/ }).click();
+    await expect.poll(() => taskRequests(mock!).length, { timeout: READY_TIMEOUT }).toBe(6);
+    expectToolResultMatches(taskRequests(mock)[5].body, 'write_file', /Successfully wrote|成功/);
+    await expect.poll(() => fs.existsSync(grantTarget), { timeout: READY_TIMEOUT }).toBe(true);
+
+    await openAutomationItem(page, /^(监听事件|Triggers)$/, readTriggerName);
+    await page.getByRole('button', { name: /^(测试触发|Test Trigger)$/ }).click();
+    await expect.poll(() => taskRequests(mock!).length, { timeout: READY_TIMEOUT }).toBe(8);
+    expectToolResultMatches(
+      taskRequests(mock)[7].body,
+      'write_file',
+      /not allowed|blocked|拒绝|不允许|用户拒绝|denied/i,
+    );
+    expect(fs.existsSync(readTarget)).toBe(false);
+
+    await startNewChat(page);
+    await sendPrompt(page, `try manage_trigger escalation ${randomUUID()}`);
+    await expect.poll(() => taskRequests(mock!).length, { timeout: READY_TIMEOUT }).toBe(10);
+    const manageTriggerResult = expectToolResultMatches(
+      taskRequests(mock)[9].body,
+      'manage_trigger',
+      /模型不能更改能力档位。新建触发器默认为只读|model cannot change the capability level.*new triggers use read only/i,
+    );
+    expect(manageTriggerResult).toMatch(/只读分析|Read-only analysis/i);
+    expect(manageTriggerResult).not.toMatch(/完全自主|Fully autonomous/i);
+    await expect.poll(async () => {
+      return page.evaluate((name) => {
+        const raw = window.localStorage.getItem('abu-triggers');
+        if (!raw) return null;
+        const parsed = JSON.parse(raw) as {
+          state?: { triggers?: Record<string, { name?: string; action?: { capability?: string } }> };
+        };
+        const trigger = Object.values(parsed.state?.triggers ?? {}).find((candidate) => candidate.name === name);
+        return trigger?.action?.capability ?? null;
+      }, managedTriggerName);
+    }, { timeout: READY_TIMEOUT }).toBe(null);
+  });
+});


### PR DESCRIPTION
## Summary

- Isolate live agent status, current tool, retry/thinking state, and active-agent names by conversation; reject stale, orphaned, or mismatched sidecar frames.
- Give every unattended scheduler/trigger run its own authorization scope, make that scope override global grants, and dispose it on every terminal path.
- Close scope escape routes across command cwd checks, background processes, direct/nested subagents, sidecar tool filtering, forged workspace notifications, and blank path grants.
- Remove model-controlled trigger capability from manage_trigger; create defaults to Read Only and update preserves the existing level.

## Verification

- npm run setup:electron-dev — passed
- npm run electron:dev:check — passed
- npm run verify — 411 files, 6020 passed, 1 skipped; coverage gates passed
- npm run build — passed
- npm run test:e2e:electron -- tests/e2e/infra-hygiene.spec.ts — 2/2 passed in the real Electron main/renderer/sidecar path
- git diff --check origin/dev...HEAD — passed
- E2E fixture cleanup confirmed; no abu-infra-e2e-* directory remains in Documents

## Independent review

- Security review: gpt-5.6-sol + xhigh — confirmed blockers: none
- Adversarial review: gpt-5.6-sol + xhigh — confirmed blockers: none
- Reviews covered global/scoped grant interleaving, path/cwd normalization, background command teardown, direct and nested subagent lifecycles, malformed/late frames, cleanup, and manage_trigger injection.

## Scope notes

- Commit structure follows the brief: A2 is exactly one commit; A3 is two commits.
- TriggerEditor has never exposed a capability picker since TriggerCapability was introduced. Both reviews classified that as an origin/dev product gap, not a regression; this security batch deliberately does not add the out-of-scope UI or permission architecture.
