### PR TITLE
fix(infra): post-merge review fixes for #281

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/shawn/Documents/Abu/Abu-opensource/node_modules

--- a/src/__tests__/toolRegistry.integration.test.ts
+++ b/src/__tests__/toolRegistry.integration.test.ts
@@ -253,6 +253,42 @@ describe('toolRegistry integration', () => {
         disposeAuthorizationScope(scopeId);
       }
     });
+
+    it('tells a workspace-less unattended run how to get a writable cwd instead of a bare refusal', async () => {
+      const previousMode = useSettingsStore.getState().permissionMode;
+      const scopeId = createAuthorizationScope();
+      const executeFn = vi.fn().mockResolvedValue('should not execute');
+      toolRegistry.register({
+        name: 'run_command',
+        description: 'Run shell command',
+        inputSchema: { type: 'object', properties: { command: { type: 'string', description: 'cmd' } } },
+        execute: executeFn,
+      });
+
+      try {
+        // Most permissive tier an unattended run can have — the refusal below
+        // is about having no judgeable cwd at all, not about the tier.
+        useSettingsStore.setState({ permissionMode: 'autonomous' });
+
+        const result = String(await executeAnyTool(
+          'run_command',
+          { command: 'touch /tmp/report.json' },
+          undefined,
+          undefined,
+          { authorizationScopeId: scopeId },
+        ));
+
+        expect(executeFn).not.toHaveBeenCalled();
+        // Distinct from the "cwd exists but is not writable" refusal, and it
+        // names both remedies so an unattended run fails loudly, not opaquely.
+        expect(result).toContain('no write-authorized working directory');
+        expect(result).toContain('workspace path');
+        expect(result).toContain('cwd');
+      } finally {
+        useSettingsStore.setState({ permissionMode: previousMode });
+        disposeAuthorizationScope(scopeId);
+      }
+    });
   });
 
   // ── Path safety through executeAnyTool ──

--- a/src/__tests__/toolRegistry.integration.test.ts
+++ b/src/__tests__/toolRegistry.integration.test.ts
@@ -32,6 +32,7 @@ vi.mock('../i18n', () => ({
       userDeniedAccess: 'user denied access',
       pathAccessDenied: 'path access denied',
       needsAuthorization: 'needs authorization',
+      scopedRunNoWorkspaceCommand: 'Error: this unattended run has no write-authorized working directory. Choose Full Autonomy, configure a workspace path for this task, or pass an absolute cwd inside an authorized directory.',
     },
   }),
 }));
@@ -284,6 +285,205 @@ describe('toolRegistry integration', () => {
         expect(result).toContain('no write-authorized working directory');
         expect(result).toContain('workspace path');
         expect(result).toContain('cwd');
+      } finally {
+        useSettingsStore.setState({ permissionMode: previousMode });
+        disposeAuthorizationScope(scopeId);
+      }
+    });
+
+    it.each(['standard', 'smart'] as const)(
+      'guides a workspace-less %s run to Full Autonomy or a workspace path',
+      async (permissionMode) => {
+        const previousMode = useSettingsStore.getState().permissionMode;
+        const scopeId = createAuthorizationScope();
+        const executeFn = vi.fn().mockResolvedValue('should not execute');
+        toolRegistry.register({
+          name: 'run_command',
+          description: 'Run shell command',
+          inputSchema: { type: 'object', properties: { command: { type: 'string', description: 'cmd' } } },
+          execute: executeFn,
+        });
+
+        try {
+          useSettingsStore.setState({ permissionMode });
+
+          const result = String(await executeAnyTool(
+            'run_command',
+            { command: 'touch /tmp/report.json' },
+            undefined,
+            undefined,
+            { authorizationScopeId: scopeId },
+          ));
+
+          expect(executeFn).not.toHaveBeenCalled();
+          expect(result).toContain('Full Autonomy');
+          expect(result).toContain('workspace path');
+        } finally {
+          useSettingsStore.setState({ permissionMode: previousMode });
+          disposeAuthorizationScope(scopeId);
+        }
+      },
+    );
+
+    it('allows a full scoped run without a workspace to write to temp paths', async () => {
+      const previousMode = useSettingsStore.getState().permissionMode;
+      const scopeId = createAuthorizationScope({ shell: 'full' });
+      const executeFn = vi.fn().mockResolvedValue('executed');
+      toolRegistry.register({
+        name: 'run_command',
+        description: 'Run shell command',
+        inputSchema: { type: 'object', properties: { command: { type: 'string', description: 'cmd' } } },
+        execute: executeFn,
+      });
+
+      try {
+        useSettingsStore.setState({ permissionMode: 'autonomous' });
+
+        const result = await executeAnyTool(
+          'run_command',
+          { command: 'touch /tmp/report.json' },
+          undefined,
+          undefined,
+          { authorizationScopeId: scopeId },
+        );
+
+        expect(result).toBe('executed');
+        expect(executeFn).toHaveBeenCalledOnce();
+      } finally {
+        useSettingsStore.setState({ permissionMode: previousMode });
+        disposeAuthorizationScope(scopeId);
+      }
+    });
+
+    it('still blocks a full scoped run without a workspace from writing Abu self-managed paths', async () => {
+      const previousMode = useSettingsStore.getState().permissionMode;
+      const scopeId = createAuthorizationScope({ shell: 'full' });
+      const executeFn = vi.fn().mockResolvedValue('should not execute');
+      toolRegistry.register({
+        name: 'run_command',
+        description: 'Run shell command',
+        inputSchema: { type: 'object', properties: { command: { type: 'string', description: 'cmd' } } },
+        execute: executeFn,
+      });
+
+      try {
+        useSettingsStore.setState({ permissionMode: 'autonomous' });
+
+        const result = String(await executeAnyTool(
+          'run_command',
+          { command: 'touch /Users/testuser/.AbU/mcp/config.json' },
+          undefined,
+          undefined,
+          { authorizationScopeId: scopeId },
+        ));
+
+        expect(result).toContain('Error');
+        expect(result).toContain('阿布');
+        expect(executeFn).not.toHaveBeenCalled();
+      } finally {
+        useSettingsStore.setState({ permissionMode: previousMode });
+        disposeAuthorizationScope(scopeId);
+      }
+    });
+
+    it.each([
+      'touch /Users/testuser && touch /Users/testuser/.AbU/mcp/config.json',
+      'Set-Content -Path "$HOME/.AbU/mcp/config.json" -Value x',
+    ])('keeps the Abu hard floor across compound and PowerShell writes: %s', async (command) => {
+      const previousMode = useSettingsStore.getState().permissionMode;
+      const scopeId = createAuthorizationScope({ shell: 'full' });
+      const executeFn = vi.fn().mockResolvedValue('should not execute');
+      toolRegistry.register({
+        name: 'run_command',
+        description: 'Run shell command',
+        inputSchema: { type: 'object', properties: { command: { type: 'string', description: 'cmd' } } },
+        execute: executeFn,
+      });
+
+      try {
+        useSettingsStore.setState({ permissionMode: 'autonomous' });
+        const result = String(await executeAnyTool(
+          'run_command',
+          { command },
+          undefined,
+          undefined,
+          { authorizationScopeId: scopeId },
+        ));
+
+        expect(result).toContain('禁止写入阿布');
+        expect(executeFn).not.toHaveBeenCalled();
+        expect((await checkWritePath('/Users/testuser/Documents/not-granted.txt', scopeId)).allowed).toBe(false);
+      } finally {
+        useSettingsStore.setState({ permissionMode: previousMode });
+        disposeAuthorizationScope(scopeId);
+      }
+    });
+
+    it.each([
+      ['macos', 'Set-Content -Path "$HOME/.ssh/authorized_keys" -Value x', '/Users/testuser/.ssh/authorized_keys'],
+      ['macos', 'Set-Content -Path "$HOME/tmp/../.AbU/mcp/config.json" -Value x', '/Users/testuser/.AbU/mcp/config.json'],
+      ['windows', 'Set-Content -Path "$env:APPDATA/Abu/config.json" -Value x', '/Users/testuser/AppData/Roaming/Abu/config.json'],
+      ['windows', 'cmd /c echo x > %USERPROFILE%\\.ssh\\authorized_keys', '/Users/testuser/.ssh/authorized_keys'],
+    ] as const)('checks expanded %s hard-floor path for %s', async (platform, command, expectedTarget) => {
+      const restorePlatform = _setPlatformForTest(platform);
+      const previousMode = useSettingsStore.getState().permissionMode;
+      const scopeId = createAuthorizationScope({ shell: 'full' });
+      const executeFn = vi.fn().mockResolvedValue('should not execute');
+      toolRegistry.register({
+        name: 'run_command',
+        description: 'Run shell command',
+        inputSchema: { type: 'object', properties: { command: { type: 'string', description: 'cmd' } } },
+        execute: executeFn,
+      });
+
+      try {
+        useSettingsStore.setState({ permissionMode: 'autonomous' });
+        expect((await checkWritePath(expectedTarget, scopeId)).allowed).toBe(false);
+        const result = String(await executeAnyTool(
+          'run_command',
+          { command },
+          undefined,
+          undefined,
+          { authorizationScopeId: scopeId },
+        ));
+
+        expect(result).toContain('Error');
+        expect(executeFn).not.toHaveBeenCalled();
+      } finally {
+        useSettingsStore.setState({ permissionMode: previousMode });
+        disposeAuthorizationScope(scopeId);
+        restorePlatform();
+      }
+    });
+
+    it('does not extend the new target preflight to full scoped runs that have a workspace', async () => {
+      const previousMode = useSettingsStore.getState().permissionMode;
+      const scopeId = createAuthorizationScope({ shell: 'full' });
+      const workspace = '/Users/testuser/Projects/myapp';
+      const outsideTarget = '/Users/testuser/Documents/outside.txt';
+      const executeFn = vi.fn().mockResolvedValue('executed');
+      toolRegistry.register({
+        name: 'run_command',
+        description: 'Run shell command',
+        inputSchema: { type: 'object', properties: { command: { type: 'string', description: 'cmd' } } },
+        execute: executeFn,
+      });
+      scopedAuthorizeWorkspace(scopeId, workspace, ['read', 'write']);
+
+      try {
+        useSettingsStore.setState({ permissionMode: 'autonomous' });
+        await expect(executeAnyTool(
+          'run_command',
+          { command: `touch ${outsideTarget}`, cwd: workspace },
+          undefined,
+          undefined,
+          { authorizationScopeId: scopeId, workspacePath: workspace },
+        )).resolves.toBe('executed');
+
+        expect(executeFn).toHaveBeenCalledOnce();
+        const outsideCheck = await checkWritePath(outsideTarget, scopeId);
+        expect(outsideCheck.allowed).toBe(false);
+        expect(outsideCheck.needsPermission).toBe(true);
       } finally {
         useSettingsStore.setState({ permissionMode: previousMode });
         disposeAuthorizationScope(scopeId);

--- a/src/core/permissions/commandBoundary.test.ts
+++ b/src/core/permissions/commandBoundary.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { analyzeCommandBoundary } from './commandBoundary';
+import {
+  analyzeCommandBoundary,
+  resolveFullNoWorkspaceCommandWriteTargets,
+} from './commandBoundary';
 import { allWorkingDirectories } from './workingDirs';
 import { useWorkspaceStore } from '../../stores/workspaceStore';
 import {
@@ -101,6 +104,39 @@ describe('commandBoundary', () => {
     });
     it('does not treat 2>&1 as a file redirect', () => {
       expect(analyzeCommandBoundary('make 2>&1', WS, HOME)).toBe('unknown');
+    });
+    it('keeps touch and mkdir outside the shared standard/smart boundary parser', () => {
+      expect(analyzeCommandBoundary('touch ~/Desktop/out.txt', WS, HOME)).toBe('unknown');
+      expect(analyzeCommandBoundary('mkdir ~/Desktop/out', WS, HOME)).toBe('unknown');
+    });
+  });
+
+  describe('full no-workspace hard-floor targets', () => {
+    it('checks every compound segment without changing the shared boundary parser', () => {
+      expect(resolveFullNoWorkspaceCommandWriteTargets(
+        'touch ~ && touch ~/.AbU/mcp/config.json',
+        undefined,
+        HOME,
+      )).toEqual(expect.arrayContaining([HOME, `${HOME}/.AbU/mcp/config.json`]));
+    });
+
+    it.each([
+      'New-Item -Path "$HOME/.AbU/mcp/config.json" -ItemType File',
+      'Set-Content -LiteralPath "$env:USERPROFILE/.ABU/mcp/config.json" -Value x',
+    ])('resolves direct PowerShell self-managed targets: %s', (command) => {
+      const targets = resolveFullNoWorkspaceCommandWriteTargets(command, undefined, HOME);
+      expect(targets.some((target) => (
+        target.toLowerCase() === `${HOME}/.abu/mcp/config.json`.toLowerCase()
+      ))).toBe(true);
+    });
+
+    it.each([
+      ['Set-Content -Path "$HOME/.ssh/authorized_keys" -Value x', `${HOME}/.ssh/authorized_keys`],
+      ['Set-Content -Path "$HOME/tmp/../.AbU/mcp/config.json" -Value x', `${HOME}/.AbU/mcp/config.json`],
+      ['Set-Content -Path "$env:APPDATA/Abu/config.json" -Value x', `${HOME}/AppData/Roaming/Abu/config.json`],
+      ['cmd /c echo x > %USERPROFILE%\\.ssh\\authorized_keys', `${HOME}/.ssh/authorized_keys`],
+    ])('expands direct shell environment paths before normalization: %s', (command, expected) => {
+      expect(resolveFullNoWorkspaceCommandWriteTargets(command, undefined, HOME)).toContain(expected);
     });
   });
 });

--- a/src/core/permissions/commandBoundary.ts
+++ b/src/core/permissions/commandBoundary.ts
@@ -94,6 +94,200 @@ function extractWriteTargets(command: string): string[] {
   return targets;
 }
 
+/** Split shell command segments without treating quoted control characters as operators. */
+function splitUnquotedCommandSegments(command: string): string[] {
+  const segments: string[] = [];
+  let current = '';
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+
+  const pushCurrent = () => {
+    const segment = current.trim();
+    if (segment) segments.push(segment);
+    current = '';
+  };
+
+  for (let index = 0; index < command.length; index++) {
+    const ch = command[index];
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      current += ch;
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      current += ch;
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      current += ch;
+      continue;
+    }
+    if (ch === ';' || ch === '|') {
+      pushCurrent();
+      if (command[index + 1] === ch) index++;
+      continue;
+    }
+    if (ch === '&' && current.endsWith('>')) {
+      current += ch; // fd redirection such as 2>&1
+      continue;
+    }
+    if (ch === '&') {
+      pushCurrent();
+      if (command[index + 1] === '&') index++;
+      continue;
+    }
+    current += ch;
+  }
+  pushCurrent();
+  return segments;
+}
+
+function simpleTokens(segment: string): string[] {
+  return segment.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
+}
+
+function optionValue(args: string[], names: string[]): string | undefined {
+  const foldedNames = names.map((name) => name.toLowerCase());
+  for (let index = 0; index < args.length; index++) {
+    const folded = args[index].toLowerCase();
+    const exactIndex = foldedNames.indexOf(folded);
+    if (exactIndex >= 0) return args[index + 1];
+    for (const name of foldedNames) {
+      if (folded.startsWith(`${name}=`)) return args[index].slice(name.length + 1);
+    }
+  }
+  return undefined;
+}
+
+function positionalArgs(args: string[]): string[] {
+  let afterDoubleDash = false;
+  return args.filter((arg) => {
+    if (arg === '--') {
+      afterDoubleDash = true;
+      return false;
+    }
+    return afterDoubleDash || !arg.startsWith('-');
+  });
+}
+
+/**
+ * Extract direct write targets for the full/no-workspace hard-floor preflight.
+ * This is intentionally separate from analyzeCommandBoundary: adding commands
+ * here must not change standard/smart interactive confirmation behaviour.
+ */
+function extractFullNoWorkspaceWriteTargets(command: string): string[] {
+  const targets = extractWriteTargets(command);
+
+  for (const segment of splitUnquotedCommandSegments(command)) {
+    const tokens = simpleTokens(segment);
+    const rawCommand = unquote(tokens[0] ?? '').replace(/\\/g, '/');
+    const commandName = rawCommand.split('/').pop()?.toLowerCase();
+    if (!commandName) continue;
+    const args = tokens.slice(1);
+    const positional = positionalArgs(args);
+
+    if (['touch', 'mkdir', 'md', 'rm', 'rmdir', 'unlink', 'del', 'erase'].includes(commandName)) {
+      targets.push(...positional);
+      continue;
+    }
+    if (['cp', 'mv', 'install', 'copy', 'move'].includes(commandName) && positional.length >= 2) {
+      targets.push(positional[positional.length - 1]);
+      continue;
+    }
+    if (commandName === 'tee') {
+      targets.push(...positional);
+      continue;
+    }
+
+    const pathOption = optionValue(args, ['-Path', '-LiteralPath', '-FilePath']);
+    const destinationOption = optionValue(args, ['-Destination']);
+    if (['new-item', 'set-content', 'add-content', 'clear-content', 'remove-item', 'out-file'].includes(commandName)) {
+      const target = pathOption ?? positional[0];
+      if (target) targets.push(target);
+      continue;
+    }
+    if (['copy-item', 'move-item'].includes(commandName)) {
+      const target = destinationOption ?? positional[1];
+      if (target) targets.push(target);
+    }
+  }
+
+  return targets;
+}
+
+function explicitAbuPathMentions(command: string, home: string): string[] {
+  const normalizedCommand = command.replace(/\\/g, '/');
+  const prefixes = [home, '~', '$HOME', '${HOME}', '%USERPROFILE%', '$env:USERPROFILE'];
+  const results: string[] = [];
+
+  for (const prefix of prefixes) {
+    const needle = `${prefix}/.abu`;
+    const foldedCommand = normalizedCommand.toLowerCase();
+    const foldedNeedle = needle.toLowerCase();
+    let start = foldedCommand.indexOf(foldedNeedle);
+    while (start >= 0) {
+      let end = start + needle.length;
+      while (end < normalizedCommand.length && !/[\s"'`;&|<>()]/.test(normalizedCommand[end])) end++;
+      const suffix = normalizedCommand.slice(start + prefix.length, end);
+      results.push(`${home}${suffix}`);
+      start = foldedCommand.indexOf(foldedNeedle, end);
+    }
+  }
+
+  return results;
+}
+
+function resolveFullNoWorkspacePath(
+  raw: string,
+  cwd: string | undefined,
+  home: string,
+): string | null {
+  let expanded = unquote(raw.trim()).replace(/\\/g, '/');
+  const appData = `${home}/AppData/Roaming`;
+  const replacements: Array<[RegExp, string]> = [
+    [/^\$\{home\}(?=\/|$)/i, home],
+    [/^\$home(?=\/|$)/i, home],
+    [/^\$env:userprofile(?=\/|$)/i, home],
+    [/^%userprofile%(?=\/|$)/i, home],
+    [/^\$env:appdata(?=\/|$)/i, appData],
+    [/^%appdata%(?=\/|$)/i, appData],
+  ];
+  for (const [pattern, value] of replacements) {
+    if (pattern.test(expanded)) {
+      expanded = expanded.replace(pattern, value);
+      break;
+    }
+  }
+  return resolvePath(expanded, cwd, home);
+}
+
+/** Resolve direct targets that need pathSafety hard-floor checks for the one
+ * full-tier/no-workspace exception. Unresolved relative targets are omitted:
+ * the scoped command sandbox still receives no ambient/global write grants. */
+export function resolveFullNoWorkspaceCommandWriteTargets(
+  command: string,
+  cwd: string | undefined,
+  home: string,
+): string[] {
+  const rawTargets = [
+    ...extractFullNoWorkspaceWriteTargets(command),
+    ...explicitAbuPathMentions(command, home),
+  ];
+  const resolved = new Set<string>();
+  for (const raw of rawTargets) {
+    const abs = resolveFullNoWorkspacePath(raw, cwd, home);
+    if (abs) resolved.add(abs);
+  }
+  return Array.from(resolved);
+}
+
 /**
  * Decide whether a command writes outside the working directories.
  * Conservative: returns 'unknown' unless write targets are confidently resolved.

--- a/src/core/scheduler/scheduler.test.ts
+++ b/src/core/scheduler/scheduler.test.ts
@@ -16,7 +16,7 @@ import { useSettingsStore } from '../../stores/settingsStore';
 import type { ScheduledTask } from '../../types/schedule';
 import type { ConfirmationInfo } from '../tools/registry';
 import { initLanguage } from '../../i18n';
-import { checkWritePath, revokeWorkspace } from '../tools/pathSafety';
+import { checkWritePath, hasFullShellAuthorizationScope, revokeWorkspace } from '../tools/pathSafety';
 
 // Mock agentLoop — control the exit reason. isIncompleteReason is a trivial pure
 // fn (tested in agentLoop.test.ts); duplicate it here to avoid importing the real
@@ -177,6 +177,35 @@ describe('SchedulerEngine permission tier', () => {
     const conversationId = latestRun(task.id)?.conversationId;
     expect(conversationId).toBeDefined();
     expect(useChatStore.getState().conversations[conversationId!]?.permissionMode).toBe('autonomous');
+  });
+
+  it('creates a full shell authorization scope for autonomous tasks', async () => {
+    const task = makeTask({ id: 'task-full-scope', permissionMode: 'autonomous' });
+    useScheduleStore.setState({ tasks: { [task.id]: task } });
+    let scopeWasFull: boolean | undefined;
+    runWithProbe(async (options) => {
+      const scopeId = (options as { authorizationScopeId?: string }).authorizationScopeId;
+      scopeWasFull = hasFullShellAuthorizationScope(scopeId);
+    }, 'completed');
+
+    await schedulerEngine.runNow(task.id);
+
+    expect(scopeWasFull).toBe(true);
+  });
+
+  it('creates a full shell scope when an unset task follows global autonomous mode', async () => {
+    useSettingsStore.setState({ permissionMode: 'autonomous' });
+    const task = makeTask({ id: 'task-follow-full', permissionMode: undefined });
+    useScheduleStore.setState({ tasks: { [task.id]: task } });
+    let scopeWasFull: boolean | undefined;
+    runWithProbe(async (options) => {
+      const scopeId = (options as { authorizationScopeId?: string }).authorizationScopeId;
+      scopeWasFull = hasFullShellAuthorizationScope(scopeId);
+    }, 'completed');
+
+    await schedulerEngine.runNow(task.id);
+
+    expect(scopeWasFull).toBe(true);
   });
 
   it('leaves the conversation permissionMode unset when the task follows global settings', async () => {

--- a/src/core/scheduler/scheduler.ts
+++ b/src/core/scheduler/scheduler.ts
@@ -198,7 +198,11 @@ class SchedulerEngine {
       prompt = `/${task.skillName} ${prompt}`;
     }
 
-    const authorizationScopeId = createAuthorizationScope();
+    const authorizationScopeId = createAuthorizationScope(
+      resolveEffectivePermissionMode(task) === 'autonomous'
+        ? { shell: 'full' }
+        : undefined,
+    );
     const permissions = resolveScheduledRunPermissions(task, authorizationScopeId);
 
     try {

--- a/src/core/tools/pathSafety.test.ts
+++ b/src/core/tools/pathSafety.test.ts
@@ -7,6 +7,7 @@ import {
   createAuthorizationScope,
   disposeAuthorizationScope,
   getAuthorizedWritablePaths,
+  hasFullShellAuthorizationScope,
   revokeWorkspace,
   scopedAuthorizeWorkspace,
   getPermissionDirectory,
@@ -185,6 +186,22 @@ describe('pathSafety', () => {
         revokeWorkspace(wsA);
         revokeWorkspace(wsB);
         revokeWorkspace(globalWs);
+      }
+    });
+
+    it('keeps full shell policy scoped to the live authorization scope', () => {
+      const strictScope = createAuthorizationScope();
+      const fullScope = createAuthorizationScope({ shell: 'full' });
+      try {
+        expect(hasFullShellAuthorizationScope(strictScope)).toBe(false);
+        expect(hasFullShellAuthorizationScope(fullScope)).toBe(true);
+        expect(hasFullShellAuthorizationScope('missing-scope')).toBe(false);
+
+        disposeAuthorizationScope(fullScope);
+        expect(hasFullShellAuthorizationScope(fullScope)).toBe(false);
+      } finally {
+        disposeAuthorizationScope(strictScope);
+        disposeAuthorizationScope(fullScope);
       }
     });
 

--- a/src/core/tools/pathSafety.ts
+++ b/src/core/tools/pathSafety.ts
@@ -182,20 +182,36 @@ const ALWAYS_ALLOWED_PATHS = [
 // Each entry maps a normalized path to its authorized capabilities
 const authorizedWorkspaces: Map<string, Set<'read' | 'write'>> = new Map();
 const scopedAuthorizedWorkspaces: Map<string, Map<string, Set<'read' | 'write'>>> = new Map();
+const authorizationScopePolicies: Map<string, AuthorizationScopePolicy> = new Map();
 let authorizationScopeCounter = 0;
 
 export type AuthorizationScopeId = string;
+export type AuthorizationScopeShellPolicy = 'strict' | 'full';
+export interface AuthorizationScopePolicy {
+  /**
+   * Shell-only policy metadata attached by the trusted shell owner of a scoped
+   * unattended run. ToolExecutionContext deliberately does not carry this.
+   */
+  shell?: AuthorizationScopeShellPolicy;
+}
 
-export function createAuthorizationScope(): AuthorizationScopeId {
+export function createAuthorizationScope(policy: AuthorizationScopePolicy = {}): AuthorizationScopeId {
   authorizationScopeCounter += 1;
   const scopeId = `auth-scope-${Date.now().toString(36)}-${authorizationScopeCounter.toString(36)}`;
   scopedAuthorizedWorkspaces.set(scopeId, new Map());
+  authorizationScopePolicies.set(scopeId, { shell: policy.shell ?? 'strict' });
   return scopeId;
 }
 
 export function disposeAuthorizationScope(scopeId: AuthorizationScopeId | undefined): void {
   if (!scopeId) return;
   scopedAuthorizedWorkspaces.delete(scopeId);
+  authorizationScopePolicies.delete(scopeId);
+}
+
+export function hasFullShellAuthorizationScope(scopeId: AuthorizationScopeId | undefined): boolean {
+  if (!scopeId) return false;
+  return authorizationScopePolicies.get(scopeId)?.shell === 'full';
 }
 
 function normalizeWorkspacePath(path: string): string {

--- a/src/core/tools/readOnlyDetector.test.ts
+++ b/src/core/tools/readOnlyDetector.test.ts
@@ -203,6 +203,20 @@ describe('readOnlyDetector', () => {
       expect(isReadOnlyCommand('Get-Process | Format-Table -AutoSize')).toBe(true);
     });
 
+    it.each([
+      'Set-Content -Path file.txt -Value x',
+      'Add-Content -Path file.txt -Value x',
+      'Clear-Content -Path file.txt',
+      'New-Item -Path file.txt -ItemType File',
+      'Remove-Item -Path file.txt',
+      'Copy-Item a.txt b.txt',
+      'Move-Item a.txt b.txt',
+      'Out-File -FilePath file.txt',
+    ])('[Windows] "%s" → NOT read-only', (command) => {
+      cleanup = setPlatformForTest('windows');
+      expect(isReadOnlyCommand(command)).toBe(false);
+    });
+
     // Windows commands that should NOT be read-only
     it('[Windows] Windows read-only cmds are rejected on macOS', () => {
       cleanup = setPlatformForTest('macos');

--- a/src/core/tools/readOnlyDetector.ts
+++ b/src/core/tools/readOnlyDetector.ts
@@ -105,6 +105,9 @@ const WRITE_INDICATORS: RegExp[] = [
   /\bmv\s/, /\bcp\s/, /\bchmod\s/, /\bchown\s/,
   /\bsudo\s/, /\bkill\s/, /\bpkill\s/, /\bkillall\s/,
   /\btee\s/, // tee writes to file
+  /\b(?:Set|Add|Clear)-Content\b/i,
+  /\b(?:New|Remove|Copy|Move)-Item\b/i,
+  /\bOut-File\b/i,
 
   // Package management (write operations)
   /\bnpm\s+install\b/, /\bnpm\s+uninstall\b/, /\bnpm\s+update\b/,

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -357,20 +357,35 @@ async function resolveBrowserActionOrigin(
   }
 }
 
-async function isScopedCommandCwdWriteAllowed(
+/**
+ * Why a scoped (unattended) run's non-read-only command was refused, so the
+ * denial the model reads says what to change instead of just "no".
+ *
+ * `no-cwd` is the notable case: an unattended run with neither an explicit
+ * `cwd` nor a trusted workspace path has NOTHING to judge the command's
+ * implicit write location against, so it fails closed — including for the
+ * `full` / `autonomous` tiers, and including writes that only touch `/tmp`.
+ * That is deliberately strict (loosening it is a permission-granularity
+ * decision, not a review fix), but it silently removes a capability those
+ * tiers used to have, so the reason has to name the remedy: give the
+ * trigger/task a workspace path, or pass an absolute `cwd`.
+ */
+type ScopedCwdDenial = 'no-cwd' | 'not-writable';
+
+async function scopedCommandCwdDenial(
   input: Record<string, unknown>,
   toolContext?: ToolExecutionContext,
-): Promise<boolean> {
+): Promise<ScopedCwdDenial | null> {
   const scopeId = toolContext?.authorizationScopeId;
-  if (scopeId === undefined) return true;
+  if (scopeId === undefined) return null;
   const effectiveCwd = typeof input.cwd === 'string' && input.cwd.trim().length > 0
     ? input.cwd
     : toolContext?.workspacePath ?? undefined;
-  if (!effectiveCwd) return false;
+  if (!effectiveCwd) return 'no-cwd';
   if (!isInsideWorkingDirs(effectiveCwd, commandWritableDirectories(scopeId))) {
-    return false;
+    return 'not-writable';
   }
-  return (await checkWritePath(effectiveCwd, scopeId)).allowed;
+  return (await checkWritePath(effectiveCwd, scopeId)).allowed ? null : 'not-writable';
 }
 
 export async function checkToolApproval(
@@ -398,11 +413,22 @@ export async function checkToolApproval(
         return { decision: 'deny', reason: `Error: ${t.commandConfirm.blocked}: ${analysis.reason}` };
       }
 
-      if (!analysis.readOnly && !(await isScopedCommandCwdWriteAllowed(input, toolContext))) {
-        return {
-          decision: 'deny',
-          reason: 'Error: command working directory is not write-authorized for this scoped run',
-        };
+      if (!analysis.readOnly) {
+        const cwdDenial = await scopedCommandCwdDenial(input, toolContext);
+        if (cwdDenial === 'no-cwd') {
+          return {
+            decision: 'deny',
+            reason: 'Error: this unattended run has no write-authorized working directory, '
+              + 'so no writing command can run. Set the trigger/task workspace path, '
+              + 'or pass an absolute `cwd` inside an authorized directory.',
+          };
+        }
+        if (cwdDenial === 'not-writable') {
+          return {
+            decision: 'deny',
+            reason: 'Error: command working directory is not write-authorized for this scoped run',
+          };
+        }
       }
 
       // Best-effort boundary check: only matters for safe, non-read-only commands

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -1,7 +1,14 @@
 import type { ToolDefinition, ToolResult, ToolExecutionContext } from '../../types';
 import { mcpManager } from '../mcp/client';
 import { analyzeCommand, type ConfirmationInfo, type DangerLevel } from './commandSafety';
-import { checkReadPath, checkWritePath, checkListPath, authorizeWorkspace, scopedAuthorizeWorkspace } from './pathSafety';
+import {
+  checkReadPath,
+  checkWritePath,
+  checkListPath,
+  authorizeWorkspace,
+  scopedAuthorizeWorkspace,
+  hasFullShellAuthorizationScope,
+} from './pathSafety';
 import { getI18n } from '../../i18n';
 import { truncateToolResult } from '../context/truncation';
 import { getSettingsReader } from '../agent/ports/settingsReader';
@@ -16,7 +23,11 @@ import {
   normalizeBrowserOrigin,
 } from '../permissions/browserToolPolicy';
 import { classifySelfExtension } from '../permissions/selfExtensionPolicy';
-import { analyzeCommandBoundary, type CmdBoundary } from '../permissions/commandBoundary';
+import {
+  analyzeCommandBoundary,
+  resolveFullNoWorkspaceCommandWriteTargets,
+  type CmdBoundary,
+} from '../permissions/commandBoundary';
 import { commandWritableDirectories, isInsideWorkingDirs } from '../permissions/workingDirs';
 import { reviewAction } from '../safety/reviewer';
 import { getLoopContext } from '../agent/permissionBridge';
@@ -361,31 +372,54 @@ async function resolveBrowserActionOrigin(
  * Why a scoped (unattended) run's non-read-only command was refused, so the
  * denial the model reads says what to change instead of just "no".
  *
- * `no-cwd` is the notable case: an unattended run with neither an explicit
- * `cwd` nor a trusted workspace path has NOTHING to judge the command's
- * implicit write location against, so it fails closed — including for the
- * `full` / `autonomous` tiers, and including writes that only touch `/tmp`.
- * That is deliberately strict (loosening it is a permission-granularity
- * decision, not a review fix), but it silently removes a capability those
- * tiers used to have, so the reason has to name the remedy: give the
- * trigger/task a workspace path, or pass an absolute `cwd`.
+ * `no-cwd` is the notable case: standard/smart runs fail closed and get an
+ * actionable remedy. A trusted full/autonomous scope receives the one narrow
+ * exception requested by the product decision; the distinct return value
+ * below keeps its hard-floor preflight from affecting scoped runs that do
+ * have a workspace.
  */
-type ScopedCwdDenial = 'no-cwd' | 'not-writable';
+type ScopedCwdDecision = 'full-no-cwd' | 'no-cwd' | 'not-writable' | null;
 
 async function scopedCommandCwdDenial(
   input: Record<string, unknown>,
   toolContext?: ToolExecutionContext,
-): Promise<ScopedCwdDenial | null> {
+): Promise<ScopedCwdDecision> {
   const scopeId = toolContext?.authorizationScopeId;
   if (scopeId === undefined) return null;
   const effectiveCwd = typeof input.cwd === 'string' && input.cwd.trim().length > 0
     ? input.cwd
     : toolContext?.workspacePath ?? undefined;
-  if (!effectiveCwd) return 'no-cwd';
+  if (!effectiveCwd) {
+    return hasFullShellAuthorizationScope(scopeId) ? 'full-no-cwd' : 'no-cwd';
+  }
   if (!isInsideWorkingDirs(effectiveCwd, commandWritableDirectories(scopeId))) {
     return 'not-writable';
   }
   return (await checkWritePath(effectiveCwd, scopeId)).allowed ? null : 'not-writable';
+}
+
+async function fullNoWorkspaceCommandTargetDenial(
+  command: string,
+  cwd: string | undefined,
+  scopeId: string | undefined,
+): Promise<string | null> {
+  if (!hasFullShellAuthorizationScope(scopeId)) return null;
+  const targets = resolveFullNoWorkspaceCommandWriteTargets(
+    command,
+    cwd,
+    await getCachedHomeDir(),
+  );
+
+  for (const target of targets) {
+    const check = await checkWritePath(target, scopeId);
+    // Autonomous approval is not a persistent path grant. Dialog-eligible
+    // targets continue to the command sandbox with an empty scoped map; hard
+    // blocks are the only path decisions enforced here.
+    if (check.allowed || check.needsPermission) continue;
+    return `Error: ${check.reason || getI18n().toolErrors.pathAccessDenied}`;
+  }
+
+  return null;
 }
 
 export async function checkToolApproval(
@@ -414,20 +448,28 @@ export async function checkToolApproval(
       }
 
       if (!analysis.readOnly) {
-        const cwdDenial = await scopedCommandCwdDenial(input, toolContext);
-        if (cwdDenial === 'no-cwd') {
+        const cwdDecision = await scopedCommandCwdDenial(input, toolContext);
+        if (cwdDecision === 'no-cwd') {
           return {
             decision: 'deny',
-            reason: 'Error: this unattended run has no write-authorized working directory, '
-              + 'so no writing command can run. Set the trigger/task workspace path, '
-              + 'or pass an absolute `cwd` inside an authorized directory.',
+            reason: t.toolErrors.scopedRunNoWorkspaceCommand,
           };
         }
-        if (cwdDenial === 'not-writable') {
+        if (cwdDecision === 'not-writable') {
           return {
             decision: 'deny',
             reason: 'Error: command working directory is not write-authorized for this scoped run',
           };
+        }
+        if (cwdDecision === 'full-no-cwd') {
+          const targetDenial = await fullNoWorkspaceCommandTargetDenial(
+            command,
+            undefined,
+            toolContext?.authorizationScopeId,
+          );
+          if (targetDenial) {
+            return { decision: 'deny', reason: targetDenial };
+          }
         }
       }
 

--- a/src/core/trigger/triggerEngine.test.ts
+++ b/src/core/trigger/triggerEngine.test.ts
@@ -453,6 +453,23 @@ describe('TriggerEngine', () => {
       expect(disposeAuthorizationScopeMock).toHaveBeenCalledWith('scope-trigger-test');
     });
 
+    it('creates a full shell authorization scope for full-capability trigger runs', async () => {
+      const trigger = makeTrigger({
+        id: 'trigger-scope-full',
+        action: { prompt: 'Do full scoped work', capability: 'full' },
+      });
+      useTriggerStore.setState({ triggers: { [trigger.id]: trigger } });
+
+      await triggerEngine.handleEvent(trigger.id, { data: { n: 1 } });
+
+      expect(createAuthorizationScopeMock).toHaveBeenCalledWith({ shell: 'full' });
+      expect(runAgentLoopMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.objectContaining({ authorizationScopeId: 'scope-trigger-test' }),
+      );
+    });
+
     it('disposes the trigger-run scope when the agent runner throws', async () => {
       const trigger = makeTrigger({
         id: 'trigger-scope-throw',

--- a/src/core/trigger/triggerEngine.ts
+++ b/src/core/trigger/triggerEngine.ts
@@ -318,15 +318,19 @@ class TriggerEngine {
       prompt = `/${trigger.action.skillName} ${prompt}`;
     }
 
-    const authorizationScopeId = createAuthorizationScope();
+    // Resolve permission callbacks based on trigger's capability level.
+    // Permissions are declared at creation time — no runtime dialogs.
+    // Pass resolved workspacePath so it gets pre-authorized for file access.
+    const actionWithWorkspace = workspacePath
+      ? { ...trigger.action, workspacePath }
+      : trigger.action;
+    const authorizationScopeId = createAuthorizationScope(
+      (actionWithWorkspace.capability ?? 'read_tools') === 'full'
+        ? { shell: 'full' }
+        : undefined,
+    );
 
     try {
-      // Resolve permission callbacks based on trigger's capability level.
-      // Permissions are declared at creation time — no runtime dialogs.
-      // Pass resolved workspacePath so it gets pre-authorized for file access.
-      const actionWithWorkspace = workspacePath
-        ? { ...trigger.action, workspacePath }
-        : trigger.action;
       const callbacks = resolveTriggerCallbacks(actionWithWorkspace, { authorizationScopeId });
       const result = await runAgentLoopDispatched(conversationId, prompt, {
         commandConfirmCallback: callbacks.commandConfirmCallback,

--- a/src/i18n/index.test.ts
+++ b/src/i18n/index.test.ts
@@ -107,6 +107,16 @@ describe('i18n', () => {
         free: 'Free',
       });
     });
+
+    it('provides scoped no-workspace command guidance in both locales', () => {
+      setLanguage('zh-CN');
+      expect(getI18n().toolErrors.scopedRunNoWorkspaceCommand).toContain('完全自主');
+      expect(getI18n().toolErrors.scopedRunNoWorkspaceCommand).toContain('工作区路径');
+
+      setLanguage('en-US');
+      expect(getI18n().toolErrors.scopedRunNoWorkspaceCommand).toContain('Full Autonomy');
+      expect(getI18n().toolErrors.scopedRunNoWorkspaceCommand).toContain('workspace path');
+    });
   });
 
   // ── getLocale ──

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -2215,6 +2215,7 @@ const enUS: TranslationDict = {
     userDeniedAccess: 'User denied access to',
     pathAccessDenied: 'Path access denied',
     needsAuthorization: 'User authorization required to access',
+    scopedRunNoWorkspaceCommand: 'Error: this unattended run has no write-authorized working directory, so no writing command can run. Choose Full Autonomy, configure a workspace path for this task, or pass an absolute `cwd` inside an authorized directory.',
   },
 
   queueStrip: {

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -2216,6 +2216,7 @@ const zhCN: TranslationDict = {
     userDeniedAccess: '用户拒绝了访问',
     pathAccessDenied: '路径访问被拒绝',
     needsAuthorization: '需要用户授权才能访问',
+    scopedRunNoWorkspaceCommand: 'Error: 当前无人值守任务没有可写授权工作目录，因此不能运行写入命令。请选择完全自主档、为此任务配置工作区路径，或传入已授权目录内的绝对 `cwd`。',
   },
 
   queueStrip: {

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -2398,6 +2398,7 @@ export interface TranslationDict {
     userDeniedAccess: string;
     pathAccessDenied: string;
     needsAuthorization: string;
+    scopedRunNoWorkspaceCommand: string;
   };
 
   // Mid-task queued-message staging strip above the composer

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -1697,6 +1697,43 @@ describe('chatStore', () => {
         status: 'streaming',
       });
     });
+
+    it('drops agent state for conversations the LRU cache evicts, keeping running ones', () => {
+      const ids: string[] = [];
+      for (let i = 0; i < 7; i++) ids.push(useChatStore.getState().createConversation());
+
+      // Give every conversation a live agent state, and mark one eviction
+      // candidate as still running so the "don't unload a running
+      // conversation" guard is exercised alongside the cleanup.
+      const runningId = ids[0];
+      useChatStore.setState((state) => {
+        const running = state.conversations[runningId];
+        if (running) running.status = 'running';
+        state.agentStates = new Map(
+          ids.map((id) => [id, {
+            status: 'tool-calling' as const,
+            currentTool: 'read_file',
+            retryInfo: null,
+            thinkingStartTime: null,
+            activeAgentNames: [],
+          }]),
+        );
+      });
+
+      useChatStore.getState().unloadOldConversations();
+
+      const { conversations, agentStates } = useChatStore.getState();
+      const evicted = ids.filter((id) => !conversations[id]);
+      expect(evicted.length).toBeGreaterThan(0);
+      expect(conversations[runningId]).toBeDefined();
+      // Evicted rows must not keep a live agent state — no writer can ever
+      // clear it again, so it would leak and resurrect a stale status strip.
+      for (const id of evicted) expect(agentStates.has(id)).toBe(false);
+      // Still-loaded rows (including the protected running one) keep theirs.
+      for (const id of ids.filter((id) => conversations[id])) {
+        expect(agentStates.get(id)).toMatchObject({ status: 'tool-calling' });
+      }
+    });
   });
 
   // ── export/import ──

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -2247,6 +2247,15 @@ export const useChatStore = create<ChatStore>()(
             // Don't unload conversations with running status
             if (state.conversations[id]?.status === 'running') continue;
             delete state.conversations[id];
+            // Drop the conversation's live agent state together with its
+            // record. Every writer (`setAgentStatus`/`setRetryInfo`) refuses
+            // to touch a conversation that is no longer loaded, so an entry
+            // left behind here can never be cleared again: it retains memory
+            // for the process lifetime AND resurrects a stale non-idle status
+            // strip the next time that conversation is loaded and viewed.
+            // Same class of leak the computerUseStatus per-conversation map
+            // had to fix after PR #209/#216.
+            state.agentStates = removeConversationAgentState(state.agentStates, id);
           }
         });
       },

--- a/tests/e2e/infra-hygiene.spec.ts
+++ b/tests/e2e/infra-hygiene.spec.ts
@@ -217,6 +217,10 @@ function taskRequests(mock: OpenAiMock): MockRequest[] {
   return mock.requests.filter((request) => request.purpose === 'task');
 }
 
+function quoteShellArgument(value: string): string {
+  return `'${value.replace(/'/g, "'\\\"'\\\"'")}'`;
+}
+
 async function waitForApp(page: Page): Promise<void> {
   await page.waitForLoadState('domcontentloaded');
   await expect(page.getByPlaceholder(CHAT_PLACEHOLDER)).toBeVisible({ timeout: READY_TIMEOUT });
@@ -313,7 +317,7 @@ function makeTrigger(
   id: string,
   name: string,
   prompt: string,
-  workspacePath: string,
+  workspacePath: string | undefined,
   capability?: 'read_tools' | 'safe_tools' | 'full' | 'custom',
 ): Record<string, unknown> {
   return {
@@ -324,7 +328,7 @@ function makeTrigger(
     filter: { type: 'always' },
     action: {
       prompt,
-      workspacePath,
+      ...(workspacePath ? { workspacePath } : {}),
       ...(capability ? { capability } : {}),
     },
     debounce: { enabled: false, windowSeconds: 0 },
@@ -601,5 +605,48 @@ test.describe.serial('Electron infra hygiene batch', () => {
         return trigger?.action?.capability ?? null;
       }, managedTriggerName);
     }, { timeout: READY_TIMEOUT }).toBe(null);
+  });
+
+  test('lets a full trigger without a workspace write to an isolated temp path', async () => {
+    fixtureRoot = fs.mkdtempSync('/tmp/abu-infra-full-no-workspace-');
+    const triggerId = `trigger-full-no-workspace-${randomUUID()}`;
+    const triggerName = `Full no-workspace trigger ${randomUUID().slice(0, 8)}`;
+    const target = path.join(fixtureRoot, 'created-by-full-trigger.txt');
+    const command = `touch -- ${quoteShellArgument(target)}`;
+
+    mock = await startOpenAiMock([
+      {
+        kind: 'tool-call',
+        toolName: 'run_command',
+        toolCallId: `call-full-no-workspace-${randomUUID()}`,
+        arguments: { command },
+      },
+      { kind: 'complete', responseText: `full no-workspace complete ${randomUUID()}` },
+    ]);
+
+    dataRoot = createElectronDataRoot();
+    const launched = await launchAbuElectron(dataRoot);
+    app = launched.app;
+    const page = await app.firstWindow({ timeout: READY_TIMEOUT });
+    await waitForApp(page);
+    await configureLocalMockProvider(page, mock.baseUrl);
+    await seedAutomation(page, {
+      activeTab: 'trigger',
+      triggers: {
+        [triggerId]: makeTrigger(
+          triggerId,
+          triggerName,
+          'full no-workspace trigger $EVENT_DATA',
+          undefined,
+          'full',
+        ),
+      },
+    });
+
+    await openAutomationItem(page, /^(监听事件|Triggers)$/, triggerName);
+    await page.getByRole('button', { name: /^(测试触发|Test Trigger)$/ }).click();
+    await expect.poll(() => taskRequests(mock!).length, { timeout: READY_TIMEOUT }).toBe(2);
+    expectToolResultMatches(taskRequests(mock)[1].body, 'run_command', /exit code: 0/);
+    await expect.poll(() => fs.existsSync(target), { timeout: READY_TIMEOUT }).toBe(true);
   });
 });


### PR DESCRIPTION
Independent post-merge review of #281 (A2 + A3 infra-hygiene batch), done by a session that did not write that code. Two fixes here; the rest of the review is findings only.

## Fixed

**1. `agentStates` leaked past LRU eviction.** `setAgentStatus` / `setRetryInfo` both refuse to touch a conversation that is no longer in the loaded-conversations cache, so an entry `unloadOldConversations` left behind could never be cleared again — retained for the process lifetime, and it resurrects a stale non-idle status strip when the conversation is reloaded. This is the same class of leak the `computerUseStatus` per-conversation map had to close after #209/#216, which the batch brief named as the lesson to copy. Cleanup now happens with the eviction; running conversations (already skipped by eviction) keep their state. Test verified red before / green after.

**2. Workspace-less unattended runs got an opaque refusal.** Probed against merged `dev`: a scoped run with neither an explicit `cwd` nor a trusted workspace path refuses *every* non-read-only command — at the `full` / `autonomous` tier too, and including writes that only touch `/tmp`. Unscoped interactive runs are unaffected. Failing closed is defensible; the bare `not write-authorized` string was not, since an unattended run has no dialog and the model cannot tell this apart from a wrong `cwd`. The two refusals are now distinct and the workspace-less one names both remedies.

> At the time of the original review this changed the message only; the product owner has since resolved the permission-granularity decision below.

## Original review findings

**A. No path left to create a trigger above `read_tools`.** #281 removed `capability` from `manage_trigger`, correctly. But grep confirms the trigger UI has never had a capability picker, so after this batch neither the model nor the user can create a `safe_tools` / `full` / `custom` trigger; existing ones keep their level, and update preserves it. #281's own description flags this as a pre-existing product gap — recording it here so it does not stay only in a PR body.

**B. The behavior change behind fix 2**, i.e. existing workspace-less scheduled tasks and triggers silently lost the ability to run any writing command. **Resolved by the 2026-08-25 product decision below.**

**C. E2E fixture root is created under the real `~/Documents`** (`tests/e2e/infra-hygiene.spec.ts`), not a temp dir — deliberate, since `/tmp` is always-allowed and would not exercise authorization. `afterEach` cleans up and no leftovers exist, but a crashed run leaves a directory in the user's Documents.

**D. `revokeWorkspace` is scope-unaware** — it only clears the global map. Harmless today because scopes are disposed wholesale at run end; worth a comment if scopes ever outlive a run.

## Review verdict on #281 itself

No blocking defect found. Scope isolation is structurally sound: a scoped run reads *only* its own grant map (not a priority overlay over the global one), `checkRead/Write/ListPath` have no other workspace-derived allow branch, disposal fails closed, and the frame/notification trust checks match the wire shapes on all four planes. Test coverage for the three A3 invariants is genuinely thorough.

## Verification

- `npx vitest run` on `chatStore`, `toolRegistry.integration`, `pathSafety`, `commandTools`, `commandBoundary`, `triggerPermission`, `scheduler`, `AgentStatusStrip` — 198 passed
- `tsc --noEmit` exit 0, `eslint` on changed files exit 0
- Full `npm run verify` for merged #281 was run by the owner on the main checkout — exit 0

## Product decision (2026-08-25): full scoped runs without a workspace

The product owner chose to restore write commands only for trusted `full` / `autonomous` scoped runs that have no workspace, under the same autonomous command rules.

- Scheduler `autonomous` tasks and trigger actions with `capability: full` receive scope-local shell policy metadata; ordinary, missing, disposed, or forged scopes remain fail-closed.
- `standard` / `smart` runs without a workspace remain denied, with zh-CN/en-US guidance to choose Full Autonomy, configure a workspace path, or pass an authorized absolute `cwd`.
- This does not restore global authorization-map inheritance, create scoped path grants, or change full runs that already have a workspace.
- Block-level commands, `pathSafety` sensitive paths, case-folded `~/.abu` self-protection, browser gates, and Computer Use gates remain hard floors.
- Final validation: `npm run verify` exit 0 (415 files; 6118 passed, 1 skipped), production build exit 0, and real Electron E2E 3/3 passed.

Not merging; leaving the final decision to the owner.
