### PR TITLE
fix(trigger): stop the model from widening a custom trigger's allowlist

### DIFF
--- a/src/core/tools/definitions/automationTools.test.ts
+++ b/src/core/tools/definitions/automationTools.test.ts
@@ -4,6 +4,8 @@ import { setLanguage } from '@/i18n';
 import { useTriggerStore } from '@/stores/triggerStore';
 import type { TriggerAction } from '@/types/trigger';
 import { manageTriggerTool } from './automationTools';
+import { resolveTriggerCallbacks } from '@/core/trigger/triggerPermission';
+import { createAuthorizationScope, disposeAuthorizationScope } from '@/core/tools/pathSafety';
 
 function resetTriggerStore() {
   useTriggerStore.setState({
@@ -38,7 +40,7 @@ describe('manageTriggerTool', () => {
 
     expect(created.action.capability).toBeUndefined();
     expect(created.action.permissions).toBeUndefined();
-    expect(String(result)).toContain('New triggers use Read Only; updates keep the existing level.');
+    expect(String(result)).toContain('New triggers use Read Only; updates keep the existing level and allowlists.');
   });
 
   it('ignores malicious capability on update while preserving existing capability and permissions', async () => {
@@ -74,7 +76,7 @@ describe('manageTriggerTool', () => {
       allowedPaths: ['/Users/example/project'],
       allowedTools: ['read_file'],
     });
-    expect(String(result)).toContain('New triggers use Read Only; updates keep the existing level.');
+    expect(String(result)).toContain('New triggers use Read Only; updates keep the existing level and allowlists.');
   });
 
   it('does not mutate action when update only receives capability', async () => {
@@ -102,34 +104,86 @@ describe('manageTriggerTool', () => {
     });
 
     expect(useTriggerStore.getState().triggers[triggerId].action).toEqual(originalAction);
-    expect(String(result)).toContain('New triggers use Read Only; updates keep the existing level.');
+    expect(String(result)).toContain('New triggers use Read Only; updates keep the existing level and allowlists.');
   });
 
-  it('filters empty allowed_paths on update while preserving legal spaces in path names', async () => {
-    const legalPathWithSpaces = '/Users/example/project with trailing space ';
+  it('does not expose the custom allowlists in the tool schema', () => {
+    const props = manageTriggerTool.inputSchema.properties!;
+    expect(props).not.toHaveProperty('allowed_commands');
+    expect(props).not.toHaveProperty('allowed_paths');
+    expect(props).not.toHaveProperty('allowed_tools');
+  });
+
+  it('cannot widen a legacy custom trigger allowlist, so its run ceiling is unchanged', async () => {
+    const narrowPermissions = {
+      allowedCommands: ['git pull'],
+      allowedPaths: ['/Users/example/project'],
+      allowedTools: ['read_file'],
+    };
     const triggerId = useTriggerStore.getState().createTrigger({
-      name: 'Existing trigger',
+      name: 'narrow legacy custom',
       source: { type: 'http' },
       filter: { type: 'always' },
       action: {
         prompt: 'Before',
+        workspacePath: '/Users/example/project',
         capability: 'custom',
-        permissions: {
-          allowedPaths: ['/Users/example/old'],
-        },
+        permissions: narrowPermissions,
       },
+      debounce: { enabled: true, windowSeconds: 300 },
+    });
+
+    // The tier is already locked, so the only remaining lever the model had
+    // was the allowlist *inside* the custom tier — which IS the run ceiling.
+    await manageTriggerTool.execute({
+      action: 'update',
+      trigger_id: triggerId,
+      prompt: 'After',
+      allowed_tools: ['*'],
+      allowed_commands: ['*'],
+      allowed_paths: ['/'],
+    });
+
+    const action = useTriggerStore.getState().triggers[triggerId].action;
+    expect(action.prompt).toBe('After');
+    expect(action.capability).toBe('custom');
+    expect(action.permissions).toEqual(narrowPermissions);
+
+    // The authority the trigger actually runs under is derived from
+    // action.permissions, so pin the resolved callbacks rather than the
+    // stored record alone.
+    const scopeId = createAuthorizationScope();
+    try {
+      const callbacks = resolveTriggerCallbacks(action, { authorizationScopeId: scopeId });
+      expect(callbacks.allowedTools).toEqual(['read_file']);
+      await expect(
+        callbacks.commandConfirmCallback!({ command: 'rm -rf /Users/example/other', level: 'warn' }),
+      ).resolves.toBe(false);
+    } finally {
+      disposeAuthorizationScope(scopeId);
+    }
+  });
+
+  it('leaves action untouched when update carries only the removed allowlist fields', async () => {
+    const originalAction: TriggerAction = {
+      prompt: 'Keep me',
+      capability: 'custom',
+      permissions: { allowedPaths: ['/Users/example/old'] },
+    };
+    const triggerId = useTriggerStore.getState().createTrigger({
+      name: 'Existing trigger',
+      source: { type: 'http' },
+      filter: { type: 'always' },
+      action: originalAction,
       debounce: { enabled: true, windowSeconds: 300 },
     });
 
     await manageTriggerTool.execute({
       action: 'update',
       trigger_id: triggerId,
-      allowed_paths: ['', '   ', legalPathWithSpaces, '/Users/example/Project Name'],
+      allowed_paths: ['/'],
     });
 
-    expect(useTriggerStore.getState().triggers[triggerId].action.permissions?.allowedPaths).toEqual([
-      legalPathWithSpaces,
-      '/Users/example/Project Name',
-    ]);
+    expect(useTriggerStore.getState().triggers[triggerId].action).toEqual(originalAction);
   });
 });

--- a/src/core/tools/definitions/automationTools.ts
+++ b/src/core/tools/definitions/automationTools.ts
@@ -11,13 +11,6 @@ import { getI18n, getLocale, format } from '../../../i18n';
 /** Locale tag for Date#toLocaleString, following the resolved UI locale. */
 const dateLocale = (): string => (getLocale() === 'zh-CN' ? 'zh-CN' : 'en-US');
 
-function filterNonBlankStringList(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) return undefined;
-  return value.filter((item): item is string =>
-    typeof item === 'string' && item.trim().length > 0,
-  );
-}
-
 export const manageScheduledTaskTool: ToolDefinition = {
   name: TOOL_NAMES.MANAGE_SCHEDULED_TASK,
   description: 'Create, list, update, delete, pause, or resume scheduled tasks. Use when the user needs an operation to run automatically on a recurring or timed schedule.',
@@ -280,21 +273,14 @@ export const manageTriggerTool: ToolDefinition = {
       source_interval: { type: 'number', description: 'Polling interval in seconds (required when source_type=cron, minimum 10)' },
       debounce_enabled: { type: 'boolean', description: 'Whether to enable debounce (default: true)' },
       debounce_seconds: { type: 'number', description: 'Debounce time window in seconds (default: 300)' },
-      allowed_commands: {
-        type: 'array',
-        items: { type: 'string' },
-        description: 'Command allowlist, glob patterns (used for triggers whose capability level is custom, e.g. ["npm run *", "git pull"])',
-      },
-      allowed_paths: {
-        type: 'array',
-        items: { type: 'string' },
-        description: 'Path allowlist, auto-authorized at runtime (used for triggers whose capability level is custom)',
-      },
-      allowed_tools: {
-        type: 'array',
-        items: { type: 'string' },
-        description: 'Tool allowlist (used for triggers whose capability level is custom, e.g. ["read_file", "http_fetch"])',
-      },
+      // allowed_commands / allowed_paths / allowed_tools are deliberately NOT
+      // exposed. A trigger's capability tier is already model-locked, but a
+      // legacy `custom` trigger's allowlist IS its ceiling: buildTriggerRun-
+      // PermissionCeiling() reads action.permissions verbatim, so letting the
+      // model rewrite those three fields let it widen its own unattended
+      // ceiling from e.g. {allowedTools:['read_file']} to ['*'] without ever
+      // touching `capability`. Host-owned means host-owned — these are edited
+      // in the trigger UI only.
       trigger_id: { type: 'string', description: 'Trigger ID (required for update/delete/pause/resume)' },
       status_filter: {
         type: 'string',
@@ -483,26 +469,18 @@ export const manageTriggerTool: ToolDefinition = {
         const hasActionUpdate =
           input.prompt !== undefined ||
           input.skill_name !== undefined ||
-          input.workspace_path !== undefined ||
-          input.allowed_commands !== undefined ||
-          input.allowed_paths !== undefined ||
-          input.allowed_tools !== undefined;
+          input.workspace_path !== undefined;
 
         if (hasActionUpdate) {
-          const existingCapability = existing.action.capability;
-          const allowedPaths = input.allowed_paths !== undefined
-            ? filterNonBlankStringList(input.allowed_paths)
-            : existing.action.permissions?.allowedPaths;
+          // capability AND permissions are both carried over untouched. The
+          // model may restate a trigger's prompt/skill/workspace; it may never
+          // restate the authority that trigger runs under.
           updateData.action = {
             prompt: (input.prompt as string) ?? existing.action.prompt,
             skillName: input.skill_name !== undefined ? input.skill_name : existing.action.skillName,
             workspacePath: input.workspace_path !== undefined ? input.workspace_path : existing.action.workspacePath,
-            capability: existingCapability,
-            permissions: existingCapability === 'custom' ? {
-              allowedCommands: input.allowed_commands !== undefined ? input.allowed_commands : existing.action.permissions?.allowedCommands,
-              allowedPaths,
-              allowedTools: input.allowed_tools !== undefined ? input.allowed_tools : existing.action.permissions?.allowedTools,
-            } : existing.action.permissions,
+            capability: existing.action.capability,
+            permissions: existing.action.permissions,
           };
         }
         if (input.filter_type !== undefined || input.filter_keywords !== undefined || input.filter_pattern !== undefined || input.filter_field !== undefined) {

--- a/src/eval/__snapshots__/toolSchemaSnapshot.test.ts.snap
+++ b/src/eval/__snapshots__/toolSchemaSnapshot.test.ts.snap
@@ -244,9 +244,6 @@ exports[`Tool schema snapshot > all tool schemas match snapshot 1`] = `
     "name": "manage_trigger",
     "paramNames": [
       "action",
-      "allowed_commands",
-      "allowed_paths",
-      "allowed_tools",
       "debounce_enabled",
       "debounce_seconds",
       "description",

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -2581,7 +2581,7 @@ const enUS: TranslationDict = {
       capFull: 'Fully autonomous',
       capCustom: 'Custom allowlist',
       capLevelLine: 'Capability level: {label}',
-      triggerCapabilityUiNotice: 'The model cannot change the capability level. New triggers use Read Only; updates keep the existing level.',
+      triggerCapabilityUiNotice: 'The model cannot change the capability level, nor a custom level\'s command/path/tool allowlists — those are edited in the trigger UI only. New triggers use Read Only; updates keep the existing level and allowlists.',
       filterLine: 'Filter: {filter}',
       debounceLine: 'Debounce: {value}',
       debounceSeconds: '{seconds}s',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -2582,7 +2582,7 @@ const zhCN: TranslationDict = {
       capFull: '完全自主',
       capCustom: '自定义白名单',
       capLevelLine: '能力等级: {label}',
-      triggerCapabilityUiNotice: '模型不能更改能力档位。新建触发器默认为只读；更新时保留现有档位。',
+      triggerCapabilityUiNotice: '模型不能更改能力档位，也不能改自定义档位的命令/路径/工具白名单——这些只能在触发器界面里改。新建触发器默认为只读；更新时保留现有档位与白名单。',
       filterLine: '过滤: {filter}',
       debounceLine: '防抖: {value}',
       debounceSeconds: '{seconds}秒',


### PR DESCRIPTION
## Root cause

#281 removed `capability` from the `manage_trigger` schema so the model can no longer pick a trigger's tier. That closes the tier, but for a legacy `custom` trigger **the tier is not the ceiling — `action.permissions` is.**

`resolveTriggerCallbacks()` reads `permissions.allowedTools` / `allowedCommands` / `allowedPaths` verbatim into the run's callbacks (and, once #286 lands, `buildTriggerRunPermissionCeiling()` reads the same three arrays into the host ceiling). `manage_trigger update` accepted all three from model input and wrote them straight through whenever the existing capability was `custom`.

So a model could widen its own unattended ceiling without ever naming `capability`:

```
manage_trigger update trigger_id=X
  allowed_tools=['*'] allowed_commands=['*'] allowed_paths=['/']
```

turning `{allowedTools:['read_file'], allowedCommands:['git pull']}` into arbitrary tool + command authority on an unattended run — one that is driven by an unauthenticated localhost trigger endpoint, with `$EVENT_DATA` substituted from the request body.

This directly contradicts the invariant #286 states in `runPermissionCeiling.ts`: *"this policy may only remove authority … must not widen it."*

Reproduced before the fix against the resolved callbacks; the previous test suite explicitly blessed the behaviour (`filters empty allowed_paths on update …` asserted the model's paths replacing the stored allowlist).

## Fix

Treat the custom allowlists exactly like `capability` already is — host-owned, UI-only:

- Remove `allowed_commands` / `allowed_paths` / `allowed_tools` from the `manage_trigger` input schema.
- On `update`, carry `permissions` over untouched alongside `capability`.
- Update the model-facing notice string (both locales) so it stops overclaiming.

The model may still restate a trigger's `prompt` / `skill_name` / `workspace_path`. Nothing that was reachable through the UI is lost — the trigger editor never exposed allowlist fields; it only preserves the existing ones.

## Validation

- `npm run lint` — exit 0
- `npm run typecheck` (app + sidecar) — exit 0
- `npx vitest run` — 416 files, 6143 passed, 1 skipped
- Red/green confirmed: the three new tests fail on `dev` and pass with the change.
- Composed against #286: applied this diff on top of a local `#286 + dev` merge — 424 files, 6271 passed.

## Relationship to #286

Independent of #286 and conflict-free with it (#286 does not touch `automationTools.ts`). Found while doing an independent cross-tool review of #286; #286 itself keeps the tier lock intact, this is the gap it left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)