### PR TITLE
fix(repo): drop committed node_modules symlink and ignore symlink form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Dependencies
-node_modules/
+# No trailing slash: also match a node_modules *symlink* (a worktree once
+# symlinked it to save an install and `git add -A` committed the link).
+node_modules
 
 # Superpowers brainstorming visual companion sessions
 .superpowers/

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/shawn/Documents/Abu/Abu-opensource/node_modules


### PR DESCRIPTION
## 问题

PR #285 在 review worktree 中开发，该 worktree 的 `node_modules` 是指向主 checkout 的符号链接（省一次安装）。`.gitignore` 的 `node_modules/` 带斜杠只匹配目录、不匹配符号链接，`git add -A` 把这个软链扫进了提交并随 #285 进入 dev：

- 公开仓库泄露本机绝对路径（`/Users/shawn/...`）
- 新 clone 得到指向不存在路径的死链接
- 已有 checkout 快进时真实 `node_modules` 目录被替换为自指循环链接（本机已实际发生并修复）

## 修复

- `git rm --cached node_modules` 移出索引
- `.gitignore` 的 `node_modules/` 去掉尾斜杠改为 `node_modules`，同时匹配目录与符号链接形态，并加注释说明缘由

绝对路径已进历史，但仅泄露用户名与目录结构，不值得重写历史，本 PR 留痕即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)