### PR TITLE
fix: release-review batch R1 — WeChat batch isolation, image snapshot fallback, log/test hygiene

### DIFF
--- a/src/components/panel/workspace/TerminalTab.test.tsx
+++ b/src/components/panel/workspace/TerminalTab.test.tsx
@@ -175,18 +175,23 @@ describe('TerminalTab theming', () => {
     // covers both, regardless of how slow the runner is. The previous
     // real-time waitFor (even at 12s) still lost this race once on a
     // contended Windows runner; event ordering cannot.
-    await act(async () => {
-      document.documentElement.classList.add('dark');
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-    expect(terminalInstances[0].options.theme).toEqual(expectedTheme(DARK_VARS));
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        document.documentElement.classList.add('dark');
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(terminalInstances[0].options.theme).toEqual(expectedTheme(DARK_VARS));
 
-    // Still the same single terminal instance — no dispose/recreate cycle.
-    expect(terminalInstances).toHaveLength(1);
-    const spawnCallsAfter = invoke.mock.calls.filter(([cmd]) => cmd === 'pty_spawn').length;
-    const killCallsAfter = invoke.mock.calls.filter(([cmd]) => cmd === 'pty_kill').length;
-    expect(spawnCallsAfter).toBe(spawnCallsBefore);
-    expect(killCallsAfter).toBe(killCallsBefore);
+      // Still the same single terminal instance — no dispose/recreate cycle.
+      expect(terminalInstances).toHaveLength(1);
+      const spawnCallsAfter = invoke.mock.calls.filter(([cmd]) => cmd === 'pty_spawn').length;
+      const killCallsAfter = invoke.mock.calls.filter(([cmd]) => cmd === 'pty_kill').length;
+      expect(spawnCallsAfter).toBe(spawnCallsBefore);
+      expect(killCallsAfter).toBe(killCallsBefore);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -316,11 +321,19 @@ describe('TerminalTab selection → add to chat', () => {
     terminalInstances[0].selection = '   \n  ';
     const host = container.querySelector('div.overflow-hidden') as HTMLDivElement;
 
-    fireEvent.mouseUp(host, { button: 0, clientX: 50, clientY: 50 });
+    vi.useFakeTimers();
+    try {
+      fireEvent.mouseUp(host, { button: 0, clientX: 50, clientY: 50 });
 
-    // Debounce window (120 ms) must elapse before asserting absence.
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    const t = getI18n();
-    expect(screen.queryByRole('button', { name: new RegExp(t.reference.addToChat) })).toBeNull();
+      // Advance exactly through the component's 120 ms debounce without making
+      // the suite depend on runner speed or wall-clock scheduling.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(120);
+      });
+      const t = getI18n();
+      expect(screen.queryByRole('button', { name: new RegExp(t.reference.addToChat) })).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/core/im/adapters/wechat.ts
+++ b/src/core/im/adapters/wechat.ts
@@ -606,14 +606,24 @@ export class WeChatInboundAdapter implements InboundAdapter {
           if (this.seenMessageIds.has(msg.message_id)) continue; // already handled
           this.seenMessageIds.add(msg.message_id);
 
-          sharedContextTokens.set(msg.from_user_id, msg.context_token);
-          persistSharedContextTokens();
-          // Await, do NOT fire-and-forget: handleMessage downloads+decrypts media
-          // for image/file items, so a text message sent right after a photo would
-          // otherwise overtake it and reach the agent first. WeChat's ordering is
-          // meaningful ("<photo>" then "describe this"), so a batch must be
-          // dispatched strictly in order.
-          await this.handleMessage(msg);
+          try {
+            sharedContextTokens.set(msg.from_user_id, msg.context_token);
+            persistSharedContextTokens();
+            // Await, do NOT fire-and-forget: handleMessage downloads+decrypts media
+            // for image/file items, so a text message sent right after a photo would
+            // otherwise overtake it and reach the agent first. WeChat's ordering is
+            // meaningful ("<photo>" then "describe this"), so a batch must be
+            // dispatched strictly in order.
+            await this.handleMessage(msg);
+          } catch (err) {
+            // The response cursor has already advanced. Isolate a bad message so
+            // it cannot strand every later message in the same response; rolling
+            // the cursor back would instead redeliver messages already dispatched.
+            wechatLog.error('inbound message processing failed', {
+              message_id: msg.message_id,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
         }
 
         failCount = 0;
@@ -689,14 +699,6 @@ export class WeChatInboundAdapter implements InboundAdapter {
         }
         case 2: {
           try {
-            // Ground-truth diagnostic: dump the real inbound image_item shape so
-            // we can see exactly which fields the server sends vs what we read.
-            wechatLog.warn('inbound image_item shape', {
-              keys: Object.keys(item.image_item ?? {}),
-              mediaKeys: Object.keys(item.image_item?.media ?? {}),
-              hasAeskey: Boolean(item.image_item?.aeskey),
-              raw: JSON.stringify(item.image_item).slice(0, 400),
-            });
             const media = item.image_item.media;
             if (!media?.encrypt_query_param && !media?.full_url) throw new Error('image_item has no media ref');
             const { bytes } = await downloadAndDecryptMedia(
@@ -709,7 +711,7 @@ export class WeChatInboundAdapter implements InboundAdapter {
               data: bytesToBase64(bytes),
               mediaType: imageMediaTypeFor('jpg'),
             });
-            wechatLog.warn('inbound image decoded ok', { bytes: images[images.length - 1]?.data.length ?? 0 });
+            wechatLog.debug('inbound image decoded ok', { bytes: images[images.length - 1]?.data.length ?? 0 });
             // No text placeholder on success: the image block itself is what the
             // model sees, and a literal "[图片]" marker alongside it reads as a
             // failed attachment ("the image didn't load") and makes the model

--- a/src/core/im/adapters/wechatInbound.test.ts
+++ b/src/core/im/adapters/wechatInbound.test.ts
@@ -12,6 +12,7 @@ import { WeChatInboundAdapter } from './wechat';
 import type { WeChatCredentials } from './wechat';
 import type { InboundMessage } from './types';
 import { checkReadPath, getAuthorizedDirs } from '../../tools/pathSafety';
+import { clearLogs, getRecentLogs } from '../../logging/logger';
 
 // Build a CDN payload the adapter can decrypt: AES-128-ECB + PKCS7 over known bytes.
 const KEY = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
@@ -91,6 +92,7 @@ describe('WeChatInboundAdapter inbound image', () => {
     getUpdatesCalls = 0;
     fakeFetch.mockClear();
     localStorage.clear();
+    clearLogs();
   });
 
   /** Collect the first `n` non-system inbound messages, in arrival order. */
@@ -121,7 +123,98 @@ describe('WeChatInboundAdapter inbound image', () => {
     // No "[图片]" placeholder on success — the image block is the content, and a
     // literal marker beside it reads to the model as a failed attachment.
     expect(msg.message.content).toBe('');
+
+    const warnings = getRecentLogs({ module: 'wechat-im', level: 'warn' });
+    expect(warnings.map((entry) => entry.message)).not.toContain('inbound image_item shape');
+    expect(warnings.map((entry) => entry.message)).not.toContain('inbound image decoded ok');
+    expect(getRecentLogs({ module: 'wechat-im', level: 'debug' }).map((entry) => entry.message))
+      .toContain('inbound image decoded ok');
   }, 10000);
+
+  it('retains an error log when an inbound image cannot be loaded', async () => {
+    getUpdatesCalls = 99;
+    fakeFetch.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ret: 0,
+        msgs: [{
+          message_id: 424244,
+          from_user_id: 'user@im.wechat',
+          message_type: 1,
+          context_token: 'ctx',
+          item_list: [{ type: 2, image_item: {} }],
+        }],
+      }),
+    } as unknown as Response));
+
+    const adapter = new WeChatInboundAdapter();
+    const received = collect(adapter, 1);
+    await adapter.connect({ appId: 'ch1', appSecret: JSON.stringify(CREDS) });
+    const [msg] = await received;
+    await adapter.disconnect();
+
+    expect(msg.message.content).toBe('[图片（加载失败）]');
+    expect(getRecentLogs({ module: 'wechat-im', level: 'error' })).toEqual(expect.arrayContaining([
+      expect.objectContaining({ message: 'inbound image download failed' }),
+    ]));
+  });
+
+  it('isolates a callback failure so later messages in the same batch are still dispatched', async () => {
+    vi.useFakeTimers();
+    const adapter = new WeChatInboundAdapter();
+
+    try {
+      getUpdatesCalls = 99; // skip the default image batch; serve the three-message regression batch
+      fakeFetch.mockImplementationOnce(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ret: 0,
+          get_updates_buf: 'cursor-after-batch',
+          msgs: [9001, 9002, 9003].map((messageId) => ({
+            message_id: messageId,
+            from_user_id: 'user@im.wechat',
+            message_type: 1,
+            context_token: 'ctx',
+            item_list: [{ type: 1, text_item: { text: `message-${messageId}` } }],
+          })),
+        }),
+      } as unknown as Response));
+
+      const attempted: number[] = [];
+      let resolveFirst!: () => void;
+      const firstAttempted = new Promise<void>((resolve) => { resolveFirst = resolve; });
+      adapter.onMessage((message) => {
+        const messageId = (message.raw as { message_id: number }).message_id;
+        attempted.push(messageId);
+        if (messageId === 9001) {
+          resolveFirst();
+          throw new Error('intentional first-message callback failure');
+        }
+      });
+
+      await adapter.connect({ appId: 'ch1', appSecret: JSON.stringify(CREDS) });
+      await firstAttempted;
+      // Each awaited handleMessage continuation consumes one microtask. Flush a
+      // bounded number of turns so this checks the current batch without using
+      // wall-clock sleeps or advancing the outer polling backoff.
+      for (let turn = 0; turn < 12; turn++) await Promise.resolve();
+      await adapter.disconnect();
+
+      expect(attempted).toEqual([9001, 9002, 9003]);
+      expect(getRecentLogs({ module: 'wechat-im', level: 'error' })).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          message: 'inbound message processing failed',
+          data: expect.objectContaining({ message_id: 9001 }),
+        }),
+      ]));
+    } finally {
+      await adapter.disconnect();
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
 
   it('grants read on an inbound file so the agent can actually open it', async () => {
     // Regression: files land in the system temp dir, which no IM channel has

--- a/src/core/session/outputSnapshots.test.ts
+++ b/src/core/session/outputSnapshots.test.ts
@@ -501,6 +501,30 @@ describe('outputSnapshots', () => {
       });
     });
 
+    it('materializes base64 under a stable manifest identity when the read_file source path is relative', async () => {
+      await mod.snapshotResultImage(CONV_ID, 'toolu_relative', {
+        mediaType: 'image/png',
+        base64: 'AQID',
+      }, 'assets/chart.png');
+
+      expect(memFs.copyFile).not.toHaveBeenCalled();
+      expect(memFs.writeFile).toHaveBeenCalledWith(
+        expect.stringMatching(/files\/.+\/result\.png$/),
+        expect.any(Uint8Array),
+      );
+
+      const manifest = await mod.__testing.loadManifest(CONV_ID);
+      const entry = manifest.entries['tool-result://toolu_relative'];
+      expect(entry).toMatchObject({
+        source: 'tool-output',
+        refKind: 'result-image',
+        refId: 'toolu_relative',
+        basename: 'result.png',
+        snapshotRelPath: expect.stringMatching(/^files\/.+\/result\.png$/),
+        size: 3,
+      });
+    });
+
     it('records an oversized base64 result without writing its bytes', async () => {
       const oversized = mod.__testing.MAX_FILE_BYTES + 1;
       base64ToUint8ArrayMock.mockReturnValueOnce({ byteLength: oversized } as Uint8Array);

--- a/src/core/session/outputSnapshots.ts
+++ b/src/core/session/outputSnapshots.ts
@@ -495,11 +495,10 @@ export async function snapshotResultImage(
       const normalized = normalizePath(expanded);
       if (!isAbsolutePath(normalized)) {
         logger.warn('[snapshot] rejected non-absolute result image path', { sourcePath, normalized });
+      } else {
+        await snapshotFileNormalized(convId, normalized, meta, originalPath, basename);
         return;
       }
-
-      await snapshotFileNormalized(convId, normalized, meta, originalPath, basename);
-      return;
     }
 
     let decodedSize = 0;


### PR DESCRIPTION
## 背景

v0.42.0 切版前对 v0.41.0→dev 全量 diff 做的对抗式复审（8 finder 角度 + 独立逐条验证）确认的 4 项，任务书见 `docs/abu-release-review-fix-brief.md` 批次 R1。**R1.1/R1.2 为发版阻断。**

## 改动

### R1.1 微信同批消息：单条失败不再拖死后续（阻断）
`getupdates` 的响应游标在派发前就已前移，循环改为顺序 `await` 后任一消息处理抛错（如 messageCallback 未捕获异常）会中止同批剩余消息且永无重试。现每条消息独立 try/catch，失败记带 `message_id` 的 error 日志后继续。不回滚游标（会导致已派发消息重复投递）。
- 回归：3 条消息批次、第 1 条回调抛错 → 断言 3 条全部尝试派发 + error 日志留痕。

### R1.2 read_file 相对路径图片回落 base64 物化（阻断）
`snapshotResultImage` 对非绝对 `sourcePath` 原先 warn 后直接 return——手里明明有 `imageBlock.base64` 却不落 manifest，会话驱逐/重启回放后缩略图退化为占位文本（本批发版主修的退化类问题的残留口子，且 #289 的脱水机制依赖该 manifest）。现回落到 base64 物化分支。
- 回归：相对路径 + base64 → 断言 `tool-result://` manifest 条目 + `files/…/result.png` 落盘。

### R1.3 微信入站图片诊断日志出厂前清理
`'inbound image_item shape'`（含原始协议 JSON 前 400 字符）与解码成功日志均为 warn 级——按 `DISK_LOG_LEVELS` 每张入站图片两次落盘写入。字段形状已验证完毕：shape 诊断删除，成功日志降 debug，失败 error 保留并补断言。

### R1.4 TerminalTab 测试去真实计时器（TESTING.md §3）
真实 200ms sleep 等 120ms 防抖 → `vi.useFakeTimers()` + `advanceTimersByTimeAsync`；顺带修复同文件 theming 用例中另一处真实计时器等待。

## 验证

- `npm run verify` 退出码 0（lint + typecheck + 全量测试 + 覆盖率门禁），本地亲跑。
- 微信真机路径（连发多条消息含失败注入）建议合并前走一遍——见任务书 R1.1 验收项。

🤖 Generated with [Claude Code](https://claude.com/claude-code)