### PR TITLE
feat(chat): click a composer image thumbnail to preview it full size

### DIFF
--- a/src/components/chat/ChatInput.test.tsx
+++ b/src/components/chat/ChatInput.test.tsx
@@ -4,7 +4,10 @@ import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import ChatInput, { mergeComposerAppend, referenceDedupeKey, referenceChipLabel } from './ChatInput';
 import { createDocReference, createDomElementReference, type BrowserElementPayload } from '@/types/chatReference';
 import { useChatStore } from '@/stores/chatStore';
-import { clearAllComposerDrafts } from '@/stores/composerDraftStore';
+import { clearAllComposerDrafts, writeComposerDraft, WELCOME_COMPOSER_DRAFT_KEY } from '@/stores/composerDraftStore';
+import { usePreviewStore } from '@/stores/previewStore';
+import { getI18n } from '@/i18n';
+import type { ImageAttachment } from '@/types';
 import { useEnterpriseStore } from '@/stores/enterpriseStore';
 import type { EnterpriseBinding } from '@/core/enterprise/types';
 
@@ -96,6 +99,47 @@ describe('ChatInput per-conversation drafts', () => {
       });
     });
     expect(textarea.value).toBe('alice draft');
+  });
+});
+
+describe('ChatInput attachment image preview', () => {
+  beforeEach(() => {
+    clearAllComposerDrafts();
+    useEnterpriseStore.setState({ mode: { kind: 'personal' }, initialized: true });
+    useChatStore.setState({
+      conversations: {},
+      conversationIndex: {},
+      activeConversationId: null,
+      pendingInput: null,
+      pendingInputAppend: null,
+      pendingReferences: [],
+      pendingAttachmentPaths: [],
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('opens the pending image in the preview panel when its thumbnail is clicked', () => {
+    const image: ImageAttachment = { id: 'img-1', data: 'aGVsbG8=', mediaType: 'image/png' };
+    writeComposerDraft(WELCOME_COMPOSER_DRAFT_KEY, {
+      text: '',
+      images: [image],
+      files: [],
+      references: [],
+      selectedSkill: null,
+      selectedAgent: null,
+    });
+    const openPreview = vi.fn();
+    usePreviewStore.setState({ openPreview });
+
+    render(<ChatInput variant="welcome" onSend={vi.fn()} />);
+
+    const thumbnail = screen.getByTitle(getI18n().chat.clickToViewFull);
+    fireEvent.click(thumbnail);
+    expect(openPreview).toHaveBeenCalledWith('data:image/png;base64,aGVsbG8=');
   });
 });
 

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -20,6 +20,7 @@ import { useSettingsStore } from '@/stores/settingsStore';
 import { useEnterpriseStore } from '@/stores/enterpriseStore';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { usePermissionStore } from '@/stores/permissionStore';
+import { usePreviewStore } from '@/stores/previewStore';
 import type { PermissionDuration } from '@/stores/permissionStore';
 import { useI18n, format } from '@/i18n';
 import { useToastStore } from '@/stores/toastStore';
@@ -999,7 +1000,9 @@ export default function ChatInput({ variant, onSend, disabled, scenarioPlacehold
                   <img
                     src={`data:${img.mediaType};base64,${img.data}`}
                     alt=""
-                    className="w-12 h-12 rounded-lg object-cover border border-[var(--abu-border-subtle)]"
+                    className="w-12 h-12 rounded-lg object-cover border border-[var(--abu-border-subtle)] cursor-pointer hover:border-[var(--abu-border-hover)] transition-colors"
+                    onClick={() => usePreviewStore.getState().openPreview(`data:${img.mediaType};base64,${img.data}`)}
+                    title={t.chat.clickToViewFull}
                   />
                   <button
                     onClick={() => removeImage(img.id)}


### PR DESCRIPTION
## 问题

输入框附件条里的图片缩略图（发送前）没有任何点击交互——是全应用唯一没有预览能力的图片面：已发送消息、生成图、markdown 内嵌图都能点开工作区预览器。

## 改动

- 缩略图加 onClick → `previewStore.openPreview(dataUrl)`，复用现有工作区图片预览器（缩放 25%-300% / 拖拽 / 旋转 / 复制），`PreviewPanel` 本就支持 `data:image/` URL（getRendererType 已有分支）
- hover 边框与「点击查看大图」tooltip 与 MessageBubble 已发送缩略图完全同款
- 新增单测：草稿带图渲染 → 点击缩略图 → 断言 openPreview 收到正确 data URL

## 验证

- `vitest run ChatInput.test.tsx`：12/12 通过
- 本地 `npm run verify` 结果将在评论补充；CI check 同门禁

🤖 Generated with [Claude Code](https://claude.com/claude-code)