### PR TITLE
fix(fs): temp-dir write no longer dead-ends at the overwrite-safety read-precheck

### DIFF
--- a/src/core/tools/registry.permissionMode.test.ts
+++ b/src/core/tools/registry.permissionMode.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { exists, stat } from '@tauri-apps/plugin-fs';
+import { tempDir } from '@tauri-apps/api/path';
+import { canonicalizeElectronPathForPolicy } from '../../utils/electronHost';
+import { setPlatformForTest } from '../../test/helpers';
+import { TOOL_NAMES } from './toolNames';
 import { useChatStore } from '../../stores/chatStore';
 import { useSettingsStore } from '../../stores/settingsStore';
 import type { PermissionMode } from '../permissions/permissionMode';
@@ -27,6 +31,11 @@ vi.mock('@/core/enterprise/policy/matcher', () => ({
 
 vi.mock('@/components/enterprise/policyConfirmQueue', () => ({
   showPolicyConfirm: (...args: unknown[]) => policyMocks.showPolicyConfirm(...args),
+}));
+
+vi.mock('../../utils/electronHost', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../utils/electronHost')>()),
+  canonicalizeElectronPathForPolicy: vi.fn().mockResolvedValue(null),
 }));
 
 // Test the conversation-level permission mode resolution formula used in registry.ts.
@@ -73,6 +82,50 @@ describe('permission mode resolution', () => {
     useChatStore.getState().setConversationPermissionMode(id, 'autonomous');
     useChatStore.getState().setConversationPermissionMode(id, undefined);
     expect(resolvePermissionMode(id)).toBe('smart');
+  });
+});
+
+// ── write_file overwrite-safety read-precheck must not dead-end on $TMPDIR ──
+// Regression for the R3.4 asymmetry: checkWritePath allows a macOS temp-dir
+// write via its implicit-root match, but the overwrite-safety read-precheck was
+// handed the CANONICAL resolved path (/private/var/folders/...), which breaks
+// checkReadPath's lexical implicit-root match — so the write dead-ended at a read
+// grant that no dialog could satisfy. The precheck must receive the lexical path.
+describe('write_file $TMPDIR overwrite-safety precheck', () => {
+  const runtimeTemp = '/var/folders/ab/cdef/T';
+
+  beforeEach(() => {
+    useChatStore.setState({ conversations: {}, conversationIndex: {}, activeConversationId: null });
+    useSettingsStore.setState({ permissionMode: 'standard' });
+    vi.mocked(tempDir).mockResolvedValue(runtimeTemp);
+    // macOS canonicalizes /var → /private/var; this is exactly the lexical↔canonical
+    // divergence that broke the precheck when the canonical form was passed in.
+    vi.mocked(canonicalizeElectronPathForPolicy).mockImplementation(async (candidate) => {
+      const value = String(candidate);
+      return value.startsWith('/var/') ? `/private${value}` : value;
+    });
+    // Fresh, non-existent (or small) target: the large-write size guard is a no-op.
+    vi.mocked(exists).mockResolvedValue(false);
+  });
+
+  it('allows a temp-dir write instead of dead-ending at "requires read authorization"', async () => {
+    const cleanup = setPlatformForTest('macos');
+    // Fail the test loudly if any code path tries to raise a permission dialog:
+    // the temp dir is an implicit root, so no read grant should be needed.
+    const onRequireFilePermission = vi.fn(async () => false);
+    try {
+      const decision = await checkToolApproval(
+        TOOL_NAMES.WRITE_FILE,
+        { path: `${runtimeTemp}/scratch.txt`, content: 'abu-test-ok' },
+        { conversationId: 'conv-tmp' } as never,
+        undefined,
+        onRequireFilePermission as never,
+      );
+      expect(decision.decision).toBe('allow');
+      expect(onRequireFilePermission).not.toHaveBeenCalled();
+    } finally {
+      cleanup();
+    }
   });
 });
 

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -674,7 +674,15 @@ export async function checkToolApproval(
       approvedExecutionPath = pathCheck.resolvedPath;
 
       if (name === TOOL_NAMES.WRITE_FILE) {
-        largeWritePathAfterApproval = approvedExecutionPath;
+        // The overwrite-safety read-precheck below calls checkReadPath, which
+        // is designed to receive the ORIGINAL (lexical) path and do its own
+        // dual lexical+canonical resolution internally. Passing the already-
+        // canonicalized resolvedPath (e.g. macOS $TMPDIR /var/folders/... →
+        // /private/var/folders/...) breaks its lexical implicit-root match, so
+        // a temp-dir write — allowed by checkWritePath's implicit-root match —
+        // would dead-end at a read grant that can never be satisfied. Keep the
+        // canonical form only for actual execution (approvedExecutionPath).
+        largeWritePathAfterApproval = pathInfo.path;
       }
     }
   }


### PR DESCRIPTION
## 问题（真机测试发现）

v0.42.0 真机 DoD 验收时发现：agent 写系统临时目录 `$TMPDIR`（`/var/folders/.../T`）**永远失败**——写权限被自动放行（临时目录是隐式写根），但 R3.4（#286）新增的强制「覆盖安全读预检」报 `write_file requires read authorization for its overwrite safety check`，**且弹不出授权框**，用户无入口可授权、retry 无效。家目录（桌面）写入正常；新建/已存在文件都一样，是**路径特有**。

## 根因

registry 的读预检把**写批准后的 canonical 路径**（`/private/var/folders/...`，macOS 把 `/var` canonical 化到 `/private/var`）喂给了 `checkReadPath`。但 `checkReadPath` 设计上接收**词法原值**、内部自己做词法+canonical 双匹配——canonical 路径破坏了它的词法隐式根匹配，于是本该被隐式根放行的临时目录读预检落到「需授权」兜底，对一个 `/private/var/...` 路径这个授权满足不了 → 死路。

## 改法（单点）

`largeWritePathAfterApproval` 改存词法原值 `pathInfo.path`（registry.ts）；实际执行路径 `approvedExecutionPath` 仍用 canonical，**TOCTOU 安全执行不变**，`checkReadPath` 内部双匹配照样抓符号链接逃逸。改的只是「用对路径形式」。

## 验证

- registry 层回归测试：write_file 到 macOS `$TMPDIR` 返回 allow、不弹多余授权框。**反向验证**：回退这一行修复，测试变红。
- `npm run verify` 退出码 0 亲跑。
- **真机复验**：修复后 `$TMPDIR` 写入直接成功，文件落盘确认（`abu-fixed-ok`）。

## 影响

R3.4 引入的可用性回归，写临时目录（暂存/中间产物，很常见）此前全部失败。**不影响安全**（无绕过，只是把自己锁死）。建议随 v0.42.0 一起发。

🤖 Generated with [Claude Code](https://claude.com/claude-code)