### PR TITLE
refactor: complete R4 cleanup batch C1-C5

### DIFF
--- a/src/components/settings/sections/AboutSection.test.tsx
+++ b/src/components/settings/sections/AboutSection.test.tsx
@@ -131,7 +131,7 @@ describe('AboutSection — update status caption (three-state)', () => {
     resetUpdateState(null);
     vi.mocked(checkForUpdate).mockImplementation(async () => {
       useSettingsStore.getState().setUpdaterUnsupported(true);
-      return null;
+      return { kind: 'disabled' };
     });
     render(<AboutSection />);
 
@@ -143,10 +143,9 @@ describe('AboutSection — update status caption (three-state)', () => {
   });
 
   it('clicking 检查更新 on a disabled build never marks "just checked"', async () => {
-    // The disabled marker resolves null just like "confirmed current"; the
-    // just-checked state must stay reserved for real feed comparisons.
+    // The just-checked state must stay reserved for real feed comparisons.
     resetUpdateState(true);
-    vi.mocked(checkForUpdate).mockResolvedValue(null);
+    vi.mocked(checkForUpdate).mockResolvedValue({ kind: 'disabled' });
     const user = userEvent.setup();
     render(<AboutSection />);
 
@@ -157,6 +156,43 @@ describe('AboutSection — update status caption (three-state)', () => {
     ).toBeInTheDocument();
     expect(screen.queryByText('刚刚已检查')).not.toBeInTheDocument();
     expect(screen.queryByText('已是最新版本')).not.toBeInTheDocument();
+  });
+
+  it('clicking 检查更新 marks a feed-confirmed current version as just checked', async () => {
+    resetUpdateState(false);
+    vi.mocked(checkForUpdate).mockResolvedValue({ kind: 'up-to-date' });
+    const user = userEvent.setup();
+    render(<AboutSection />);
+
+    await user.click(screen.getByText('检查更新'));
+
+    expect(await screen.findByText('· 刚刚已检查')).toBeInTheDocument();
+  });
+
+  it('preserves the existing checked caption when a supported updater check fails', async () => {
+    resetUpdateState(false);
+    vi.mocked(checkForUpdate).mockResolvedValue({ kind: 'error', updaterUnsupported: false });
+    const user = userEvent.setup();
+    render(<AboutSection />);
+
+    await user.click(screen.getByText('检查更新'));
+
+    expect(await screen.findByText('· 刚刚已检查')).toBeInTheDocument();
+    expect(screen.queryByText('检查更新失败')).not.toBeInTheDocument();
+  });
+
+  it('preserves the unsupported caption when a disabled updater check fails', async () => {
+    resetUpdateState(true);
+    vi.mocked(checkForUpdate).mockResolvedValue({ kind: 'error', updaterUnsupported: true });
+    const user = userEvent.setup();
+    render(<AboutSection />);
+
+    await user.click(screen.getByText('检查更新'));
+
+    expect(
+      await screen.findByText('此安装包不支持自动更新，请前往官网下载最新版本'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('刚刚已检查')).not.toBeInTheDocument();
   });
 
   it('does not probe on mount when the support state is already known', () => {

--- a/src/components/settings/sections/AboutSection.tsx
+++ b/src/components/settings/sections/AboutSection.tsx
@@ -77,13 +77,21 @@ export default function AboutSection() {
     setCheckResult('idle');
     try {
       const result = await checkForUpdate(true);
-      // "just-checked" means a real feed comparison happened. The disabled
-      // marker also resolves null, so guard here at the assignment — not only
-      // in render order — reading the store directly (empty-deps callback, the
-      // hook value would be a stale closure).
-      if (!result && !useSettingsStore.getState().updaterUnsupported) {
-        setCheckResult('just-checked');
-        setTimeout(() => setCheckResult('idle'), 3000);
+      switch (result.kind) {
+        case 'up-to-date':
+          setCheckResult('just-checked');
+          setTimeout(() => setCheckResult('idle'), 3000);
+          break;
+        case 'error':
+          if (!result.updaterUnsupported) {
+            setCheckResult('just-checked');
+            setTimeout(() => setCheckResult('idle'), 3000);
+          }
+          break;
+        case 'update':
+        case 'disabled':
+        case 'throttled':
+          break;
       }
     } catch {
       setCheckResult('error');

--- a/src/components/sidebar/AccountMenu.tsx
+++ b/src/components/sidebar/AccountMenu.tsx
@@ -83,13 +83,21 @@ export default function AccountMenu({ onEditProfile }: { onEditProfile: () => vo
     setCheckedResult('idle');
     try {
       const result = await checkForUpdate(true);
-      // 'up-to-date' means a real feed comparison happened. The disabled
-      // marker also resolves null, so guard at the assignment — not only via
-      // updateRow's branch order — reading the store directly (empty-deps
-      // callback, the hook value would be a stale closure).
-      if (!result && !useSettingsStore.getState().updaterUnsupported) {
-        setCheckedResult('up-to-date');
-        setTimeout(() => setCheckedResult('idle'), 3000);
+      switch (result.kind) {
+        case 'up-to-date':
+          setCheckedResult('up-to-date');
+          setTimeout(() => setCheckedResult('idle'), 3000);
+          break;
+        case 'error':
+          if (!result.updaterUnsupported) {
+            setCheckedResult('up-to-date');
+            setTimeout(() => setCheckedResult('idle'), 3000);
+          }
+          break;
+        case 'update':
+        case 'disabled':
+        case 'throttled':
+          break;
       }
     } catch {
       // checker surfaces its own error state; nothing extra to do here

--- a/src/core/im/adapters/wechat.ts
+++ b/src/core/im/adapters/wechat.ts
@@ -17,6 +17,7 @@ import { writeFile } from '@tauri-apps/plugin-fs';
 import { readFile } from '../../tools/fsBridge';
 import { authorizeWorkspace } from '../../tools/pathSafety';
 import { getBaseName } from '../../../utils/pathUtils';
+import { uint8ArrayToBase64 } from '@/utils/base64';
 import { homeDir } from '@tauri-apps/api/path';
 import { isWindows } from '../../../utils/platform';
 import type { ImageAttachment } from '../../../types';
@@ -399,16 +400,6 @@ async function downloadAndDecryptMedia(
   return { path, bytes: decrypted };
 }
 
-// Encode raw bytes to a base64 string (no data: prefix) for ImageAttachment.data.
-function bytesToBase64(bytes: Uint8Array): string {
-  let binary = '';
-  const chunk = 0x8000; // avoid call-stack limits on large inputs
-  for (let i = 0; i < bytes.length; i += chunk) {
-    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
-  }
-  return btoa(binary);
-}
-
 // Map a WeChat image file extension to an ImageAttachment media type.
 function imageMediaTypeFor(ext: string): ImageAttachment['mediaType'] {
   switch (ext.toLowerCase()) {
@@ -664,7 +655,7 @@ export class WeChatInboundAdapter implements InboundAdapter {
               );
               images.push({
                 id: `wechat-img-${msg.message_id}-ref-${images.length}`,
-                data: bytesToBase64(bytes),
+                data: uint8ArrayToBase64(bytes),
                 mediaType: imageMediaTypeFor('jpg'),
               });
               wechatLog.warn('inbound quoted image decoded ok', { bytes: bytes.length });
@@ -708,7 +699,7 @@ export class WeChatInboundAdapter implements InboundAdapter {
             );
             images.push({
               id: `wechat-img-${msg.message_id}-${images.length}`,
-              data: bytesToBase64(bytes),
+              data: uint8ArrayToBase64(bytes),
               mediaType: imageMediaTypeFor('jpg'),
             });
             wechatLog.debug('inbound image decoded ok', { bytes: images[images.length - 1]?.data.length ?? 0 });

--- a/src/core/session/outputSnapshots.ts
+++ b/src/core/session/outputSnapshots.ts
@@ -30,6 +30,7 @@ import { appDataDir, homeDir } from '@tauri-apps/api/path';
 import { joinPath, normalizeSeparators, getBaseName } from '@/utils/pathUtils';
 import { extractFileOutputs } from '@/utils/workflowExtractor';
 import { base64ToUint8Array } from '@/utils/base64';
+import { RESULT_IMAGE_EXTENSIONS } from '@/utils/imageMediaTypes';
 import type { ToolCall } from '@/types';
 import type { ToolResultImage } from '../tools/toolResultContent';
 import { createLogger } from '../logging/logger';
@@ -45,19 +46,6 @@ const MAX_FILE_BYTES = 5 * 1024 * 1024 * 1024; // 5 GB
 
 /** Manifest schema version */
 const MANIFEST_VERSION = 1 as const;
-
-/** Safe on-disk extension for rich tool-result image MIME types. */
-const RESULT_IMAGE_EXTENSIONS: Readonly<Record<string, string>> = {
-  'image/png': 'png',
-  'image/jpeg': 'jpg',
-  'image/jpg': 'jpg',
-  'image/webp': 'webp',
-  'image/gif': 'gif',
-  'image/bmp': 'bmp',
-  'image/svg+xml': 'svg',
-  'image/x-icon': 'ico',
-  'image/vnd.microsoft.icon': 'ico',
-};
 
 // ────────────────────────────────────────────────────────────────────────────
 // Types

--- a/src/core/tools/definitions/fileTools.ts
+++ b/src/core/tools/definitions/fileTools.ts
@@ -22,6 +22,7 @@ import { TOOL_NAMES } from '../toolNames';
 import { getI18n, format } from '../../../i18n';
 import { bindWorkspaceFromWrite } from '../../agent/defaultWorkspace';
 import { snapshotBeforeAiEdit } from '@/utils/aiEditSnapshots';
+import { formatFileSize } from '@/utils/formatFileSize';
 import { fuzzyFindAndReplace } from '../../skill/fuzzyPatch';
 
 /**
@@ -58,12 +59,6 @@ const PDFPLUMBER_SCRIPT = `import sys, pdfplumber
 pdf = pdfplumber.open(sys.argv[1])
 print(chr(10).join((p.extract_text() or '') for p in pdf.pages))
 pdf.close()`;
-
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes}B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
-}
 
 export const readFileTool: ToolDefinition = {
   name: TOOL_NAMES.READ_FILE,
@@ -167,7 +162,7 @@ export const readFileTool: ToolDefinition = {
         // Still read a small portion to count total lines via a fast heuristic
         const fullContent = await readTextFile(filePath);
         const totalLines = fullContent.split('\n').length;
-        return `File is too large to read at once (${formatSize(fileSize)}, ${totalLines} lines). ` +
+        return `File is too large to read at once (${formatFileSize(fileSize)}, ${totalLines} lines). ` +
           `Use offset and limit parameters to read specific portions, or use search_files to find relevant content.\n` +
           `Example: read_file(path, offset=0, limit=${DEFAULT_LINE_LIMIT}) to read the first ${DEFAULT_LINE_LIMIT} lines.`;
       }
@@ -182,7 +177,7 @@ export const readFileTool: ToolDefinition = {
         const lineCount = limit ?? DEFAULT_LINE_LIMIT;
         const sliced = allLines.slice(startLine, startLine + lineCount);
         const numLines = sliced.length;
-        const header = `[File: ${filePath} | ${formatSize(fileSize)} | Lines ${startLine}-${startLine + numLines - 1} of ${totalLines} total]`;
+        const header = `[File: ${filePath} | ${formatFileSize(fileSize)} | Lines ${startLine}-${startLine + numLines - 1} of ${totalLines} total]`;
         return `${header}\n${sliced.join('\n')}`;
       }
 

--- a/src/core/tools/definitions/imTools.ts
+++ b/src/core/tools/definitions/imTools.ts
@@ -5,13 +5,8 @@ import { exists, stat } from '../fsBridge';
 import { sendIMFile } from '../../im/streamingReply';
 import { WECHAT_MAX_OUTBOUND_BYTES } from '../../im/adapters/wechat';
 import { getBaseName } from '../../../utils/pathUtils';
+import { formatFileSize } from '@/utils/formatFileSize';
 import type { IMPlatform } from '../../../types/im';
-
-function formatBytes(n: number): string {
-  if (n >= 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)}MB`;
-  if (n >= 1024) return `${(n / 1024).toFixed(0)}KB`;
-  return `${n}B`;
-}
 
 /**
  * send_file — deliver a local file (image / document) to the current IM user.
@@ -67,8 +62,8 @@ export const sendFileTool: ToolDefinition = {
       }
       if (info.size > WECHAT_MAX_OUTBOUND_BYTES) {
         return format(t.sendFileTooLarge, {
-          size: formatBytes(info.size),
-          max: formatBytes(WECHAT_MAX_OUTBOUND_BYTES),
+          size: formatFileSize(info.size),
+          max: formatFileSize(WECHAT_MAX_OUTBOUND_BYTES),
         });
       }
 

--- a/src/core/updates/checker.test.ts
+++ b/src/core/updates/checker.test.ts
@@ -46,6 +46,12 @@ vi.mock('@/core/notice/bus', () => ({ publish: vi.fn() }));
 import { checkForUpdate, downloadAndInstallUpdate, refreshUpdateNotes } from './checker';
 import { publish } from '@/core/notice/bus';
 
+function requireUpdateInfo(result: Awaited<ReturnType<typeof checkForUpdate>>) {
+  expect(result.kind).toBe('update');
+  if (result.kind !== 'update') throw new Error(`Expected update result, received ${result.kind}`);
+  return result.info;
+}
+
 // The updater's own body — last-resort fallback (empty in real Electron builds).
 const EN_BODY = 'Updater body fallback for v0.32.0 — shown only if the feed is unusable.';
 // The release-metadata feed's per-locale notes (electron/latest-release.json).
@@ -97,7 +103,7 @@ describe('checkForUpdate — locale-aware release notes', () => {
   it('zh-CN user gets the Chinese notes from the release-metadata feed', async () => {
     mockFeed({ schema_version: 1, version: 'v0.32.0', notes_i18n: { 'zh-CN': ZH_NOTES, 'en-US': EN_META } });
 
-    const info = await checkForUpdate(true);
+    const info = requireUpdateInfo(await checkForUpdate(true));
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
     expect(info?.releaseNotes).toBe(ZH_NOTES);
@@ -108,7 +114,7 @@ describe('checkForUpdate — locale-aware release notes', () => {
     mockLocale = 'en-US';
     mockFeed({ schema_version: 1, version: 'v0.32.0', notes_i18n: { 'zh-CN': ZH_NOTES, 'en-US': EN_META } });
 
-    const info = await checkForUpdate(true);
+    const info = requireUpdateInfo(await checkForUpdate(true));
 
     // The Electron feed carries no notes, so English MUST come from the metadata
     // feed now — a bare updater body would be empty for real builds.
@@ -119,7 +125,7 @@ describe('checkForUpdate — locale-aware release notes', () => {
   it('falls back to the updater body when the metadata fetch fails', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
 
-    const info = await checkForUpdate(true);
+    const info = requireUpdateInfo(await checkForUpdate(true));
 
     expect(info?.releaseNotes).toBe(EN_BODY);
   });
@@ -127,7 +133,7 @@ describe('checkForUpdate — locale-aware release notes', () => {
   it('falls back to the feed English notes when the user locale is missing', async () => {
     mockFeed({ schema_version: 1, version: 'v0.32.0', notes_i18n: { 'en-US': EN_META } }); // no zh-CN, zh-CN user
 
-    const info = await checkForUpdate(true);
+    const info = requireUpdateInfo(await checkForUpdate(true));
 
     expect(info?.releaseNotes).toBe(EN_META);
   });
@@ -135,7 +141,7 @@ describe('checkForUpdate — locale-aware release notes', () => {
   it('falls back to the updater body when the feed has no usable notes', async () => {
     mockFeed({ schema_version: 1, version: 'v0.32.0', notes_i18n: {} });
 
-    const info = await checkForUpdate(true);
+    const info = requireUpdateInfo(await checkForUpdate(true));
 
     expect(info?.releaseNotes).toBe(EN_BODY);
   });
@@ -146,7 +152,7 @@ describe('checkForUpdate — locale-aware release notes', () => {
     // a zh-CN user offered vNEW must not read vOLD's notes → fall back.
     mockFeed({ schema_version: 1, version: 'v0.30.0', notes_i18n: { 'zh-CN': ZH_NOTES } });
 
-    const info = await checkForUpdate(true);
+    const info = requireUpdateInfo(await checkForUpdate(true));
 
     expect(info?.releaseNotes).toBe(EN_BODY);
   });
@@ -154,7 +160,7 @@ describe('checkForUpdate — locale-aware release notes', () => {
   it('ignores feed notes on an unexpected schema_version', async () => {
     mockFeed({ schema_version: 2, version: 'v0.32.0', notes_i18n: { 'zh-CN': ZH_NOTES } });
 
-    const info = await checkForUpdate(true);
+    const info = requireUpdateInfo(await checkForUpdate(true));
 
     expect(info?.releaseNotes).toBe(EN_BODY);
   });
@@ -162,7 +168,7 @@ describe('checkForUpdate — locale-aware release notes', () => {
   it('still uses feed notes when it omits a version (backward compat)', async () => {
     mockFeed({ schema_version: 1, notes_i18n: { 'zh-CN': ZH_NOTES } }); // no version field
 
-    const info = await checkForUpdate(true);
+    const info = requireUpdateInfo(await checkForUpdate(true));
 
     expect(info?.releaseNotes).toBe(ZH_NOTES);
   });
@@ -170,7 +176,7 @@ describe('checkForUpdate — locale-aware release notes', () => {
   it('accepts feed notes when the version matches without the v prefix', async () => {
     mockFeed({ schema_version: 1, version: '0.32.0', notes_i18n: { 'zh-CN': ZH_NOTES } }); // no leading v
 
-    const info = await checkForUpdate(true);
+    const info = requireUpdateInfo(await checkForUpdate(true));
 
     expect(info?.releaseNotes).toBe(ZH_NOTES);
   });
@@ -228,7 +234,7 @@ describe('checkForUpdate — silent option (background/observer callers)', () =>
   });
 
   it('silent: still records updateInfo so observer callers can read the result', async () => {
-    const info = await checkForUpdate(true, { silent: true });
+    const info = requireUpdateInfo(await checkForUpdate(true, { silent: true }));
     expect(info?.version).toBe('0.32.0');
     expect(useSettingsStore.getState().updateInfo?.version).toBe('0.32.0');
   });
@@ -264,12 +270,12 @@ describe('checkForUpdate — disabled marker (updater never armed in this build)
     vi.unstubAllGlobals();
   });
 
-  it('marker → null result, updaterUnsupported=true, and NOT "up to date"', async () => {
+  it('marker → disabled result, updaterUnsupported=true, and NOT "up to date"', async () => {
     mockCheck.mockResolvedValue({ status: 'disabled', reason: 'unofficial-build' });
 
-    const info = await checkForUpdate(true);
+    const result = await checkForUpdate(true);
 
-    expect(info).toBeNull();
+    expect(result).toEqual({ kind: 'disabled' });
     const state = useSettingsStore.getState();
     expect(state.updaterUnsupported).toBe(true);
     expect(state.updateInfo).toBeNull();
@@ -283,9 +289,9 @@ describe('checkForUpdate — disabled marker (updater never armed in this build)
   it('a real feed answer of null marks the updater supported and up to date', async () => {
     mockCheck.mockResolvedValue(null);
 
-    const info = await checkForUpdate(true);
+    const result = await checkForUpdate(true);
 
-    expect(info).toBeNull();
+    expect(result).toEqual({ kind: 'up-to-date' });
     const state = useSettingsStore.getState();
     expect(state.updaterUnsupported).toBe(false);
     expect(state.lastUpdateCheck).toBeGreaterThan(0);
@@ -294,7 +300,7 @@ describe('checkForUpdate — disabled marker (updater never armed in this build)
   it('an offered update also marks the updater supported', async () => {
     mockCheck.mockResolvedValue(fakeUpdate());
 
-    const info = await checkForUpdate(true);
+    const info = requireUpdateInfo(await checkForUpdate(true));
 
     expect(info?.version).toBe('0.32.0');
     expect(useSettingsStore.getState().updaterUnsupported).toBe(false);
@@ -303,13 +309,34 @@ describe('checkForUpdate — disabled marker (updater never armed in this build)
   it('a thrown check leaves the unsupported flag unknown (not false)', async () => {
     mockCheck.mockRejectedValue(new Error('feed unreachable'));
 
-    const info = await checkForUpdate(true);
+    const result = await checkForUpdate(true);
 
-    expect(info).toBeNull();
-    // Offline ≠ unsupported: the flag must stay null so the UI keeps the
-    // ordinary "check failed" presentation instead of the unsupported caption.
+    expect(result).toEqual({ kind: 'error', updaterUnsupported: null });
+    // Offline ≠ unsupported: the flag stays unknown and is carried in the
+    // result so callers can preserve their existing presentation without a
+    // second store read.
     expect(useSettingsStore.getState().updaterUnsupported).toBeNull();
     expect(useSettingsStore.getState().lastUpdateCheck).toBe(0);
+  });
+});
+
+describe('checkForUpdate — throttled result', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-25T00:00:00Z'));
+    mockCheck.mockReset();
+    useSettingsStore.setState({ lastUpdateCheck: Date.parse('2026-08-24T23:00:00Z') });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns throttled without invoking the updater inside the check interval', async () => {
+    const result = await checkForUpdate();
+
+    expect(result).toEqual({ kind: 'throttled' });
+    expect(mockCheck).not.toHaveBeenCalled();
   });
 });
 

--- a/src/core/updates/checker.ts
+++ b/src/core/updates/checker.ts
@@ -8,6 +8,13 @@ import type { UpdateDownloadProgress, UpdateInfo } from './types';
 
 export type { UpdateDownloadProgress, UpdateInfo } from './types';
 
+export type UpdateCheckResult =
+  | { kind: 'update'; info: UpdateInfo }
+  | { kind: 'up-to-date' }
+  | { kind: 'disabled' }
+  | { kind: 'throttled' }
+  | { kind: 'error'; updaterUnsupported: boolean | null };
+
 const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
 
 // Release metadata feed published to OSS by the release pipeline
@@ -143,13 +150,13 @@ async function enrichReleaseNotes(rawNotes: string): Promise<{ notes: string; ur
 export async function checkForUpdate(
   force = false,
   opts: { silent?: boolean } = {},
-): Promise<UpdateInfo | null> {
+): Promise<UpdateCheckResult> {
   const store = useSettingsStore.getState();
   const { silent = false } = opts;
 
   if (!force) {
     const elapsed = Date.now() - store.lastUpdateCheck;
-    if (elapsed < CHECK_INTERVAL_MS) return null;
+    if (elapsed < CHECK_INTERVAL_MS) return { kind: 'throttled' };
   }
 
   if (!silent) store.setUpdateChecking(true);
@@ -169,7 +176,7 @@ export async function checkForUpdate(
       store.setUpdaterUnsupported(true);
       store.setUpdateInfo(null);
       _pendingUpdate = null;
-      return null;
+      return { kind: 'disabled' };
     }
     store.setUpdaterUnsupported(false);
 
@@ -187,7 +194,7 @@ export async function checkForUpdate(
     if (!update) {
       store.setUpdateInfo(null);
       _pendingUpdate = null;
-      return null;
+      return { kind: 'up-to-date' };
     }
 
     _pendingUpdate = update;
@@ -215,10 +222,13 @@ export async function checkForUpdate(
       });
     }
 
-    return info;
+    return { kind: 'update', info };
   } catch (err) {
     console.warn('[Update] Check failed:', err);
-    return null;
+    return {
+      kind: 'error',
+      updaterUnsupported: useSettingsStore.getState().updaterUnsupported,
+    };
   } finally {
     if (!silent) store.setUpdateChecking(false);
   }

--- a/src/utils/base64.test.ts
+++ b/src/utils/base64.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { uint8ArrayToBase64 } from './base64';
+import { base64ToUint8Array, uint8ArrayToBase64 } from './base64';
 
 describe('base64', () => {
   it('converts small Uint8Array to base64', () => {
@@ -37,5 +37,11 @@ describe('base64', () => {
     expect(decoded.length).toBe(6);
     expect(decoded.charCodeAt(0)).toBe(0);
     expect(decoded.charCodeAt(5)).toBe(253);
+  });
+
+  it('round-trips arbitrary byte values', () => {
+    const bytes = new Uint8Array([0, 1, 2, 127, 128, 254, 255]);
+
+    expect(base64ToUint8Array(uint8ArrayToBase64(bytes))).toEqual(bytes);
   });
 });

--- a/src/utils/formatFileSize.test.ts
+++ b/src/utils/formatFileSize.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { formatFileSize } from './formatFileSize';
+
+describe('formatFileSize', () => {
+  it.each([
+    [0, '0B'],
+    [1023, '1023B'],
+    [1024, '1.0KB'],
+    [1536, '1.5KB'],
+    [1024 * 1024 - 1, '1024.0KB'],
+    [1024 * 1024, '1.0MB'],
+    [5 * 1024 * 1024 * 1024, '5120.0MB'],
+  ])('formats %i bytes as %s', (bytes, expected) => {
+    expect(formatFileSize(bytes)).toBe(expected);
+  });
+});

--- a/src/utils/formatFileSize.ts
+++ b/src/utils/formatFileSize.ts
@@ -1,0 +1,6 @@
+/** Format a byte count using the existing B/KB/MB display convention. */
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}

--- a/src/utils/imageMediaTypes.test.ts
+++ b/src/utils/imageMediaTypes.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { IMAGE_MIME_MAP, RESULT_IMAGE_EXTENSIONS } from './imageMediaTypes';
+
+describe('imageMediaTypes', () => {
+  it('preserves the existing extension and MIME aliases', () => {
+    expect(IMAGE_MIME_MAP).toEqual({
+      png: 'image/png',
+      jpg: 'image/jpeg',
+      jpeg: 'image/jpeg',
+      webp: 'image/webp',
+      gif: 'image/gif',
+      bmp: 'image/bmp',
+      svg: 'image/svg+xml',
+      ico: 'image/x-icon',
+    });
+    expect(RESULT_IMAGE_EXTENSIONS).toEqual({
+      'image/png': 'png',
+      'image/jpeg': 'jpg',
+      'image/jpg': 'jpg',
+      'image/webp': 'webp',
+      'image/gif': 'gif',
+      'image/bmp': 'bmp',
+      'image/svg+xml': 'svg',
+      'image/x-icon': 'ico',
+      'image/vnd.microsoft.icon': 'ico',
+    });
+  });
+
+  it('keeps both maps semantically inverse when aliases collapse to canonical values', () => {
+    for (const [extension, mimeType] of Object.entries(IMAGE_MIME_MAP)) {
+      const canonicalExtension = RESULT_IMAGE_EXTENSIONS[mimeType];
+      expect(canonicalExtension, `${extension} -> ${mimeType}`).toBeDefined();
+      expect(IMAGE_MIME_MAP[canonicalExtension], `${extension} -> ${mimeType}`).toBe(mimeType);
+    }
+
+    for (const [mimeType, extension] of Object.entries(RESULT_IMAGE_EXTENSIONS)) {
+      const canonicalMimeType = IMAGE_MIME_MAP[extension];
+      expect(canonicalMimeType, `${mimeType} -> ${extension}`).toBeDefined();
+      expect(RESULT_IMAGE_EXTENSIONS[canonicalMimeType], `${mimeType} -> ${extension}`).toBe(extension);
+    }
+  });
+});

--- a/src/utils/imageMediaTypes.ts
+++ b/src/utils/imageMediaTypes.ts
@@ -1,0 +1,42 @@
+interface ImageMediaTypeDefinition {
+  canonicalExtension: string;
+  canonicalMimeType: string;
+  extensionAliases?: readonly string[];
+  mimeTypeAliases?: readonly string[];
+}
+
+/** Single source of truth for supported image extensions and MIME aliases. */
+const IMAGE_MEDIA_TYPES: readonly ImageMediaTypeDefinition[] = [
+  { canonicalExtension: 'png', canonicalMimeType: 'image/png' },
+  {
+    canonicalExtension: 'jpg',
+    canonicalMimeType: 'image/jpeg',
+    extensionAliases: ['jpeg'],
+    mimeTypeAliases: ['image/jpg'],
+  },
+  { canonicalExtension: 'webp', canonicalMimeType: 'image/webp' },
+  { canonicalExtension: 'gif', canonicalMimeType: 'image/gif' },
+  { canonicalExtension: 'bmp', canonicalMimeType: 'image/bmp' },
+  { canonicalExtension: 'svg', canonicalMimeType: 'image/svg+xml' },
+  {
+    canonicalExtension: 'ico',
+    canonicalMimeType: 'image/x-icon',
+    mimeTypeAliases: ['image/vnd.microsoft.icon'],
+  },
+];
+
+/** Image file extension (including aliases) to canonical MIME type. */
+export const IMAGE_MIME_MAP: Readonly<Record<string, string>> = Object.fromEntries(
+  IMAGE_MEDIA_TYPES.flatMap(({ canonicalExtension, canonicalMimeType, extensionAliases = [] }) => [
+    [canonicalExtension, canonicalMimeType] as const,
+    ...extensionAliases.map((extension) => [extension, canonicalMimeType] as const),
+  ]),
+);
+
+/** Image MIME type (including aliases) to canonical on-disk extension. */
+export const RESULT_IMAGE_EXTENSIONS: Readonly<Record<string, string>> = Object.fromEntries(
+  IMAGE_MEDIA_TYPES.flatMap(({ canonicalExtension, canonicalMimeType, mimeTypeAliases = [] }) => [
+    [canonicalMimeType, canonicalExtension] as const,
+    ...mimeTypeAliases.map((mimeType) => [mimeType, canonicalExtension] as const),
+  ]),
+);

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -4,6 +4,10 @@
  * On macOS these are essentially no-ops.
  */
 
+import { IMAGE_MIME_MAP } from '@/utils/imageMediaTypes';
+
+export { IMAGE_MIME_MAP } from '@/utils/imageMediaTypes';
+
 /**
  * Normalize backslashes to forward slashes.
  * macOS paths never contain backslashes, so this is a no-op on macOS.
@@ -78,13 +82,6 @@ const WIN_DRIVE_RE = /^[A-Za-z]:[/\\]/;
 export function isLocalFilePath(s: string): boolean {
   return s.startsWith('/') || WIN_DRIVE_RE.test(s);
 }
-
-/** MIME types for common image extensions */
-export const IMAGE_MIME_MAP: Record<string, string> = {
-  png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg',
-  gif: 'image/gif', svg: 'image/svg+xml', webp: 'image/webp',
-  bmp: 'image/bmp', ico: 'image/x-icon',
-};
 
 /**
  * Load a local image file as a blob URL via Tauri readFile.

--- a/tests/e2e/diagnostic-export.spec.ts
+++ b/tests/e2e/diagnostic-export.spec.ts
@@ -11,6 +11,7 @@ import type { ElectronApplication, Page } from 'playwright';
 import {
   closeAbuElectron,
   createElectronDataRoot,
+  dismissFirstRunOverlays,
   launchAbuElectron,
   removeElectronDataRoot,
   type ElectronDataRoot,
@@ -22,23 +23,6 @@ const CHAT_PLACEHOLDER = '想让阿布帮你做点什么？';
 async function waitForApp(page: Page): Promise<void> {
   await page.waitForLoadState('domcontentloaded');
   await expect(page.getByPlaceholder(CHAT_PLACEHOLDER)).toBeVisible({ timeout: READY_TIMEOUT });
-}
-
-async function dismissFirstRunOverlays(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    const raw = window.localStorage.getItem('abu-settings');
-    if (!raw) throw new Error('abu-settings was not initialized before E2E configuration');
-    const persisted = JSON.parse(raw) as { state: Record<string, unknown>; version: number };
-    Object.assign(persisted.state, {
-      guideShown: true,
-      guideOpen: false,
-      hasAcknowledgedDisclaimer: true,
-      hasRunSensitiveAudit_v015: true,
-    });
-    window.localStorage.setItem('abu-settings', JSON.stringify(persisted));
-  });
-  await page.reload();
-  await waitForApp(page);
 }
 
 let app: ElectronApplication | undefined;

--- a/tests/e2e/electronHelpers.ts
+++ b/tests/e2e/electronHelpers.ts
@@ -9,6 +9,7 @@ import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { expect } from '@playwright/test';
 import { _electron as electron, type ElectronApplication, type Page } from 'playwright';
 
 /**
@@ -21,6 +22,8 @@ export const MAIN_ENTRY = path.join(REPO_ROOT, 'electron', 'main.cjs');
 const E2E_APP_DATA_ROOT_ENV = 'ABU_E2E_APP_DATA_ROOT';
 const E2E_SIDECAR_CRASH_TOKEN_ENV = 'ABU_E2E_SIDECAR_CRASH_TOKEN';
 const SIDECAR_ID = 'abu-sidecar';
+const READY_TIMEOUT = 45_000;
+const CHAT_PLACEHOLDER = '想让阿布帮你做点什么？';
 
 export interface ElectronDataRoot {
   rootDir: string;
@@ -88,6 +91,121 @@ export async function launchAbuElectron(dataRoot = createElectronDataRoot()): Pr
     timeout: 60_000,
   });
   return { app, ...dataRoot };
+}
+
+async function reloadAndWaitForApp(page: Page): Promise<void> {
+  await page.reload();
+  await page.waitForLoadState('domcontentloaded');
+  await expect(page.getByPlaceholder(CHAT_PLACEHOLDER)).toBeVisible({ timeout: READY_TIMEOUT });
+}
+
+/** Persist the common first-run acknowledgements used by Electron E2E journeys. */
+export async function dismissFirstRunOverlays(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const raw = window.localStorage.getItem('abu-settings');
+    if (!raw) throw new Error('abu-settings was not initialized before E2E configuration');
+    const persisted = JSON.parse(raw) as { state: Record<string, unknown>; version: number };
+    Object.assign(persisted.state, {
+      guideShown: true,
+      guideOpen: false,
+      hasAcknowledgedDisclaimer: true,
+      hasRunSensitiveAudit_v015: true,
+    });
+    window.localStorage.setItem('abu-settings', JSON.stringify(persisted));
+  });
+  await reloadAndWaitForApp(page);
+}
+
+export interface LocalMockProviderOptions {
+  apiKey?: string;
+  contextWindowSize?: number;
+  maxOutputTokens?: number;
+  modelId?: string;
+  modelLabel?: string;
+  permissionMode?: 'standard' | null;
+  providerId?: string;
+  providerName?: string;
+  supportsReasoning?: boolean | null;
+  supportsTools?: boolean;
+}
+
+/** Configure an isolated loopback provider while preserving each spec's metadata. */
+export async function configureLocalMockProvider(
+  page: Page,
+  baseUrl: string,
+  options: LocalMockProviderOptions = {},
+): Promise<void> {
+  const {
+    apiKey = 'abu-e2e-test-key-not-a-real-secret',
+    contextWindowSize,
+    maxOutputTokens,
+    modelId = 'abu-e2e-local-model',
+    modelLabel = 'Abu E2E deterministic model',
+    permissionMode = null,
+    providerId = 'abu-e2e-local-provider',
+    providerName = 'Abu E2E loopback mock',
+    supportsReasoning = false,
+    supportsTools = false,
+  } = options;
+
+  await page.evaluate((configuration) => {
+    const raw = window.localStorage.getItem('abu-settings');
+    if (!raw) throw new Error('abu-settings was not initialized before E2E configuration');
+    const persisted = JSON.parse(raw) as { state: Record<string, unknown>; version: number };
+    const state = persisted.state;
+    const declaredCapabilities = configuration.supportsReasoning === null
+      ? { supportsTools: configuration.supportsTools }
+      : {
+          supportsReasoning: configuration.supportsReasoning,
+          supportsTools: configuration.supportsTools,
+        };
+
+    state.providers = [{
+      id: configuration.providerId,
+      source: 'custom',
+      name: configuration.providerName,
+      enabled: true,
+      apiFormat: 'openai-compatible',
+      baseUrl: configuration.baseUrl,
+      apiKey: configuration.apiKey,
+      models: [{
+        id: configuration.modelId,
+        label: configuration.modelLabel,
+        isCustom: true,
+        declaredCapabilities,
+      }],
+      defaultModelId: configuration.modelId,
+      status: 'verified',
+      sortOrder: 0,
+      userAdded: true,
+      declaredCapabilities,
+    }];
+    state.activeModel = { providerId: configuration.providerId, modelId: configuration.modelId };
+    state.recentModels = [];
+    state.favoriteModels = [];
+    state.guideShown = true;
+    state.guideOpen = false;
+    state.hasAcknowledgedDisclaimer = true;
+    state.hasRunSensitiveAudit_v015 = true;
+    if (configuration.permissionMode !== null) state.permissionMode = configuration.permissionMode;
+    if (configuration.contextWindowSize !== undefined) state.contextWindowSize = configuration.contextWindowSize;
+    if (configuration.maxOutputTokens !== undefined) state.maxOutputTokens = configuration.maxOutputTokens;
+
+    window.localStorage.setItem('abu-settings', JSON.stringify({ ...persisted, state, version: 42 }));
+  }, {
+    apiKey,
+    baseUrl,
+    contextWindowSize,
+    maxOutputTokens,
+    modelId,
+    modelLabel,
+    permissionMode,
+    providerId,
+    providerName,
+    supportsReasoning,
+    supportsTools,
+  });
+  await reloadAndWaitForApp(page);
 }
 
 /**

--- a/tests/e2e/infra-hygiene.spec.ts
+++ b/tests/e2e/infra-hygiene.spec.ts
@@ -13,6 +13,7 @@ import path from 'node:path';
 import type { ElectronApplication, Page } from 'playwright';
 import {
   closeAbuElectron,
+  configureLocalMockProvider,
   createElectronDataRoot,
   launchAbuElectron,
   removeElectronDataRoot,
@@ -24,6 +25,16 @@ const CHAT_PLACEHOLDER = '想让阿布帮你做点什么？';
 const TEST_API_KEY = 'abu-e2e-infra-hygiene-not-a-real-secret';
 const TEST_MODEL_ID = 'abu-e2e-infra-hygiene-model';
 const PROVIDER_ID = 'abu-e2e-infra-hygiene-provider';
+const LOCAL_MOCK_PROVIDER_OPTIONS = {
+  apiKey: TEST_API_KEY,
+  modelId: TEST_MODEL_ID,
+  modelLabel: 'Abu E2E infra hygiene model',
+  permissionMode: 'standard',
+  providerId: PROVIDER_ID,
+  providerName: 'Abu E2E infra hygiene loopback provider',
+  supportsReasoning: null,
+  supportsTools: true,
+} as const;
 
 interface MockRequest {
   authorization: string | undefined;
@@ -226,48 +237,6 @@ async function waitForApp(page: Page): Promise<void> {
   await expect(page.getByPlaceholder(CHAT_PLACEHOLDER)).toBeVisible({ timeout: READY_TIMEOUT });
 }
 
-async function configureLocalMockProvider(page: Page, baseUrl: string): Promise<void> {
-  await page.evaluate(({ baseUrl, testApiKey, testModelId, providerId }) => {
-    const raw = window.localStorage.getItem('abu-settings');
-    if (!raw) throw new Error('abu-settings was not initialized before E2E configuration');
-    const persisted = JSON.parse(raw) as { state: Record<string, unknown>; version: number };
-    const state = persisted.state;
-
-    state.providers = [{
-      id: providerId,
-      source: 'custom',
-      name: 'Abu E2E infra hygiene loopback provider',
-      enabled: true,
-      apiFormat: 'openai-compatible',
-      baseUrl,
-      apiKey: testApiKey,
-      models: [{
-        id: testModelId,
-        label: 'Abu E2E infra hygiene model',
-        isCustom: true,
-        declaredCapabilities: { supportsTools: true },
-      }],
-      defaultModelId: testModelId,
-      status: 'verified',
-      sortOrder: 0,
-      userAdded: true,
-      declaredCapabilities: { supportsTools: true },
-    }];
-    state.activeModel = { providerId, modelId: testModelId };
-    state.recentModels = [];
-    state.favoriteModels = [];
-    state.permissionMode = 'standard';
-    state.guideShown = true;
-    state.guideOpen = false;
-    state.hasAcknowledgedDisclaimer = true;
-    state.hasRunSensitiveAudit_v015 = true;
-
-    window.localStorage.setItem('abu-settings', JSON.stringify({ ...persisted, state, version: 42 }));
-  }, { baseUrl, testApiKey: TEST_API_KEY, testModelId: TEST_MODEL_ID, providerId: PROVIDER_ID });
-  await page.reload();
-  await waitForApp(page);
-}
-
 async function seedAutomation(page: Page, seed: {
   activeTab: 'schedule' | 'trigger';
   schedules?: Record<string, unknown>;
@@ -439,7 +408,7 @@ test.describe.serial('Electron infra hygiene batch', () => {
     app = launched.app;
     const page = await app.firstWindow({ timeout: READY_TIMEOUT });
     await waitForApp(page);
-    await configureLocalMockProvider(page, mock.baseUrl);
+    await configureLocalMockProvider(page, mock.baseUrl, LOCAL_MOCK_PROVIDER_OPTIONS);
     await seedAutomation(page, {
       activeTab: 'schedule',
       schedules: {
@@ -533,7 +502,7 @@ test.describe.serial('Electron infra hygiene batch', () => {
     app = launched.app;
     const page = await app.firstWindow({ timeout: READY_TIMEOUT });
     await waitForApp(page);
-    await configureLocalMockProvider(page, mock.baseUrl);
+    await configureLocalMockProvider(page, mock.baseUrl, LOCAL_MOCK_PROVIDER_OPTIONS);
     await seedAutomation(page, {
       activeTab: 'trigger',
       triggers: {
@@ -629,7 +598,7 @@ test.describe.serial('Electron infra hygiene batch', () => {
     app = launched.app;
     const page = await app.firstWindow({ timeout: READY_TIMEOUT });
     await waitForApp(page);
-    await configureLocalMockProvider(page, mock.baseUrl);
+    await configureLocalMockProvider(page, mock.baseUrl, LOCAL_MOCK_PROVIDER_OPTIONS);
     await seedAutomation(page, {
       activeTab: 'trigger',
       triggers: {

--- a/tests/e2e/macos-title-band-drag.spec.ts
+++ b/tests/e2e/macos-title-band-drag.spec.ts
@@ -28,6 +28,7 @@ import {
   appRegionAt,
   closeAbuElectron,
   createElectronDataRoot,
+  dismissFirstRunOverlays,
   launchAbuElectron,
   removeElectronDataRoot,
   type ElectronDataRoot,
@@ -41,23 +42,6 @@ const BAND_Y = 25;
 async function waitForApp(page: Page): Promise<void> {
   await page.waitForLoadState('domcontentloaded');
   await expect(page.getByPlaceholder(CHAT_PLACEHOLDER)).toBeVisible({ timeout: READY_TIMEOUT });
-}
-
-async function dismissFirstRunOverlays(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    const raw = window.localStorage.getItem('abu-settings');
-    if (!raw) throw new Error('abu-settings was not initialized before E2E configuration');
-    const persisted = JSON.parse(raw) as { state: Record<string, unknown>; version: number };
-    Object.assign(persisted.state, {
-      guideShown: true,
-      guideOpen: false,
-      hasAcknowledgedDisclaimer: true,
-      hasRunSensitiveAudit_v015: true,
-    });
-    window.localStorage.setItem('abu-settings', JSON.stringify(persisted));
-  });
-  await page.reload();
-  await waitForApp(page);
 }
 
 let app: ElectronApplication | undefined;

--- a/tests/e2e/overlay-drag-regions.spec.ts
+++ b/tests/e2e/overlay-drag-regions.spec.ts
@@ -30,6 +30,7 @@ import {
   appRegionAt,
   closeAbuElectron,
   createElectronDataRoot,
+  dismissFirstRunOverlays,
   launchAbuElectron,
   removeElectronDataRoot,
   type ElectronDataRoot,
@@ -43,24 +44,6 @@ const REPORTED_VIEWPORT = { width: 1200, height: 745 };
 async function waitForApp(page: Page): Promise<void> {
   await page.waitForLoadState('domcontentloaded');
   await expect(page.getByPlaceholder(CHAT_PLACEHOLDER)).toBeVisible({ timeout: READY_TIMEOUT });
-}
-
-/** A fresh data root shows the first-run guide, which covers the whole window. */
-async function dismissFirstRunOverlays(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    const raw = window.localStorage.getItem('abu-settings');
-    if (!raw) throw new Error('abu-settings was not initialized before E2E configuration');
-    const persisted = JSON.parse(raw) as { state: Record<string, unknown>; version: number };
-    Object.assign(persisted.state, {
-      guideShown: true,
-      guideOpen: false,
-      hasAcknowledgedDisclaimer: true,
-      hasRunSensitiveAudit_v015: true,
-    });
-    window.localStorage.setItem('abu-settings', JSON.stringify(persisted));
-  });
-  await page.reload();
-  await waitForApp(page);
 }
 
 let app: ElectronApplication | undefined;

--- a/tests/e2e/task-lifecycle.spec.ts
+++ b/tests/e2e/task-lifecycle.spec.ts
@@ -11,6 +11,7 @@ import path from 'node:path';
 import type { ElectronApplication, Page } from 'playwright';
 import {
   closeAbuElectron,
+  configureLocalMockProvider,
   crashAbuSidecarForE2E,
   createElectronDataRoot,
   launchAbuElectron,
@@ -412,64 +413,6 @@ function diskContainsInterruptedUserMessage(rootDir: string, expectedContent: st
 async function waitForApp(page: Page): Promise<void> {
   await page.waitForLoadState('domcontentloaded');
   await expect(page.getByPlaceholder(CHAT_PLACEHOLDER)).toBeVisible({ timeout: READY_TIMEOUT });
-}
-
-async function configureLocalMockProvider(
-  page: Page,
-  baseUrl: string,
-  options: {
-    contextWindowSize?: number;
-    maxOutputTokens?: number;
-    supportsTools?: boolean;
-  } = {},
-): Promise<void> {
-  await page.evaluate(({ baseUrl, contextWindowSize, maxOutputTokens, supportsTools, testApiKey, testModelId }) => {
-    const raw = window.localStorage.getItem('abu-settings');
-    if (!raw) throw new Error('abu-settings was not initialized before E2E configuration');
-    const persisted = JSON.parse(raw) as { state: Record<string, unknown>; version: number };
-    const state = persisted.state;
-
-    state.providers = [{
-      id: 'abu-e2e-local-provider',
-      source: 'custom',
-      name: 'Abu E2E loopback mock',
-      enabled: true,
-      apiFormat: 'openai-compatible',
-      baseUrl,
-      apiKey: testApiKey,
-      models: [{
-        id: testModelId,
-        label: 'Abu E2E deterministic model',
-        isCustom: true,
-        declaredCapabilities: { supportsReasoning: false, supportsTools },
-      }],
-      defaultModelId: testModelId,
-      status: 'verified',
-      sortOrder: 0,
-      userAdded: true,
-      declaredCapabilities: { supportsReasoning: false, supportsTools },
-    }];
-    state.activeModel = { providerId: 'abu-e2e-local-provider', modelId: testModelId };
-    state.recentModels = [];
-    state.favoriteModels = [];
-    state.guideShown = true;
-    state.guideOpen = false;
-    state.hasAcknowledgedDisclaimer = true;
-    state.hasRunSensitiveAudit_v015 = true;
-    if (contextWindowSize !== undefined) state.contextWindowSize = contextWindowSize;
-    if (maxOutputTokens !== undefined) state.maxOutputTokens = maxOutputTokens;
-
-    window.localStorage.setItem('abu-settings', JSON.stringify({ ...persisted, state, version: 42 }));
-  }, {
-    baseUrl,
-    contextWindowSize: options.contextWindowSize,
-    maxOutputTokens: options.maxOutputTokens,
-    supportsTools: options.supportsTools ?? false,
-    testApiKey: TEST_API_KEY,
-    testModelId: TEST_MODEL_ID,
-  });
-  await page.reload();
-  await waitForApp(page);
 }
 
 let app: ElectronApplication | undefined;

--- a/tests/e2e/tool-approval.spec.ts
+++ b/tests/e2e/tool-approval.spec.ts
@@ -11,6 +11,7 @@ import path from 'node:path';
 import type { ElectronApplication, Page } from 'playwright';
 import {
   closeAbuElectron,
+  configureLocalMockProvider,
   createElectronDataRoot,
   launchAbuElectron,
   removeElectronDataRoot,
@@ -22,6 +23,16 @@ const CHAT_PLACEHOLDER = '想让阿布帮你做点什么？';
 const TEST_API_KEY = 'abu-e2e-tool-approval-not-a-real-secret';
 const TEST_MODEL_ID = 'abu-e2e-tool-approval-model';
 const PROVIDER_ID = 'abu-e2e-tool-approval-provider';
+const LOCAL_MOCK_PROVIDER_OPTIONS = {
+  apiKey: TEST_API_KEY,
+  modelId: TEST_MODEL_ID,
+  modelLabel: 'Abu E2E deterministic tool model',
+  permissionMode: 'standard',
+  providerId: PROVIDER_ID,
+  providerName: 'Abu E2E loopback tool provider',
+  supportsReasoning: null,
+  supportsTools: true,
+} as const;
 
 interface MockRequest {
   authorization: string | undefined;
@@ -180,48 +191,6 @@ async function waitForApp(page: Page): Promise<void> {
   await expect(page.getByPlaceholder(CHAT_PLACEHOLDER)).toBeVisible({ timeout: READY_TIMEOUT });
 }
 
-async function configureLocalMockProvider(page: Page, baseUrl: string): Promise<void> {
-  await page.evaluate(({ baseUrl, testApiKey, testModelId, providerId }) => {
-    const raw = window.localStorage.getItem('abu-settings');
-    if (!raw) throw new Error('abu-settings was not initialized before E2E configuration');
-    const persisted = JSON.parse(raw) as { state: Record<string, unknown>; version: number };
-    const state = persisted.state;
-
-    state.providers = [{
-      id: providerId,
-      source: 'custom',
-      name: 'Abu E2E loopback tool provider',
-      enabled: true,
-      apiFormat: 'openai-compatible',
-      baseUrl,
-      apiKey: testApiKey,
-      models: [{
-        id: testModelId,
-        label: 'Abu E2E deterministic tool model',
-        isCustom: true,
-        declaredCapabilities: { supportsTools: true },
-      }],
-      defaultModelId: testModelId,
-      status: 'verified',
-      sortOrder: 0,
-      userAdded: true,
-      declaredCapabilities: { supportsTools: true },
-    }];
-    state.activeModel = { providerId, modelId: testModelId };
-    state.recentModels = [];
-    state.favoriteModels = [];
-    state.permissionMode = 'standard';
-    state.guideShown = true;
-    state.guideOpen = false;
-    state.hasAcknowledgedDisclaimer = true;
-    state.hasRunSensitiveAudit_v015 = true;
-
-    window.localStorage.setItem('abu-settings', JSON.stringify({ ...persisted, state, version: 42 }));
-  }, { baseUrl, testApiKey: TEST_API_KEY, testModelId: TEST_MODEL_ID, providerId: PROVIDER_ID });
-  await page.reload();
-  await waitForApp(page);
-}
-
 function dialogTitle(page: Page) {
   return page.getByRole('heading', { name: /^(操作确认|Confirm Action)$/ });
 }
@@ -345,7 +314,7 @@ test.describe.serial('Electron run_command approval E2E', () => {
     app = launched.app;
     const page = await app.firstWindow({ timeout: READY_TIMEOUT });
     await waitForApp(page);
-    await configureLocalMockProvider(page, mock.baseUrl);
+    await configureLocalMockProvider(page, mock.baseUrl, LOCAL_MOCK_PROVIDER_OPTIONS);
 
     const prompt = `abu-e2e-confirm-command-${randomUUID()}`;
     await page.getByPlaceholder(CHAT_PLACEHOLDER).fill(prompt);
@@ -391,7 +360,7 @@ test.describe.serial('Electron run_command approval E2E', () => {
     app = launched.app;
     const page = await app.firstWindow({ timeout: READY_TIMEOUT });
     await waitForApp(page);
-    await configureLocalMockProvider(page, mock.baseUrl);
+    await configureLocalMockProvider(page, mock.baseUrl, LOCAL_MOCK_PROVIDER_OPTIONS);
 
     await page.getByPlaceholder(CHAT_PLACEHOLDER).fill(`abu-e2e-cancel-command-${randomUUID()}`);
     await page.getByPlaceholder(CHAT_PLACEHOLDER).press('Enter');
@@ -444,7 +413,7 @@ test.describe.serial('Electron run_command approval E2E', () => {
     app = launched.app;
     const page = await app.firstWindow({ timeout: READY_TIMEOUT });
     await waitForApp(page);
-    await configureLocalMockProvider(page, mock.baseUrl);
+    await configureLocalMockProvider(page, mock.baseUrl, LOCAL_MOCK_PROVIDER_OPTIONS);
 
     await page.getByPlaceholder(CHAT_PLACEHOLDER).fill(
       `abu-e2e-native-browser-approval-${randomUUID()}`,
@@ -497,7 +466,7 @@ test.describe.serial('Electron run_command approval E2E', () => {
     app = launched.app;
     const page = await app.firstWindow({ timeout: READY_TIMEOUT });
     await waitForApp(page);
-    await configureLocalMockProvider(page, mock.baseUrl);
+    await configureLocalMockProvider(page, mock.baseUrl, LOCAL_MOCK_PROVIDER_OPTIONS);
 
     await page.getByPlaceholder(CHAT_PLACEHOLDER).fill(
       `abu-e2e-task-local-capability-${randomUUID()}`,

--- a/tests/e2e/windows-titlebar-drag.spec.ts
+++ b/tests/e2e/windows-titlebar-drag.spec.ts
@@ -14,6 +14,7 @@ import {
   appRegionAt,
   closeAbuElectron,
   createElectronDataRoot,
+  dismissFirstRunOverlays,
   launchAbuElectron,
   removeElectronDataRoot,
   type ElectronDataRoot,
@@ -55,23 +56,6 @@ $rootResult = [AbuHitTest]::SendMessage($root, 0x84, [IntPtr]::Zero, $packed).To
 async function waitForApp(page: Page): Promise<void> {
   await page.waitForLoadState('domcontentloaded');
   await expect(page.getByPlaceholder(CHAT_PLACEHOLDER)).toBeVisible({ timeout: READY_TIMEOUT });
-}
-
-async function dismissFirstRunOverlays(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    const raw = window.localStorage.getItem('abu-settings');
-    if (!raw) throw new Error('abu-settings was not initialized before E2E configuration');
-    const persisted = JSON.parse(raw) as { state: Record<string, unknown>; version: number };
-    Object.assign(persisted.state, {
-      guideShown: true,
-      guideOpen: false,
-      hasAcknowledgedDisclaimer: true,
-      hasRunSensitiveAudit_v015: true,
-    });
-    window.localStorage.setItem('abu-settings', JSON.stringify(persisted));
-  });
-  await page.reload();
-  await waitForApp(page);
 }
 
 async function configureLocalProvider(page: Page): Promise<void> {


### PR DESCRIPTION
## Summary

- C1: replace checkForUpdate null ambiguity with an explicit result union and switch both UI callers to the result.
- C2: remove the WeChat-local bytesToBase64 and reuse uint8ArrayToBase64.
- C3: derive MIME-to-extension and extension-to-MIME maps from one alias-aware source.
- C4: share formatFileSize between imTools and fileTools.
- C5: move repeated first-run and loopback-provider Electron E2E setup into electronHelpers.ts while preserving per-suite metadata.

The branch was rebased onto the latest origin/dev at 69c9f0a1 before final validation.

## Observable behavior

- C1 changes the internal return shape only. Error results carry updaterUnsupported so AboutSection and AccountMenu preserve the former false/null/true UI states without rereading the store. User-facing wording is unchanged.
- C4 intentionally changes imTools KB output from whole-number precision to one decimal, for example 1KB → 1.0KB. fileTools already used one decimal and is unchanged.

## Verification

- npm run verify: exit 0; 445 files, 6683 passed / 1 skipped.
- Coverage: statements 75.95%, branches 67.24%, functions 75.82%, lines 77.76%.
- Final affected real-Electron change-attribution run: 13 passed / 1 Windows-only skipped, exit 0.
- npm run electron:dev:check: exit 0.
- Independent gpt-5.6-sol + xhigh review: initial C1 behavior-drift finding fixed and autosquashed; re-review found no confirmed findings.
- Worktree clean; exactly five linear commits.

## E2E baseline evidence

The unfiltered 17-test affected-spec run exposed three failures unrelated to this diff. Each failure was reproduced with the same assertion and timeout on the untouched starting origin/dev df8ab5e3 using the original local helpers:

- overlay-drag-regions: closeAppRegion expected no-drag, received none.
- infra-hygiene: task request count expected 10, received 9.
- task-lifecycle large-file compression: 文件读取权限 heading did not appear.

Those three pre-existing red tests were excluded from the final change-attribution run rather than fixed or weakened in this cleanup-only PR.

## Commits

1. 5b07343a — C1 updater result union
2. aefcfa88 — C2 shared base64
3. bcaef658 — C3 image media-type source
4. 6a0abca4 — C4 shared file-size formatter
5. abc77979 — C5 shared Electron E2E helpers