### PR TITLE
fix(test): imageSaveHost defaultPath assertion is OS-native, not POSIX

### DIFF
--- a/electron/imageSaveHost.test.cjs
+++ b/electron/imageSaveHost.test.cjs
@@ -48,7 +48,10 @@ test('saves validated inline bytes to the user-selected path', async () => {
 
   assert.deepEqual(result, { saved: true, fileName: 'export.png' });
   assert.equal(dialogs.length, 1);
-  assert.equal(dialogs[0][1].defaultPath, '/downloads/Abu image.png');
+  // defaultPath is built with path.join, so its separator is OS-native
+  // (backslash on Windows). Compare against the platform-joined form rather
+  // than a hardcoded POSIX string, which would fail the Windows release gate.
+  assert.equal(dialogs[0][1].defaultPath, path.join('/downloads', 'Abu image.png'));
   assert.deepEqual(dialogs[0][1].filters, [{ name: 'PNG image', extensions: ['png'] }]);
   assert.equal(writes.length, 1);
   assert.equal(writes[0].target, '/chosen/export.png');


### PR DESCRIPTION
## 问题

v0.42.0-rc.1 的 Windows 发版门在 `imageSaveHost.test.cjs:51` 失败，导致 Windows 构建停在门禁、未产出安装包：

```
actual:   '\downloads\Abu image.png'   (Windows 反斜杠)
expected: '/downloads/Abu image.png'     (硬编码正斜杠)
```

## 判断：测试 bug，产品代码正确

产品 `imageSaveHost.cjs:196` 用 `path.join(app.getPath('downloads'), fileName)` 构造喂给系统「另存为」对话框的默认路径——在 Windows 上产出反斜杠是**正确**的（对话框要 OS 原生路径）。测试硬编码了 POSIX 正斜杠，只在 macOS/Linux 成立。这是「只有 Windows CI 才抓得到」的跨平台断言假设。

## 改法

一行：断言改成 `path.join('/downloads', 'Abu image.png')`，两平台都成立。**产品代码零改动**，只碰 imageSaveHost 测试。本地 `node --test electron/imageSaveHost.test.cjs` 11/11 通过。

合入后重打 `v0.42.0-rc.2` 验证 Windows 构建产出安装包。

🤖 Generated with [Claude Code](https://claude.com/claude-code)