### PR TITLE
feat(feedback): require description and conversation selection before diagnostic upload

### DIFF
--- a/src/components/settings/sections/diagnostic/DiagnosticUpload.test.tsx
+++ b/src/components/settings/sections/diagnostic/DiagnosticUpload.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment happy-dom
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DiagnosticUpload from './DiagnosticUpload';
+import { useFeedbackDraftStore } from '@/stores/feedbackDraftStore';
+import { useChatStore } from '@/stores/chatStore';
+
+const collectAndZip = vi.fn();
+const produceBundle = vi.fn();
+vi.mock('@/core/diagnostic/bundle', () => ({
+  collectAndZip: (...a: unknown[]) => collectAndZip(...a),
+  produceBundle: (...a: unknown[]) => produceBundle(...a),
+}));
+
+const uploadDiagnosticBundle = vi.fn();
+vi.mock('@/utils/consoleDiagnostic', () => ({
+  uploadDiagnosticBundle: (...a: unknown[]) => uploadDiagnosticBundle(...a),
+  isDiagnosticUploadUnavailable: () => false,
+}));
+
+// Child pickers carry their own store/DOM dependencies — out of scope here.
+vi.mock('./ConversationPicker', () => ({ default: () => <div data-testid="conversation-picker" /> }));
+vi.mock('./ScreenshotUpload', () => ({ default: () => <div data-testid="screenshot-upload" /> }));
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      diagnostic: {
+        descriptionLabel: 'Problem description',
+        descriptionRequired: 'Please describe the problem',
+        conversationRequired: 'Please select at least one conversation to attach',
+        uploadDescriptionPlaceholder: 'Describe the issue',
+        screenshotTitle: 'Attach screenshots',
+        screenshotCount: '{n}/5',
+        conversationPickerTitle: 'Select conversations',
+        conversationPickerInfoTooltip: 'info',
+        exportIncludeRaw: 'Include raw text',
+        exportIncludeRawHint: 'hint',
+        uploadAutoIncludedHint: 'auto-included',
+        uploadButton: 'Upload bundle',
+        uploadInProgress: 'Uploading…',
+        uploadSuccess: 'Uploaded',
+        uploadFailed: 'Upload failed',
+        uploadUnavailable: 'unavailable',
+        exportButton: 'Export offline bundle',
+        exportInProgress: 'Packing…',
+        exportFailed: 'Export failed',
+        errMap: { unknown: 'unknown' },
+      },
+    },
+  }),
+  format: (tpl: string) => tpl,
+}));
+
+function renderUpload(description = '') {
+  return render(
+    <DiagnosticUpload onExportSuccess={vi.fn()} description={description} onDescriptionChange={vi.fn()} />,
+  );
+}
+
+describe('DiagnosticUpload required fields', () => {
+  beforeEach(() => {
+    collectAndZip.mockReset().mockResolvedValue({ bytes: new Uint8Array(), filename: 'x.zip' });
+    produceBundle.mockReset().mockResolvedValue({ path: '/x', sizeBytes: 1, scrubbedTextCount: 0, fileList: [] });
+    uploadDiagnosticBundle.mockReset().mockResolvedValue(undefined);
+    useChatStore.setState({ activeConversationId: null });
+    useFeedbackDraftStore.setState({
+      description: '',
+      selectedConversationIds: [],
+      touchedSelection: true, // stop the effect from re-syncing to the active conversation
+      screenshots: [],
+    });
+  });
+
+  afterEach(cleanup);
+
+  it('blocks upload and shows both errors when description and conversations are empty', async () => {
+    const user = userEvent.setup();
+    renderUpload('');
+
+    await user.click(screen.getByRole('button', { name: /Upload bundle/ }));
+
+    expect(collectAndZip).not.toHaveBeenCalled();
+    expect(uploadDiagnosticBundle).not.toHaveBeenCalled();
+    expect(screen.getByText('Please describe the problem')).toBeInTheDocument();
+    expect(screen.getByText('Please select at least one conversation to attach')).toBeInTheDocument();
+  });
+
+  it('whitespace-only description still counts as empty', async () => {
+    const user = userEvent.setup();
+    useFeedbackDraftStore.setState({ selectedConversationIds: ['c1'] });
+    renderUpload('   \n  ');
+
+    await user.click(screen.getByRole('button', { name: /Upload bundle/ }));
+
+    expect(uploadDiagnosticBundle).not.toHaveBeenCalled();
+    expect(screen.getByText('Please describe the problem')).toBeInTheDocument();
+    expect(screen.queryByText('Please select at least one conversation to attach')).not.toBeInTheDocument();
+  });
+
+  it('shows only the conversation error when just the description is filled', async () => {
+    const user = userEvent.setup();
+    renderUpload('It crashed when I sent a message');
+
+    await user.click(screen.getByRole('button', { name: /Upload bundle/ }));
+
+    expect(uploadDiagnosticBundle).not.toHaveBeenCalled();
+    expect(screen.queryByText('Please describe the problem')).not.toBeInTheDocument();
+    expect(screen.getByText('Please select at least one conversation to attach')).toBeInTheDocument();
+  });
+
+  it('uploads when both fields are filled', async () => {
+    const user = userEvent.setup();
+    useFeedbackDraftStore.setState({ selectedConversationIds: ['c1'] });
+    renderUpload('It crashed when I sent a message');
+
+    await user.click(screen.getByRole('button', { name: /Upload bundle/ }));
+
+    expect(collectAndZip).toHaveBeenCalledTimes(1);
+    expect(uploadDiagnosticBundle).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Please describe the problem')).not.toBeInTheDocument();
+    expect(screen.queryByText('Please select at least one conversation to attach')).not.toBeInTheDocument();
+  });
+
+  it('offline export stays available without the required fields', async () => {
+    const user = userEvent.setup();
+    renderUpload('');
+
+    await user.click(screen.getByRole('button', { name: /Export offline bundle/ }));
+
+    expect(produceBundle).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Please describe the problem')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/settings/sections/diagnostic/DiagnosticUpload.tsx
+++ b/src/components/settings/sections/diagnostic/DiagnosticUpload.tsx
@@ -49,6 +49,11 @@ export default function DiagnosticUpload({ onExportSuccess, description, onDescr
 
   const [uploadInProgress, setUploadInProgress] = useState(false);
   const [uploadDone, setUploadDone] = useState(false);
+  // Required-field errors only appear after an upload attempt, and self-clear
+  // as soon as the field is filled (each render re-checks the condition).
+  const [showRequiredErrors, setShowRequiredErrors] = useState(false);
+  const descriptionMissing = description.trim().length === 0;
+  const conversationMissing = selectedConversationIds.length === 0;
 
   // Click-to-toggle info popover next to the "select conversations" label
   // (a hover tooltip vanishes on mouse-out; users want it to stay open).
@@ -83,6 +88,11 @@ export default function DiagnosticUpload({ onExportSuccess, description, onDescr
 
   const onUpload = async () => {
     if (uploadInProgress || exportInProgress) return;
+    if (descriptionMissing || conversationMissing) {
+      setShowRequiredErrors(true);
+      return;
+    }
+    setShowRequiredErrors(false);
     setUploadInProgress(true);
     setUploadDone(false);
     try {
@@ -144,14 +154,21 @@ export default function DiagnosticUpload({ onExportSuccess, description, onDescr
       <div>
         <div className="mb-1.5 text-body font-medium text-[var(--abu-text-secondary)]">
           {t.diagnostic.descriptionLabel}
+          <span className="ml-0.5 text-[var(--abu-danger)]">*</span>
         </div>
         <Textarea
           value={description}
           onChange={(e) => onDescriptionChange(e.target.value)}
           placeholder={t.diagnostic.uploadDescriptionPlaceholder}
-          className="min-h-[104px] text-body resize-none"
+          className={cn(
+            'min-h-[104px] text-body resize-none',
+            showRequiredErrors && descriptionMissing && 'border-[var(--abu-danger)]',
+          )}
           disabled={busy}
         />
+        {showRequiredErrors && descriptionMissing && (
+          <div className="mt-1 text-caption text-[var(--abu-danger)]">{t.diagnostic.descriptionRequired}</div>
+        )}
       </div>
 
       {/* Field 2 — screenshots (label + right-aligned counter). */}
@@ -173,6 +190,7 @@ export default function DiagnosticUpload({ onExportSuccess, description, onDescr
         <div className="mb-1.5 flex items-center gap-1.5">
           <span className="text-body font-medium text-[var(--abu-text-secondary)]">
             {t.diagnostic.conversationPickerTitle}
+            <span className="ml-0.5 text-[var(--abu-danger)]">*</span>
           </span>
           <div ref={infoRef} className="relative flex items-center">
             <button
@@ -198,6 +216,9 @@ export default function DiagnosticUpload({ onExportSuccess, description, onDescr
           onChange={handleSelectedConversationIdsChange}
           disabled={busy}
         />
+        {showRequiredErrors && conversationMissing && (
+          <div className="mt-1 text-caption text-[var(--abu-danger)]">{t.diagnostic.conversationRequired}</div>
+        )}
 
         {/* Raw-text toggle — ON by default (message text is included, secrets
             still scrubbed). Off strips text down to a size placeholder. */}

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -1177,6 +1177,8 @@ const enUS: TranslationDict = {
     conversationPickerInfoTooltip: 'Only the conversations you select are included; API keys, secrets and other sensitive data are stripped automatically. Attach up to 5 conversations, each contributing its most recent 100 messages.',
     conversationPickerTooMany: 'You can attach at most {max} conversations',
     descriptionLabel: 'Problem description',
+    descriptionRequired: 'Please describe the problem',
+    conversationRequired: 'Please select at least one conversation to attach',
     screenshotTitle: 'Attach screenshots',
     screenshotAddHint: 'Click, drag & drop, or paste to add (up to 5 images, 5MB total)',
     screenshotCount: '{n}/5',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -1177,6 +1177,8 @@ const zhCN: TranslationDict = {
     conversationPickerInfoTooltip: '只会包含你勾选的对话，API Key、密钥等敏感信息已自动剔除。最多可选 5 个对话，默认每个对话取最近 100 条消息。',
     conversationPickerTooMany: '最多可选 {max} 个对话',
     descriptionLabel: '问题描述',
+    descriptionRequired: '请填写问题描述',
+    conversationRequired: '请选择要附带的对话',
     screenshotTitle: '附加截图',
     screenshotAddHint: '点击、拖拽或粘贴图片添加（最多 5 张，合计 5MB）',
     screenshotCount: '{n}/5',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1341,6 +1341,9 @@ export interface TranslationDict {
     conversationPickerTooMany: string; // {max}
     // Feedback form field label
     descriptionLabel: string;
+    // Required-field validation errors (upload path)
+    descriptionRequired: string;
+    conversationRequired: string;
     // Screenshot upload (feedback form)
     screenshotTitle: string;
     screenshotAddHint: string;


### PR DESCRIPTION
## 背景

反馈页此前不填「问题描述」、不选「选择对话」也能直接上传诊断包，收到的空包难以定位问题。

## 改动

- **上传路径必填校验**：点「上传诊断包」时，描述为空（纯空白也算空）或未选任何对话 → 阻止上传，对应字段下方显示红字提示，描述框描红边
- 「问题描述」「选择对话」两个标签加红色 `*` 必填标记
- 提示只在点过上传后出现，字段填好即自动消失（每次渲染重查条件）
- **「导出离线诊断包」不拦**：它是反馈服务不可用时的本地兜底通道，保持无限制
- i18n 新增 `descriptionRequired` / `conversationRequired` 两个 key（zh-CN + en-US + types）

## 测试

- 新增 `DiagnosticUpload.test.tsx` 5 个用例：双空拦截、纯空白描述算空、只差对话时只报对话错、双填通过并真正调用上传、离线导出不受必填限制
- pre-commit 门禁（ESLint + vitest related 192 文件 / 3205 用例）全绿
- Vite 预览实测：空提交拦截 + 双提示展示 + 填写后自清（桌面 Electron 壳建议合并前再过一遍反馈页路径）

🤖 Generated with [Claude Code](https://claude.com/claude-code)