### PR TITLE
fix(sidecar): capture run ownership before out-of-band abort_command dispatch

### DIFF
--- a/scripts/build-sidecar.mjs
+++ b/scripts/build-sidecar.mjs
@@ -82,6 +82,10 @@ const packageJson = JSON.parse(readFileSync(path.resolve(root, 'package.json'), 
  */
 const SHIM_TARGETS = [
   { real: path.resolve(srcDir, 'core/logging/logger.ts'), shim: path.resolve(__dirname, '../sidecar/src/shims/logger.ts') },
+  // Capture native-command ownership at registration time so out-of-band
+  // AbortSignal callbacks can re-enter the correct ALS context. The renderer
+  // implementation remains a browser-safe identity wrapper.
+  { real: path.resolve(srcDir, 'core/tools/helpers/taskCommandInvoke.ts'), shim: path.resolve(__dirname, '../sidecar/src/shims/taskCommandInvokeRun.ts') },
   { real: path.resolve(srcDir, 'core/observability/compatEvents.ts'), shim: path.resolve(__dirname, '../sidecar/src/shims/compatEvents.ts') },
   { real: path.resolve(srcDir, 'core/llm/tauriFetch.ts'), shim: path.resolve(__dirname, '../sidecar/src/shims/tauriFetch.ts') },
   // P1-3a additions (docs/2026-07-19-phase1-p3-loop-migration-staging.md §2

--- a/sidecar/src/shims/scopedCommandRun.integration.test.ts
+++ b/sidecar/src/shims/scopedCommandRun.integration.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { agentRunContext } from '../agentRunContext';
+
+const sendRequestMock = vi.hoisted(() => vi.fn());
+vi.mock('../rpcClient', () => ({
+  sendRequest: (...args: unknown[]) => sendRequestMock(...args),
+}));
+
+// Mirror build-sidecar.mjs's production module redirect. The redirected
+// implementation calls the real sidecar invoke shim; only JSON-RPC transport
+// is intercepted, so this test never mocks invoke itself.
+vi.mock('@/core/tools/helpers/taskCommandInvoke', async () => {
+  return import('./taskCommandInvokeRun');
+});
+
+import { invokeTaskCommand } from '@/core/tools/helpers/scopedCommand';
+
+function setElectronMarker(enabled: boolean): void {
+  const runtime = globalThis as typeof globalThis & {
+    __ABU_SHELL__?: { mainSupervisesSidecar?: boolean };
+  };
+  if (enabled) {
+    runtime.__ABU_SHELL__ = { mainSupervisesSidecar: true };
+  } else {
+    delete runtime.__ABU_SHELL__;
+  }
+}
+
+describe('sidecar scoped command abort dispatch', () => {
+  beforeEach(() => {
+    sendRequestMock.mockReset();
+    setElectronMarker(true);
+  });
+
+  afterEach(() => {
+    setElectronMarker(false);
+  });
+
+  it('retains the starting run owner when Stop aborts outside its AsyncLocalStorage scope', async () => {
+    const controller = new AbortController();
+    let resolveCommand!: (value: unknown) => void;
+    sendRequestMock.mockImplementation((_method: unknown, rawParams: unknown) => {
+      const params = rawParams as { cmd?: string };
+      if (params.cmd === 'run_shell_command') {
+        return new Promise((resolve) => {
+          resolveCommand = resolve;
+        });
+      }
+      return Promise.resolve(true);
+    });
+
+    let running!: Promise<unknown>;
+    agentRunContext.run({ runId: 'main-run' } as never, () => {
+      running = invokeTaskCommand(
+        'run_shell_command',
+        { command: 'sleep 60' },
+        { abortSignal: controller.signal, loopId: 'main-run' },
+        { commandIdPrefix: 'stop-regression' },
+      );
+    });
+
+    const startCall = sendRequestMock.mock.calls.find(([, params]) => (
+      params as { cmd?: string }
+    ).cmd === 'run_shell_command');
+    const commandId = (
+      startCall?.[1] as { args?: { commandId?: string } }
+    ).args?.commandId;
+    expect(commandId).toMatch(/^stop-regression-/);
+
+    try {
+      controller.abort();
+
+      expect(sendRequestMock).toHaveBeenCalledWith('native.invoke', {
+        runId: 'main-run',
+        cmd: 'abort_command',
+        args: { commandId },
+      });
+    } finally {
+      resolveCommand({ code: -1, stdout: '', stderr: '[Command aborted]' });
+      await running;
+    }
+  });
+});

--- a/sidecar/src/shims/taskCommandInvokeRun.ts
+++ b/sidecar/src/shims/taskCommandInvokeRun.ts
@@ -1,0 +1,39 @@
+/**
+ * Sidecar replacement for `src/core/tools/helpers/taskCommandInvoke.ts`.
+ *
+ * AbortSignal listeners run in the async context that calls `abort()`, not
+ * the context that registered the listener. Capture the current owner while
+ * a command is being registered and explicitly re-enter it for every later
+ * native call, including the out-of-band `abort_command` cleanup callback.
+ */
+import { agentRunContext } from '../agentRunContext';
+import { subagentRunContext } from '../subagentRunContext';
+import { invoke, invokeCleanupForCapturedRun } from './tauriCoreInvokeRun';
+
+type TaskCommandInvoke = <T>(
+  cmd: string,
+  args?: Record<string, unknown>,
+) => Promise<T>;
+
+export function captureTaskCommandInvoke(runIdHint?: string): TaskCommandInvoke {
+  const agentContext = agentRunContext.getStore();
+  if (agentContext) {
+    return <T>(cmd: string, args?: Record<string, unknown>) => (
+      agentRunContext.run(agentContext, () => invoke<T>(cmd, args))
+    );
+  }
+
+  const subagentContext = subagentRunContext.getStore();
+  if (subagentContext) {
+    return <T>(cmd: string, args?: Record<string, unknown>) => (
+      subagentRunContext.run(subagentContext, () => invoke<T>(cmd, args))
+    );
+  }
+
+  return <T>(cmd: string, args?: Record<string, unknown>) => {
+    if (cmd === 'abort_command' && runIdHint) {
+      return invokeCleanupForCapturedRun<T>(runIdHint, cmd, args);
+    }
+    return invoke<T>(cmd, args);
+  };
+}

--- a/sidecar/src/shims/tauriCoreInvokeRun.test.ts
+++ b/sidecar/src/shims/tauriCoreInvokeRun.test.ts
@@ -7,7 +7,7 @@ vi.mock('../rpcClient', () => ({
   sendRequest: (...args: unknown[]) => sendRequestMock(...args),
 }));
 
-import { invoke } from './tauriCoreInvokeRun';
+import { invoke, invokeCleanupForCapturedRun } from './tauriCoreInvokeRun';
 
 describe('tauriCoreInvokeRun', () => {
   beforeEach(() => {
@@ -43,6 +43,23 @@ describe('tauriCoreInvokeRun', () => {
     await expect(invoke('run_shell_command', { command: 'pwd' })).rejects.toThrow(
       /outside an agent\/subagent run context/,
     );
+    expect(sendRequestMock).not.toHaveBeenCalled();
+  });
+
+  it('allows an explicitly captured owner to dispatch cleanup outside ALS', async () => {
+    await invokeCleanupForCapturedRun('main-run', 'abort_command', { commandId: 'cmd-1' });
+
+    expect(sendRequestMock).toHaveBeenCalledWith('native.invoke', {
+      runId: 'main-run',
+      cmd: 'abort_command',
+      args: { commandId: 'cmd-1' },
+    });
+  });
+
+  it('rejects explicit owner overrides for non-cleanup commands', async () => {
+    await expect(invokeCleanupForCapturedRun('main-run', 'run_shell_command', { command: 'pwd' }))
+      .rejects
+      .toThrow(/restricted to cleanup commands/);
     expect(sendRequestMock).not.toHaveBeenCalled();
   });
 });

--- a/sidecar/src/shims/tauriCoreInvokeRun.ts
+++ b/sidecar/src/shims/tauriCoreInvokeRun.ts
@@ -42,6 +42,29 @@ import { sendRequest } from '../rpcClient';
 import { agentRunContext } from '../agentRunContext';
 import { subagentRunContext } from '../subagentRunContext';
 
+const CLEANUP_COMMANDS: ReadonlySet<string> = new Set([
+  'abort_command',
+  'ax_close_session',
+  'computer_use_end_task',
+]);
+
+/**
+ * Cleanup-only fallback for callbacks that already captured their owning
+ * runId but execute without an ambient AsyncLocalStorage store. The shell
+ * still validates both the run owner and its native-command allowlist.
+ */
+export async function invokeCleanupForCapturedRun<T>(
+  runId: string,
+  cmd: string,
+  args?: Record<string, unknown>,
+): Promise<T> {
+  if (!runId || !CLEANUP_COMMANDS.has(cmd)) {
+    throw new Error(`[sidecar] explicit native.invoke owner override is restricted to cleanup commands: ${cmd}`);
+  }
+  console.error('[sidecar:native.invoke] cleanup dispatch used an explicit captured run owner', { runId, cmd });
+  return sendRequest('native.invoke', { runId, cmd, args }) as Promise<T>;
+}
+
 export async function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
   const runId = agentRunContext.getStore()?.runId ?? subagentRunContext.getStore()?.runId;
   if (!runId) {

--- a/src/core/tools/helpers/scopedCommand.test.ts
+++ b/src/core/tools/helpers/scopedCommand.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { invoke } from '@tauri-apps/api/core';
+import { clearLogs, getRecentLogs } from '@/core/logging/logger';
 import { invokeTaskCommand, TaskCommandAbortedError } from './scopedCommand';
 
 function setElectronMarker(enabled: boolean): void {
@@ -19,12 +20,14 @@ describe('invokeTaskCommand', () => {
 
   beforeEach(() => {
     vi.mocked(invoke).mockReset();
+    clearLogs();
     delete process.env.ELECTRON_RUN_AS_NODE;
     delete process.env.ABU_ELECTRON_COMMAND_HOST;
     setElectronMarker(false);
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.mocked(invoke).mockReset();
     if (oldElectronRunAsNode === undefined) {
       delete process.env.ELECTRON_RUN_AS_NODE;
@@ -119,5 +122,44 @@ describe('invokeTaskCommand', () => {
       .rejects
       .toThrow(TaskCommandAbortedError);
     expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('records a warning when abort_command dispatch fails', async () => {
+    vi.useFakeTimers();
+    setElectronMarker(true);
+    const controller = new AbortController();
+    let resolveCommand!: (value: unknown) => void;
+    vi.mocked(invoke).mockImplementation(async (cmd) => {
+      if (cmd === 'run_shell_command') {
+        return await new Promise((resolve) => {
+          resolveCommand = resolve;
+        });
+      }
+      if (cmd === 'abort_command') throw new Error('sidecar transport closed');
+      return undefined;
+    });
+
+    const running = invokeTaskCommand(
+      'run_shell_command',
+      { command: 'sleep 60' },
+      { abortSignal: controller.signal },
+      { commandIdPrefix: 'warn-test' },
+    );
+
+    controller.abort();
+    await Promise.resolve();
+
+    const warning = getRecentLogs({ module: 'scoped-command', level: 'warn' }).at(-1);
+    expect(warning).toMatchObject({
+      message: 'abort_command dispatch failed',
+      data: {
+        commandId: expect.stringMatching(/^warn-test-/),
+        error: 'sidecar transport closed',
+      },
+    });
+
+    resolveCommand({ code: -1, stdout: '', stderr: '[Command aborted]' });
+    await running;
+    await vi.advanceTimersByTimeAsync(500);
   });
 });

--- a/src/core/tools/helpers/scopedCommand.ts
+++ b/src/core/tools/helpers/scopedCommand.ts
@@ -1,8 +1,11 @@
-import { invoke } from '@tauri-apps/api/core';
-import type { ToolExecutionContext } from '../../../types';
-import { hasElectronCommandHost } from '../../../utils/electronHost';
+import type { ToolExecutionContext } from '@/types';
+import { createLogger } from '@/core/logging/logger';
+import { hasElectronCommandHost } from '@/utils/electronHost';
+import { captureTaskCommandInvoke } from '@/core/tools/helpers/taskCommandInvoke';
 
-export { hasElectronCommandHost } from '../../../utils/electronHost';
+export { hasElectronCommandHost } from '@/utils/electronHost';
+
+const logger = createLogger('scoped-command');
 
 export class TaskCommandAbortedError extends Error {
   constructor() {
@@ -36,20 +39,28 @@ export async function invokeTaskCommand<T>(
     throw new TaskCommandAbortedError();
   }
 
+  const taskInvoke = captureTaskCommandInvoke(context?.loopId);
   const commandId = hasElectronCommandHost()
     ? makeCommandId(options?.commandIdPrefix ?? 'task-command')
     : undefined;
   let keepAbortListener = false;
 
   const abortCommand = () => {
-    if (commandId) invoke('abort_command', { commandId }).catch(() => {});
+    if (commandId) {
+      taskInvoke('abort_command', { commandId }).catch((error: unknown) => {
+        logger.warn('abort_command dispatch failed', {
+          commandId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    }
     abortSignal?.removeEventListener('abort', abortCommand);
   };
 
   if (commandId) abortSignal?.addEventListener('abort', abortCommand, { once: true });
 
   try {
-    const result = await invoke<T>(cmd, {
+    const result = await taskInvoke<T>(cmd, {
       ...(commandId ? { commandId } : {}),
       ...args,
     });

--- a/src/core/tools/helpers/taskCommandInvoke.ts
+++ b/src/core/tools/helpers/taskCommandInvoke.ts
@@ -1,0 +1,18 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export type TaskCommandInvoke = <T>(
+  cmd: string,
+  args?: Record<string, unknown>,
+) => Promise<T>;
+
+/**
+ * Capture the native command dispatcher used by one task command.
+ *
+ * The renderer has no ambient run ownership, so its dispatcher is simply the
+ * normal Tauri-shaped invoke function. The sidecar bundle redirects this
+ * module to a Node-only implementation that binds the owning run context at
+ * command registration time, before an out-of-band abort can lose it.
+ */
+export function captureTaskCommandInvoke(_runIdHint?: string): TaskCommandInvoke {
+  return invoke;
+}


### PR DESCRIPTION
## Root cause (v0.42.0 release blocker)

The packaged "real Stop path" smoke failed cross-platform in rc.1..rc.3 (Windows + mac-arm64): pressing Stop left the command tree alive, while the explicit-abort check kept passing.

**Mutation-verified root cause**: AbortSignal listeners run in the aborter's async context, not the registering one. After 1b61f3cf made the sidecar invoke shim require an ambient AsyncLocalStorage runId, the out-of-band `abort_command` dispatch inside `scopedCommand` threw `[sidecar] native.invoke called outside an agent/subagent run context` — and `.catch(() => {})` swallowed it silently, so the shell never received the abort. Unit tests missed it because they mocked `invoke`.

## Fix (keeps the run-ownership guard intact — not a rollback of 1b61f3cf)

- **`taskCommandInvoke`**: capture the owning run context at command registration time; the sidecar build (`SHIM_TARGETS`) redirects it to `taskCommandInvokeRun`, which re-enters that context for every later native call, including the out-of-band abort callback. Renderer keeps a browser-safe identity wrapper (zero behavior change).
- **`invokeCleanupForCapturedRun`**: last-resort explicit-owner dispatch, restricted to a cleanup-command allowlist (`abort_command`, `ax_close_session`, `computer_use_end_task`) and logged loudly; the shell still validates the run owner and its native-command allowlist.
- **Observability**: `abort_command` dispatch failures now `logger.warn` instead of vanishing.

Industry cross-check (DSH source, firsthand): AbortSignal is threaded explicitly to spawn, and ALS is only ever best-effort lineage — never "throw on missing". Design follows the same discipline. See `../docs/abu-stop-abort-regression-brief.md`.

## Regression test

`scopedCommandRun.integration.test.ts` mirrors the production sidecar module redirect and exercises the **real shim chain (no invoke mock)** with `abort()` fired outside the run scope. Mutation check: reverting the context re-entry makes it fail with exactly the swallowed error above.

## Verification (all run locally, exit codes checked)

- `npm run verify` ✅ exit 0
- `npm run electron:test` ✅ exit 0
- `npm run pack:electron && npm run smoke:electron:packaged` ✅ `packagedTaskStopKillsCommandTree: true`, `PASSED = true` — the exact check that failed in CI now passes in a real packaged app
- Independent review completed (this PR was implemented by Codex, root-caused and reviewed by a separate session)

After merge: retag `v0.42.0-rc.4` to validate the release gate on all three platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)