### PR TITLE
fix: restore composer ownership and preview tab styling

### DIFF
--- a/sidecar/src/agentLoopHost.test.ts
+++ b/sidecar/src/agentLoopHost.test.ts
@@ -319,7 +319,7 @@ describe('agentLoopHost', () => {
         version: 1,
         runId: errParams.runId,
         state: 'failed',
-        result: { reason: 'error', error: 'boom' },
+        result: { reason: 'error', error: 'boom', messageTaken: true },
         failure: {
           errorType: 'error',
           message: 'boom',

--- a/sidecar/src/agentLoopHost.ts
+++ b/sidecar/src/agentLoopHost.ts
@@ -932,7 +932,7 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
     const message = error instanceof Error ? error.message : String(error);
     const terminal = createAgentRunTerminal(
       runId,
-      { reason: 'error', error: message },
+      { reason: 'error', error: message, messageTaken: true },
       {
         errorType: sidecarRuntimeErrorType(error),
         message,

--- a/src/components/chat/ChatInput.test.tsx
+++ b/src/components/chat/ChatInput.test.tsx
@@ -4,13 +4,19 @@ import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import ChatInput, { mergeComposerAppend, referenceDedupeKey, referenceChipLabel } from './ChatInput';
 import { createDocReference, createDomElementReference, type BrowserElementPayload } from '@/types/chatReference';
 import { useChatStore } from '@/stores/chatStore';
-import { clearAllComposerDrafts, writeComposerDraft, WELCOME_COMPOSER_DRAFT_KEY } from '@/stores/composerDraftStore';
+import {
+  clearAllComposerDrafts,
+  readComposerDraft,
+  writeComposerDraft,
+  WELCOME_COMPOSER_DRAFT_KEY,
+} from '@/stores/composerDraftStore';
 import { usePreviewStore } from '@/stores/previewStore';
 import { useImageLightboxStore } from '@/stores/imageLightboxStore';
 import { getI18n } from '@/i18n';
 import type { ImageAttachment } from '@/types';
 import { useEnterpriseStore } from '@/stores/enterpriseStore';
 import type { EnterpriseBinding } from '@/core/enterprise/types';
+import { shouldRestoreComposerAfterDispatch } from './composerSendResult';
 
 const enterpriseBinding = (userId: string): EnterpriseBinding => ({
   serverUrl: 'https://example.test',
@@ -102,6 +108,54 @@ describe('ChatInput per-conversation drafts', () => {
       });
     });
     expect(textarea.value).toBe('alice draft');
+  });
+
+  it.each([
+    ['missing API key', () => Promise.resolve(false)],
+    [
+      'busy conversation',
+      () => Promise.resolve(
+        shouldRestoreComposerAfterDispatch({
+          reason: 'error',
+          error: 'conversation busy',
+          messageTaken: false,
+        }) ? false : undefined,
+      ),
+    ],
+  ])('restores the welcome draft when %s rejects the send', async (_scenario, onSend) => {
+    render(<ChatInput variant="welcome" onSend={onSend} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'hello' } });
+
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: 'Enter' });
+      await Promise.resolve();
+    });
+
+    expect(textarea.value).toBe('hello');
+    expect(readComposerDraft(WELCOME_COMPOSER_DRAFT_KEY).text).toBe('hello');
+  });
+
+  it('keeps the welcome draft empty after a post-commit run failure', async () => {
+    const onSend = vi.fn(() => Promise.resolve(
+      shouldRestoreComposerAfterDispatch({
+        reason: 'error',
+        error: 'provider unavailable',
+        messageTaken: true,
+      }) ? false : undefined,
+    ));
+    render(<ChatInput variant="welcome" onSend={onSend} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'hello' } });
+
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: 'Enter' });
+      await Promise.resolve();
+    });
+
+    expect(onSend).toHaveBeenCalledWith('hello', undefined, null);
+    expect(textarea.value).toBe('');
+    expect(readComposerDraft(WELCOME_COMPOSER_DRAFT_KEY).text).toBe('');
   });
 });
 

--- a/src/components/chat/ChatView.composerDispatch.test.tsx
+++ b/src/components/chat/ChatView.composerDispatch.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChatView from './ChatView';
+import { useChatStore } from '@/stores/chatStore';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { useEnterpriseStore } from '@/stores/enterpriseStore';
+import { useToastStore } from '@/stores/toastStore';
+import { AgentLoopDispatchError } from '@/core/agent/agentLoopDispatchError';
+import {
+  clearAllComposerDrafts,
+  readComposerDraft,
+  WELCOME_COMPOSER_DRAFT_KEY,
+} from '@/stores/composerDraftStore';
+
+const { dispatchMock } = vi.hoisted(() => ({
+  dispatchMock: vi.fn(),
+}));
+
+vi.mock('@/core/agent/agentLoopRunner', () => ({
+  runAgentLoopDispatched: (...args: unknown[]) => dispatchMock(...args),
+}));
+
+vi.mock('react-virtuoso', async () => {
+  const { createElement, forwardRef } = await import('react');
+  type MockVirtuosoProps = {
+    data?: unknown[];
+    itemContent?: (index: number, item: unknown) => ReturnType<typeof createElement>;
+  };
+  return {
+    Virtuoso: forwardRef<unknown, MockVirtuosoProps>(function MockVirtuoso(
+      { data = [], itemContent },
+      _ref,
+    ) {
+      return createElement(
+        'div',
+        { 'data-testid': 'mock-virtuoso' },
+        data.map((item, index) => createElement(
+          'div',
+          { key: index },
+          itemContent?.(index, item),
+        )),
+      );
+    }),
+  };
+});
+
+// The guide is unrelated to dispatch ownership. Keep the real ChatInput so
+// these tests cross the actual ChatView -> composer restoration boundary.
+vi.mock('./ScenarioGuide', () => ({
+  default: () => null,
+}));
+
+function configureApiKey(): void {
+  useSettingsStore.setState((state) => ({
+    providers: state.providers.map((provider) =>
+      provider.id === 'anthropic'
+        ? { ...provider, enabled: true, apiKey: 'test-key' }
+        : provider,
+    ),
+  }));
+}
+
+async function submitWelcome(text: string): Promise<HTMLTextAreaElement> {
+  const user = userEvent.setup();
+  const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+  await user.type(textarea, text);
+  await user.keyboard('{Enter}');
+  return textarea;
+}
+
+describe('ChatView welcome composer dispatch ownership', () => {
+  beforeEach(() => {
+    clearAllComposerDrafts();
+    dispatchMock.mockReset();
+    useChatStore.setState(useChatStore.getInitialState(), true);
+    useSettingsStore.setState(useSettingsStore.getInitialState(), true);
+    useEnterpriseStore.setState({ mode: { kind: 'personal' }, initialized: true });
+    useToastStore.setState(useToastStore.getInitialState(), true);
+  });
+
+  afterEach(() => {
+    cleanup();
+    clearAllComposerDrafts();
+    useToastStore.setState(useToastStore.getInitialState(), true);
+  });
+
+  it('keeps the composer empty after a post-commit dispatch failure', async () => {
+    configureApiKey();
+    dispatchMock.mockResolvedValueOnce({
+      reason: 'error',
+      error: 'provider unavailable',
+      messageTaken: true,
+    });
+
+    render(<ChatView />);
+    const textarea = await submitWelcome('hello');
+
+    await waitFor(() => expect(dispatchMock).toHaveBeenCalledTimes(1));
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      'hello',
+      { images: undefined },
+    );
+    await waitFor(() => expect(textarea).toHaveValue(''));
+    expect(readComposerDraft(WELCOME_COMPOSER_DRAFT_KEY).text).toBe('');
+    expect(useToastStore.getState().toasts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'error', title: 'provider unavailable' }),
+      ]),
+    );
+  });
+
+  it('keeps the composer empty after a post-commit dispatch rejection', async () => {
+    configureApiKey();
+    dispatchMock.mockImplementationOnce(async (conversationId: string, text: string) => {
+      useChatStore.getState().addMessage(conversationId, {
+        id: 'failed-user-message',
+        role: 'user',
+        content: text,
+        timestamp: 1,
+        loopId: 'failed-run',
+        runState: 'failed',
+        runError: 'disk unavailable',
+      });
+      throw new AgentLoopDispatchError(new Error('disk unavailable'), true);
+    });
+
+    render(<ChatView />);
+    await submitWelcome('persist once');
+
+    await waitFor(() => expect(dispatchMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByRole('textbox')).toHaveValue(''));
+    expect(readComposerDraft(WELCOME_COMPOSER_DRAFT_KEY).text).toBe('');
+    expect(screen.getByTestId('mock-virtuoso')).toHaveTextContent('persist once');
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    expect(useToastStore.getState().toasts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'error', title: 'disk unavailable' }),
+      ]),
+    );
+  });
+
+  it('restores the draft when the dispatcher rejects ownership', async () => {
+    configureApiKey();
+    dispatchMock.mockResolvedValueOnce({
+      reason: 'error',
+      error: 'conversation busy',
+      messageTaken: false,
+    });
+
+    render(<ChatView />);
+    const textarea = await submitWelcome('retry me');
+
+    await waitFor(() => expect(dispatchMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(textarea).toHaveValue('retry me'));
+    expect(readComposerDraft(WELCOME_COMPOSER_DRAFT_KEY).text).toBe('retry me');
+  });
+
+  it('restores the draft after a pre-accept dispatch rejection', async () => {
+    configureApiKey();
+    dispatchMock.mockRejectedValueOnce(new Error('failed before ownership'));
+
+    render(<ChatView />);
+    const textarea = await submitWelcome('still mine');
+
+    await waitFor(() => expect(dispatchMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(textarea).toHaveValue('still mine'));
+    expect(readComposerDraft(WELCOME_COMPOSER_DRAFT_KEY).text).toBe('still mine');
+  });
+
+  it('restores the draft before dispatch when the API key is missing', async () => {
+    render(<ChatView />);
+    const textarea = await submitWelcome('keep this');
+
+    await waitFor(() => expect(textarea).toHaveValue('keep this'));
+    expect(dispatchMock).not.toHaveBeenCalled();
+    expect(readComposerDraft(WELCOME_COMPOSER_DRAFT_KEY).text).toBe('keep this');
+    expect(useSettingsStore.getState()).toMatchObject({
+      systemSettingsOpen: true,
+      activeSystemTab: 'ai-services',
+    });
+  });
+});

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -2,7 +2,12 @@ import { useState, useCallback, useEffect, useLayoutEffect, useRef, useSyncExter
 import { Virtuoso, type Components, type VirtuosoHandle } from 'react-virtuoso';
 import { getConversationAgentState, useChatStore, useActiveConversation } from '@/stores/chatStore';
 import type { Message, ImageAttachment } from '@/types';
-import { runAgentLoopDispatched } from '@/core/agent/agentLoopRunner';
+import {
+  runAgentLoopDispatched,
+  type AgentLoopDispatchResult,
+} from '@/core/agent/agentLoopRunner';
+import { AgentLoopDispatchError } from '@/core/agent/agentLoopDispatchError';
+import { shouldRestoreComposerAfterDispatch } from './composerSendResult';
 import { getPendingCommandConfirmation, resolveCommandConfirmation, subscribeToCommandConfirmation, getPendingFilePermission, resolveFilePermission, subscribeToFilePermission, getPendingWorkspaceRequest, resolveWorkspaceRequest, subscribeToWorkspaceRequest, getPendingUserQuestions, subscribeUserQuestion, findQuestionOwningMessage } from '@/core/agent/permissionBridge';
 import { useSettingsStore, getActiveApiKey, providerRequiresApiKey } from '@/stores/settingsStore';
 import { useEnterpriseStore } from '@/stores/enterpriseStore';
@@ -473,7 +478,23 @@ export default function ChatView({
     // freshly-appended item on its own next render, so this doesn't need to
     // wait for a DOM mutation callback the way the old MutationObserver did.
     scrollToLatest('auto');
-    const dispatch = await runAgentLoopDispatched(convId, text, { images });
+    let dispatch: AgentLoopDispatchResult;
+    try {
+      dispatch = await runAgentLoopDispatched(convId, text, { images });
+    } catch (error) {
+      // The runner deliberately keeps persistence/transport failures as
+      // rejections for non-UI callers. Once it has appended the user message,
+      // however, the failed transcript row (and its Retry action) owns
+      // recovery; handing the same text back to ChatInput would duplicate it.
+      if (!(error instanceof AgentLoopDispatchError) || !error.messageTaken) {
+        throw error;
+      }
+      useToastStore.getState().addToast({
+        type: 'error',
+        title: error.message || t.chat.conversationBusy,
+      });
+      return;
+    }
     // A rejected dispatch (conversation busy, attachment mid-run) used to be
     // discarded here: the composer had already cleared, so the text and any
     // images simply vanished with no feedback. Surface it and hand the draft
@@ -483,7 +504,7 @@ export default function ChatView({
         type: 'error',
         title: dispatch.error || t.chat.conversationBusy,
       });
-      return false;
+      if (shouldRestoreComposerAfterDispatch(dispatch)) return false;
     }
   };
 

--- a/src/components/chat/QueuedMessagesStrip.test.tsx
+++ b/src/components/chat/QueuedMessagesStrip.test.tsx
@@ -9,6 +9,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import QueuedMessagesStrip from './QueuedMessagesStrip';
+import { AgentLoopDispatchError } from '@/core/agent/agentLoopDispatchError';
 import {
   enqueueUserInput,
   clearInputQueue,
@@ -94,7 +95,7 @@ describe('QueuedMessagesStrip', () => {
     expect(screen.getByText('当前回复已停止，队列已暂停')).toBeInTheDocument();
   });
 
-  it('re-pauses the remaining queue when resume fails during startup', async () => {
+  it('restores the oldest item at the front when resume throws before acceptance', async () => {
     const user = userEvent.setup();
     runAgentLoopDispatchedMock.mockRejectedValueOnce(new Error('startup failed'));
     enqueueUserInput(CONV, '第一条');
@@ -107,6 +108,44 @@ describe('QueuedMessagesStrip', () => {
     await vi.waitFor(() => {
       expect(screen.getByText('当前回复已停止，队列已暂停')).toBeInTheDocument();
     });
-    expect(getQueuedInputs(CONV).map((item) => item.text)).toEqual(['第二条']);
+    expect(getQueuedInputs(CONV).map((item) => item.text)).toEqual(['第一条', '第二条']);
+  });
+
+  it('restores the oldest item at the front when resume is rejected', async () => {
+    const user = userEvent.setup();
+    runAgentLoopDispatchedMock.mockResolvedValueOnce({
+      reason: 'error',
+      error: 'conversation busy',
+      messageTaken: false,
+    });
+    enqueueUserInput(CONV, '第一条');
+    enqueueUserInput(CONV, '第二条');
+    pauseUserInputQueue(CONV);
+    render(<QueuedMessagesStrip conversationId={CONV} />);
+
+    await user.click(screen.getByRole('button', { name: '继续队列' }));
+
+    await vi.waitFor(() => {
+      expect(getQueuedInputs(CONV).map((item) => item.text)).toEqual(['第一条', '第二条']);
+    });
+    expect(screen.getByText('当前回复已停止，队列已暂停')).toBeInTheDocument();
+  });
+
+  it('does not requeue an item after dispatch accepted it and then rejected', async () => {
+    const user = userEvent.setup();
+    runAgentLoopDispatchedMock.mockRejectedValueOnce(
+      new AgentLoopDispatchError(new Error('terminal persistence failed'), true),
+    );
+    enqueueUserInput(CONV, '第一条');
+    enqueueUserInput(CONV, '第二条');
+    pauseUserInputQueue(CONV);
+    render(<QueuedMessagesStrip conversationId={CONV} />);
+
+    await user.click(screen.getByRole('button', { name: '继续队列' }));
+
+    await vi.waitFor(() => {
+      expect(getQueuedInputs(CONV).map((item) => item.text)).toEqual(['第二条']);
+    });
+    expect(screen.getByText('当前回复已停止，队列已暂停')).toBeInTheDocument();
   });
 });

--- a/src/components/chat/QueuedMessagesStrip.tsx
+++ b/src/components/chat/QueuedMessagesStrip.tsx
@@ -7,9 +7,11 @@ import {
   isUserInputQueuePaused,
   pauseUserInputQueue,
   removeQueuedInput,
+  restoreDequeuedUserInput,
   resumeUserInputQueue,
 } from '@/core/agent/userInputQueue';
 import { runAgentLoopDispatched } from '@/core/agent/agentLoopRunner';
+import { AgentLoopDispatchError } from '@/core/agent/agentLoopDispatchError';
 import { useI18n } from '@/i18n';
 import { Button } from '@/components/ui/button';
 
@@ -36,9 +38,19 @@ export default function QueuedMessagesStrip({ conversationId }: { conversationId
     resumeUserInputQueue(conversationId);
     const next = dequeueNextUserInput(conversationId);
     try {
-      if (next) await runAgentLoopDispatched(conversationId, next.text);
-    } catch {
-      pauseUserInputQueue(conversationId);
+      if (next) {
+        const result = await runAgentLoopDispatched(conversationId, next.text);
+        if (result.reason === 'error' && !result.messageTaken) {
+          restoreDequeuedUserInput(conversationId, next);
+        }
+      }
+    } catch (error) {
+      if (
+        next
+        && (!(error instanceof AgentLoopDispatchError) || !error.messageTaken)
+      ) {
+        restoreDequeuedUserInput(conversationId, next);
+      }
     } finally {
       if (getQueuedInputs(conversationId).some((item) => !item.isSystem)) {
         pauseUserInputQueue(conversationId);

--- a/src/components/chat/composerSendResult.ts
+++ b/src/components/chat/composerSendResult.ts
@@ -1,0 +1,8 @@
+import type { AgentLoopDispatchResult } from '@/core/agent/agentLoopRunner';
+
+/** The composer restores only a draft that the dispatcher explicitly rejected. */
+export function shouldRestoreComposerAfterDispatch(
+  result: AgentLoopDispatchResult,
+): boolean {
+  return result.reason === 'error' && result.messageTaken === false;
+}

--- a/src/components/panel/workspace/TabStrip.test.tsx
+++ b/src/components/panel/workspace/TabStrip.test.tsx
@@ -184,10 +184,17 @@ describe('TabStrip pointer interactions', () => {
     expect(Array.from(tablist.querySelectorAll<HTMLElement>('[tabindex="0"]'))).toEqual([summary]);
   });
 
-  it('renders the close control as an adjacent named button', () => {
+  it('keeps every close control visible as an adjacent named button', () => {
     renderTabs();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Close Task Summary' }));
+    const closeButtons = screen.getAllByRole('button', { name: /^Close / });
+    expect(closeButtons).toHaveLength(2);
+    for (const button of closeButtons) {
+      expect(button).not.toHaveClass('opacity-0');
+      expect(button).not.toHaveClass('group-hover:opacity-100');
+    }
+
+    fireEvent.click(closeButtons[0]);
 
     expect(usePreviewStore.getState().tabs.map((tab) => tab.id)).toEqual([TERMINAL_ID]);
   });

--- a/src/components/panel/workspace/TabStrip.test.tsx
+++ b/src/components/panel/workspace/TabStrip.test.tsx
@@ -140,6 +140,16 @@ describe('TabStrip pointer interactions', () => {
     expect(screen.queryByText(/base64/)).not.toBeInTheDocument();
   });
 
+  it('uses the selected-state token for the active tab background', () => {
+    renderTabs();
+
+    const summary = screen.getByRole('tab', { name: /Task Summary/ });
+    const terminal = screen.getByRole('tab', { name: /Terminal/ });
+    expect(terminal.closest('[data-tab-id]')).toHaveClass('bg-[var(--abu-bg-active)]');
+    expect(terminal.closest('[data-tab-id]')).not.toHaveClass('bg-[var(--abu-bg-base)]');
+    expect(summary.closest('[data-tab-id]')).not.toHaveClass('bg-[var(--abu-bg-active)]');
+  });
+
   it('exposes a real tablist with roving tabIndex and aria tabpanel linkage', () => {
     renderTabs();
 

--- a/src/components/panel/workspace/TabStrip.tsx
+++ b/src/components/panel/workspace/TabStrip.tsx
@@ -46,7 +46,7 @@ function tabTitle(tab: WorkspaceTab, t: ReturnType<typeof useI18n>['t']): string
 
 /**
  * Horizontal workspace tab bar (TRAE Solo-style): tab kind icon + title +
- * hover close, active-tab styling, trailing `+` new-tab menu, middle-click
+ * always-visible close, active-tab styling, trailing `+` new-tab menu, middle-click
  * close, and lightweight pointer-based drag-to-reorder (no dnd-kit — mirrors
  * TRAE's `swapOpenedTab(i, j)`). See docs/2026-07-17-workspace-tabs-design.md.
  *
@@ -331,7 +331,7 @@ export default function TabStrip() {
                   e.stopPropagation();
                   closeTab(tab.id, { focusAfterClose: true });
                 }}
-                className="mr-1 shrink-0 rounded p-0.5 opacity-0 group-hover:opacity-100 hover:bg-[var(--abu-bg-pressed)] focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--abu-clay)]"
+                className="mr-1 shrink-0 rounded p-0.5 hover:bg-[var(--abu-bg-pressed)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--abu-clay)]"
                 aria-label={format(t.workspace.closeTabLabel, { title })}
                 title={t.workspace.closeTab}
               >

--- a/src/components/panel/workspace/TabStrip.tsx
+++ b/src/components/panel/workspace/TabStrip.tsx
@@ -278,7 +278,7 @@ export default function TabStrip() {
                 'border-r border-[var(--abu-bg-pressed)] text-minor transition-shadow',
                 draggingId === tab.id && 'cursor-grabbing',
                 active
-                  ? 'bg-[var(--abu-bg-base)] text-[var(--abu-text-primary)]'
+                  ? 'bg-[var(--abu-bg-active)] text-[var(--abu-text-primary)]'
                   : 'text-[var(--abu-text-tertiary)] hover:bg-[var(--abu-bg-hover)]',
                 // The dragged tab lifts off the strip; a drop target gets highlighted.
                 // pointer-events-none lets elementFromPoint "see through" it to the

--- a/src/core/agent/agentLoop.test.ts
+++ b/src/core/agent/agentLoop.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import {
   buildUserMessageContent,
   isInteractiveDesktop,
@@ -12,10 +12,68 @@ import {
   buildDirectDelegateSubagentOptions,
   buildInterruptedToolCallContext,
   resolveToolContextWorkspacePath,
+  runAgentLoop,
 } from './agentLoop';
 import { trimOldScreenshots } from '../context/contextManager';
 import type { Message, ToolDefinition, ToolResultContent } from '../../types';
 import type { ToolInvoker } from './ports/toolInvoker';
+import {
+  getConversationReader,
+  setConversationReader,
+} from './ports/conversationReader';
+import {
+  getAbortRegistry,
+  setAbortRegistry,
+} from './ports/abortRegistry';
+import {
+  clearInputQueue,
+  getQueuedInputs,
+  subscribeToInputQueue,
+} from './userInputQueue';
+
+describe('runAgentLoop live-run queue ownership', () => {
+  const conversationId = 'conv-live-observer-failure';
+  const defaultConversationReader = getConversationReader();
+  const defaultAbortRegistry = getAbortRegistry();
+
+  afterEach(() => {
+    setConversationReader(defaultConversationReader);
+    setAbortRegistry(defaultAbortRegistry);
+    clearInputQueue(conversationId);
+  });
+
+  it('returns enqueued after queue observers throw', async () => {
+    setConversationReader({
+      getConversation: () => ({
+        id: conversationId,
+        title: 'running conversation',
+        status: 'running',
+        messages: [],
+      }) as never,
+      getIndexEntry: () => undefined,
+      getThinkingStartTime: () => null,
+    });
+    setAbortRegistry({
+      hasAbortController: () => true,
+      getAbortController: () => new AbortController(),
+      clearAbortController: () => undefined,
+    });
+    const healthySubscriber = vi.fn();
+    const unsubscribeThrowing = subscribeToInputQueue(() => {
+      throw new Error('broken queue observer');
+    });
+    const unsubscribeHealthy = subscribeToInputQueue(healthySubscriber);
+
+    try {
+      await expect(runAgentLoop(conversationId, 'follow-up')).resolves.toEqual({ reason: 'enqueued' });
+      expect(getQueuedInputs(conversationId).map((item) => item.text)).toEqual(['follow-up']);
+      expect(healthySubscriber).toHaveBeenCalledOnce();
+    } finally {
+      unsubscribeThrowing();
+      unsubscribeHealthy();
+    }
+  });
+});
 
 // escalateMaxOutputTokens / shouldContinueTruncatedToolCalls moved to
 // loopGuards.ts + loopGuards.test.ts (P1-3a-pre): they're pure and shared

--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -529,6 +529,12 @@ export interface AgentLoopOptions {
    * an in-process fallback or a queued continuation with a new controller.
    */
   onAbortControllerReady?: (controller: AbortController) => void;
+  /**
+   * Process-local ownership signal for renderer dispatch. Invoked only after
+   * the initial user message is already present in the transcript (or when a
+   * pre-persisted shell row is handed in). Never serialized to the sidecar.
+   */
+  onMessageTaken?: () => void;
   /** Host-owned, immutable authority ceiling for unattended/background runs. */
   runPermissionCeiling?: import('../permissions/runPermissionCeiling').RunPermissionCeiling;
   /** Shell-only factory; deliberately omitted from every sidecar wire shape. */
@@ -649,12 +655,25 @@ export function buildInterruptedToolCallContext(
   };
 }
 
-export interface AgentLoopResult {
-  reason: AgentLoopExitReason;
+interface AgentLoopResultBase {
   error?: string;
   /** Machine-readable terminal cause when `reason: 'error'` needs caller-specific handling. */
   stopReason?: 'sidecar_unavailable';
 }
+
+/**
+ * A failed loop must say who owns recovery for the user message. Rejected
+ * entry guards leave it with the caller (`false`); once the message is queued
+ * or appended to the transcript, the message ledger owns recovery (`true`).
+ */
+export type AgentLoopResult =
+  | (AgentLoopResultBase & {
+      reason: Exclude<AgentLoopExitReason, 'error'>;
+    })
+  | (AgentLoopResultBase & {
+      reason: 'error';
+      messageTaken: boolean;
+    });
 
 /**
  * Gate for "only run when the user can actually review the result".
@@ -730,6 +749,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
           return {
             reason: 'error',
             error: 'A restricted recovery run cannot join an existing agent loop',
+            messageTaken: false,
           };
         }
         // The message lives in the cancellable queue strip until the current
@@ -743,9 +763,12 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         error: hasImages
           ? getI18n().chat.attachmentDuringRun
           : getI18n().chat.conversationBusy,
+        messageTaken: false,
       };
     }
   }
+
+  if (options?.prePersistedUserMessageId) options.onMessageTaken?.();
 
   // New turn starts clean: drop any stale plan-mode lock from a prior/abandoned plan (see planMode.ts).
   clearPlanMode(conversationId);
@@ -823,6 +846,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         timestamp: Date.now(),
         loopId,
       });
+      options?.onMessageTaken?.();
     }
     chatDelta.addMessage(conversationId, {
       id: generateId(),
@@ -831,7 +855,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       timestamp: Date.now(),
       loopId,
     });
-    return { reason: 'error', error: 'API Key not configured' };
+    return { reason: 'error', error: 'API Key not configured', messageTaken: true };
   }
 
   // Create TaskExecution for this agent loop (after apiKey check to avoid leaking executions)
@@ -913,6 +937,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         timestamp: Date.now(),
         loopId,
       });
+      options?.onMessageTaken?.();
     }
     const detail = error instanceof Error ? error.message : String(error);
     chatDelta.addMessage(conversationId, {
@@ -923,7 +948,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       loopId,
     });
     logger.error('orchestration failed before the loop started', { conversationId, error: detail });
-    return { reason: 'error', error: detail };
+    return { reason: 'error', error: detail, messageTaken: true };
   }
   const { route, systemPromptSections } = orchestration;
   options?.runtimeEvent?.('agent_route_selected', {
@@ -1052,6 +1077,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         description: route.delegateAgent.description,
       } : undefined,
     });
+    options?.onMessageTaken?.();
   }
 
   // Enterprise mode always uses OpenAI-compatible adapter (LiteLLM exposes that interface).
@@ -1079,7 +1105,11 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       });
       chatDelta.setConversationStatus(conversationId, 'idle');
       executionPort.cancelExecution(execution.id);
-      return { reason: 'error', error: `Missing required tools: ${missing.join(', ')}` };
+      return {
+        reason: 'error',
+        error: `Missing required tools: ${missing.join(', ')}`,
+        messageTaken: true,
+      };
     }
   }
 
@@ -1261,7 +1291,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         chatDelta.setAgentStatus(conversationId, 'idle');
         chatDelta.setConversationStatus(conversationId, 'error');
         notifyTaskError(convTitle, conversationId);
-        return { reason: 'error', error: result.text };
+        return { reason: 'error', error: result.text, messageTaken: true };
       }
 
       eventRouter.route({
@@ -1318,7 +1348,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       chatDelta.setConversationStatus(conversationId, 'error');
       const convTitle = getConversationReader().getIndexEntry(conversationId)?.title ?? getI18n().chat.notificationTaskFallback;
       notifyTaskError(convTitle, conversationId);
-      return { reason: 'error', error: errorMessage };
+      return { reason: 'error', error: errorMessage, messageTaken: true };
     }
     return { reason: 'completed' };
   }
@@ -2936,5 +2966,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
   }
   await endComputerUseTaskLease();
   endConversationTrace(conversationId, { output: { reason: exitReason }, error: exitError });
-  return { reason: exitReason, error: exitError };
+  return exitReason === 'error'
+    ? { reason: 'error', error: exitError, messageTaken: true }
+    : { reason: exitReason, error: exitError };
 }

--- a/src/core/agent/agentLoopDispatchError.ts
+++ b/src/core/agent/agentLoopDispatchError.ts
@@ -1,0 +1,26 @@
+/**
+ * A dispatch rejection that can still state who owns the submitted message.
+ *
+ * The runner keeps rejecting persistence/transport exceptions for non-UI
+ * callers, while the renderer can distinguish an exception raised after the
+ * user message entered the transcript from one raised before ownership.
+ */
+export class AgentLoopDispatchError extends Error {
+  readonly messageTaken: boolean;
+
+  constructor(error: unknown, messageTaken: boolean) {
+    super(error instanceof Error ? error.message : String(error), { cause: error });
+    this.name = 'AgentLoopDispatchError';
+    this.messageTaken = messageTaken;
+  }
+}
+
+export function wrapAgentLoopDispatchError(
+  error: unknown,
+  messageTaken: boolean,
+): AgentLoopDispatchError {
+  if (error instanceof AgentLoopDispatchError && error.messageTaken === messageTaken) {
+    return error;
+  }
+  return new AgentLoopDispatchError(error, messageTaken);
+}

--- a/src/core/agent/agentLoopRunner.test.ts
+++ b/src/core/agent/agentLoopRunner.test.ts
@@ -238,6 +238,7 @@ const removeQueuedInputMock = vi.fn();
 const drainSystemQueuedInputsMock = vi.fn().mockReturnValue([]);
 const pauseUserInputQueueMock = vi.fn();
 const dequeueNextUserInputMock = vi.fn().mockReturnValue(undefined);
+const restoreDequeuedUserInputMock = vi.fn();
 let capturedQueueCb: (() => void) | undefined;
 const queueUnsubMock = vi.fn();
 const subscribeToInputQueueMock = vi.fn((cb: () => void) => {
@@ -251,6 +252,7 @@ vi.mock('./userInputQueue', () => ({
   drainSystemQueuedInputs: (...a: unknown[]) => drainSystemQueuedInputsMock(...a),
   pauseUserInputQueue: (...a: unknown[]) => pauseUserInputQueueMock(...a),
   dequeueNextUserInput: (...a: unknown[]) => dequeueNextUserInputMock(...a),
+  restoreDequeuedUserInput: (...a: unknown[]) => restoreDequeuedUserInputMock(...a),
   subscribeToInputQueue: (...a: [() => void]) => subscribeToInputQueueMock(...a),
 }));
 
@@ -633,6 +635,7 @@ describe('agentLoopRunner', () => {
     pauseUserInputQueueMock.mockReset();
     dequeueNextUserInputMock.mockReset();
     dequeueNextUserInputMock.mockReturnValue(undefined);
+    restoreDequeuedUserInputMock.mockReset();
     subscribeToInputQueueMock.mockClear();
     queueUnsubMock.mockReset();
     capturedQueueCb = undefined;
@@ -2752,11 +2755,88 @@ describe('agentLoopRunner', () => {
 
       expect(runAgentLoopMock).toHaveBeenCalledTimes(1);
       expect(runAgentLoopMock).toHaveBeenCalledWith('conv-1', 'hello', {
+        onMessageTaken: expect.any(Function),
         runtimeEvent: expect.any(Function),
         skillCommandApprovalFactory: expect.any(Function),
       });
       expect(sidecarRequestMock).not.toHaveBeenCalled();
       expect(result).toEqual({ reason: 'completed' });
+    });
+
+    it('preserves an in-process ownership rejection instead of marking every error as taken', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      getSidecarStatusMock.mockReturnValue('stopped');
+      runAgentLoopMock.mockResolvedValueOnce({
+        reason: 'error',
+        error: 'conversation became busy during preprocessing',
+        messageTaken: false,
+      });
+
+      const result = await runAgentLoopDispatched('conv-1', 'hello');
+
+      expect(result).toEqual({
+        reason: 'error',
+        error: 'conversation became busy during preprocessing',
+        messageTaken: false,
+      });
+      expect(runAgentLoopMock).toHaveBeenCalledTimes(1);
+      expect(sidecarRequestMock).not.toHaveBeenCalled();
+    });
+
+    it('leaves an in-process exception unwrapped before dispatch ownership is known', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      getSidecarStatusMock.mockReturnValue('stopped');
+      const preAcceptError = new Error('failed before ownership');
+      runAgentLoopMock.mockRejectedValueOnce(preAcceptError);
+
+      await expect(runAgentLoopDispatched('conv-1', 'hello')).rejects.toBe(preAcceptError);
+
+      expect(runAgentLoopMock).toHaveBeenCalledTimes(1);
+      expect(sidecarRequestMock).not.toHaveBeenCalled();
+    });
+
+    it('wraps an in-process exception after runAgentLoop accepts the message', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      getSidecarStatusMock.mockReturnValue('stopped');
+      runAgentLoopMock.mockImplementationOnce(async (
+        _conversationId,
+        _message,
+        options: { onMessageTaken?: () => void },
+      ) => {
+        options.onMessageTaken?.();
+        throw new Error('agent hook failed after addMessage');
+      });
+
+      await expect(runAgentLoopDispatched('conv-1', 'hello')).rejects.toMatchObject({
+        name: 'AgentLoopDispatchError',
+        message: 'agent hook failed after addMessage',
+        messageTaken: true,
+      });
+
+      expect(sidecarRequestMock).not.toHaveBeenCalled();
+    });
+
+    it('records internal ownership before an external acceptance callback can throw', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      getSidecarStatusMock.mockReturnValue('stopped');
+      runAgentLoopMock.mockImplementationOnce(async (
+        _conversationId,
+        _message,
+        options: { onMessageTaken?: () => void },
+      ) => {
+        options.onMessageTaken?.();
+        return { reason: 'completed' };
+      });
+
+      await expect(runAgentLoopDispatched('conv-1', 'hello', {
+        onMessageTaken: () => { throw new Error('acceptance observer failed'); },
+      })).rejects.toMatchObject({
+        name: 'AgentLoopDispatchError',
+        message: 'acceptance observer failed',
+        messageTaken: true,
+      });
+
+      expect(sidecarRequestMock).not.toHaveBeenCalled();
     });
 
     it('dispatches agent.run when the sidecar is running and returns the sidecar result', async () => {
@@ -2846,6 +2926,101 @@ describe('agentLoopRunner', () => {
           expect.objectContaining({ content: 'second follow-up', loopId: payloads[2].runId }),
         ]),
       );
+    });
+
+    it('does not let a queued pre-accept rejection restore the original accepted send', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      getSidecarStatusMock
+        .mockReturnValueOnce('running')
+        .mockReturnValueOnce('stopped');
+      sidecarRequestMock.mockResolvedValueOnce({ reason: 'completed' });
+      runAgentLoopMock.mockRejectedValueOnce(new Error('queued run failed before ownership'));
+      dequeueNextUserInputMock
+        .mockReturnValueOnce({ id: 'q1', text: 'queued follow-up', timestamp: 1 })
+        .mockReturnValueOnce(undefined);
+
+      await expect(runAgentLoopDispatched('conv-1', 'original')).rejects.toMatchObject({
+        name: 'AgentLoopDispatchError',
+        message: 'queued run failed before ownership',
+        messageTaken: true,
+      });
+
+      expect(sidecarRequestMock).toHaveBeenCalledTimes(1);
+      expect(runAgentLoopMock).toHaveBeenCalledTimes(1);
+      expect(restoreDequeuedUserInputMock).toHaveBeenCalledWith(
+        'conv-1',
+        { id: 'q1', text: 'queued follow-up', timestamp: 1 },
+      );
+    });
+
+    it('requeues a handed-off item when dispatch resolves without accepting it', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      getSidecarStatusMock
+        .mockReturnValueOnce('running')
+        .mockReturnValueOnce('stopped');
+      sidecarRequestMock.mockResolvedValueOnce({ reason: 'completed' });
+      runAgentLoopMock.mockResolvedValueOnce({
+        reason: 'error',
+        error: 'conversation became busy',
+        messageTaken: false,
+      });
+      dequeueNextUserInputMock
+        .mockReturnValueOnce({ id: 'q1', text: 'queued follow-up', timestamp: 1 })
+        .mockReturnValueOnce(undefined);
+
+      await expect(runAgentLoopDispatched('conv-1', 'original')).resolves.toEqual({
+        reason: 'completed',
+      });
+
+      expect(restoreDequeuedUserInputMock).toHaveBeenCalledWith(
+        'conv-1',
+        { id: 'q1', text: 'queued follow-up', timestamp: 1 },
+      );
+    });
+
+    it('does not requeue a taken handoff and pauses the remaining queue after rejection', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      getSidecarStatusMock
+        .mockReturnValueOnce('running')
+        .mockReturnValueOnce('stopped');
+      sidecarRequestMock.mockResolvedValueOnce({ reason: 'completed' });
+      runAgentLoopMock.mockImplementationOnce(async (
+        _conversationId,
+        _message,
+        options: { onMessageTaken?: () => void },
+      ) => {
+        options.onMessageTaken?.();
+        throw new Error('local terminal persistence failed');
+      });
+      dequeueNextUserInputMock
+        .mockReturnValueOnce({ id: 'q1', text: 'queued follow-up', timestamp: 1 })
+        .mockReturnValueOnce(undefined);
+      getQueuedInputsMock.mockReturnValue([
+        { id: 'q2', text: 'remaining follow-up', timestamp: 2 },
+      ]);
+
+      await expect(runAgentLoopDispatched('conv-1', 'original')).rejects.toMatchObject({
+        name: 'AgentLoopDispatchError',
+        message: 'local terminal persistence failed',
+        messageTaken: true,
+      });
+
+      expect(restoreDequeuedUserInputMock).not.toHaveBeenCalled();
+      expect(pauseUserInputQueueMock).toHaveBeenCalledWith('conv-1');
+    });
+
+    it('does not claim ownership when post-result queue inspection fails after an entry rejection', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      getSidecarStatusMock.mockReturnValue('stopped');
+      runAgentLoopMock.mockResolvedValueOnce({
+        reason: 'error',
+        error: 'conversation busy',
+        messageTaken: false,
+      });
+      const queueError = new Error('queue snapshot failed');
+      getQueuedInputsMock.mockImplementationOnce(() => { throw queueError; });
+
+      await expect(runAgentLoopDispatched('conv-1', 'original')).rejects.toBe(queueError);
     });
 
     it('does not let a desktop queued follow-up inherit the unattended run authority owner', async () => {
@@ -2976,6 +3151,7 @@ describe('agentLoopRunner', () => {
       await expect(runAgentLoopDispatched('conv-1', 'hello')).resolves.toEqual({
         reason: 'error',
         error: '消息未能写入磁盘，阿布没有启动任务。请检查磁盘权限后重试。',
+        messageTaken: true,
       });
 
       expect(agentStartRequestMock).not.toHaveBeenCalled();
@@ -3077,6 +3253,7 @@ describe('agentLoopRunner', () => {
         reason: 'error',
         error: 'Sidecar run state remained unavailable during reattach',
         stopReason: 'sidecar_unavailable',
+        messageTaken: true,
       });
       expect(agentStartRequestMock).toHaveBeenCalledTimes(1);
       expect(runAgentLoopMock).not.toHaveBeenCalled();
@@ -3220,7 +3397,11 @@ describe('agentLoopRunner', () => {
       terminalHandler(failed);
       terminalHandler(failed);
 
-      await expect(running).resolves.toEqual({ reason: 'error', error: 'provider failed' });
+      await expect(running).resolves.toEqual({
+        reason: 'error',
+        error: 'provider failed',
+        messageTaken: true,
+      });
       expect(runAgentLoopMock).not.toHaveBeenCalled();
       expect(chatDeltaAppendTextMock).toHaveBeenCalledTimes(1);
       expect(chatDeltaAppendTextMock).toHaveBeenCalledWith('conv-1', expect.stringContaining('provider failed'));
@@ -3248,7 +3429,11 @@ describe('agentLoopRunner', () => {
         failure: { errorType: 'agent_loop_error', message: '余额不足或无可用资源包，请充值。' },
       });
 
-      await expect(running).resolves.toEqual({ reason: 'error', error: '余额不足或无可用资源包，请充值。' });
+      await expect(running).resolves.toEqual({
+        reason: 'error',
+        error: '余额不足或无可用资源包，请充值。',
+        messageTaken: true,
+      });
       expect(runAgentLoopMock).not.toHaveBeenCalled();
       // agentLoop's own catch branch already appended the display error inside
       // the sidecar — the shell must not render it a second time.
@@ -3286,7 +3471,11 @@ describe('agentLoopRunner', () => {
       await vi.waitFor(() => expect(waitForConversationPersistenceMock).toHaveBeenCalledTimes(4));
       expect(settled).toBe(false);
       failurePersistence.resolve();
-      await expect(running).resolves.toEqual({ reason: 'error', error: 'provider failed' });
+      await expect(running).resolves.toEqual({
+        reason: 'error',
+        error: 'provider failed',
+        messageTaken: true,
+      });
     });
 
     it('records a stall after 30 seconds without a non-empty delta, without changing run behavior', async () => {
@@ -4013,7 +4202,7 @@ describe('agentLoopRunner', () => {
       expect(result.error).toContain('sidecar crashed after local write');
     });
 
-    it('a post-commit failure finalizes the conversation UI so it never hangs on "thinking"', async () => {
+    it('keeps a post-commit failure on the accepted message as a retryable failed run', async () => {
       const { runAgentLoopDispatched } = await importFresh();
       const d = deferred<unknown>();
       sidecarRequestMock.mockReturnValue(d.promise);
@@ -4026,17 +4215,28 @@ describe('agentLoopRunner', () => {
       deltaHandler({ runId, frames: [{ p: 'chat', m: 'appendText', a: ['conv-1', 'thinking…'] }] }); // marks committed → "thinking" shown
 
       d.reject(new Error('sidecar crashed mid-run'));
-      await p;
+      const result = await p;
 
-      // The sidecar's own terminal frames never arrived — the shell must
-      // finalize the UI itself (mirrors the in-process error path), else the
-      // conversation hangs streaming forever.
+      expect(result).toEqual({
+        reason: 'error',
+        error: 'sidecar crashed mid-run',
+        messageTaken: true,
+      });
+      expect(chatStoreAddMessageMock).toHaveBeenCalledWith('conv-1', expect.objectContaining({
+        role: 'user',
+        content: 'hello',
+      }));
+      expect(chatStoreUpdateUserMessageRunMock).toHaveBeenCalledWith(
+        'conv-1',
+        expect.any(String),
+        expect.objectContaining({ state: 'failed' }),
+      );
       expect(chatDeltaFinishStreamingMock).toHaveBeenCalledWith('conv-1');
       expect(chatDeltaSetConversationStatusMock).toHaveBeenCalledWith('conv-1', 'error');
       expect(chatDeltaSetAgentStatusMock).toHaveBeenCalledWith('conv-1', 'idle');
     });
 
-    it('rejects a post-commit failure result when its terminal state cannot be persisted', async () => {
+    it('rejects a post-commit persistence failure with accepted-message ownership', async () => {
       const { runAgentLoopDispatched } = await importFresh();
       const d = deferred<unknown>();
       waitForConversationPersistenceMock.mockImplementation(() => (
@@ -4055,7 +4255,12 @@ describe('agentLoopRunner', () => {
       });
       d.reject(new Error('sidecar crashed mid-run'));
 
-      await expect(running).rejects.toThrow('disk unavailable');
+      await expect(running).rejects.toMatchObject({
+        name: 'AgentLoopDispatchError',
+        message: 'disk unavailable',
+        messageTaken: true,
+        cause: expect.objectContaining({ message: 'disk unavailable' }),
+      });
       expect(runAgentLoopMock).not.toHaveBeenCalled();
       expect(chatDeltaSetConversationStatusMock).toHaveBeenCalledWith('conv-1', 'error');
     });
@@ -4074,7 +4279,11 @@ describe('agentLoopRunner', () => {
       d.reject(new Error('Sidecar process closed'));
       const result = await p;
 
-      expect(result).toEqual({ reason: 'error', error: 'Sidecar process closed' });
+      expect(result).toEqual({
+        reason: 'error',
+        error: 'Sidecar process closed',
+        messageTaken: true,
+      });
       expect(chatDeltaAppendTextMock).toHaveBeenCalledWith(
         'conv-1',
         expect.stringContaining('后台服务意外中断，正在自动恢复'),
@@ -4138,6 +4347,31 @@ describe('agentLoopRunner', () => {
       expect(result).toEqual({ reason: 'completed' });
     });
 
+    it('preserves ownership when a pre-persisted in-process fallback rejects', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      resolveEffectiveLlmCredsMock.mockImplementation(() => {
+        throw new Error('EnterpriseLlmUnavailableError');
+      });
+      runAgentLoopMock.mockRejectedValueOnce(new Error('local provider failed'));
+
+      await expect(runAgentLoopDispatched('conv-1', 'hello')).rejects.toMatchObject({
+        name: 'AgentLoopDispatchError',
+        message: 'local provider failed',
+        messageTaken: true,
+      });
+
+      expect(runAgentLoopMock).toHaveBeenCalledWith(
+        'conv-1',
+        'hello',
+        expect.objectContaining({ prePersistedUserMessageId: expect.any(String) }),
+      );
+      expect(chatStoreUpdateUserMessageRunMock).toHaveBeenCalledWith(
+        'conv-1',
+        expect.any(String),
+        expect.objectContaining({ state: 'failed', error: 'local provider failed' }),
+      );
+    });
+
     it('upgrades the durable raw message to multimodal content before an early in-process fallback', async () => {
       const { runAgentLoopDispatched } = await importFresh();
       getConversationMock.mockReturnValue({
@@ -4182,6 +4416,50 @@ describe('agentLoopRunner', () => {
       expect(sidecarRequestMock).not.toHaveBeenCalled();
     });
 
+    it('preserves ownership when the multimodal fallback upgrade cannot persist', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      chatStoreAddMessageMock.mockImplementation((_convId, message) => {
+        getConversationMock.mockReturnValue({
+          id: 'conv-1',
+          title: 't',
+          status: 'running',
+          messages: [message],
+        });
+      });
+      buildUserMessageContentMock.mockResolvedValue([
+        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'x' } },
+      ]);
+      resolveEffectiveLlmCredsMock.mockImplementation(() => {
+        throw new Error('EnterpriseLlmUnavailableError');
+      });
+      waitForConversationPersistenceMock
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('multimodal update not durable'));
+
+      await expect(runAgentLoopDispatched('conv-1', 'look', {
+        images: [{ id: 'i1', data: 'x', mediaType: 'image/png' }],
+      })).rejects.toMatchObject({
+        name: 'AgentLoopDispatchError',
+        message: 'multimodal update not durable',
+        messageTaken: true,
+      });
+
+      expect(chatStoreUpdateUserMessageRunMock).toHaveBeenCalledWith(
+        'conv-1',
+        expect.any(String),
+        expect.objectContaining({ content: expect.any(Array) }),
+      );
+      expect(chatStoreUpdateUserMessageRunMock).toHaveBeenCalledWith(
+        'conv-1',
+        expect.any(String),
+        expect.objectContaining({
+          state: 'failed',
+          error: 'multimodal update not durable',
+        }),
+      );
+      expect(runAgentLoopMock).not.toHaveBeenCalled();
+    });
+
     it('a malformed agent.run response is treated as a failure (pre-commit → falls back in-process)', async () => {
       const { runAgentLoopDispatched } = await importFresh();
       sidecarRequestMock.mockResolvedValue({ notReason: 'oops' });
@@ -4206,6 +4484,7 @@ describe('agentLoopRunner', () => {
         expect(result).toEqual({
           reason: 'error',
           error: '请等待当前任务结束后再发送图片，草稿已为你保留。',
+          messageTaken: false,
         });
         expect(runAgentLoopMock).not.toHaveBeenCalled();
         expect(sidecarRequestMock).not.toHaveBeenCalled();
@@ -4223,6 +4502,7 @@ describe('agentLoopRunner', () => {
         expect(result).toEqual({
           reason: 'error',
           error: '当前会话已有任务在运行，请等待结束后再启动新任务。',
+          messageTaken: false,
         });
         expect(runAgentLoopMock).not.toHaveBeenCalled();
         expect(sidecarRequestMock).not.toHaveBeenCalled();
@@ -4289,6 +4569,7 @@ describe('agentLoopRunner', () => {
         expect(result).toEqual({
           reason: 'error',
           error: 'A restricted recovery run cannot join an existing agent loop',
+          messageTaken: false,
         });
         expect(notifySidecar).not.toHaveBeenCalledWith('agent.enqueueInput', expect.anything());
         expect(sidecarRequestMock).not.toHaveBeenCalled();
@@ -4320,6 +4601,7 @@ describe('agentLoopRunner', () => {
         expect(result).toEqual({
           reason: 'error',
           error: 'A restricted recovery run cannot join an existing agent loop',
+          messageTaken: false,
         });
         expect(enqueueUserInputMock).not.toHaveBeenCalled();
         expect(sidecarRequestMock).not.toHaveBeenCalled();
@@ -4376,6 +4658,7 @@ describe('agentLoopRunner', () => {
         expect(result).toEqual({
           reason: 'error',
           error: '请等待当前任务结束后再发送图片，草稿已为你保留。',
+          messageTaken: false,
         });
       });
 
@@ -4392,6 +4675,7 @@ describe('agentLoopRunner', () => {
         expect(result).toEqual({
           reason: 'error',
           error: '当前会话已有任务在运行，请等待结束后再启动新任务。',
+          messageTaken: false,
         });
       });
     });

--- a/src/core/agent/agentLoopRunner.ts
+++ b/src/core/agent/agentLoopRunner.ts
@@ -108,6 +108,7 @@ import {
   getQueuedInputs,
   pauseUserInputQueue,
   removeQueuedInput,
+  restoreDequeuedUserInput,
   subscribeToInputQueue,
 } from './userInputQueue';
 import { registerSidecarRunPredicate } from './sidecarRunPredicate';
@@ -127,6 +128,7 @@ import {
 } from '../observability/runtimeTrace';
 import { getElectronSidecarRunFact } from '../../utils/electronHost';
 import { attachTrustedSkillCommandApproval } from './skillCommandApproval';
+import { AgentLoopDispatchError, wrapAgentLoopDispatchError } from './agentLoopDispatchError';
 import {
   createRunResourceSettlement,
   getRunResourceSettlement,
@@ -135,6 +137,20 @@ import {
   __resetRunResourceSettlementsForTests,
   type RunResourceSettlement,
 } from './runResourceSettlement';
+
+/**
+ * Renderer dispatch result with an explicit ownership answer for failed sends.
+ * `false` means the composer still owns the draft because the dispatch was
+ * rejected; `true` means the message already lives in the queue/transcript and
+ * its failed bubble is now the sole recovery path.
+ */
+export type AgentLoopDispatchResult = AgentLoopResult;
+
+function markReturnedErrorAsTaken(result: AgentLoopResult): AgentLoopDispatchResult {
+  return result.reason === 'error'
+    ? { ...result, messageTaken: true }
+    : result;
+}
 
 const logger = createLogger('agent-loop-runner');
 const AGENT_ABORT_ACK_TIMEOUT_MS = 1_000;
@@ -153,9 +169,18 @@ class SidecarRunStateUnavailableError extends Error {
   }
 }
 
-function rendererRuntimeOptions(options?: AgentLoopOptions): AgentLoopOptions {
+function rendererRuntimeOptions(
+  options?: AgentLoopOptions,
+  onMessageTaken?: () => void,
+): AgentLoopOptions {
   return {
     ...options,
+    onMessageTaken: onMessageTaken || options?.onMessageTaken
+      ? () => {
+          onMessageTaken?.();
+          options?.onMessageTaken?.();
+        }
+      : undefined,
     // This function never crosses the wire. Rebuild it for every in-process
     // fallback so skill directives use the same registry/policy chain as a
     // normal tool call.
@@ -570,24 +595,27 @@ async function runInProcessWithPersistedMessage(
   runId: string,
   clientMessageId: string,
   options?: AgentLoopOptions,
-): Promise<AgentLoopResult> {
-  // Params preparation can fail before it upgrades the durable raw message
-  // to multimodal content. Do that here before the in-process handoff so a
-  // pre-dispatch failure never drops an attached image merely because the
-  // local loop is told not to append a duplicate user row.
-  const persistedMessage = getConversationReader()
-    .getConversation(conversationId)
-    ?.messages.find((message) => message.id === clientMessageId);
-  if (options?.images?.length && typeof persistedMessage?.content === 'string') {
-    const content = await buildUserMessageContent(conversationId, userMessage, options.images);
-    useChatStore.getState().updateUserMessageRun(conversationId, clientMessageId, {
-      state: 'pending',
-      content,
-    });
-    await waitForConversationPersistence(conversationId);
-  }
-  useChatStore.getState().updateUserMessageRun(conversationId, clientMessageId, { state: 'running' });
+): Promise<AgentLoopDispatchResult> {
   try {
+    // Params preparation can fail before it upgrades the durable raw message
+    // to multimodal content. Do that here before the in-process handoff so a
+    // pre-dispatch failure never drops an attached image merely because the
+    // local loop is told not to append a duplicate user row. This belongs
+    // inside the same failure finalization as the local loop: once the shell
+    // has appended the row, every thrown preparation/persistence step must
+    // leave it retryable instead of stranded at `pending`.
+    const persistedMessage = getConversationReader()
+      .getConversation(conversationId)
+      ?.messages.find((message) => message.id === clientMessageId);
+    if (options?.images?.length && typeof persistedMessage?.content === 'string') {
+      const content = await buildUserMessageContent(conversationId, userMessage, options.images);
+      useChatStore.getState().updateUserMessageRun(conversationId, clientMessageId, {
+        state: 'pending',
+        content,
+      });
+      await waitForConversationPersistence(conversationId);
+    }
+    useChatStore.getState().updateUserMessageRun(conversationId, clientMessageId, { state: 'running' });
     const result = await runAgentLoop(conversationId, userMessage, rendererRuntimeOptions({
       ...options,
       loopId: runId,
@@ -603,7 +631,7 @@ async function runInProcessWithPersistedMessage(
       ...(result.error ? { error: result.error } : {}),
     });
     await waitForConversationPersistence(conversationId);
-    return result;
+    return markReturnedErrorAsTaken(result);
   } catch (error) {
     useChatStore.getState().updateUserMessageRun(conversationId, clientMessageId, {
       state: 'failed',
@@ -620,7 +648,7 @@ async function finalizePreDispatchInterruptedRun(
   runId: string,
   stage: 'params_build_aborted' | 'before_dispatch',
   runtimeStartedAt: number,
-): Promise<AgentLoopResult> {
+): Promise<AgentLoopDispatchResult> {
   useChatStore.getState().updateUserMessageRun(conversationId, clientMessageId, {
     state: 'interrupted',
   });
@@ -2422,11 +2450,12 @@ async function buildAgentRunParams(
  * `EnterpriseLlmUnavailableError`, or a missing conversation record) is
  * ALSO pre-commit by construction — same in-process fallback.
  */
-async function runSingleAgentLoopDispatched(
+async function runSingleAgentLoopDispatchedWithOwnership(
   conversationId: string,
   userMessage: string,
+  ownership: { messageTaken: boolean },
   options?: AgentLoopOptions,
-): Promise<AgentLoopResult> {
+): Promise<AgentLoopDispatchResult> {
   const sidecarRunning = getSidecarStatus() === 'running';
 
   // ── Concurrency guard — see doc above for the two-venue rationale. This
@@ -2443,13 +2472,14 @@ async function runSingleAgentLoopDispatched(
     if (runningSession?.runId) {
       const interactive = isInteractiveDesktop(options, runningConv);
       if (!interactive || hasImages || !stageable) {
-        return { reason: 'error', error: getBusyError() };
+        return { reason: 'error', error: getBusyError(), messageTaken: false };
       }
       if (stageable) {
         if (options?.requireNewRun) {
           return {
             reason: 'error',
             error: 'A restricted recovery run cannot join an existing agent loop',
+            messageTaken: false,
           };
         }
         enqueueUserInput(conversationId, userMessage);
@@ -2459,13 +2489,14 @@ async function runSingleAgentLoopDispatched(
     if (runningConv?.status === 'running' && getAbortRegistry().hasAbortController(conversationId)) {
       const interactive = isInteractiveDesktop(options, runningConv);
       if (!interactive || hasImages || !stageable) {
-        return { reason: 'error', error: getBusyError() };
+        return { reason: 'error', error: getBusyError(), messageTaken: false };
       }
       if (stageable) {
         if (options?.requireNewRun) {
           return {
             reason: 'error',
             error: 'A restricted recovery run cannot join an existing agent loop',
+            messageTaken: false,
           };
         }
         // A live IN-PROCESS run for this conversation — stage into ITS
@@ -2479,7 +2510,11 @@ async function runSingleAgentLoopDispatched(
 
   if (!sidecarRunning) {
     await ensureBuiltinBrowserRuntime();
-    return runAgentLoop(conversationId, userMessage, rendererRuntimeOptions(options));
+    return runAgentLoop(
+      conversationId,
+      userMessage,
+      rendererRuntimeOptions(options, () => { ownership.messageTaken = true; }),
+    );
   }
 
   ensureHandlersRegistered();
@@ -2505,6 +2540,7 @@ async function runSingleAgentLoopDispatched(
     timestamp: runtimeStartedAt,
     loopId: runId,
   });
+  ownership.messageTaken = true;
   shellChatDelta.setConversationStatus(conversationId, 'running');
   try {
     await waitForConversationPersistence(conversationId);
@@ -2529,7 +2565,7 @@ async function runSingleAgentLoopDispatched(
     // Let the failed lifecycle replacement attempt settle in the background;
     // execution remains fenced regardless of whether the disk is still down.
     void waitForConversationPersistence(conversationId).catch(() => undefined);
-    return { reason: 'error', error: displayMessage };
+    return { reason: 'error', error: displayMessage, messageTaken: true };
   }
   markRuntimeRunStage(runId, 'local_message_persisted');
   traceRuntimeEvent('renderer.local_message_persisted', {
@@ -2710,7 +2746,7 @@ async function runSingleAgentLoopDispatched(
   let handedOffToLocal = false;
   const scopedRun = options?.authorizationScopeId !== undefined;
 
-  const settleFromTerminal = async (terminal: AgentRunTerminal): Promise<AgentLoopResult> => {
+  const settleFromTerminal = async (terminal: AgentRunTerminal): Promise<AgentLoopDispatchResult> => {
     await settleRunPersistence(session);
     if (session.abortRequested) {
       await finalizeAbortedRun(session, 'run-terminal');
@@ -2752,7 +2788,7 @@ async function runSingleAgentLoopDispatched(
       // only chance to surface the failure.
       const alreadyRenderedBySidecar = terminal.failure?.errorType === 'agent_loop_error';
       await finalizeFailedRun(session, displayMessage, 'failed', alreadyRenderedBySidecar);
-      return { reason: 'error', error: realMessage };
+      return { reason: 'error', error: realMessage, messageTaken: true };
     }
 
     const eventName = terminal.state === 'interrupted'
@@ -2773,7 +2809,7 @@ async function runSingleAgentLoopDispatched(
       terminal.state === 'interrupted' ? 'interrupted' : 'completed',
     );
     await waitForConversationPersistence(conversationId);
-    return terminal.result;
+    return markReturnedErrorAsTaken(terminal.result);
   };
 
   try {
@@ -2840,7 +2876,7 @@ async function runSingleAgentLoopDispatched(
       raw.error,
     );
     await waitForConversationPersistence(conversationId);
-    return raw;
+    return markReturnedErrorAsTaken(raw);
   } catch (err) {
     let transportError = err;
     let acceptedExecutionStateUnknown = false;
@@ -2946,7 +2982,7 @@ async function runSingleAgentLoopDispatched(
             replayOutcome.raw.error,
           );
           await waitForConversationPersistence(conversationId);
-          return replayOutcome.raw;
+          return markReturnedErrorAsTaken(replayOutcome.raw);
         } catch (replayError) {
           transportError = replayError;
         }
@@ -3042,6 +3078,7 @@ async function runSingleAgentLoopDispatched(
     return {
       reason: 'error',
       error: realMessage,
+      messageTaken: true,
       ...(transportError instanceof SidecarRunStateUnavailableError
         ? { stopReason: transportError.stopReason }
         : {}),
@@ -3119,6 +3156,25 @@ async function runSingleAgentLoopDispatched(
   }
 }
 
+async function runSingleAgentLoopDispatched(
+  conversationId: string,
+  userMessage: string,
+  options?: AgentLoopOptions,
+): Promise<AgentLoopDispatchResult> {
+  const ownership = { messageTaken: false };
+  try {
+    return await runSingleAgentLoopDispatchedWithOwnership(
+      conversationId,
+      userMessage,
+      ownership,
+      options,
+    );
+  } catch (error) {
+    if (!ownership.messageTaken) throw error;
+    throw wrapAgentLoopDispatchError(error, true);
+  }
+}
+
 /**
  * Dispatch one user turn, then hand staged user follow-ups off one-by-one after
  * each completed run. Each follow-up re-enters the full dispatcher and therefore
@@ -3132,38 +3188,66 @@ export async function runAgentLoopDispatched(
   conversationId: string,
   userMessage: string,
   options?: AgentLoopOptions,
-): Promise<AgentLoopResult> {
+): Promise<AgentLoopDispatchResult> {
   const initialResult = await runSingleAgentLoopDispatched(conversationId, userMessage, options);
+  const initialMessageTaken = initialResult.reason !== 'error' || initialResult.messageTaken;
   let previousResult = initialResult;
+  let queuedInputInFlight: ReturnType<typeof dequeueNextUserInput>;
 
-  while (
-    previousResult.reason === 'completed'
-    || previousResult.reason === 'max_turns'
-    || previousResult.reason === 'no_progress'
-  ) {
-    const queuedInput = dequeueNextUserInput(conversationId);
-    if (!queuedInput) break;
-    previousResult = await runSingleAgentLoopDispatched(
-      conversationId,
-      queuedInput.text,
-      // User queue entries are authored by the desktop composer (or by the
-      // two concurrency guards, which only admit interactive desktop sends).
-      // They are not owned by the run that happened to be active when they
-      // were staged. Reusing that old run's callbacks/scope/ceiling/IM target
-      // would either elevate the desktop message into an unattended full run
-      // or incorrectly retain a lower ceiling. System-authored wake-ups never
-      // reach this dequeue path (`dequeueNextUserInput` skips them).
-      undefined,
-    );
-  }
+  try {
+    while (
+      previousResult.reason === 'completed'
+      || previousResult.reason === 'max_turns'
+      || previousResult.reason === 'no_progress'
+    ) {
+      const queuedInput = dequeueNextUserInput(conversationId);
+      if (!queuedInput) break;
+      queuedInputInFlight = queuedInput;
+      const handoffResult = await runSingleAgentLoopDispatched(
+        conversationId,
+        queuedInput.text,
+        // User queue entries are authored by the desktop composer (or by the
+        // two concurrency guards, which only admit interactive desktop sends).
+        // They are not owned by the run that happened to be active when they
+        // were staged. Reusing that old run's callbacks/scope/ceiling/IM target
+        // would either elevate the desktop message into an unattended full run
+        // or incorrectly retain a lower ceiling. System-authored wake-ups never
+        // reach this dequeue path (`dequeueNextUserInput` skips them).
+        undefined,
+      );
+      if (handoffResult.reason === 'error' && !handoffResult.messageTaken) {
+        restoreDequeuedUserInput(conversationId, queuedInput);
+        queuedInputInFlight = undefined;
+        previousResult = handoffResult;
+        break;
+      }
+      queuedInputInFlight = undefined;
+      previousResult = handoffResult;
+    }
 
-  if (
-    (previousResult.reason === 'aborted'
-      || previousResult.reason === 'error'
-      || previousResult.reason === 'awaiting_user')
-    && getQueuedInputs(conversationId).some((queued) => !queued.isSystem)
-  ) {
-    pauseUserInputQueue(conversationId);
+    if (
+      (previousResult.reason === 'aborted'
+        || previousResult.reason === 'error'
+        || previousResult.reason === 'awaiting_user')
+      && getQueuedInputs(conversationId).some((queued) => !queued.isSystem)
+    ) {
+      pauseUserInputQueue(conversationId);
+    }
+  } catch (error) {
+    if (queuedInputInFlight) {
+      if (!(error instanceof AgentLoopDispatchError) || !error.messageTaken) {
+        restoreDequeuedUserInput(conversationId, queuedInputInFlight);
+      }
+      // A taken q1 owns a failed bubble; an untaken q1 was restored above.
+      // In both cases, any remaining q2+ must stop auto-handoff and expose the
+      // queue strip's explicit Resume control.
+      pauseUserInputQueue(conversationId);
+    }
+    if (!initialMessageTaken) throw error;
+    // This promise still belongs to the original turn. Once that turn is
+    // accepted, a later queue-handoff/bookkeeping rejection must not make
+    // ChatInput restore (and potentially resend) its original draft.
+    throw wrapAgentLoopDispatchError(error, true);
   }
 
   return initialResult;

--- a/src/core/agent/userInputQueue.test.ts
+++ b/src/core/agent/userInputQueue.test.ts
@@ -3,7 +3,7 @@
  * cancellable staging area until the current task finishes; system wake-ups
  * may be consumed inside the current loop.
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   enqueueUserInput,
   enqueueUserInputWithId,
@@ -16,7 +16,9 @@ import {
   isUserInputQueuePaused,
   pauseUserInputQueue,
   removeQueuedInput,
+  restoreDequeuedUserInput,
   resumeUserInputQueue,
+  subscribeToInputQueue,
 } from './userInputQueue';
 
 const CONV = 'conv-queue-test';
@@ -90,6 +92,98 @@ describe('userInputQueue staging', () => {
     expect(isUserInputQueuePaused(CONV)).toBe(false);
     expect(dequeueNextUserInput(CONV)?.id).toBe('user-1');
     expect(dequeueNextUserInput(CONV)?.id).toBe('user-2');
+  });
+
+  it('atomically restores a failed handoff at the front and pauses the queue', () => {
+    enqueueUserInputWithId(CONV, 'user-1', 'first user');
+    enqueueUserInputWithId(CONV, 'user-2', 'second user');
+    const first = dequeueNextUserInput(CONV)!;
+    const observedPausedStates: boolean[] = [];
+    const unsubscribe = subscribeToInputQueue(() => {
+      observedPausedStates.push(isUserInputQueuePaused(CONV));
+    });
+
+    restoreDequeuedUserInput(CONV, first);
+    unsubscribe();
+
+    expect(getQueuedInputs(CONV).map((item) => item.id)).toEqual(['user-1', 'user-2']);
+    expect(getQueuedInputs(CONV)[0]).toEqual(first);
+    expect(isUserInputQueuePaused(CONV)).toBe(true);
+    expect(observedPausedStates).toEqual([true]);
+    expect(dequeueNextUserInput(CONV)).toBeUndefined();
+
+    resumeUserInputQueue(CONV);
+    expect(dequeueNextUserInput(CONV)?.id).toBe('user-1');
+    expect(dequeueNextUserInput(CONV)?.id).toBe('user-2');
+  });
+
+  it('deduplicates a repeated restore of the same dequeued item', () => {
+    enqueueUserInputWithId(CONV, 'user-1', 'first user');
+    enqueueUserInputWithId(CONV, 'user-2', 'second user');
+    const first = dequeueNextUserInput(CONV)!;
+
+    restoreDequeuedUserInput(CONV, first);
+    restoreDequeuedUserInput(CONV, first);
+
+    expect(getQueuedInputs(CONV).map((item) => item.id)).toEqual(['user-1', 'user-2']);
+    expect(getQueuedInputs(CONV).filter((item) => item.id === 'user-1')).toHaveLength(1);
+  });
+
+  it('keeps an enqueued message accepted when one subscriber throws', () => {
+    const healthySubscriber = vi.fn();
+    const unsubscribeThrowing = subscribeToInputQueue(() => {
+      throw new Error('broken queue observer');
+    });
+    const unsubscribeHealthy = subscribeToInputQueue(healthySubscriber);
+
+    try {
+      expect(() => enqueueUserInput(CONV, 'accepted follow-up')).not.toThrow();
+      expect(getQueuedInputs(CONV).map((item) => item.text)).toEqual(['accepted follow-up']);
+      expect(healthySubscriber).toHaveBeenCalledOnce();
+    } finally {
+      unsubscribeThrowing();
+      unsubscribeHealthy();
+    }
+  });
+
+  it('returns a dequeued message even when one subscriber throws', () => {
+    enqueueUserInputWithId(CONV, 'user-1', 'first user');
+    enqueueUserInputWithId(CONV, 'user-2', 'second user');
+    const healthySubscriber = vi.fn();
+    const unsubscribeThrowing = subscribeToInputQueue(() => {
+      throw new Error('broken queue observer');
+    });
+    const unsubscribeHealthy = subscribeToInputQueue(healthySubscriber);
+
+    try {
+      expect(dequeueNextUserInput(CONV)?.id).toBe('user-1');
+      expect(getQueuedInputs(CONV).map((item) => item.id)).toEqual(['user-2']);
+      expect(healthySubscriber).toHaveBeenCalledOnce();
+    } finally {
+      unsubscribeThrowing();
+      unsubscribeHealthy();
+    }
+  });
+
+  it('finishes restoring and pausing a handoff when one subscriber throws', () => {
+    enqueueUserInputWithId(CONV, 'user-1', 'first user');
+    enqueueUserInputWithId(CONV, 'user-2', 'second user');
+    const first = dequeueNextUserInput(CONV)!;
+    const healthySubscriber = vi.fn();
+    const unsubscribeThrowing = subscribeToInputQueue(() => {
+      throw new Error('broken queue observer');
+    });
+    const unsubscribeHealthy = subscribeToInputQueue(healthySubscriber);
+
+    try {
+      expect(() => restoreDequeuedUserInput(CONV, first)).not.toThrow();
+      expect(getQueuedInputs(CONV).map((item) => item.id)).toEqual(['user-1', 'user-2']);
+      expect(isUserInputQueuePaused(CONV)).toBe(true);
+      expect(healthySubscriber).toHaveBeenCalledOnce();
+    } finally {
+      unsubscribeThrowing();
+      unsubscribeHealthy();
+    }
   });
 
   it('clears the paused state after the last user item is cancelled', () => {

--- a/src/core/agent/userInputQueue.ts
+++ b/src/core/agent/userInputQueue.ts
@@ -26,8 +26,15 @@ const EMPTY_QUEUE: readonly QueuedInput[] = [];
 // Listeners for queue state changes
 const listeners = new Set<() => void>();
 
-function notifyListeners() {
-  listeners.forEach(fn => fn());
+function notifyListeners(): void {
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch {
+      // Queue ownership mutations must remain committed even when a UI
+      // observer is stale or faulty. Keep notifying the other subscribers.
+    }
+  }
 }
 
 /**
@@ -149,6 +156,22 @@ export function dequeueNextUserInput(conversationId: string): QueuedInput | unde
   else inputQueues.set(conversationId, next);
   notifyListeners();
   return item;
+}
+
+/**
+ * Restore a user-authored item whose handoff failed before addMessage.
+ *
+ * The original id/timestamp and FIFO position are retained, and the queue is
+ * paused before subscribers are notified so no observer can see the restored
+ * item as runnable in the same turn. Replacing an accidental duplicate id
+ * keeps retries idempotent.
+ */
+export function restoreDequeuedUserInput(conversationId: string, item: QueuedInput): void {
+  const queue = inputQueues.get(conversationId) ?? [];
+  const withoutDuplicate = queue.filter((queued) => queued.id !== item.id);
+  inputQueues.set(conversationId, [item, ...withoutDuplicate]);
+  if (!item.isSystem) pausedUserQueues.add(conversationId);
+  notifyListeners();
 }
 
 /** Pause user-authored follow-ups after the active run is interrupted. */


### PR DESCRIPTION
## 根因

- `reason: "error"` 同时承载“发送前拒收”和“消息已进入会话后的失败”，`ChatView` 因而让 `ChatInput` 回填所有失败草稿；post-commit 消息同时保留 failed + Retry，形成双重恢复。
- queue 自动 handoff / 手动 Resume 在 dequeue 后、ownership 前失败时缺少可恢复状态；同步 queue observer 抛错还会让已完成的 enqueue/dequeue/restore mutation 对调用方表现为失败。

## 改动

- P0：将 `messageTaken` 贯穿 in-process、sidecar、持久化异常和 UI dispatch；只有未接管失败才恢复 composer。已接管失败保留 failed bubble + Retry。
- P0：queue handoff 未接管时保留原 id/timestamp 并 front-requeue + pause；已接管时不回插 q1，但暂停 q2；observer 通知逐 listener fault-isolated。
- P1：所有预览标签的关闭按钮常显（保留中键/右键行为）；激活标签改用 `--abu-bg-active`，明暗主题 token 分别协调 panel chrome。

## 提交（保持三条）

1. `6ba28476` `fix(chat): keep accepted failures out of composer drafts`
2. `bec546f5` `fix(preview): keep tab close controls visible`
3. `9d0cf87b` `fix(preview): soften active tab background`

## 回归与门禁

- `npm run verify` → exit 0；451 files，6767 passed / 1 skipped；coverage gate 通过。
- `npm run electron:test` → exit 0；最终 `ACCEPTANCE PASS`，含 kill/revive 与 no-orphan。
- `npm run electron:dev:check` → exit 0。
- P0 独立 xhigh 终审：相关 5 files / 316 tests 通过，未发现 P0/P1/P2 finding。
- 负向证据：throwing subscriber 修复前 enqueue/dequeue/restore 三测均红；修复后真实 `runAgentLoop` live-run 路径与 queue API 一并通过。

## 真实 Electron 验收

使用隔离 app-data + 本地 OpenAI-compatible mock，走真实 `npm run electron:dev`：

1. 未填 Key 点击发送：应用打开模型设置，welcome 草稿原样保留（未接管恢复）。
2. mock 返回 503：会话出现单个用户气泡、`发送失败` + `重试`；会话 composer 为空；点 `新建任务` 后 welcome composer 也为空。
3. 将同一 mock 切为成功并点击 `重试`：显示唯一回复 `RETRY_OK_ONCE`；UI 仅一个用户气泡，最后流式请求 `roles=[system,user]`，目标 prompt 出现 1 次。
4. 打开 `任务摘要 / alpha.md / beta.md` 三个真实 panel tab：浅色、暗色主题下三个关闭按钮均常显；激活 `beta.md` 背景与各主题 chrome 协调。

## 独立 finding

任务书明确要求不改 `restoreInput` 的跨会话保护逻辑；reviewer 提到的旧 draft 闭包边界留作独立 finding，待产品/机制确认，不在本 PR 顺手扩大范围。

请复审；本 PR 不自动合并。
