### PR TITLE
fix(llm): 修复压缩后内容安全 403 错误链路

### DIFF
--- a/sidecar/src/agentLoopHost.test.ts
+++ b/sidecar/src/agentLoopHost.test.ts
@@ -3,6 +3,8 @@ import { RpcError } from './protocol';
 import type { SubagentLoopOptions, SubagentProgressEvent } from '@/core/agent/subagentLoop';
 import { canonicalizeActiveToolResultContent } from '@/core/agent/activeToolResultContent';
 import { firstImageContent } from '@/core/tools/toolResultContent';
+import { FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE } from '@/core/agent/__contractFixtures__/agentRunTerminalFixture';
+import { LLMError } from '@/core/llm/adapter';
 
 // ── Mocked dependencies ─────────────────────────────────────────────────
 
@@ -386,6 +388,62 @@ describe('agentLoopHost', () => {
           stack: expect.stringContaining('Error: boom'),
         },
       });
+    });
+
+    it('projects an unexpected top-level LLMError into a safe terminal and RPC error', async () => {
+      const rawBody = '{"private":"raw provider body"}';
+      const upstream = {
+        status: 403,
+        error_type: 'governance.alicloud_content_safety_input_rejected',
+        traceId: 'host-unexpected-trace-403',
+      } as const;
+      runAgentLoopMock.mockRejectedValueOnce(new LLMError(rawBody, 'content_policy', {
+        retryable: false,
+        statusCode: 403,
+        rawBody,
+        upstream,
+      }));
+      const params = reliableParams();
+      handleAgentStart(params);
+
+      await expect(handleAgentRun(params)).rejects.toMatchObject({
+        code: -32000,
+        message: 'HTTP 403 · content_policy',
+        data: expect.objectContaining({
+          message: 'HTTP 403 · content_policy',
+          upstream,
+        }),
+      });
+      const terminal = sendNotificationMock.mock.calls
+        .filter((call) => call[0] === 'agent.terminal')
+        .at(-1)?.[1];
+      expect(terminal).toMatchObject({
+        state: 'failed',
+        result: {
+          reason: 'error',
+          error: 'HTTP 403 · content_policy',
+          messageTaken: true,
+          upstream,
+        },
+        failure: {
+          errorType: 'llmerror',
+          message: 'HTTP 403 · content_policy',
+          upstream,
+        },
+      });
+      expect((terminal as { failure?: { stack?: string } }).failure?.stack).toBeUndefined();
+      expect(JSON.stringify(terminal)).not.toContain('raw provider body');
+    });
+
+    it('publishes structured upstream failure details returned by the agent loop', async () => {
+      runAgentLoopMock.mockResolvedValueOnce(FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE.result);
+
+      await handleStartedAgentRun({ runId: FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE.runId });
+
+      expect(sendNotificationMock).toHaveBeenCalledWith(
+        'agent.terminal',
+        FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE,
+      );
     });
 
     it('aborts scoped run controllers on normal completion so background commands cannot outlive unattended runs', async () => {

--- a/sidecar/src/agentLoopHost.ts
+++ b/sidecar/src/agentLoopHost.ts
@@ -71,6 +71,7 @@ import {
   materializeSidecarMediaRefsForShell,
   sidecarValueHasOpaqueMediaRefs,
 } from '@/core/subagent/delegatedUserTurnMaterializer';
+import { formatLlmTerminalError, LLMError, normalizeUpstreamErrorDetails } from '@/core/llm/adapter';
 
 /** Sidecar-local declaration — never imported from shell-side code (same "src/ never runtime-imports sidecar/, and vice versa across this boundary" discipline `frameApplier.ts`/`subagentHost.ts` already document). */
 interface SerializableToolDefinition {
@@ -785,7 +786,7 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
     const terminal = createAgentRunTerminal(runId, result);
     rememberTerminal(runId, terminal);
     sendNotification('agent.terminal', terminal);
-    return result;
+    return terminal.result;
   }
   if (registryEntry) registryEntry.state = 'running';
   traceSidecarRuntimeEvent('sidecar.agent_run_received', {
@@ -1001,7 +1002,7 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
     const terminal = createAgentRunTerminal(runId, result);
     rememberTerminal(runId, terminal);
     sendNotification('agent.terminal', terminal);
-    return result;
+    return terminal.result;
   } catch (error) {
     traceSidecarRuntimeEvent('sidecar.agent_run_failed', {
       runId,
@@ -1013,18 +1014,41 @@ export async function handleAgentRun(rawParams: unknown): Promise<unknown> {
     });
     await chatDelta.drain();
     coalescer.flush();
-    const message = error instanceof Error ? error.message : String(error);
+    const upstream = error instanceof LLMError
+      ? normalizeUpstreamErrorDetails(error.upstream)
+      : undefined;
+    const message = error instanceof LLMError
+      ? formatLlmTerminalError(error)
+      : error instanceof Error ? error.message : String(error);
     const terminal = createAgentRunTerminal(
       runId,
-      { reason: 'error', error: message, messageTaken: true },
+      {
+        reason: 'error',
+        error: message,
+        messageTaken: true,
+        ...(upstream ? { upstream } : {}),
+      },
       {
         errorType: sidecarRuntimeErrorType(error),
         message,
-        ...(error instanceof Error && error.stack ? { stack: error.stack } : {}),
+        ...(error instanceof Error && !(error instanceof LLMError) && error.stack
+          ? { stack: error.stack }
+          : {}),
+        ...(upstream ? { upstream } : {}),
       },
     );
     rememberTerminal(runId, terminal);
     sendNotification('agent.terminal', terminal);
+    if (error instanceof LLMError) {
+      throw new RpcError(-32000, message, {
+        name: 'LLMError',
+        code: error.code,
+        retryable: error.retryable,
+        statusCode: error.statusCode,
+        message,
+        ...(upstream ? { upstream } : {}),
+      });
+    }
     throw error;
   } finally {
     coalescer.flush();

--- a/sidecar/src/agentRunTerminal.contract.test.ts
+++ b/sidecar/src/agentRunTerminal.contract.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE } from '@/core/agent/__contractFixtures__/agentRunTerminalFixture';
+import { createAgentRunTerminal } from '@/core/agent/agentRunTerminal';
+
+describe('agent.terminal wire contract — sender', () => {
+  it('projects the shared upstream fields into the failed terminal without renaming or dropping them', () => {
+    const terminal = createAgentRunTerminal(
+      FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE.runId,
+      FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE.result,
+    );
+
+    expect(terminal).toEqual(FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE);
+    expect(JSON.parse(JSON.stringify(terminal))).toEqual(FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE);
+  });
+
+  it('drops a privacy-unsafe upstream object at the sender boundary', () => {
+    const terminal = createAgentRunTerminal('unsafe-terminal-run', {
+      reason: 'error',
+      error: 'HTTP 403 · content_policy',
+      messageTaken: true,
+      upstream: {
+        status: 403,
+        rawBody: 'private prompt text',
+      } as never,
+    });
+
+    expect(terminal.result.upstream).toBeUndefined();
+    expect(terminal.failure?.upstream).toBeUndefined();
+    expect(JSON.stringify(terminal)).not.toContain('rawBody');
+    expect(JSON.stringify(terminal)).not.toContain('private prompt text');
+  });
+});

--- a/sidecar/src/llmHost.test.ts
+++ b/sidecar/src/llmHost.test.ts
@@ -167,6 +167,89 @@ describe('llmHost', () => {
       });
     });
 
+    it('preserves bounded upstream error details in the legacy llm.chat RPC error', async () => {
+      const upstream = {
+        status: 403,
+        error_type: 'governance.alicloud_content_safety_input_rejected',
+        traceId: 'llm-host-trace-403',
+        summary: 'The content safety system rejected the request.',
+      } as const;
+      claudeChat.mockRejectedValue(new LLMError(upstream.summary, 'content_policy', {
+        retryable: false,
+        statusCode: 403,
+        rawBody: '{"must":"not cross the llm RPC"}',
+        upstream,
+      }));
+      const { sender } = makeSender();
+      const host = createLlmHost(sender);
+
+      await expect(host.handleChat(chatParams())).rejects.toMatchObject({
+        code: -32000,
+        data: {
+          name: 'LLMError',
+          code: 'content_policy',
+          retryable: false,
+          statusCode: 403,
+          message: upstream.summary,
+          upstream,
+        },
+      });
+      await expect(host.handleChat(chatParams())).rejects.not.toMatchObject({
+        data: expect.objectContaining({ rawBody: expect.anything() }),
+      });
+    });
+
+    it('does not put a message-less JSON provider body in the outer RPC error message', async () => {
+      const rawBody = '{"private":"credential-adjacent provider metadata"}';
+      claudeChat.mockRejectedValue(new LLMError(rawBody, 'authentication', {
+        retryable: false,
+        statusCode: 403,
+        rawBody,
+        upstream: { status: 403 },
+      }));
+      const { sender } = makeSender();
+      const host = createLlmHost(sender);
+
+      await expect(host.handleChat(chatParams())).rejects.toMatchObject({
+        code: -32000,
+        message: 'HTTP 403 · authentication',
+        data: expect.objectContaining({
+          message: 'HTTP 403 · authentication',
+          upstream: { status: 403 },
+        }),
+      });
+      await expect(host.handleChat(chatParams())).rejects.not.toMatchObject({
+        message: expect.stringContaining('private'),
+      });
+    });
+
+    it('fresh-projects a mutated LLMError upstream object before writing RPC data', async () => {
+      const error = new LLMError('safe provider failure', 'unknown');
+      error.upstream = {
+        status: 403,
+        rawBody: 'private prompt text',
+      } as never;
+      claudeChat.mockRejectedValue(error);
+      const { sender } = makeSender();
+      const host = createLlmHost(sender);
+
+      let caught: unknown;
+      try {
+        await host.handleChat(chatParams());
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toMatchObject({
+        code: -32000,
+        message: 'safe provider failure',
+        data: expect.objectContaining({ message: 'safe provider failure' }),
+      });
+      expect((caught as { data?: { upstream?: unknown } }).data?.upstream).toBeUndefined();
+      expect(JSON.stringify(caught)).not.toContain('rawBody');
+      expect(JSON.stringify(caught)).not.toContain('private prompt text');
+    });
+
     it('a non-LLMError thrown by the adapter still serializes name/message (no code/retryable)', async () => {
       claudeChat.mockRejectedValue(new TypeError('boom'));
       const { sender } = makeSender();

--- a/sidecar/src/llmHost.ts
+++ b/sidecar/src/llmHost.ts
@@ -13,9 +13,9 @@
  * `protocol.ts`'s `writeLine`.
  */
 
-import type { Message, StreamEvent } from '@/types';
+import type { Message, StreamEvent, UpstreamErrorDetails } from '@/types';
 import type { ChatOptions, LLMAdapter, AdapterKind } from '@/core/llm/adapter';
-import { LLMError } from '@/core/llm/adapter';
+import { formatLlmTerminalError, LLMError, normalizeUpstreamErrorDetails } from '@/core/llm/adapter';
 import { ClaudeAdapter } from '@/core/llm/claude';
 import { OpenAICompatibleAdapter } from '@/core/llm/openai-compatible';
 import { createEventCoalescer } from './eventCoalescer';
@@ -99,14 +99,25 @@ function createAdapter(kind: AdapterKind): LLMAdapter {
 }
 
 /** Reconstruct the `data` payload the shell's SidecarLLMAdapter uses to rebuild a faithful LLMError. */
-function errorDataFor(err: unknown): { name: string; code?: string; retryable?: boolean; retryAfterMs?: number; message: string } {
+function errorDataFor(err: unknown): {
+  name: string;
+  code?: string;
+  retryable?: boolean;
+  retryAfterMs?: number;
+  statusCode?: number;
+  upstream?: UpstreamErrorDetails;
+  message: string;
+} {
   if (err instanceof LLMError) {
+    const upstream = normalizeUpstreamErrorDetails(err.upstream);
     return {
       name: 'LLMError',
       code: err.code,
       retryable: err.retryable,
       retryAfterMs: err.retryAfterMs,
-      message: err.message,
+      statusCode: err.statusCode,
+      upstream,
+      message: formatLlmTerminalError(err),
     };
   }
   const message = err instanceof Error ? err.message : String(err);
@@ -186,7 +197,10 @@ export function createLlmHost(sender: SidecarRpcSender): LlmHost {
     } catch (err) {
       drain(call, callId);
       logger.warn('llm.chat failed', { callId, error: err instanceof Error ? err.message : String(err) });
-      throw new RpcError(-32000, err instanceof Error ? err.message : String(err), errorDataFor(err));
+      const wireMessage = err instanceof LLMError
+        ? formatLlmTerminalError(err)
+        : err instanceof Error ? err.message : String(err);
+      throw new RpcError(-32000, wireMessage, errorDataFor(err));
     } finally {
       activeCalls.delete(callId);
     }

--- a/sidecar/src/subagentHost.test.ts
+++ b/sidecar/src/subagentHost.test.ts
@@ -93,6 +93,12 @@ function resultShape(text: string) {
 // production return type.
 type SubagentRunResult = ReturnType<typeof resultShape> & {
   stopReason: 'completed' | 'aborted' | 'error' | 'max_turns';
+  upstream?: {
+    status: number;
+    error_type?: string;
+    traceId?: string;
+    summary?: string;
+  };
 };
 
 describe('subagentHost', () => {
@@ -245,6 +251,39 @@ describe('subagentHost', () => {
       const result = (await handleSubagentRun(baseParams({ runId: 'stop-reason-run' }))) as SubagentRunResult;
 
       expect(result.stopReason).toBe('error');
+    });
+
+    it('returns the bounded upstream projection across the subagent wire', async () => {
+      const upstream = {
+        status: 403,
+        error_type: 'governance.alicloud_content_safety_input_rejected',
+        traceId: 'subagent-host-trace-403',
+        summary: 'provider rejected the request',
+      } as const;
+      runSubagentLoopMock.mockResolvedValueOnce({
+        ...resultShape('Error: content policy rejected'),
+        stopReason: 'error',
+        upstream,
+      });
+
+      const result = (await handleSubagentRun(baseParams({ runId: 'upstream-run' }))) as SubagentRunResult;
+
+      expect(result).toMatchObject({ stopReason: 'error', upstream });
+      expect(result).not.toHaveProperty('rawBody');
+    });
+
+    it('drops a privacy-unsafe upstream object before writing the subagent response', async () => {
+      runSubagentLoopMock.mockResolvedValueOnce({
+        ...resultShape('Error: content policy rejected'),
+        stopReason: 'error',
+        upstream: { status: 403, rawBody: 'private prompt text' },
+      });
+
+      const result = (await handleSubagentRun(baseParams({ runId: 'unsafe-upstream-run' }))) as SubagentRunResult;
+
+      expect(result.upstream).toBeUndefined();
+      expect(JSON.stringify(result)).not.toContain('rawBody');
+      expect(JSON.stringify(result)).not.toContain('private prompt text');
     });
 
     it('parses and restores blockedTools into the sidecar SubagentLoopOptions', async () => {

--- a/sidecar/src/subagentHost.ts
+++ b/sidecar/src/subagentHost.ts
@@ -19,7 +19,7 @@
  * `createReverseToolInvoker` doc comment for why: correctness over latency,
  * per the design doc's explicit instruction).
  */
-import type { SubagentDefinition, ToolDefinition, ToolExecutionContext, ToolResult } from '@/types';
+import type { SubagentDefinition, ToolDefinition, ToolExecutionContext, ToolResult, UpstreamErrorDetails } from '@/types';
 import type { IMContext } from '@/core/agent/orchestrator';
 import type { SettingsReader } from '@/core/agent/ports/settingsReader';
 import type { ToolInvoker } from '@/core/agent/ports/toolInvoker';
@@ -45,6 +45,7 @@ import { findActiveRunDeltaForConversation } from './agentLoopHost';
 import { subagentRunContext, type SubagentRunContext } from './subagentRunContext';
 import { SUBAGENT_RUN_WIRE_FIELDS as SHARED_SUBAGENT_RUN_WIRE_FIELDS } from '@/core/agent/subagentWireContract';
 import { makeSubagentProgressToolCallId } from '@/core/agent/subagentProgressIdentity';
+import { normalizeUpstreamErrorDetails } from '@/core/llm/adapter';
 
 interface SerializableToolDefinition {
   name: string;
@@ -141,6 +142,7 @@ interface SerializableSubagentResult {
   tokenUsage: { input: number; output: number };
   duration: number;
   stopReason: SubagentStopReason;
+  upstream?: UpstreamErrorDetails;
 }
 
 const PROGRESS_MEDIA_TRANSPORT_ERROR = 'Error: Could not prepare sidecar progress media for transport.';
@@ -529,6 +531,7 @@ export async function handleSubagentRun(rawParams: unknown): Promise<unknown> {
   try {
     const result = await subagentRunContext.run(runCtx, () => runSubagentLoop(options));
     await drainProgress();
+    const upstream = normalizeUpstreamErrorDetails(result.upstream);
     return {
       text: result.text,
       toolCallCount: result.toolCallCount,
@@ -536,6 +539,7 @@ export async function handleSubagentRun(rawParams: unknown): Promise<unknown> {
       tokenUsage: result.tokenUsage,
       duration: result.duration,
       stopReason: result.stopReason,
+      ...(upstream ? { upstream } : {}),
     } satisfies SerializableSubagentResult;
   } finally {
     await drainProgress();

--- a/src/__tests__/agentPipeline.integration.test.ts
+++ b/src/__tests__/agentPipeline.integration.test.ts
@@ -503,6 +503,46 @@ describe('Agent Pipeline Integration', () => {
     ]);
   });
 
+  it('preserves structured upstream details when a direct @agent provider call is rejected', async () => {
+    const { routeInput } = await import('../core/agent/orchestrator');
+    vi.mocked(routeInput).mockReturnValueOnce({
+      type: 'delegate', cleanInput: 'Use a delegated agent.', name: 'abu',
+      delegateAgent: { name: 'researcher', description: 'research', systemPrompt: 'research', filePath: '__preset__' },
+    } as never);
+    const upstream = {
+      status: 403,
+      error_type: 'governance.alicloud_content_safety_input_rejected',
+      traceId: 'delegate-pipeline-trace-403',
+      summary: 'provider rejected the delegated request',
+    } as const;
+    mockClaudeChat.mockRejectedValueOnce(new LLMError(
+      '{"private":"raw delegated provider body"}',
+      'content_policy',
+      {
+        retryable: false,
+        statusCode: 403,
+        rawBody: '{"private":"raw delegated provider body"}',
+        upstream,
+      },
+    ));
+    const conversationId = useChatStore.getState().createConversation();
+
+    const result = await runAgentLoop(conversationId, 'Use a delegated agent.');
+
+    expect(result).toMatchObject({
+      reason: 'error',
+      messageTaken: true,
+      upstream,
+    });
+    const assistantText = useChatStore.getState().conversations[conversationId].messages
+      .filter((message) => message.role === 'assistant')
+      .map((message) => typeof message.content === 'string' ? message.content : '')
+      .join('\n');
+    expect(assistantText).toMatch(/content[- ]safety|内容安全/i);
+    expect(assistantText).not.toContain('raw delegated provider body');
+    expect(mockClaudeChat).toHaveBeenCalledTimes(1);
+  });
+
   it('re-materializes delegated media refs for each primary provider retry attempt', async () => {
     const mediaRef = {
       id: 'delegated-media-retry',
@@ -548,6 +588,40 @@ describe('Agent Pipeline Integration', () => {
     expect(delegatedMediaStore.readDelegatedMedia).toHaveBeenCalledTimes(2);
     expect(outboundPayloads[0]).toContain('AQID');
     expect(outboundPayloads[1]).toContain('BAUG');
+  });
+
+  it('returns structured upstream details and renders friendly copy for a content-policy rejection', async () => {
+    const upstream = {
+      status: 403,
+      error_type: 'governance.alicloud_content_safety_input_rejected',
+      traceId: 'pipeline-trace-403',
+      summary: 'The upstream content safety system rejected the request.',
+    } as const;
+    mockClaudeChat.mockRejectedValueOnce(new LLMError(
+      upstream.summary,
+      'content_policy',
+      {
+        retryable: false,
+        statusCode: 403,
+        rawBody: '{"private":"raw provider body must stay out of the chat"}',
+        upstream,
+      },
+    ));
+    const conversationId = useChatStore.getState().createConversation();
+
+    const result = await runAgentLoop(conversationId, 'Fixed non-sensitive fixture input.');
+
+    expect(result).toMatchObject({
+      reason: 'error',
+      messageTaken: true,
+      upstream,
+    });
+    const assistantText = useChatStore.getState().conversations[conversationId].messages
+      .filter((message) => message.role === 'assistant')
+      .map((message) => typeof message.content === 'string' ? message.content : '')
+      .join('\n');
+    expect(assistantText).not.toContain('raw provider body must stay out of the chat');
+    expect(assistantText).not.toContain(upstream.error_type);
   });
 
   it('returns aborted before starting a direct delegate provider call when its linked signal is already aborted', async () => {

--- a/src/components/chat/MessageBubble.test.tsx
+++ b/src/components/chat/MessageBubble.test.tsx
@@ -77,7 +77,35 @@ describe('MessageBubble user run status', () => {
 
     render(<MessageBubble message={message} />);
 
-    expect(screen.getByText('Send failed')).toBeInTheDocument();
+    const failureLabel = screen.getByText('Send failed');
+    expect(failureLabel).toBeInTheDocument();
+    expect(failureLabel.parentElement).not.toHaveAttribute('title');
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('renders structured upstream failure fields without a raw JSON blob', () => {
+    const message: Message = {
+      ...baseMessage,
+      runState: 'failed',
+      runError: '{"error_type":"governance.alicloud_content_safety_input_rejected"}',
+      runErrorDetails: {
+        status: 403,
+        error_type: 'governance.alicloud_content_safety_input_rejected',
+        traceId: 'trace-403-local',
+        summary: 'The upstream content safety system rejected the request.',
+      },
+    };
+    setConversation(message, 'idle');
+
+    render(<MessageBubble message={message} />);
+
+    expect(screen.getByText('HTTP 403')).toBeInTheDocument();
+    expect(screen.getByText('governance.alicloud_content_safety_input_rejected')).toBeInTheDocument();
+    expect(screen.getByText('trace-403-local')).toBeInTheDocument();
+    expect(screen.getByText('The upstream content safety system rejected the request.')).toBeInTheDocument();
+    expect(screen.queryByText(message.runError as string)).not.toBeInTheDocument();
+    expect(screen.getByText('Send failed').parentElement).not.toHaveAttribute('title');
+    expect(screen.queryByText(/conversation history/i)).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
   });
 

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -710,7 +710,7 @@ export default function MessageBubble({
                   communicates that work is in progress; only actionable failures belong
                   under the user's message. */}
               {hasRunFailure && (
-                <div className="flex items-center gap-1.5 text-caption text-[var(--abu-danger)]" title={message.runError}>
+                <div className="flex items-center gap-1.5 text-caption text-[var(--abu-danger)]">
                   <span>
                     {message.runState === 'failed' && t.chat.runFailed}
                     {message.runState === 'connection-failed' && t.chat.runConnectionFailed}
@@ -720,6 +720,31 @@ export default function MessageBubble({
                       <RefreshCw className="h-3 w-3" />
                       {t.chat.runRetry}
                     </Button>
+                  )}
+                </div>
+              )}
+              {hasRunFailure && message.runErrorDetails && (
+                <div
+                  role="alert"
+                  className="max-w-2xl space-y-1.5 rounded-lg border border-[var(--abu-danger)] bg-[var(--abu-danger-bg)] px-3 py-2 text-minor text-[var(--abu-text-primary)]"
+                >
+                  <div className="flex flex-wrap gap-x-3 gap-y-1 font-mono text-caption">
+                    <span>HTTP {message.runErrorDetails.status}</span>
+                    {message.runErrorDetails.error_type && (
+                      <span className="break-all">
+                        error_type: <span>{message.runErrorDetails.error_type}</span>
+                      </span>
+                    )}
+                    {message.runErrorDetails.traceId && (
+                      <span className="break-all">
+                        traceId: <span>{message.runErrorDetails.traceId}</span>
+                      </span>
+                    )}
+                  </div>
+                  {message.runErrorDetails.summary && (
+                    <p className="break-words text-[var(--abu-text-secondary)]">
+                      {message.runErrorDetails.summary}
+                    </p>
                   )}
                 </div>
               )}

--- a/src/core/agent/__contractFixtures__/agentRunTerminalFixture.ts
+++ b/src/core/agent/__contractFixtures__/agentRunTerminalFixture.ts
@@ -1,0 +1,25 @@
+import type { AgentRunTerminal } from '../agentRunTerminal';
+
+export const UPSTREAM_ERROR_CONTRACT_FIXTURE = {
+  status: 403,
+  error_type: 'governance.alicloud_content_safety_input_rejected',
+  traceId: 'contract-trace-403',
+  summary: 'The upstream content safety system rejected the request.',
+} as const;
+
+export const FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE = {
+  version: 1,
+  runId: 'run-upstream-contract',
+  state: 'failed',
+  result: {
+    reason: 'error',
+    error: 'The upstream content safety system rejected the request.',
+    messageTaken: true,
+    upstream: UPSTREAM_ERROR_CONTRACT_FIXTURE,
+  },
+  failure: {
+    errorType: 'agent_loop_error',
+    message: 'The upstream content safety system rejected the request.',
+    upstream: UPSTREAM_ERROR_CONTRACT_FIXTURE,
+  },
+} as const satisfies AgentRunTerminal;

--- a/src/core/agent/agentLoop.ts
+++ b/src/core/agent/agentLoop.ts
@@ -1,7 +1,7 @@
-import type { StreamEvent, ToolCall, TokenUsage, ImageAttachment, Message, MessageContent, SubagentStopReason, ToolExecutionContext } from '../../types';
+import type { StreamEvent, ToolCall, TokenUsage, ImageAttachment, Message, MessageContent, SubagentStopReason, ToolExecutionContext, UpstreamErrorDetails } from '../../types';
 import type { ToolCallContext } from '../../types/execution';
 import type { LLMAdapter } from '../llm/adapter';
-import { LLMError, formatLlmDisplayError } from '../llm/adapter';
+import { LLMError, formatLlmDisplayError, formatLlmTerminalError } from '../llm/adapter';
 import { recordProviderCallOutcome, isConfigFailureCode } from '../llm/providerCallHealth';
 import { selectChatAdapter } from '../llm/selectChatAdapter';
 import { getToolInvoker, type ToolInvoker, type FilePermissionCallback } from './ports/toolInvoker';
@@ -538,7 +538,7 @@ export interface AgentLoopOptions {
    * the initial user message is already present in the transcript (or when a
    * pre-persisted shell row is handed in). Never serialized to the sidecar.
    */
-  onMessageTaken?: () => void;
+  onMessageTaken?: (messageId?: string) => void;
   /** Host-owned, immutable authority ceiling for unattended/background runs. */
   runPermissionCeiling?: import('../permissions/runPermissionCeiling').RunPermissionCeiling;
   /** Shell-only factory; deliberately omitted from every sidecar wire shape. */
@@ -690,6 +690,8 @@ export function buildToolRosterUpdateMessage(options: {
 
 interface AgentLoopResultBase {
   error?: string;
+  /** Bounded upstream fields for the failed-run terminal; never the raw body. */
+  upstream?: UpstreamErrorDetails;
   /** Machine-readable terminal cause when `reason: 'error'` needs caller-specific handling. */
   stopReason?: 'sidecar_unavailable';
 }
@@ -801,7 +803,9 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
     }
   }
 
-  if (options?.prePersistedUserMessageId) options.onMessageTaken?.();
+  if (options?.prePersistedUserMessageId) {
+    options.onMessageTaken?.(options.prePersistedUserMessageId);
+  }
 
   // New turn starts clean: drop any stale plan-mode lock from a prior/abandoned plan (see planMode.ts).
   clearPlanMode(conversationId);
@@ -872,14 +876,15 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
     // the user needs to configure a key before any skill/agent routing takes effect.
     if (!options?.prePersistedUserMessageId) {
       const userContent = await buildUserMessageContent(conversationId, userMessage, options?.images);
+      const userMessageId = generateId();
       chatDelta.addMessage(conversationId, {
-        id: generateId(),
+        id: userMessageId,
         role: 'user',
         content: userContent,
         timestamp: Date.now(),
         loopId,
       });
-      options?.onMessageTaken?.();
+      options?.onMessageTaken?.(userMessageId);
     }
     chatDelta.addMessage(conversationId, {
       id: generateId(),
@@ -963,14 +968,15 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
     // same shape as the missing-API-key path above.
     if (!options?.prePersistedUserMessageId) {
       const userContent = await buildUserMessageContent(conversationId, userMessage, options?.images);
+      const userMessageId = generateId();
       chatDelta.addMessage(conversationId, {
-        id: generateId(),
+        id: userMessageId,
         role: 'user',
         content: userContent,
         timestamp: Date.now(),
         loopId,
       });
-      options?.onMessageTaken?.();
+      options?.onMessageTaken?.(userMessageId);
     }
     const detail = error instanceof Error ? error.message : String(error);
     chatDelta.addMessage(conversationId, {
@@ -1094,9 +1100,10 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
   // Include skill info if a skill was triggered; build multimodal content if images are attached
   if (!options?.prePersistedUserMessageId) {
     const userContent = await buildUserMessageContent(conversationId, route.cleanInput, options?.images);
+    const userMessageId = generateId();
 
     chatDelta.addMessage(conversationId, {
-      id: generateId(),
+      id: userMessageId,
       role: 'user',
       content: userContent,
       timestamp: Date.now(),
@@ -1110,7 +1117,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         description: route.delegateAgent.description,
       } : undefined,
     });
-    options?.onMessageTaken?.();
+    options?.onMessageTaken?.(userMessageId);
   }
 
   // Enterprise mode always uses OpenAI-compatible adapter (LiteLLM exposes that interface).
@@ -1330,7 +1337,12 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         chatDelta.setAgentStatus(conversationId, 'idle');
         chatDelta.setConversationStatus(conversationId, 'error');
         notifyTaskError(convTitle, conversationId);
-        return { reason: 'error', error: result.text, messageTaken: true };
+        return {
+          reason: 'error',
+          error: result.text,
+          messageTaken: true,
+          ...(result.upstream ? { upstream: result.upstream } : {}),
+        };
       }
 
       eventRouter.route({
@@ -1364,11 +1376,16 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         return { reason: 'aborted' };
       }
       const errorMessage = err instanceof Error ? err.message : String(err);
+      const terminalErrorMessage = err instanceof LLMError
+        ? formatLlmTerminalError(err)
+        : errorMessage;
       if (err instanceof LLMError && isConfigFailureCode(err.code)) {
         recordProviderCallOutcome(getActiveProvider(settingsForModel)?.id, { ok: false, code: err.code, at: Date.now() });
       }
       let delegateDisplayError = err instanceof EnterpriseLlmUnavailableError
         ? getI18n().chat.gatewayUnreachable
+        : err instanceof LLMError && err.code === 'content_policy'
+        ? getI18n().chat.contentPolicyRejected
         : formatLlmDisplayError(err, errorMessage, getI18n().chat.errorEmptyBody);
       if (err instanceof LLMError && err.code === 'not_found') {
         delegateDisplayError += `\n\n${getI18n().chat.errorNotFoundHint}`;
@@ -1383,12 +1400,17 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       });
       chatDelta.finishStreaming(conversationId, delegateErrorId);
       abortRegistry.clearAbortController(conversationId);
-      eventRouter.route({ type: 'error', loopId, error: errorMessage });
+      eventRouter.route({ type: 'error', loopId, error: terminalErrorMessage });
       persistExecutionSnapshot(conversationId, loopId);
       chatDelta.setConversationStatus(conversationId, 'error');
       const convTitle = getConversationReader().getIndexEntry(conversationId)?.title ?? getI18n().chat.notificationTaskFallback;
       notifyTaskError(convTitle, conversationId);
-      return { reason: 'error', error: errorMessage, messageTaken: true };
+      return {
+        reason: 'error',
+        error: terminalErrorMessage,
+        messageTaken: true,
+        ...(err instanceof LLMError && err.upstream ? { upstream: err.upstream } : {}),
+      };
     }
     return { reason: 'completed' };
   }
@@ -1412,6 +1434,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
   let continueLoop = true;
   let exitReason: AgentLoopExitReason = 'completed';
   let exitError: string | undefined;
+  let exitUpstream: UpstreamErrorDetails | undefined;
   let awaitingUserRecovery = false;
   // Cache of filePath → base64 for image rehydration, shared across every turn
   // of this request's tool-use loop so a stripped image is read from disk once,
@@ -2904,6 +2927,9 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
 
       clearLoopContext(loopId);
       const errorMessage = err instanceof Error ? err.message : String(err);
+      const terminalErrorMessage = err instanceof LLMError
+        ? formatLlmTerminalError(err)
+        : errorMessage;
       const errorCode = err instanceof LLMError
         ? err.code
         : err instanceof ContextBudgetError
@@ -2914,6 +2940,10 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         code: errorCode,
         model: effectiveModelId,
         providerId: getActiveProvider(settingsForModel)?.id,
+        status: err instanceof LLMError ? err.upstream?.status : undefined,
+        error_type: err instanceof LLMError ? err.upstream?.error_type : undefined,
+        traceId: err instanceof LLMError ? err.upstream?.traceId : undefined,
+        providerSummary: err instanceof LLMError ? err.upstream?.summary : undefined,
       });
 
       // Fire-and-forget: report to console for quality monitoring
@@ -2943,7 +2973,8 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         && /^forbidden\s*$/i.test(err.message.trim());
       // Provider-returned balance/resource-package exhaustion (e.g. Zhipu GLM
       // answers HTTP 429 with this Chinese text). Replace the raw provider
-      // string with actionable copy; `result.error` keeps the original.
+      // string with actionable copy; the diagnostic path keeps the raw body,
+      // while the terminal/store path keeps only the bounded provider summary.
       const isInsufficientBalanceError = /余额不足|无可用资源包/.test(errorMessage);
       const isEnterpriseGatewayUnavailable = err instanceof EnterpriseLlmUnavailableError;
       const isContextBudgetError = err instanceof ContextBudgetError;
@@ -2959,6 +2990,8 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
         ? getI18n().chat.ollamaForbidden
         : isInsufficientBalanceError
         ? getI18n().chat.insufficientBalance
+        : errorCode === 'content_policy'
+        ? getI18n().chat.contentPolicyRejected
         : formatLlmDisplayError(err, errorMessage, getI18n().chat.errorEmptyBody);
       if (errorCode === 'not_found') {
         displayError += `\n\n${getI18n().chat.errorNotFoundHint}`;
@@ -2972,7 +3005,7 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       chatDelta.finishStreaming(conversationId, assistantMsgId);
       abortRegistry.clearAbortController(conversationId);
       // Error the TaskExecution
-      eventRouter.route({ type: 'error', loopId, error: errorMessage });
+      eventRouter.route({ type: 'error', loopId, error: terminalErrorMessage });
       persistExecutionSnapshot(conversationId, loopId);
       // Auto-deactivate skills on error
       deactivateAllSkills(conversationId, loopId);
@@ -2995,7 +3028,8 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
       const convTitle = getConversationReader().getIndexEntry(conversationId)?.title ?? getI18n().chat.notificationTaskFallback;
       notifyTaskError(convTitle, conversationId);
       exitReason = 'error';
-      exitError = errorMessage;
+      exitError = terminalErrorMessage;
+      exitUpstream = err instanceof LLMError ? err.upstream : undefined;
       continueLoop = false;
     } finally {
       if (streamFlushTimer) clearInterval(streamFlushTimer);
@@ -3008,6 +3042,11 @@ export async function runAgentLoop(conversationId: string, userMessage: string, 
   await endComputerUseTaskLease();
   endConversationTrace(conversationId, { output: { reason: exitReason }, error: exitError });
   return exitReason === 'error'
-    ? { reason: 'error', error: exitError, messageTaken: true }
+    ? {
+        reason: 'error',
+        error: exitError,
+        messageTaken: true,
+        ...(exitUpstream ? { upstream: exitUpstream } : {}),
+      }
     : { reason: exitReason, error: exitError };
 }

--- a/src/core/agent/agentLoopRunner.test.ts
+++ b/src/core/agent/agentLoopRunner.test.ts
@@ -42,6 +42,13 @@ const runGetStateRequestMock = vi.fn((params: { runId: string }) => Promise.reso
   runId: params.runId,
   state: 'not_found',
 }));
+const loggerWarnMock = vi.fn();
+vi.mock('../logging/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    warn: (...args: unknown[]) => loggerWarnMock(...args),
+  }),
+}));
 vi.mock('../sidecar/sidecarManager', () => ({
   onSidecarNotification: (...a: unknown[]) => onSidecarNotification(...a),
   onSidecarRequest: (...a: unknown[]) => onSidecarRequest(...a),
@@ -438,6 +445,7 @@ vi.mock('../../i18n', () => ({
       messageSaveFailed: '消息未能写入磁盘，阿布没有启动任务。请检查磁盘权限后重试。',
       attachmentDuringRun: '请等待当前任务结束后再发送附件，草稿已为你保留。',
       conversationBusy: '当前会话已有任务在运行，请等待结束后再启动新任务。',
+      errorEmptyBody: '请求失败但无详情',
     },
   }),
   getLocale: () => 'zh-CN',
@@ -651,6 +659,7 @@ describe('agentLoopRunner', () => {
     getSidecarStatusMock.mockReset();
     getSidecarStatusMock.mockReturnValue('running');
     sidecarRequestMock.mockReset();
+    loggerWarnMock.mockReset();
     agentStartRequestMock.mockReset();
     agentStartRequestMock.mockImplementation((params: { runId: string; clientMessageId: string }) => Promise.resolve({
       version: 1,
@@ -978,7 +987,7 @@ describe('agentLoopRunner', () => {
         version: 1,
         runId: 'run-terminal',
         state: 'failed',
-        result: { reason: 'error', error: 'late conflict' },
+        result: { reason: 'error', error: 'late conflict', messageTaken: true },
         failure: { errorType: 'error', message: 'late conflict' },
       });
       deltaHandler({ runId: 'run-terminal', frames: [{ p: 'chat', m: 'appendText', a: ['conv-1', 'late'] }] });
@@ -2839,6 +2848,13 @@ describe('agentLoopRunner', () => {
       return { promise, resolve, reject };
     }
 
+    const upstreamErrorDetails = {
+      status: 403,
+      error_type: 'governance.alicloud_content_safety_input_rejected',
+      traceId: 'runner-compat-trace-403',
+      summary: 'provider rejected the request',
+    } as const;
+
     /** Advances microtasks until the given mock has been called (or gives up after `times` ticks) — dispatch does async work (buildAgentRunParams awaits precomputeOrchestration) before it reaches sidecarRequest. */
     async function waitForCall(mock: ReturnType<typeof vi.fn>, times = 30): Promise<void> {
       for (let i = 0; i < times; i++) {
@@ -2867,6 +2883,49 @@ describe('agentLoopRunner', () => {
       });
       expect(sidecarRequestMock).not.toHaveBeenCalled();
       expect(result).toEqual({ reason: 'completed' });
+    });
+
+    it('persists structured failure details for the startup in-process path', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      getSidecarStatusMock.mockReturnValue('stopped');
+      runAgentLoopMock.mockImplementationOnce(async (
+        _conversationId,
+        _message,
+        options: { onMessageTaken?: (messageId?: string) => void },
+      ) => {
+        options.onMessageTaken?.('local-user-1');
+        return {
+          reason: 'error',
+          error: 'HTTP 403 · content_policy',
+          messageTaken: true,
+          upstream: upstreamErrorDetails,
+        };
+      });
+
+      await expect(runAgentLoopDispatched('conv-1', 'hello')).resolves.toEqual({
+        reason: 'error',
+        error: 'HTTP 403 · content_policy',
+        messageTaken: true,
+        upstream: upstreamErrorDetails,
+      });
+      expect(chatStoreUpdateUserMessageRunMock).toHaveBeenNthCalledWith(
+        1,
+        'conv-1',
+        'local-user-1',
+        { state: 'running' },
+      );
+      expect(chatStoreUpdateUserMessageRunMock).toHaveBeenNthCalledWith(
+        2,
+        'conv-1',
+        'local-user-1',
+        {
+          state: 'failed',
+          error: 'HTTP 403 · content_policy',
+          errorDetails: upstreamErrorDetails,
+        },
+      );
+      expect(waitForConversationPersistenceMock).toHaveBeenCalledWith('conv-1');
+      expect(sidecarRequestMock).not.toHaveBeenCalled();
     });
 
     it('preserves an in-process ownership rejection instead of marking every error as taken', async () => {
@@ -3205,7 +3264,7 @@ describe('agentLoopRunner', () => {
       const { runAgentLoopDispatched } = await importFresh();
       sidecarRequestMock
         .mockResolvedValueOnce({ reason: 'completed' })
-        .mockResolvedValueOnce({ reason: 'error', error: 'provider unavailable' });
+        .mockResolvedValueOnce({ reason: 'error', error: 'provider unavailable', messageTaken: true });
       dequeueNextUserInputMock
         .mockReturnValueOnce({ id: 'q1', text: 'first follow-up', timestamp: 1 })
         .mockReturnValueOnce({ id: 'q2', text: 'must remain queued', timestamp: 2 });
@@ -3219,6 +3278,79 @@ describe('agentLoopRunner', () => {
       expect(sidecarRequestMock).toHaveBeenCalledTimes(2);
       expect(dequeueNextUserInputMock).toHaveBeenCalledTimes(1);
       expect(pauseUserInputQueueMock).toHaveBeenCalledWith('conv-1');
+    });
+
+    it('preserves upstream details from an older sidecar raw RPC result', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      sidecarRequestMock.mockResolvedValue({
+        reason: 'error',
+        error: 'HTTP 403 · content_policy',
+        messageTaken: true,
+        upstream: upstreamErrorDetails,
+      });
+
+      await expect(runAgentLoopDispatched('conv-1', 'hello')).resolves.toEqual({
+        reason: 'error',
+        error: 'HTTP 403 · content_policy',
+        upstream: upstreamErrorDetails,
+        messageTaken: true,
+      });
+      expect(chatStoreUpdateUserMessageRunMock).toHaveBeenCalledWith(
+        'conv-1',
+        expect.any(String),
+        {
+          state: 'failed',
+          error: 'HTTP 403 · content_policy',
+          errorDetails: upstreamErrorDetails,
+        },
+      );
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        'agent loop reported a failed result',
+        expect.objectContaining({
+          resultSource: 'raw-rpc',
+          status: 403,
+          error_type: upstreamErrorDetails.error_type,
+          traceId: upstreamErrorDetails.traceId,
+          providerSummary: upstreamErrorDetails.summary,
+        }),
+      );
+    });
+
+    it('sanitizes a baseline sidecar raw RPC JSON error before store and return', async () => {
+      const legacyRaw = '{"private":"legacy provider body"}';
+      const { runAgentLoopDispatched } = await importFresh();
+      sidecarRequestMock.mockResolvedValue({
+        reason: 'error',
+        error: legacyRaw,
+        messageTaken: true,
+      });
+
+      await expect(runAgentLoopDispatched('conv-1', 'hello')).resolves.toEqual({
+        reason: 'error',
+        error: '请求失败但无详情',
+        messageTaken: true,
+      });
+      expect(chatStoreUpdateUserMessageRunMock).toHaveBeenCalledWith(
+        'conv-1',
+        expect.any(String),
+        { state: 'failed', error: '请求失败但无详情' },
+      );
+      expect(JSON.stringify(chatStoreUpdateUserMessageRunMock.mock.calls)).not.toContain(legacyRaw);
+    });
+
+    it('rejects a completed raw RPC result carrying failure details', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      sidecarRequestMock.mockResolvedValue({
+        reason: 'completed',
+        error: 'must not survive',
+        upstream: upstreamErrorDetails,
+      });
+
+      await expect(runAgentLoopDispatched('conv-1', 'hello')).resolves.toEqual({ reason: 'completed' });
+
+      expect(runAgentLoopMock).toHaveBeenCalledTimes(1);
+      expect(JSON.stringify(chatStoreUpdateUserMessageRunMock.mock.calls)).not.toContain('must not survive');
+      expect(JSON.stringify(chatStoreUpdateUserMessageRunMock.mock.calls)).not.toContain(upstreamErrorDetails.traceId);
     });
 
     it('persists the user message before the bounded start handshake', async () => {
@@ -3428,6 +3560,45 @@ describe('agentLoopRunner', () => {
       expect(runAgentLoopMock).not.toHaveBeenCalled();
     });
 
+    it('preserves upstream details from the raw result of a replayed execution', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      sidecarRequestMock
+        .mockRejectedValueOnce(new Error('sidecar restarted'))
+        .mockResolvedValueOnce({
+          reason: 'error',
+          error: 'HTTP 403 · content_policy',
+          messageTaken: true,
+          upstream: upstreamErrorDetails,
+        });
+
+      await expect(runAgentLoopDispatched('conv-1', 'hello')).resolves.toEqual({
+        reason: 'error',
+        error: 'HTTP 403 · content_policy',
+        upstream: upstreamErrorDetails,
+        messageTaken: true,
+      });
+      expect(chatStoreUpdateUserMessageRunMock).toHaveBeenCalledWith(
+        'conv-1',
+        expect.any(String),
+        {
+          state: 'failed',
+          error: 'HTTP 403 · content_policy',
+          errorDetails: upstreamErrorDetails,
+        },
+      );
+      expect(sidecarRequestMock.mock.calls.filter((call) => call[0] === 'agent.run')).toHaveLength(2);
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        'agent loop reported a failed result',
+        expect.objectContaining({
+          resultSource: 'replay-rpc',
+          status: 403,
+          error_type: upstreamErrorDetails.error_type,
+          traceId: upstreamErrorDetails.traceId,
+          providerSummary: upstreamErrorDetails.summary,
+        }),
+      );
+    });
+
     it('uses a cached terminal returned by run.getState and never replays work', async () => {
       const { runAgentLoopDispatched } = await importFresh();
       sidecarRequestMock.mockRejectedValueOnce(new Error('response lost'));
@@ -3530,8 +3701,28 @@ describe('agentLoopRunner', () => {
         version: 1,
         runId,
         state: 'failed',
-        result: { reason: 'error', error: 'provider failed' },
-        failure: { errorType: 'provider_error', message: 'provider failed', stack: 'provider stack' },
+        result: {
+          reason: 'error',
+          error: 'provider failed',
+          messageTaken: true,
+          upstream: {
+            status: 403,
+            error_type: 'governance.alicloud_content_safety_input_rejected',
+            traceId: 'runner-trace-403',
+            summary: 'provider rejected the request',
+          },
+        },
+        failure: {
+          errorType: 'provider_error',
+          message: 'provider failed',
+          stack: 'provider stack',
+          upstream: {
+            status: 403,
+            error_type: 'governance.alicloud_content_safety_input_rejected',
+            traceId: 'runner-trace-403',
+            summary: 'provider rejected the request',
+          },
+        },
       };
       terminalHandler(failed);
       terminalHandler(failed);
@@ -3540,12 +3731,55 @@ describe('agentLoopRunner', () => {
         reason: 'error',
         error: 'provider failed',
         messageTaken: true,
+        upstream: failed.failure.upstream,
       });
       expect(runAgentLoopMock).not.toHaveBeenCalled();
       expect(chatDeltaAppendTextMock).toHaveBeenCalledTimes(1);
       expect(chatDeltaAppendTextMock).toHaveBeenCalledWith('conv-1', expect.stringContaining('provider failed'));
       expect(chatDeltaFinishStreamingMock).toHaveBeenCalledTimes(1);
       expect(chatDeltaSetConversationStatusMock).toHaveBeenCalledWith('conv-1', 'error');
+      expect(chatStoreUpdateUserMessageRunMock).toHaveBeenCalledWith(
+        'conv-1',
+        expect.any(String),
+        {
+          state: 'failed',
+          error: 'provider failed',
+          errorDetails: failed.failure.upstream,
+        },
+      );
+    });
+
+    it('sanitizes a baseline failed terminal JSON error before UI, store, and return', async () => {
+      const legacyRaw = '{"private":"legacy terminal provider body"}';
+      const { runAgentLoopDispatched } = await importFresh();
+      sidecarRequestMock.mockImplementation((_method: string, _params: unknown, _timeout: number, signal?: AbortSignal) => (
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+        })
+      ));
+
+      const running = runAgentLoopDispatched('conv-1', 'hello');
+      await waitForCall(sidecarRequestMock);
+      const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
+      handlerFor(onSidecarNotification, 'agent.terminal')({
+        version: 1,
+        runId,
+        state: 'failed',
+        result: { reason: 'error', error: legacyRaw, messageTaken: true },
+        failure: { errorType: 'llmerror', message: legacyRaw },
+      });
+
+      await expect(running).resolves.toEqual({
+        reason: 'error',
+        error: '请求失败但无详情',
+        messageTaken: true,
+      });
+      expect(chatDeltaAppendTextMock).toHaveBeenCalledWith(
+        'conv-1',
+        expect.stringContaining('请求失败但无详情'),
+      );
+      expect(JSON.stringify(chatDeltaAppendTextMock.mock.calls)).not.toContain(legacyRaw);
+      expect(JSON.stringify(chatStoreUpdateUserMessageRunMock.mock.calls)).not.toContain(legacyRaw);
     });
 
     it('skips re-appending the error text when agentLoop already rendered it (errorType: agent_loop_error)', async () => {
@@ -3564,7 +3798,7 @@ describe('agentLoopRunner', () => {
         version: 1,
         runId,
         state: 'failed',
-        result: { reason: 'error', error: '余额不足或无可用资源包，请充值。' },
+        result: { reason: 'error', error: '余额不足或无可用资源包，请充值。', messageTaken: true },
         failure: { errorType: 'agent_loop_error', message: '余额不足或无可用资源包，请充值。' },
       });
 
@@ -3603,7 +3837,7 @@ describe('agentLoopRunner', () => {
         version: 1,
         runId,
         state: 'failed',
-        result: { reason: 'error', error: 'provider failed' },
+        result: { reason: 'error', error: 'provider failed', messageTaken: true },
         failure: { errorType: 'provider_error', message: 'provider failed' },
       });
 
@@ -4251,6 +4485,42 @@ describe('agentLoopRunner', () => {
       expect(result).toEqual({ reason: 'completed' });
     });
 
+    it('preserves upstream details when a pre-commit transport failure falls back in-process', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      sidecarRequestMock.mockRejectedValue(new Error('sidecar process closed'));
+      runAgentLoopMock.mockResolvedValueOnce({
+        reason: 'error',
+        error: 'HTTP 403 · content_policy',
+        upstream: upstreamErrorDetails,
+      });
+
+      await expect(runAgentLoopDispatched('conv-1', 'hello')).resolves.toEqual({
+        reason: 'error',
+        error: 'HTTP 403 · content_policy',
+        upstream: upstreamErrorDetails,
+        messageTaken: true,
+      });
+      expect(chatStoreUpdateUserMessageRunMock).toHaveBeenCalledWith(
+        'conv-1',
+        expect.any(String),
+        {
+          state: 'failed',
+          error: 'HTTP 403 · content_policy',
+          errorDetails: upstreamErrorDetails,
+        },
+      );
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        'agent loop reported a failed result',
+        expect.objectContaining({
+          resultSource: 'fallback-in-process',
+          status: 403,
+          error_type: upstreamErrorDetails.error_type,
+          traceId: upstreamErrorDetails.traceId,
+          providerSummary: upstreamErrorDetails.summary,
+        }),
+      );
+    });
+
     it('keeps the replacement local task controller after a pre-commit sidecar fallback', async () => {
       const { runAgentLoopDispatched } = await importFresh();
       let activeController: AbortController | undefined;
@@ -4456,6 +4726,50 @@ describe('agentLoopRunner', () => {
       expect(chatDeltaAppendTextMock).toHaveBeenCalledWith('conv-1', expect.stringContaining('Maximum call stack size exceeded'));
     });
 
+    it('sanitizes post-commit RPC data while preserving bounded upstream details', async () => {
+      const legacyRaw = 'Request failed\n{"private":"committed provider body"}';
+      const { runAgentLoopDispatched } = await importFresh();
+      const d = deferred<unknown>();
+      sidecarRequestMock.mockReturnValue(d.promise);
+
+      const running = runAgentLoopDispatched('conv-1', 'hello');
+      await waitForCall(sidecarRequestMock);
+      const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
+      handlerFor(onSidecarNotification, 'agent.delta')({
+        runId,
+        frames: [{ p: 'chat', m: 'appendText', a: ['conv-1', 'partial'] }],
+      });
+      d.reject(Object.assign(new Error('Sidecar error -32603: Internal error'), {
+        data: {
+          message: legacyRaw,
+          stack: `Error: safe heading\n{"private":"committed provider stack"}`,
+          upstream: upstreamErrorDetails,
+        },
+      }));
+
+      await expect(running).resolves.toEqual({
+        reason: 'error',
+        error: upstreamErrorDetails.summary,
+        messageTaken: true,
+        upstream: upstreamErrorDetails,
+      });
+      expect(chatDeltaAppendTextMock).toHaveBeenCalledWith(
+        'conv-1',
+        expect.stringContaining(upstreamErrorDetails.summary),
+      );
+      expect(chatStoreUpdateUserMessageRunMock).toHaveBeenCalledWith(
+        'conv-1',
+        expect.any(String),
+        {
+          state: 'failed',
+          error: upstreamErrorDetails.summary,
+          errorDetails: upstreamErrorDetails,
+        },
+      );
+      expect(JSON.stringify(chatDeltaAppendTextMock.mock.calls)).not.toContain('committed provider body');
+      expect(JSON.stringify(loggerWarnMock.mock.calls)).not.toContain('committed provider stack');
+    });
+
     it('a transport failure AFTER the run is committed via an agent.delta frame (no tool call yet) ALSO surfaces an error — NO rerun', async () => {
       const { runAgentLoopDispatched } = await importFresh();
       const d = deferred<unknown>();
@@ -4607,6 +4921,22 @@ describe('agentLoopRunner', () => {
 
       expect(runAgentLoopMock).toHaveBeenCalledTimes(1);
       expect(result).toEqual({ reason: 'completed' });
+    });
+
+    it('rejects an agent.run response carrying an unknown raw provider field', async () => {
+      const { runAgentLoopDispatched } = await importFresh();
+      sidecarRequestMock.mockResolvedValue({
+        reason: 'error',
+        error: 'HTTP 403 · content_policy',
+        messageTaken: true,
+        rawBody: 'private prompt text',
+      });
+
+      const result = await runAgentLoopDispatched('conv-1', 'hello');
+
+      expect(runAgentLoopMock).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ reason: 'completed' });
+      expect(JSON.stringify(chatStoreUpdateUserMessageRunMock.mock.calls)).not.toContain('private prompt text');
     });
 
     describe('concurrency guard', () => {

--- a/src/core/agent/agentLoopRunner.ts
+++ b/src/core/agent/agentLoopRunner.ts
@@ -30,7 +30,7 @@
  */
 import type { ConfirmationInfo, FilePermissionCallback } from '../tools/registry';
 import { checkToolApproval, type ToolApprovalDecision } from '../tools/registry';
-import type { ToolExecutionContext, Conversation, ToolExecutionMetadata } from '../../types';
+import type { ToolExecutionContext, Conversation, ToolExecutionMetadata, UpstreamErrorDetails } from '../../types';
 import {
   onSidecarNotification,
   onSidecarRequest,
@@ -88,6 +88,7 @@ import {
   resolveToolContextWorkspacePath,
   type AgentLoopOptions,
   type AgentLoopResult,
+  type AgentLoopExitReason,
 } from './agentLoop';
 import {
   materializeSidecarMediaRefsForShell,
@@ -98,11 +99,18 @@ import {
 import {
   areAgentRunTerminalsEqual,
   isAgentRunTerminal,
+  sanitizeReceivedAgentRunTerminal,
   type AgentRunTerminal,
 } from './agentRunTerminal';
 import { precomputeOrchestration } from './entryOrchestration';
 import type { RouteResult, IMContext } from './orchestrator';
 import type { PromptSection } from '../llm/promptSections';
+import {
+  isUpstreamErrorDetails,
+  isUnsafeStructuredLlmErrorText,
+  normalizeUpstreamErrorDetails,
+  sanitizeUntrustedLlmErrorText,
+} from '../llm/adapter';
 import type { ConversationMeta } from '../session/conversationStorage';
 import { resolveEntryModel } from './resolveEntryModel';
 import { getActiveApiKey, getActiveProvider } from '../../utils/settingsSelectors';
@@ -165,6 +173,38 @@ const AGENT_FIRST_FRAME_STALL_MS = 30_000;
 const AGENT_START_ACK_TIMEOUT_MS = 3_000;
 const AGENT_STATE_QUERY_TIMEOUT_MS = 2_000;
 const MAX_REATTACH_UNAVAILABLE_CHECKS = 3;
+const AGENT_LOOP_EXIT_REASONS = new Set<AgentLoopExitReason>([
+  'completed',
+  'aborted',
+  'error',
+  'max_turns',
+  'no_progress',
+  'awaiting_user',
+  'enqueued',
+]);
+
+function warnFailedAgentResult(params: {
+  runId: string;
+  conversationId: string;
+  cause: string;
+  source: 'terminal' | 'raw-rpc' | 'replay-rpc' | 'fallback-in-process';
+  upstream?: UpstreamErrorDetails;
+  errorType?: string;
+  stack?: string;
+}): void {
+  logger.warn('agent loop reported a failed result', {
+    runId: params.runId,
+    conversationId: params.conversationId,
+    resultSource: params.source,
+    sidecarCause: params.cause,
+    sidecarErrorType: params.errorType,
+    sidecarStack: params.stack,
+    status: params.upstream?.status,
+    error_type: params.upstream?.error_type,
+    traceId: params.upstream?.traceId,
+    providerSummary: params.upstream?.summary,
+  });
+}
 
 class SidecarRunStateUnavailableError extends Error {
   readonly stopReason = 'sidecar_unavailable' as const;
@@ -177,14 +217,14 @@ class SidecarRunStateUnavailableError extends Error {
 
 function rendererRuntimeOptions(
   options?: AgentLoopOptions,
-  onMessageTaken?: () => void,
+  onMessageTaken?: (messageId?: string) => void,
 ): AgentLoopOptions {
   return {
     ...options,
     onMessageTaken: onMessageTaken || options?.onMessageTaken
-      ? () => {
-          onMessageTaken?.();
-          options?.onMessageTaken?.();
+      ? (messageId) => {
+          onMessageTaken?.(messageId);
+          options?.onMessageTaken?.(messageId);
         }
       : undefined,
     // This function never crosses the wire. Rebuild it for every in-process
@@ -565,29 +605,30 @@ function handleAgentDelta(rawParams: unknown): void {
 /** `agent.terminal` (NOTIFICATION) — first valid terminal wins per run. */
 function handleAgentTerminal(rawParams: unknown): void {
   if (!isAgentRunTerminal(rawParams)) return;
-  const session = sessions.get(rawParams.runId);
+  const terminal = sanitizeReceivedAgentRunTerminal(rawParams, getI18n().chat.errorEmptyBody);
+  const session = sessions.get(terminal.runId);
   if (!session) return;
 
   if (session.terminal) {
-    if (!areAgentRunTerminalsEqual(session.terminal, rawParams)) {
+    if (!areAgentRunTerminalsEqual(session.terminal, terminal)) {
       logger.warn('conflicting agent terminal ignored', {
-        runId: rawParams.runId,
+        runId: terminal.runId,
         firstState: session.terminal.state,
-        conflictingState: rawParams.state,
+        conflictingState: terminal.state,
       });
     }
     return;
   }
 
-  session.terminal = rawParams;
+  session.terminal = terminal;
   session.dropFrames = true;
   if (session.firstFrameStallTimer) {
     clearTimeout(session.firstFrameStallTimer);
     session.firstFrameStallTimer = undefined;
   }
-  markRuntimeRunStage(rawParams.runId, 'terminal_received');
+  markRuntimeRunStage(terminal.runId, 'terminal_received');
   traceRuntimeEvent('renderer.agent_terminal_received', {
-    runId: rawParams.runId,
+    runId: terminal.runId,
     executionPath: 'sidecar',
     stage: 'terminal_received',
     outcome: rawParams.result.reason,
@@ -595,19 +636,24 @@ function handleAgentTerminal(rawParams: unknown): void {
       ? undefined
       : Date.now() - session.runtimeStartedAt,
   });
-  session.resolveTerminal?.(rawParams);
+  session.resolveTerminal?.(terminal);
 }
 
 function updateSessionMessageState(
   session: RunSession,
   state: NonNullable<Conversation['messages'][number]['runState']>,
   error?: string,
+  errorDetails?: UpstreamErrorDetails,
 ): void {
   if (!session.userMessageId) return;
   useChatStore.getState().updateUserMessageRun(
     session.conversationId,
     session.userMessageId,
-    { state, ...(error ? { error } : {}) },
+    {
+      state,
+      ...(error ? { error } : {}),
+      ...(errorDetails ? { errorDetails } : {}),
+    },
   );
 }
 
@@ -648,9 +694,19 @@ async function runInProcessWithPersistedMessage(
       : result.reason === 'error'
         ? 'failed'
         : 'completed';
+    if (result.reason === 'error') {
+      warnFailedAgentResult({
+        runId,
+        conversationId,
+        cause: result.error || 'Agent run failed',
+        source: 'fallback-in-process',
+        upstream: result.upstream,
+      });
+    }
     useChatStore.getState().updateUserMessageRun(conversationId, clientMessageId, {
       state,
       ...(result.error ? { error: result.error } : {}),
+      ...(result.upstream ? { errorDetails: result.upstream } : {}),
     });
     await waitForConversationPersistence(conversationId);
     return markReturnedErrorAsTaken(result);
@@ -708,12 +764,13 @@ async function finalizeFailedRun(
   displayMessage: string,
   state: 'failed' | 'connection-failed' = 'failed',
   skipErrorAppend = false,
+  errorDetails?: UpstreamErrorDetails,
 ): Promise<void> {
   if (session.failureFinalizationPromise) return session.failureFinalizationPromise;
 
   session.failureFinalizationPromise = (async () => {
     session.dropFrames = true;
-    updateSessionMessageState(session, state, displayMessage);
+    updateSessionMessageState(session, state, displayMessage, errorDetails);
     await (session.frameApplyTail ?? Promise.resolve());
     try {
       const chatDelta = getChatDelta();
@@ -2009,7 +2066,36 @@ interface AgentRunParams {
 
 /** Defensive validation of the `agent.run` response before trusting it as an `AgentLoopResult` — same discipline as subagentRunner.ts's `isSerializableSubagentResult`. A malformed response is treated identically to any other transport failure by the caller (same committed-flag fallback decision). */
 function isAgentLoopResult(v: unknown): v is AgentLoopResult {
-  return typeof v === 'object' && v !== null && typeof (v as Record<string, unknown>).reason === 'string';
+  if (typeof v !== 'object' || v === null) return false;
+  const candidate = v as Record<string, unknown>;
+  const allowedKeys = new Set(['reason', 'error', 'stopReason', 'messageTaken', 'upstream']);
+  return Object.keys(candidate).every((key) => allowedKeys.has(key))
+    && typeof candidate.reason === 'string'
+    && AGENT_LOOP_EXIT_REASONS.has(candidate.reason as AgentLoopExitReason)
+    && (candidate.error === undefined || typeof candidate.error === 'string')
+    && (candidate.stopReason === undefined || candidate.stopReason === 'sidecar_unavailable')
+    && (candidate.reason === 'error' || candidate.stopReason === undefined)
+    && (candidate.reason === 'error' || candidate.error === undefined)
+    && (candidate.messageTaken === undefined || typeof candidate.messageTaken === 'boolean')
+    && (candidate.reason === 'error'
+      ? typeof candidate.messageTaken === 'boolean'
+      : candidate.messageTaken === undefined)
+    && (candidate.reason === 'error' || candidate.upstream === undefined)
+    && (candidate.upstream === undefined || isUpstreamErrorDetails(candidate.upstream));
+}
+
+function sanitizeReceivedAgentLoopResult(result: AgentLoopResult): AgentLoopResult {
+  const upstream = normalizeUpstreamErrorDetails(result.upstream);
+  const error = result.error === undefined
+    ? undefined
+    : sanitizeUntrustedLlmErrorText(result.error, getI18n().chat.errorEmptyBody);
+  return {
+    reason: result.reason,
+    ...(error !== undefined ? { error } : {}),
+    ...(result.stopReason !== undefined ? { stopReason: result.stopReason } : {}),
+    ...(result.reason === 'error' ? { messageTaken: result.messageTaken } : {}),
+    ...(upstream ? { upstream } : {}),
+  } as AgentLoopResult;
 }
 
 interface AgentStartAck {
@@ -2542,11 +2628,64 @@ async function runSingleAgentLoopDispatchedWithOwnership(
 
   if (!sidecarRunning) {
     await ensureBuiltinBrowserRuntime();
-    return runAgentLoop(
-      conversationId,
-      userMessage,
-      rendererRuntimeOptions(options, () => { ownership.messageTaken = true; }),
-    );
+    let localUserMessageId: string | undefined;
+    try {
+      const result = await runAgentLoop(
+        conversationId,
+        userMessage,
+        rendererRuntimeOptions(options, (messageId) => {
+          ownership.messageTaken = true;
+          localUserMessageId = messageId;
+          if (messageId) {
+            useChatStore.getState().updateUserMessageRun(conversationId, messageId, {
+              state: 'running',
+            });
+          }
+        }),
+      );
+      if (localUserMessageId) {
+        const upstream = result.reason === 'error'
+          ? normalizeUpstreamErrorDetails(result.upstream)
+          : undefined;
+        const error = result.reason === 'error' && result.error
+          ? sanitizeUntrustedLlmErrorText(
+              result.error,
+              upstream?.summary ?? (upstream ? `HTTP ${upstream.status}` : getI18n().chat.errorEmptyBody),
+            )
+          : undefined;
+        useChatStore.getState().updateUserMessageRun(conversationId, localUserMessageId, {
+          state: result.reason === 'aborted'
+            ? 'interrupted'
+            : result.reason === 'error'
+              ? 'failed'
+              : 'completed',
+          ...(error ? { error } : {}),
+          ...(upstream ? { errorDetails: upstream } : {}),
+        });
+        await waitForConversationPersistence(conversationId);
+      }
+      return result;
+    } catch (error) {
+      if (localUserMessageId) {
+        const errorRecord = error && typeof error === 'object'
+          ? error as { message?: unknown; upstream?: unknown }
+          : undefined;
+        const upstream = normalizeUpstreamErrorDetails(errorRecord?.upstream);
+        const rawMessage = typeof errorRecord?.message === 'string'
+          ? errorRecord.message
+          : String(error);
+        useChatStore.getState().updateUserMessageRun(conversationId, localUserMessageId, {
+          state: 'failed',
+          error: sanitizeUntrustedLlmErrorText(
+            rawMessage,
+            upstream?.summary ?? (upstream ? `HTTP ${upstream.status}` : getI18n().chat.errorEmptyBody),
+          ),
+          ...(upstream ? { errorDetails: upstream } : {}),
+        });
+        await waitForConversationPersistence(conversationId);
+      }
+      throw error;
+    }
   }
 
   ensureHandlersRegistered();
@@ -2779,6 +2918,7 @@ async function runSingleAgentLoopDispatchedWithOwnership(
   const scopedRun = options?.authorizationScopeId !== undefined;
 
   const settleFromTerminal = async (terminal: AgentRunTerminal): Promise<AgentLoopDispatchResult> => {
+    terminal = sanitizeReceivedAgentRunTerminal(terminal, getI18n().chat.errorEmptyBody);
     await settleRunPersistence(session);
     if (session.abortRequested) {
       await finalizeAbortedRun(session, 'run-terminal');
@@ -2794,15 +2934,18 @@ async function runSingleAgentLoopDispatchedWithOwnership(
 
     if (terminal.state === 'failed') {
       const realMessage = terminal.result.error || 'Agent run failed';
+      const upstream = terminal.failure?.upstream ?? terminal.result.upstream;
       const displayMessage = realMessage === 'Sidecar process closed'
         ? getI18n().chat.sidecarInterrupted
         : realMessage;
-      logger.warn('agent loop reported a failed terminal', {
+      warnFailedAgentResult({
         runId,
         conversationId,
-        sidecarCause: realMessage,
-        sidecarErrorType: terminal.failure?.errorType,
-        sidecarStack: terminal.failure?.stack,
+        cause: realMessage,
+        source: 'terminal',
+        upstream,
+        errorType: terminal.failure?.errorType,
+        stack: terminal.failure?.stack,
       });
       traceRuntimeEvent('renderer.agent_run_failed', {
         runId,
@@ -2819,8 +2962,13 @@ async function runSingleAgentLoopDispatchedWithOwnership(
       // crash / uncaught throw, where nothing rendered and this append is the
       // only chance to surface the failure.
       const alreadyRenderedBySidecar = terminal.failure?.errorType === 'agent_loop_error';
-      await finalizeFailedRun(session, displayMessage, 'failed', alreadyRenderedBySidecar);
-      return { reason: 'error', error: realMessage, messageTaken: true };
+      await finalizeFailedRun(session, displayMessage, 'failed', alreadyRenderedBySidecar, upstream);
+      return {
+        reason: 'error',
+        error: realMessage,
+        messageTaken: true,
+        ...(upstream ? { upstream } : {}),
+      };
     }
 
     const eventName = terminal.state === 'interrupted'
@@ -2869,10 +3017,10 @@ async function runSingleAgentLoopDispatchedWithOwnership(
       return await settleFromTerminal(outcome.terminal);
     }
 
-    const raw = outcome.raw;
-    if (!isAgentLoopResult(raw)) {
+    if (!isAgentLoopResult(outcome.raw)) {
       throw new Error('agent.run response did not match the expected AgentLoopResult shape');
     }
+    const raw = sanitizeReceivedAgentLoopResult(outcome.raw);
     // The sidecar flushes its coalescer before replying, and the transport
     // preserves byte order. Await the shell-side FIFO plus the store's
     // fire-and-forget JSONL writes before exposing a completed turn.
@@ -2902,10 +3050,20 @@ async function runSingleAgentLoopDispatchedWithOwnership(
         ? undefined
         : session.firstDeltaAt - runtimeStartedAt,
     });
+    if (raw.reason === 'error') {
+      warnFailedAgentResult({
+        runId,
+        conversationId,
+        cause: raw.error || 'Agent run failed',
+        source: 'raw-rpc',
+        upstream: raw.upstream,
+      });
+    }
     updateSessionMessageState(
       session,
       raw.reason === 'aborted' ? 'interrupted' : raw.reason === 'error' ? 'failed' : 'completed',
       raw.error,
+      raw.upstream,
     );
     await waitForConversationPersistence(conversationId);
     return markReturnedErrorAsTaken(raw);
@@ -3002,19 +3160,30 @@ async function runSingleAgentLoopDispatchedWithOwnership(
           if (!isAgentLoopResult(replayOutcome.raw)) {
             throw new Error('replayed agent.run response did not match the expected result shape', { cause: err });
           }
+          const replayResult = sanitizeReceivedAgentLoopResult(replayOutcome.raw);
           await settleRunPersistence(session);
           if (session.terminal) return await settleFromTerminal(session.terminal);
+          if (replayResult.reason === 'error') {
+            warnFailedAgentResult({
+              runId,
+              conversationId,
+              cause: replayResult.error || 'Agent run failed',
+              source: 'replay-rpc',
+              upstream: replayResult.upstream,
+            });
+          }
           updateSessionMessageState(
             session,
-            replayOutcome.raw.reason === 'aborted'
+            replayResult.reason === 'aborted'
               ? 'interrupted'
-              : replayOutcome.raw.reason === 'error'
+              : replayResult.reason === 'error'
                 ? 'failed'
                 : 'completed',
-            replayOutcome.raw.error,
+            replayResult.error,
+            replayResult.upstream,
           );
           await waitForConversationPersistence(conversationId);
-          return markReturnedErrorAsTaken(replayOutcome.raw);
+          return markReturnedErrorAsTaken(replayResult);
         } catch (replayError) {
           transportError = replayError;
         }
@@ -3064,10 +3233,21 @@ async function runSingleAgentLoopDispatchedWithOwnership(
     // Logging only `err.message` (the generic wrapper) threw that away — pull
     // `data` out so the on-disk log names the actual failure.
     const errData = (transportError as { data?: unknown } | null)?.data;
-    const realMessage =
-      errData && typeof errData === 'object' && 'message' in errData
-        ? String((errData as { message: unknown }).message)
-        : transportError instanceof Error ? transportError.message : String(transportError);
+    const errDataRecord = errData && typeof errData === 'object' && !Array.isArray(errData)
+      ? errData as Record<string, unknown>
+      : undefined;
+    const upstream = normalizeUpstreamErrorDetails(errDataRecord?.upstream);
+    const rawCause = typeof errDataRecord?.message === 'string'
+      ? errDataRecord.message
+      : transportError instanceof Error ? transportError.message : String(transportError);
+    const realMessage = sanitizeUntrustedLlmErrorText(
+      rawCause,
+      upstream?.summary ?? (upstream ? `HTTP ${upstream.status}` : getI18n().chat.errorEmptyBody),
+    );
+    const sidecarStack = typeof errDataRecord?.stack === 'string'
+      && !isUnsafeStructuredLlmErrorText(errDataRecord.stack)
+      ? errDataRecord.stack
+      : undefined;
     const displayMessage =
       transportError instanceof SidecarRunStateUnavailableError
         ? getI18n().chat.sidecarUnavailable
@@ -3079,10 +3259,11 @@ async function runSingleAgentLoopDispatchedWithOwnership(
       conversationId,
       error: transportError instanceof Error ? transportError.message : String(transportError),
       sidecarCause: realMessage,
-      sidecarStack:
-        errData && typeof errData === 'object' && 'stack' in errData
-          ? String((errData as { stack: unknown }).stack)
-          : undefined,
+      sidecarStack,
+      status: upstream?.status,
+      error_type: upstream?.error_type,
+      traceId: upstream?.traceId,
+      providerSummary: upstream?.summary,
     });
     traceRuntimeEvent('renderer.agent_run_failed', {
       runId,
@@ -3106,11 +3287,14 @@ async function runSingleAgentLoopDispatchedWithOwnership(
       session,
       displayMessage,
       isConnectionFailure ? 'connection-failed' : 'failed',
+      false,
+      upstream,
     );
     return {
       reason: 'error',
       error: realMessage,
       messageTaken: true,
+      ...(upstream ? { upstream } : {}),
       ...(transportError instanceof SidecarRunStateUnavailableError
         ? { stopReason: transportError.stopReason }
         : {}),

--- a/src/core/agent/agentRunTerminal.contract.test.ts
+++ b/src/core/agent/agentRunTerminal.contract.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE } from './__contractFixtures__/agentRunTerminalFixture';
+import { isAgentRunTerminal } from './agentRunTerminal';
+
+describe('agent.terminal wire contract — receiver', () => {
+  it('accepts the shared failed-terminal fixture after an NDJSON-compatible round trip', () => {
+    const wireValue: unknown = JSON.parse(JSON.stringify(FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE));
+
+    expect(isAgentRunTerminal(wireValue)).toBe(true);
+    expect(wireValue).toEqual(FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE);
+  });
+});

--- a/src/core/agent/agentRunTerminal.test.ts
+++ b/src/core/agent/agentRunTerminal.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
+  areAgentRunTerminalsEqual,
   createAgentRunTerminal,
   isAgentRunTerminal,
+  sanitizeReceivedAgentRunTerminal,
   terminalStateForAgentLoopResult,
 } from './agentRunTerminal';
+import { FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE } from './__contractFixtures__/agentRunTerminalFixture';
 
 describe('agentRunTerminal', () => {
   it.each([
@@ -30,14 +33,14 @@ describe('agentRunTerminal', () => {
       version: 1,
       runId: 'run-1',
       state: 'failed',
-      result: { reason: 'error', error: 'boom' },
+      result: { reason: 'error', error: 'boom', messageTaken: true },
       failure: { errorType: 'provider_error', message: 'boom', stack: 'stack' },
     })).toBe(true);
     expect(isAgentRunTerminal({
       version: 1,
       runId: 'run-1',
       state: 'completed',
-      result: { reason: 'error', error: 'boom' },
+      result: { reason: 'error', error: 'boom', messageTaken: true },
       failure: { errorType: 'provider_error', message: 'boom' },
     })).toBe(false);
     expect(isAgentRunTerminal({
@@ -52,5 +55,147 @@ describe('agentRunTerminal', () => {
       state: 'completed',
       result: { reason: 'completed' },
     })).toBe(false);
+  });
+
+  it('validates and compares bounded upstream error details', () => {
+    const fixture = structuredClone(FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE);
+    expect(isAgentRunTerminal(fixture)).toBe(true);
+    expect(areAgentRunTerminalsEqual(fixture, structuredClone(fixture))).toBe(true);
+    expect(areAgentRunTerminalsEqual(fixture, {
+      ...fixture,
+      failure: {
+        ...fixture.failure,
+        upstream: { ...fixture.failure.upstream, traceId: 'different-trace' },
+      },
+    })).toBe(false);
+    expect(areAgentRunTerminalsEqual(fixture, {
+      ...fixture,
+      result: { ...fixture.result, messageTaken: false },
+    })).toBe(false);
+    expect(areAgentRunTerminalsEqual(fixture, {
+      ...fixture,
+      result: { ...fixture.result, stopReason: 'sidecar_unavailable' },
+    })).toBe(false);
+  });
+
+  it('drops failure-only fields from a completed sender result', () => {
+    expect(createAgentRunTerminal('completed-projection', {
+      reason: 'completed',
+      error: 'must not cross',
+      upstream: { status: 403 },
+    })).toEqual({
+      version: 1,
+      runId: 'completed-projection',
+      state: 'completed',
+      result: { reason: 'completed' },
+    });
+  });
+
+  it.each([
+    '{"private":"legacy provider body"}',
+    '<html><body>legacy proxy body</body></html>',
+  ])('sanitizes legacy terminal text before renderer use: %s', (message) => {
+    const terminal = createAgentRunTerminal(
+      'legacy-terminal',
+      { reason: 'error', error: message, messageTaken: true },
+      { errorType: 'llmerror', message, stack: `LLMError: ${message}\n    at legacy-adapter.ts:1:1` },
+    );
+
+    const sanitized = sanitizeReceivedAgentRunTerminal(terminal, 'safe terminal failure');
+
+    expect(sanitized.result.error).toBe('safe terminal failure');
+    expect(sanitized.failure?.message).toBe('safe terminal failure');
+    expect(sanitized.failure?.stack).toBeUndefined();
+    expect(JSON.stringify(sanitized)).not.toContain('legacy provider body');
+    expect(JSON.stringify(sanitized)).not.toContain('legacy proxy body');
+  });
+
+  it.each([
+    ['missing status', { error_type: 'content_policy' }],
+    ['non-integer status', { status: 403.5 }],
+    ['out-of-range status', { status: 999 }],
+    ['empty error_type', { status: 403, error_type: '' }],
+    ['non-string traceId', { status: 403, traceId: 42 }],
+    ['non-string summary', { status: 403, summary: {} }],
+    ['privacy-unsafe extra field', { status: 403, rawBody: 'private prompt text' }],
+  ])('rejects malformed upstream details: %s', (_label, upstream) => {
+    expect(isAgentRunTerminal({
+      ...FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE,
+      result: {
+        ...FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE.result,
+        upstream,
+      },
+      failure: {
+        ...FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE.failure,
+        upstream,
+      },
+    })).toBe(false);
+  });
+
+  it('rejects conflicting upstream projections duplicated in result and failure', () => {
+    expect(isAgentRunTerminal({
+      ...FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE,
+      failure: {
+        ...FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE.failure,
+        upstream: {
+          ...FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE.failure.upstream,
+          traceId: 'conflicting-trace',
+        },
+      },
+    })).toBe(false);
+  });
+
+  it.each([
+    ['terminal', {
+      ...FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE,
+      rawBody: 'private prompt text',
+    }],
+    ['result', {
+      ...FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE,
+      result: {
+        ...FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE.result,
+        rawBody: 'private prompt text',
+      },
+    }],
+    ['failure', {
+      ...FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE,
+      failure: {
+        ...FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE.failure,
+        rawBody: 'private prompt text',
+      },
+    }],
+  ])('rejects unknown privacy-unsafe keys on the %s object', (_label, terminal) => {
+    expect(isAgentRunTerminal(terminal)).toBe(false);
+  });
+
+  it.each([
+    ['missing messageTaken', {
+      ...FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE,
+      result: { reason: 'error', error: 'failed' },
+    }],
+    ['non-boolean messageTaken', {
+      ...FAILED_AGENT_TERMINAL_CONTRACT_FIXTURE,
+      result: { reason: 'error', error: 'failed', messageTaken: 'yes' },
+    }],
+    ['invalid stopReason', {
+      version: 1,
+      runId: 'invalid-stop-reason',
+      state: 'completed',
+      result: { reason: 'completed', stopReason: 'anything' },
+    }],
+    ['completed with error text', {
+      version: 1,
+      runId: 'completed-with-error',
+      state: 'completed',
+      result: { reason: 'completed', error: 'must not survive' },
+    }],
+    ['completed with upstream failure details', {
+      version: 1,
+      runId: 'completed-with-upstream',
+      state: 'completed',
+      result: { reason: 'completed', upstream: { status: 403 } },
+    }],
+  ])('rejects invalid AgentLoopResult semantics: %s', (_label, terminal) => {
+    expect(isAgentRunTerminal(terminal)).toBe(false);
   });
 });

--- a/src/core/agent/agentRunTerminal.ts
+++ b/src/core/agent/agentRunTerminal.ts
@@ -1,4 +1,11 @@
 import type { AgentLoopExitReason, AgentLoopResult } from './agentLoop';
+import type { UpstreamErrorDetails } from '../../types';
+import {
+  isUpstreamErrorDetails,
+  isUnsafeStructuredLlmErrorText,
+  normalizeUpstreamErrorDetails,
+  sanitizeUntrustedLlmErrorText,
+} from '../llm/adapter';
 
 export const AGENT_RUN_TERMINAL_VERSION = 1 as const;
 
@@ -8,6 +15,7 @@ export interface AgentRunTerminalFailure {
   errorType: string;
   message: string;
   stack?: string;
+  upstream?: UpstreamErrorDetails;
 }
 
 /**
@@ -35,6 +43,13 @@ const AGENT_LOOP_EXIT_REASONS = new Set<AgentLoopExitReason>([
   'awaiting_user',
   'enqueued',
 ]);
+const AGENT_RUN_TERMINAL_KEYS = new Set(['version', 'runId', 'state', 'result', 'failure']);
+const AGENT_LOOP_RESULT_KEYS = new Set(['reason', 'error', 'stopReason', 'messageTaken', 'upstream']);
+const AGENT_RUN_TERMINAL_FAILURE_KEYS = new Set(['errorType', 'message', 'stack', 'upstream']);
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: ReadonlySet<string>): boolean {
+  return Object.keys(value).every((key) => allowed.has(key));
+}
 
 export function terminalStateForAgentLoopResult(result: AgentLoopResult): AgentRunTerminalState {
   if (result.reason === 'error') return 'failed';
@@ -47,41 +62,123 @@ export function createAgentRunTerminal(
   result: AgentLoopResult,
   failure?: AgentRunTerminalFailure,
 ): AgentRunTerminal {
-  const state = terminalStateForAgentLoopResult(result);
+  const upstream = normalizeUpstreamErrorDetails(result.upstream);
+  const projectedResult: AgentLoopResult = {
+    reason: result.reason,
+    ...(result.reason === 'error' && result.error !== undefined ? { error: result.error } : {}),
+    ...(result.reason === 'error' && result.stopReason !== undefined ? { stopReason: result.stopReason } : {}),
+    ...(result.reason === 'error' ? { messageTaken: result.messageTaken } : {}),
+    ...(result.reason === 'error' && upstream ? { upstream } : {}),
+  } as AgentLoopResult;
+  const state = terminalStateForAgentLoopResult(projectedResult);
+  const sourceFailure = state === 'failed'
+    ? failure ?? {
+        errorType: 'agent_loop_error',
+        message: projectedResult.error || 'Agent run failed',
+        ...(upstream ? { upstream } : {}),
+      }
+    : undefined;
+  const failureUpstream = normalizeUpstreamErrorDetails(sourceFailure?.upstream);
+  const resolvedFailure = state === 'failed'
+    && sourceFailure
+    ? {
+        errorType: sourceFailure.errorType,
+        message: sourceFailure.message,
+        ...(sourceFailure.stack !== undefined ? { stack: sourceFailure.stack } : {}),
+        ...(failureUpstream ? { upstream: failureUpstream } : {}),
+      }
+    : undefined;
   return {
     version: AGENT_RUN_TERMINAL_VERSION,
     runId,
     state,
-    result,
-    ...(state === 'failed' ? {
-      failure: failure ?? {
-        errorType: 'agent_loop_error',
-        message: result.error || 'Agent run failed',
-      },
-    } : {}),
+    result: projectedResult,
+    ...(resolvedFailure ? { failure: resolvedFailure } : {}),
   };
+}
+
+function areUpstreamErrorsEqual(left?: UpstreamErrorDetails, right?: UpstreamErrorDetails): boolean {
+  return left?.status === right?.status
+    && left?.error_type === right?.error_type
+    && left?.traceId === right?.traceId
+    && left?.summary === right?.summary;
 }
 
 export function isAgentRunTerminal(value: unknown): value is AgentRunTerminal {
   if (typeof value !== 'object' || value === null) return false;
   const candidate = value as Record<string, unknown>;
+  if (!hasOnlyKeys(candidate, AGENT_RUN_TERMINAL_KEYS)) return false;
   if (candidate.version !== AGENT_RUN_TERMINAL_VERSION) return false;
   if (typeof candidate.runId !== 'string' || candidate.runId.length === 0) return false;
   if (candidate.state !== 'completed' && candidate.state !== 'failed' && candidate.state !== 'interrupted') return false;
   if (typeof candidate.result !== 'object' || candidate.result === null) return false;
 
   const result = candidate.result as Record<string, unknown>;
+  if (!hasOnlyKeys(result, AGENT_LOOP_RESULT_KEYS)) return false;
   if (typeof result.reason !== 'string' || !AGENT_LOOP_EXIT_REASONS.has(result.reason as AgentLoopExitReason)) return false;
   if (result.error !== undefined && typeof result.error !== 'string') return false;
+  if (result.stopReason !== undefined && result.stopReason !== 'sidecar_unavailable') return false;
+  if (result.reason !== 'error' && result.stopReason !== undefined) return false;
+  if (result.reason !== 'error' && result.error !== undefined) return false;
+  if (result.messageTaken !== undefined && typeof result.messageTaken !== 'boolean') return false;
+  if (result.reason === 'error' && typeof result.messageTaken !== 'boolean') return false;
+  if (result.reason !== 'error' && result.messageTaken !== undefined) return false;
+  if (result.reason !== 'error' && result.upstream !== undefined) return false;
+  if (result.upstream !== undefined && !isUpstreamErrorDetails(result.upstream)) return false;
 
   if (candidate.state !== terminalStateForAgentLoopResult(result as unknown as AgentLoopResult)) return false;
   if (candidate.state !== 'failed') return candidate.failure === undefined;
   if (typeof candidate.failure !== 'object' || candidate.failure === null) return false;
   const failure = candidate.failure as Record<string, unknown>;
-  return typeof failure.errorType === 'string'
+  if (!hasOnlyKeys(failure, AGENT_RUN_TERMINAL_FAILURE_KEYS)) return false;
+  const failureIsValid = typeof failure.errorType === 'string'
     && failure.errorType.length > 0
     && typeof failure.message === 'string'
-    && (failure.stack === undefined || typeof failure.stack === 'string');
+    && (failure.stack === undefined || typeof failure.stack === 'string')
+    && (failure.upstream === undefined || isUpstreamErrorDetails(failure.upstream));
+  if (!failureIsValid) return false;
+  if (result.upstream !== undefined && failure.upstream !== undefined) {
+    return areUpstreamErrorsEqual(
+      result.upstream as UpstreamErrorDetails,
+      failure.upstream as UpstreamErrorDetails,
+    );
+  }
+  return true;
+}
+
+/**
+ * Renderer-side compatibility projection for terminals emitted before the
+ * bounded upstream contract existed. Matched-version senders already provide
+ * safe text; legacy JSON/HTML bodies degrade to a generic message here.
+ */
+export function sanitizeReceivedAgentRunTerminal(
+  terminal: AgentRunTerminal,
+  fallbackMessage: string,
+): AgentRunTerminal {
+  if (terminal.state !== 'failed') return terminal;
+  const { upstream: _resultUpstream, ...resultWithoutUpstream } = terminal.result;
+  const resultUpstream = normalizeUpstreamErrorDetails(terminal.result.upstream);
+  const error = sanitizeUntrustedLlmErrorText(terminal.result.error, fallbackMessage);
+  let failure: AgentRunTerminalFailure | undefined;
+  if (terminal.failure) {
+    const { upstream: _failureUpstream, stack, ...failureWithoutUpstreamOrStack } = terminal.failure;
+    const failureUpstream = normalizeUpstreamErrorDetails(terminal.failure.upstream);
+    failure = {
+      ...failureWithoutUpstreamOrStack,
+      message: sanitizeUntrustedLlmErrorText(terminal.failure.message, error),
+      ...(stack && !isUnsafeStructuredLlmErrorText(stack) ? { stack } : {}),
+      ...(failureUpstream ? { upstream: failureUpstream } : {}),
+    };
+  }
+  return {
+    ...terminal,
+    result: {
+      ...resultWithoutUpstream,
+      error,
+      ...(resultUpstream ? { upstream: resultUpstream } : {}),
+    },
+    ...(failure ? { failure } : {}),
+  };
 }
 
 export function areAgentRunTerminalsEqual(left: AgentRunTerminal, right: AgentRunTerminal): boolean {
@@ -90,7 +187,12 @@ export function areAgentRunTerminalsEqual(left: AgentRunTerminal, right: AgentRu
     && left.state === right.state
     && left.result.reason === right.result.reason
     && left.result.error === right.result.error
+    && (left.result.reason === 'error' ? left.result.messageTaken : undefined)
+      === (right.result.reason === 'error' ? right.result.messageTaken : undefined)
+    && left.result.stopReason === right.result.stopReason
+    && areUpstreamErrorsEqual(left.result.upstream, right.result.upstream)
     && left.failure?.errorType === right.failure?.errorType
     && left.failure?.message === right.failure?.message
-    && left.failure?.stack === right.failure?.stack;
+    && left.failure?.stack === right.failure?.stack
+    && areUpstreamErrorsEqual(left.failure?.upstream, right.failure?.upstream);
 }

--- a/src/core/agent/retry.test.ts
+++ b/src/core/agent/retry.test.ts
@@ -40,6 +40,14 @@ describe('retry', () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
+  it('does not retry a content-policy rejection', async () => {
+    const err = new LLMError('content rejected', 'content_policy', { retryable: false });
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(withRetry(fn)).rejects.toThrow('content rejected');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
   it('does not retry non-LLMError', async () => {
     const fn = vi.fn().mockRejectedValue(new Error('generic error'));
 

--- a/src/core/agent/subagentLoop.ts
+++ b/src/core/agent/subagentLoop.ts
@@ -6,10 +6,10 @@
  * Message history is maintained in a local array and never written to chatStore.
  */
 
-import type { StreamEvent, Message, SubagentDefinition, SubagentStopReason, ToolDefinition, ToolExecutionContext, ToolResultContent } from '../../types';
+import type { StreamEvent, Message, SubagentDefinition, SubagentStopReason, ToolDefinition, ToolExecutionContext, ToolResultContent, UpstreamErrorDetails } from '../../types';
 import type { IMContext } from './orchestrator';
 import type { LLMAdapter } from '../llm/adapter';
-import { LLMError, formatLlmDisplayError } from '../llm/adapter';
+import { LLMError, formatLlmDisplayError, normalizeUpstreamErrorDetails } from '../llm/adapter';
 import { selectChatAdapter } from '../llm/selectChatAdapter';
 import { getToolInvoker, type ToolInvoker, type FilePermissionCallback } from './ports/toolInvoker';
 import type { ConfirmationInfo } from '../tools/commandSafety';
@@ -227,6 +227,8 @@ export class SubagentResult {
   readonly tokenUsage: { input: number; output: number };
   readonly duration: number; // seconds
   readonly stopReason: SubagentStopReason;
+  /** Bounded provider projection for a failed delegated run; never rawBody. */
+  readonly upstream?: UpstreamErrorDetails;
 
   constructor(params: {
     text: string;
@@ -235,6 +237,7 @@ export class SubagentResult {
     tokenUsage: { input: number; output: number };
     duration: number;
     stopReason: SubagentStopReason;
+    upstream?: UpstreamErrorDetails;
   }) {
     this.text = params.text;
     this.toolCallCount = params.toolCallCount;
@@ -242,6 +245,7 @@ export class SubagentResult {
     this.tokenUsage = params.tokenUsage;
     this.duration = params.duration;
     this.stopReason = params.stopReason;
+    this.upstream = normalizeUpstreamErrorDetails(params.upstream);
   }
 
   /** Backward compatible — callers that expect `string` get the text content */
@@ -1261,12 +1265,17 @@ export async function runSubagentLoop(options: SubagentLoopOptions): Promise<Sub
       return abortResult;
     }
     const errorResult = new SubagentResult({
-      text: `Error: ${err instanceof LLMError ? formatLlmDisplayError(err, errMsg, getI18n().chat.errorEmptyBody) : errMsg}`,
+      text: `Error: ${err instanceof LLMError && err.code === 'content_policy'
+        ? getI18n().chat.contentPolicyRejected
+        : err instanceof LLMError
+        ? formatLlmDisplayError(err, errMsg, getI18n().chat.errorEmptyBody)
+        : errMsg}`,
       toolCallCount: totalToolCalls,
       turnCount: 0,
       tokenUsage: { input: totalInputTokens, output: totalOutputTokens },
       duration: (Date.now() - startTime) / 1000,
       stopReason: 'error',
+      ...(err instanceof LLMError && err.upstream ? { upstream: err.upstream } : {}),
     });
     await emitHook({ type: 'subagentEnd', timestamp: Date.now(), agentName: agent.name, result: errorResult.text, error: true });
     subagentSpan.end({ output: errorResult.text, tokenUsage: errorResult.tokenUsage, toolCallCount: errorResult.toolCallCount, turnCount: errorResult.turnCount, duration: errorResult.duration, error: errMsg });

--- a/src/core/agent/subagentRecovery.integration.test.ts
+++ b/src/core/agent/subagentRecovery.integration.test.ts
@@ -743,6 +743,32 @@ describe('subagent max_tokens recovery (integration)', () => {
     expect(result.stopReason).toBe('error');
   });
 
+  it('preserves a bounded content-policy projection from a delegated provider failure', async () => {
+    const upstream = {
+      status: 403,
+      error_type: 'governance.alicloud_content_safety_input_rejected',
+      traceId: 'subagent-trace-403',
+      summary: 'provider rejected the request',
+    } as const;
+    mockClaudeChat.mockRejectedValueOnce(new LLMError(
+      '{"private":"raw delegated provider body"}',
+      'content_policy',
+      {
+        retryable: false,
+        statusCode: 403,
+        rawBody: '{"private":"raw delegated provider body"}',
+        upstream,
+      },
+    ));
+
+    const result = await runSubagentLoop({ agent, task: 'do the thing' });
+
+    expect(result.stopReason).toBe('error');
+    expect(result.upstream).toEqual(upstream);
+    expect(result.text).toMatch(/content[- ]safety|内容安全/i);
+    expect(result.text).not.toContain('raw delegated provider body');
+  });
+
   it('marks a normal end_turn with no text or tools as no-content error', async () => {
     mockClaudeChat.mockImplementationOnce(emits([
       { type: 'done', stopReason: 'end_turn' } as StreamEvent,

--- a/src/core/agent/subagentRunner.test.ts
+++ b/src/core/agent/subagentRunner.test.ts
@@ -50,6 +50,12 @@ vi.mock('./subagentLoop', () => {
     readonly tokenUsage: { input: number; output: number };
     readonly duration: number;
     readonly stopReason: string;
+    readonly upstream?: {
+      status: number;
+      error_type?: string;
+      traceId?: string;
+      summary?: string;
+    };
 
     constructor(params: {
       text: string;
@@ -58,6 +64,12 @@ vi.mock('./subagentLoop', () => {
       tokenUsage: { input: number; output: number };
       duration: number;
       stopReason: string;
+      upstream?: {
+        status: number;
+        error_type?: string;
+        traceId?: string;
+        summary?: string;
+      };
     }) {
       this.text = params.text;
       this.toolCallCount = params.toolCallCount;
@@ -65,6 +77,7 @@ vi.mock('./subagentLoop', () => {
       this.tokenUsage = params.tokenUsage;
       this.duration = params.duration;
       this.stopReason = params.stopReason;
+      this.upstream = params.upstream;
     }
 
     toString(): string {
@@ -599,6 +612,98 @@ describe('subagentRunner', () => {
       expect(result.stopReason).toBe('completed');
     });
 
+    it('reconstructs a strict bounded upstream projection from a failed sidecar subagent', async () => {
+      getSidecarStatus.mockReturnValue('running');
+      const upstream = {
+        status: 403,
+        error_type: 'governance.alicloud_content_safety_input_rejected',
+        traceId: 'subagent-runner-trace-403',
+        summary: 'provider rejected the request',
+      } as const;
+      sidecarRequestMock.mockResolvedValue({
+        text: 'Error: content policy rejected',
+        toolCallCount: 0,
+        turnCount: 0,
+        tokenUsage: { input: 0, output: 0 },
+        duration: 1,
+        stopReason: 'error',
+        upstream,
+      });
+      const { runSubagent } = await importFresh();
+
+      const result = await runSubagent({ agent, task: 'do the thing' });
+
+      expect(result.stopReason).toBe('error');
+      expect(result.upstream).toEqual(upstream);
+    });
+
+    it('rejects a subagent upstream projection with privacy-unsafe extra fields', async () => {
+      getSidecarStatus.mockReturnValue('running');
+      sidecarRequestMock.mockResolvedValue({
+        text: 'Error: content policy rejected',
+        toolCallCount: 0,
+        turnCount: 0,
+        tokenUsage: { input: 0, output: 0 },
+        duration: 1,
+        stopReason: 'error',
+        upstream: { status: 403, rawBody: 'private prompt text' },
+      });
+      const { runSubagent } = await importFresh();
+
+      const result = await runSubagent({ agent, task: 'do the thing' });
+
+      expect(runSubagentLoopMock).toHaveBeenCalledTimes(1);
+      expect(result.text).toBe('in-process result');
+      expect(result.upstream).toBeUndefined();
+    });
+
+    it.each([
+      ['missing tokenUsage', { tokenUsage: undefined }],
+      ['string token count', { tokenUsage: { input: '10', output: 2 } }],
+      ['missing output token count', { tokenUsage: { input: 1 } }],
+      ['negative tool count', { toolCallCount: -1 }],
+      ['fractional turn count', { turnCount: 1.5 }],
+      ['non-finite duration', { duration: Number.POSITIVE_INFINITY }],
+      ['unknown top-level key', { rawBody: 'private prompt text' }],
+    ])('rejects malformed sidecar result metrics/shape: %s', async (_label, override) => {
+      getSidecarStatus.mockReturnValue('running');
+      sidecarRequestMock.mockResolvedValue({
+        text: 'sidecar result',
+        toolCallCount: 0,
+        turnCount: 1,
+        tokenUsage: { input: 1, output: 2 },
+        duration: 1,
+        stopReason: 'completed',
+        ...override,
+      });
+      const { runSubagent } = await importFresh();
+
+      const result = await runSubagent({ agent, task: 'do the thing' });
+
+      expect(runSubagentLoopMock).toHaveBeenCalledTimes(1);
+      expect(result.text).toBe('in-process result');
+    });
+
+    it('rejects a completed sidecar result carrying failure-only upstream details', async () => {
+      getSidecarStatus.mockReturnValue('running');
+      sidecarRequestMock.mockResolvedValue({
+        text: 'completed text',
+        toolCallCount: 0,
+        turnCount: 1,
+        tokenUsage: { input: 1, output: 2 },
+        duration: 1,
+        stopReason: 'completed',
+        upstream: { status: 403 },
+      });
+      const { runSubagent } = await importFresh();
+
+      const result = await runSubagent({ agent, task: 'do the thing' });
+
+      expect(runSubagentLoopMock).toHaveBeenCalledTimes(1);
+      expect(result.text).toBe('in-process result');
+      expect(result.upstream).toBeUndefined();
+    });
+
     it('defaults a legacy sidecar result with no stopReason to completed', async () => {
       getSidecarStatus.mockReturnValue('running');
       sidecarRequestMock.mockResolvedValue({
@@ -614,6 +719,64 @@ describe('subagentRunner', () => {
 
       expect(runSubagentLoopMock).not.toHaveBeenCalled();
       expect(result.text).toBe('legacy sidecar result');
+      expect(result.stopReason).toBe('completed');
+    });
+
+    it.each([
+      'Error: {"private":"legacy delegated provider body"}',
+      'Error: <html><body>legacy delegated proxy page</body></html>',
+    ])('sanitizes a legacy failed subagent response before returning it: %s', async (text) => {
+      getSidecarStatus.mockReturnValue('running');
+      sidecarRequestMock.mockResolvedValue({
+        text,
+        toolCallCount: 0,
+        turnCount: 1,
+        tokenUsage: { input: 0, output: 0 },
+        duration: 1,
+        stopReason: 'error',
+      });
+      const { runSubagent } = await importFresh();
+
+      const result = await runSubagent({ agent, task: 'do the thing' });
+
+      expect(runSubagentLoopMock).not.toHaveBeenCalled();
+      expect(result.text).toBe('Error: 空响应');
+      expect(result.text).not.toContain('legacy delegated');
+      expect(result.stopReason).toBe('error');
+    });
+
+    it('sanitizes an Error-prefixed legacy result with no stopReason', async () => {
+      getSidecarStatus.mockReturnValue('running');
+      sidecarRequestMock.mockResolvedValue({
+        text: 'Error: {"private":"legacy no-stop provider body"}',
+        toolCallCount: 0,
+        turnCount: 1,
+        tokenUsage: { input: 0, output: 0 },
+        duration: 1,
+      });
+      const { runSubagent } = await importFresh();
+
+      const result = await runSubagent({ agent, task: 'do the thing' });
+
+      expect(result.text).toBe('Error: 空响应');
+      expect(result.text).not.toContain('legacy no-stop provider body');
+      expect(result.stopReason).toBe('error');
+    });
+
+    it('infers a missing legacy stopReason only for an Error-prefixed result', async () => {
+      getSidecarStatus.mockReturnValue('running');
+      sidecarRequestMock.mockResolvedValue({
+        text: '{"normal":"successful JSON output"}',
+        toolCallCount: 0,
+        turnCount: 1,
+        tokenUsage: { input: 0, output: 0 },
+        duration: 1,
+      });
+      const { runSubagent } = await importFresh();
+
+      const result = await runSubagent({ agent, task: 'do the thing' });
+
+      expect(result.text).toBe('{"normal":"successful JSON output"}');
       expect(result.stopReason).toBe('completed');
     });
 
@@ -1609,6 +1772,26 @@ describe('subagentRunner', () => {
       expect(result.stopReason).toBe('error');
       expect(result.toolCallCount).toBe(0);
       expect(result.turnCount).toBe(0);
+    });
+
+    it('sanitizes a structured transport error after tool execution without rerunning', async () => {
+      getSidecarStatus.mockReturnValue('running');
+      const d = deferred<unknown>();
+      sidecarRequestMock.mockReturnValue(d.promise);
+      const { runSubagent } = await importFresh();
+
+      const runPromise = runSubagent({ agent, task: 'do the thing' });
+      const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
+      const toolInvokeHandler = onSidecarRequest.mock.calls.find((c) => c[0] === 'tool.invoke')![1] as (p: unknown) => Promise<unknown>;
+      await toolInvokeHandler({ runId, toolName: 'read_file', input: {} });
+      d.reject(new Error('{"private":"committed provider body"}'));
+
+      const result = await runPromise;
+
+      expect(runSubagentLoopMock).not.toHaveBeenCalled();
+      expect(result.text).toBe('Error: 空响应');
+      expect(result.text).not.toContain('committed provider body');
+      expect(result.stopReason).toBe('error');
     });
   });
 

--- a/src/core/agent/subagentRunner.ts
+++ b/src/core/agent/subagentRunner.ts
@@ -66,7 +66,7 @@
  * is buffered until that commit point (or a valid successful response), so a
  * pre-commit transport failure cannot leave a ghost tool step behind.
  */
-import type { ToolDefinition, ToolExecutionContext } from '../../types';
+import type { ToolDefinition, ToolExecutionContext, UpstreamErrorDetails } from '../../types';
 import {
   getSidecarStatus,
   request as sidecarRequest,
@@ -87,6 +87,7 @@ import { resolveSubagentToolRoster } from './subagentToolRoster';
 import { registerToolInvokeSource, ensureToolInvokeRouterRegistered } from './toolInvokeRouter';
 import { ensureHookBridgeRegistered, registerHookSignalSource } from './hookBridge';
 import { createLogger } from '../logging/logger';
+import { isUpstreamErrorDetails, sanitizeUntrustedLlmErrorText } from '../llm/adapter';
 import type { LoopContext } from './permissionBridge';
 import { attachTrustedSkillCommandApproval } from './skillCommandApproval';
 import { normalizeIMRunCapability } from '../permissions/runPermissionCeiling';
@@ -260,23 +261,48 @@ interface SerializableSubagentResult {
   tokenUsage: { input: number; output: number };
   duration: number;
   stopReason?: SubagentStopReason;
+  upstream?: UpstreamErrorDetails;
 }
 
 function isSubagentStopReason(v: unknown): v is SubagentStopReason {
   return v === 'completed' || v === 'aborted' || v === 'error' || v === 'max_turns';
 }
 
+const SERIALIZABLE_SUBAGENT_RESULT_KEYS = new Set([
+  'text',
+  'toolCallCount',
+  'turnCount',
+  'tokenUsage',
+  'duration',
+  'stopReason',
+  'upstream',
+]);
+const SUBAGENT_TOKEN_USAGE_KEYS = new Set(['input', 'output']);
+
+function isFiniteNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}
+
 function isSerializableSubagentResult(v: unknown): v is SerializableSubagentResult {
+  if (typeof v !== 'object' || v === null || Array.isArray(v)) return false;
   const record = v as Record<string, unknown>;
-  return (
-    typeof v === 'object' &&
-    v !== null &&
-    typeof record.text === 'string' &&
-    typeof record.toolCallCount === 'number' &&
-    typeof record.turnCount === 'number' &&
-    typeof record.duration === 'number' &&
-    (record.stopReason === undefined || isSubagentStopReason(record.stopReason))
-  );
+  if (Object.keys(record).some((key) => !SERIALIZABLE_SUBAGENT_RESULT_KEYS.has(key))) return false;
+  if (typeof record.tokenUsage !== 'object' || record.tokenUsage === null || Array.isArray(record.tokenUsage)) {
+    return false;
+  }
+  const tokenUsage = record.tokenUsage as Record<string, unknown>;
+  return Object.keys(tokenUsage).every((key) => SUBAGENT_TOKEN_USAGE_KEYS.has(key))
+    && typeof record.text === 'string'
+    && isFiniteNonNegativeInteger(record.toolCallCount)
+    && isFiniteNonNegativeInteger(record.turnCount)
+    && isFiniteNonNegativeInteger(tokenUsage.input)
+    && isFiniteNonNegativeInteger(tokenUsage.output)
+    && typeof record.duration === 'number'
+    && Number.isFinite(record.duration)
+    && record.duration >= 0
+    && (record.stopReason === undefined || isSubagentStopReason(record.stopReason))
+    && (record.upstream === undefined
+      || (record.stopReason === 'error' && isUpstreamErrorDetails(record.upstream)));
 }
 
 // ── Run-session registry ────────────────────────────────────────────────
@@ -656,9 +682,15 @@ function reconstructSubagentResult(raw: unknown): SubagentResult {
   if (!isSerializableSubagentResult(raw)) {
     throw new Error('subagent.run response did not match the expected SubagentResult shape');
   }
+  const looksLikeLegacyError = raw.stopReason === undefined && /^\s*Error\s*:/i.test(raw.text);
+  const stopReason = raw.stopReason ?? (looksLikeLegacyError ? 'error' : 'completed');
+  const text = stopReason === 'error'
+    ? sanitizeUntrustedLlmErrorText(raw.text, `Error: ${getI18n().chat.errorEmptyBody}`)
+    : raw.text;
   return new SubagentResult({
     ...raw,
-    stopReason: raw.stopReason ?? 'completed',
+    text,
+    stopReason,
   });
 }
 
@@ -836,7 +868,10 @@ async function runSubagentForSignal(options: SubagentLoopOptions): Promise<Subag
     // At least one tool already ran with (possibly real) side effects —
     // surface as a failed result, matching the shape runSubagentLoop's own
     // outer catch produces today. NO rerun.
-    const message = err instanceof Error ? err.message : String(err);
+    const message = sanitizeUntrustedLlmErrorText(
+      err instanceof Error ? err.message : String(err),
+      getI18n().chat.errorEmptyBody,
+    );
     return new SubagentResult({
       text: `Error: ${message}`,
       toolCallCount: 0,

--- a/src/core/context/autoCompact.test.ts
+++ b/src/core/context/autoCompact.test.ts
@@ -157,6 +157,40 @@ describe('autoCompact', () => {
       }
     });
 
+    it('treats content-policy rejections as ordinary failures with the five-minute breaker', () => {
+      vi.useFakeTimers();
+      try {
+        const tracker = new AutoCompactTracker();
+        tracker.recordFailure('content_policy');
+        expect(tracker.isDisabled()).toBe(false);
+        tracker.recordFailure('content_policy');
+        expect(tracker.isDisabled()).toBe(false);
+        tracker.recordFailure('content_policy');
+        expect(tracker.isDisabled()).toBe(true);
+
+        vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+        expect(tracker.isDisabled()).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('keeps authentication failures on the thirty-minute disable path', () => {
+      vi.useFakeTimers();
+      try {
+        const tracker = new AutoCompactTracker();
+        tracker.recordFailure('authentication');
+        expect(tracker.isDisabled()).toBe(true);
+
+        vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+        expect(tracker.isDisabled()).toBe(true);
+        vi.advanceTimersByTime(25 * 60 * 1000);
+        expect(tracker.isDisabled()).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('tracks warning level', () => {
       const tracker = new AutoCompactTracker();
       expect(tracker.getLastLevel()).toBe(0);

--- a/src/core/context/autoCompact.ts
+++ b/src/core/context/autoCompact.ts
@@ -14,7 +14,10 @@
  * is disabled for the rest of the session to avoid infinite retry loops.
  */
 
+import type { LLMErrorCode } from '../llm/adapter';
+
 export type ContextWarningLevel = 0 | 1 | 2 | 3;
+export type AutoCompactFailureCode = LLMErrorCode | 'timeout' | 'error';
 
 /** Thresholds as fractions of max input tokens */
 const LEVEL_1_THRESHOLD = 0.60;
@@ -99,7 +102,7 @@ export class AutoCompactTracker {
    * Record a failed compression — may trip the circuit breaker with cooldown.
    * Error-type-aware: network errors don't accumulate, auth errors disable immediately.
    */
-  recordFailure(errorCode?: string): void {
+  recordFailure(errorCode?: AutoCompactFailureCode): void {
     // Network/rate-limit errors are transient — don't punish the compressor
     if (errorCode === 'network_error' || errorCode === 'rate_limit' || errorCode === 'overloaded') {
       return;
@@ -109,6 +112,9 @@ export class AutoCompactTracker {
       this.disabledUntil = Date.now() + 30 * 60 * 1000; // 30 minutes
       return;
     }
+    // Content-policy rejection is conversation-specific, not a broken API
+    // credential. It deliberately uses the ordinary 3-failure / 5-minute
+    // breaker below instead of the authentication 30-minute disable path.
     // Other errors (LLM quality, invalid request, etc.) — accumulate toward circuit breaker
     this.consecutiveFailures++;
     if (this.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {

--- a/src/core/context/contextCompressor.test.ts
+++ b/src/core/context/contextCompressor.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { compressContextIfNeeded } from './contextCompressor';
 import type { Message } from '../../types';
-import type { LLMAdapter } from '../llm/adapter';
+import { LLMError, type LLMAdapter } from '../llm/adapter';
 
 /** Build `rounds` user/assistant pairs with enough text to cross the 65% threshold. */
 function makeMessages(rounds: number): Message[] {
@@ -59,4 +59,27 @@ describe('compressContextIfNeeded — independent timeout (Bug 1: 同意后死�
     expect(result.compressed).toBe(false);
     expect(result.failed).toBeFalsy();
   });
+
+  it.each(['content_policy', 'authentication'] as const)(
+    'preserves the %s provider code for the auto-compact breaker',
+    async (code) => {
+      const adapter = {
+        chat: vi.fn().mockRejectedValue(new LLMError('provider rejected summary', code, { retryable: false })),
+      } as unknown as LLMAdapter;
+
+      const result = await compressContextIfNeeded(
+        makeMessages(8),
+        'system',
+        2000,
+        500,
+        { adapter, model: 'm', apiKey: 'k', timeoutMs: 50 },
+      );
+
+      expect(result).toMatchObject({
+        compressed: false,
+        failed: true,
+        failureCode: code,
+      });
+    },
+  );
 });

--- a/src/core/context/contextCompressor.ts
+++ b/src/core/context/contextCompressor.ts
@@ -14,7 +14,7 @@
  */
 
 import type { Message } from '../../types';
-import type { LLMAdapter } from '../llm/adapter';
+import { LLMError, type LLMAdapter, type LLMErrorCode } from '../llm/adapter';
 import type { ChatOptions } from '../llm/adapter';
 import { estimateTokens, estimateMessageTokens } from './tokenEstimator';
 import { getMessageText, identifyRounds, RECENT_ROUNDS_TO_KEEP } from './contextUtils';
@@ -50,8 +50,8 @@ export interface CompressionResult {
   /** True when the summarization attempt failed (timeout / error), so the
    *  caller can record it against the auto-compact circuit breaker. */
   failed?: boolean;
-  /** Coarse reason when `failed` is true: 'timeout' | 'error'. */
-  failureCode?: string;
+  /** Provider code when available; otherwise a coarse timeout/error reason. */
+  failureCode?: LLMErrorCode | 'timeout' | 'error';
 }
 
 /**
@@ -326,6 +326,12 @@ ${middleText}
     // LLM call failed — fall back gracefully, don't block the agent
     const errorMessage = err instanceof Error ? err.message : String(err);
     logger.warn('Context compression failed', { error: errorMessage });
-    return { messages, compressed: false, savedTokens: 0, failed: true, failureCode: 'error' };
+    return {
+      messages,
+      compressed: false,
+      savedTokens: 0,
+      failed: true,
+      failureCode: err instanceof LLMError ? err.code : 'error',
+    };
   }
 }

--- a/src/core/diagnostic/errorMap.test.ts
+++ b/src/core/diagnostic/errorMap.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { initLanguage } from '@/i18n';
+import { mapAIServiceError } from './errorMap';
+
+describe('mapAIServiceError', () => {
+  afterEach(() => {
+    initLanguage('zh-CN');
+  });
+
+  it.each([
+    ['zh-CN', '上游内容安全系统拒绝了请求（通常由对话历史触发，可尝试新开会话继续）'],
+    ['en-US', 'The upstream content-safety system rejected the request (often triggered by conversation history; try continuing in a new conversation)'],
+  ] as const)('maps content_policy without steering users to API-key settings in %s', (locale, expected) => {
+    initLanguage(locale);
+
+    const mapped = mapAIServiceError({
+      errorCode: 'content_policy',
+      statusCode: 403,
+      rawMessage: 'The request was rejected by the content safety system.',
+    });
+
+    expect(mapped).toEqual({ message: expected });
+  });
+
+  it.each([
+    'budget has been exceeded',
+    'UnsupportedModel',
+    'timeout (30s)',
+    'forbidden',
+  ])('keeps the structured content_policy classification ahead of conflicting raw text: %s', (rawMessage) => {
+    const mapped = mapAIServiceError({
+      errorCode: 'content_policy',
+      statusCode: 403,
+      rawMessage,
+    });
+
+    expect(mapped).toEqual({
+      message: '上游内容安全系统拒绝了请求（通常由对话历史触发，可尝试新开会话继续）',
+    });
+  });
+});

--- a/src/core/diagnostic/errorMap.ts
+++ b/src/core/diagnostic/errorMap.ts
@@ -45,6 +45,14 @@ export function mapAIServiceError(opts: MapAIErrorOpts): FriendlyError {
   const t = getI18n();
   const raw = opts.rawMessage ?? '';
 
+  // A classified policy rejection is authoritative. Provider summaries can
+  // contain words that look like another failure (for example "timeout" or
+  // "budget exceeded"), but must never steer the user toward an API-key,
+  // model, balance, or retry action once the structured code is known.
+  if (opts.errorCode === 'content_policy') {
+    return { message: t.diagnostic.errMap.aiContentPolicy };
+  }
+
   // Substring layer FIRST for high-signal patterns (provider may return 200
   // with a JSON error body, in which case errorCode is missing).
   if (/budget.has.been.exceeded|budget_exceeded/i.test(raw)) {

--- a/src/core/llm/adapter.test.ts
+++ b/src/core/llm/adapter.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { classifyError, LLMError, formatLlmDisplayError } from './adapter';
+import {
+  classifyError,
+  LLMError,
+  formatLlmDisplayError,
+  formatLlmTerminalError,
+  isUpstreamErrorDetails,
+  normalizeUpstreamErrorDetails,
+  sanitizeUntrustedLlmErrorText,
+} from './adapter';
 
 describe('adapter', () => {
   // ── LLMError class ──
@@ -27,6 +35,55 @@ describe('adapter', () => {
       const err = new LLMError('test', 'unknown');
       expect(err).toBeInstanceOf(Error);
       expect(err).toBeInstanceOf(LLMError);
+    });
+  });
+
+  describe('sanitizeUntrustedLlmErrorText', () => {
+    it.each([
+      '{"private":"provider body"}',
+      'Error: {"private":"provider body"}',
+      ' 403 {"private":"provider body"}',
+      '403{"private":"provider body"}',
+      '403: {"private":"provider body"}',
+      'HTTP 403: {"private":"provider body"}',
+      'Error: 403 {"private":"truncated"',
+      '<html><body>private proxy page</body></html>',
+      '403 <!doctype html><title>private proxy page</title>',
+      '403:<html><body>private proxy page</body></html>',
+      'HTTP 403: <html><body>private proxy page</body></html>',
+      'Request failed\n{"private":"provider body on the next line"}',
+      'Request failed\n<html><body>proxy page on the next line</body></html>',
+    ])('drops structured or markup wire text: %s', (message) => {
+      expect(sanitizeUntrustedLlmErrorText(message, 'safe fallback')).toBe('safe fallback');
+    });
+
+    it('keeps bounded plain-text compatibility messages', () => {
+      expect(sanitizeUntrustedLlmErrorText('rate limited', 'safe fallback')).toBe('rate limited');
+    });
+  });
+
+  describe('upstream error projection', () => {
+    it.each([
+      { status: 403, error_type: '   ' },
+      { status: 403, traceId: '\n' },
+      { status: 403, summary: '   ' },
+    ])('rejects whitespace-only optional fields: %j', (details) => {
+      expect(isUpstreamErrorDetails(details)).toBe(false);
+      expect(normalizeUpstreamErrorDetails(details)).toBeUndefined();
+    });
+
+    it('fresh-projects trimmed optional fields', () => {
+      expect(normalizeUpstreamErrorDetails({
+        status: 403,
+        error_type: '  content_policy  ',
+        traceId: '  trace-403  ',
+        summary: '  provider rejected the request  ',
+      })).toEqual({
+        status: 403,
+        error_type: 'content_policy',
+        traceId: 'trace-403',
+        summary: 'provider rejected the request',
+      });
     });
   });
 
@@ -83,6 +140,145 @@ describe('adapter', () => {
       expect(err.retryable).toBe(false);
     });
 
+    it('Alibaba governance 403 → content_policy with bounded upstream details', () => {
+      const err = classifyError(403, JSON.stringify({
+        error: {
+          message: 'The request was rejected by the content safety system.',
+        },
+        error_type: 'governance.alicloud_content_safety_input_rejected',
+        traceId: 'e7bfa851aa3de992-local-fixture',
+      }));
+
+      expect(err).toMatchObject({
+        code: 'content_policy',
+        retryable: false,
+        statusCode: 403,
+        upstream: {
+          status: 403,
+          error_type: 'governance.alicloud_content_safety_input_rejected',
+          traceId: 'e7bfa851aa3de992-local-fixture',
+          summary: 'The request was rejected by the content safety system.',
+        },
+      });
+    });
+
+    it.each([
+      ['content_safety error type', { error_type: 'provider.content_safety.rejected', message: 'rejected' }],
+      ['content_policy error type', { error: { error_type: 'content_policy_violation', message: 'rejected' } }],
+      ['safety-system detail', { detail: 'Blocked by the upstream safety system.' }],
+    ])('403 with %s → content_policy', (_label, body) => {
+      expect(classifyError(403, JSON.stringify(body)).code).toBe('content_policy');
+    });
+
+    it('401 remains authentication even when a provider body mentions content safety', () => {
+      const err = classifyError(401, JSON.stringify({
+        error_type: 'governance.alicloud_content_safety_input_rejected',
+      }));
+      expect(err.code).toBe('authentication');
+      expect(err.retryable).toBe(false);
+    });
+
+    it('does not promote an unrelated 403 merely because its message says rejected', () => {
+      const err = classifyError(403, JSON.stringify({ error: { message: 'Request rejected.' } }));
+      expect(err.code).toBe('authentication');
+      expect(err.retryable).toBe(false);
+    });
+
+    it.each([
+      'The safety system API credential is missing.',
+      'The safety system endpoint is forbidden.',
+      'User input literally said safety system.',
+    ])('does not classify a message-only safety-system phrase as content_policy: %s', (message) => {
+      const err = classifyError(403, JSON.stringify({ error: { message } }));
+
+      expect(err.code).toBe('authentication');
+      expect(err.retryable).toBe(false);
+    });
+
+    it.each([
+      "User input: 'error_type':'content_policy'",
+      "User input: 'detail':'blocked by safety system'",
+    ])('does not regex quoted pseudo-fields inside a valid JSON message: %s', (message) => {
+      const err = classifyError(403, JSON.stringify({ message }));
+
+      expect(err.code).toBe('authentication');
+      expect(err.retryable).toBe(false);
+    });
+
+    it('does not copy a message-less JSON body into the upstream summary', () => {
+      const rawBody = JSON.stringify({
+        error_type: 'governance.alicloud_content_safety_input_rejected',
+        traceId: 'trace-without-message',
+        private: 'must not appear in the terminal projection',
+      });
+
+      const err = classifyError(403, rawBody);
+
+      expect(err.upstream).toEqual({
+        status: 403,
+        error_type: 'governance.alicloud_content_safety_input_rejected',
+        traceId: 'trace-without-message',
+      });
+      expect(err.message).toBe('HTTP 403 · content_policy');
+      expect(formatLlmTerminalError(err)).toBe('HTTP 403 · content_policy');
+      expect(JSON.stringify(err.upstream)).not.toContain('private');
+    });
+
+    it('projects a leading-space status-prefixed JSON body without copying the raw object', () => {
+      const rawBody = ` 403 ${JSON.stringify({
+        error_type: 'governance.alicloud_content_safety_input_rejected',
+        traceId: 'trace-leading-space',
+        private: 'credential-adjacent provider metadata',
+      })}`;
+
+      const err = classifyError(403, rawBody);
+
+      expect(err).toMatchObject({
+        code: 'content_policy',
+        upstream: {
+          status: 403,
+          error_type: 'governance.alicloud_content_safety_input_rejected',
+          traceId: 'trace-leading-space',
+        },
+      });
+      expect(err.upstream).not.toHaveProperty('summary');
+      expect(formatLlmTerminalError(err)).toBe('HTTP 403 · content_policy');
+      expect(formatLlmTerminalError(err)).not.toContain('private');
+    });
+
+    it.each([
+      '403{"error_type":"content_policy","private":"secret"}',
+      '403: {"error_type":"content_policy","private":"secret"}',
+      'HTTP 403: {"error_type":"content_policy","private":"secret"}',
+    ])('normalizes compact status prefixes without exposing JSON: %s', (rawBody) => {
+      const err = classifyError(403, rawBody);
+
+      expect(err.code).toBe('content_policy');
+      expect(err.upstream).toEqual({ status: 403, error_type: 'content_policy' });
+      expect(formatLlmTerminalError(err)).toBe('HTTP 403 · content_policy');
+      expect(JSON.stringify(err.upstream)).not.toContain('secret');
+    });
+
+    it('formats an unrelated message-less JSON 403 as status/code instead of raw JSON for the terminal', () => {
+      const err = classifyError(403, JSON.stringify({ private: 'credential-adjacent provider metadata' }));
+
+      expect(err.code).toBe('authentication');
+      expect(formatLlmTerminalError(err)).toBe('HTTP 403 · authentication');
+      expect(formatLlmTerminalError(err)).not.toContain('private');
+    });
+
+    it.each([
+      ['array', JSON.stringify([{ private: 'credential-adjacent provider metadata' }])],
+      ['string scalar', JSON.stringify('credential-adjacent provider metadata')],
+      ['number scalar', JSON.stringify(403403)],
+    ])('does not treat a parsed top-level JSON %s as a plain-text provider summary', (_label, rawBody) => {
+      const err = classifyError(403, rawBody);
+
+      expect(err.upstream).toEqual({ status: 403 });
+      expect(formatLlmTerminalError(err)).toBe('HTTP 403 · authentication');
+      expect(formatLlmTerminalError(err)).not.toContain(rawBody);
+    });
+
     it('404 → not_found (not retryable)', () => {
       const err = classifyError(404, 'Model not found');
       expect(err.code).toBe('not_found');
@@ -136,6 +332,33 @@ describe('adapter', () => {
       expect(err.code).toBe('network_blocked');
     });
 
+    it.each([
+      '<body>\'error_type\':\'content_policy\'</body>',
+      '<!-- proxy --> <html><script>var e={"error_type":"content_policy"}</script></html>',
+      '<?xml version="1.0"?><html><body>\'error_type\':\'content_policy\'</body></html>',
+      '<!-- first --><!-- second --><body>\'error_type\':\'content_policy\'</body>',
+    ])('document-level HTML prologs win over policy-shaped page text: %s', (rawBody) => {
+      const err = classifyError(403, rawBody);
+
+      expect(err.code).toBe('network_blocked');
+      expect(err.retryable).toBe(false);
+      expect(formatLlmTerminalError(err)).not.toContain('content_policy');
+    });
+
+    it.each([
+      '403 <html><body>proxy denied</body></html>',
+      '403 <!doctype html><script>var e={"error_type":"content_policy"}</script>',
+      '403:<html><body>private proxy page</body></html>',
+      'HTTP 403: <html><body>private proxy page</body></html>',
+    ])('status-prefixed HTML stays network_blocked and never becomes a terminal summary', (rawBody) => {
+      const err = classifyError(403, rawBody);
+
+      expect(err.code).toBe('network_blocked');
+      expect(err.retryable).toBe(false);
+      expect(formatLlmTerminalError(err)).not.toContain('<');
+      expect(formatLlmTerminalError(err)).not.toContain('content_policy');
+    });
+
     it('JSON body starting with < is not misclassified (edge case)', () => {
       // Some providers (edge case) might return JSON — make sure plain JSON isn't hit
       const json = '{"error":{"message":"bad request"}}';
@@ -160,14 +383,32 @@ describe('adapter', () => {
       expect(result).toBe('HTTP 404 · not_found');
     });
 
-    it('does NOT append a rawBody snippet (classifyError already surfaces non-empty bodies as the message)', () => {
-      // A non-empty rawBody would already have become err.message via
-      // extractApiErrorMessage, so the fallback path only runs for empty bodies.
+    it('does not append a rawBody snippet to an empty classified error', () => {
       // We must never leak an opaque body (e.g. a WAF page) into the chat surface.
       const err = new LLMError('', 'not_found', { statusCode: 404, rawBody: '<html>blocked by proxy</html>' });
       const result = formatLlmDisplayError(err, '', emptyBodyFallback);
       expect(result).toBe('HTTP 404 · not_found');
       expect(result).not.toContain('html');
+    });
+
+    it('does not display a message-less JSON body from a classified provider error', () => {
+      const err = classifyError(403, JSON.stringify({
+        private: 'credential-adjacent provider metadata',
+      }));
+
+      const result = formatLlmDisplayError(err, err.message, emptyBodyFallback);
+
+      expect(result).toBe('HTTP 403 · authentication');
+      expect(result).not.toContain('private');
+    });
+
+    it('never falls back to a rawBody-backed message when status is unavailable', () => {
+      const err = new LLMError('private provider response', 'unknown', {
+        rawBody: 'private provider response',
+      });
+
+      expect(formatLlmTerminalError(err)).toBe('unknown');
+      expect(formatLlmDisplayError(err, err.message, emptyBodyFallback)).toBe('unknown');
     });
 
     it('non-LLMError + empty message → emptyBodyFallback string', () => {

--- a/src/core/llm/adapter.ts
+++ b/src/core/llm/adapter.ts
@@ -1,4 +1,4 @@
-import type { StreamEvent, Message, ToolDefinition, BuiltinSearchMethod } from '../../types';
+import type { StreamEvent, Message, ToolDefinition, BuiltinSearchMethod, UpstreamErrorDetails } from '../../types';
 import type { PromptSection } from './promptSections';
 import type { Logger } from '../logging/logger';
 
@@ -128,7 +128,8 @@ export type LLMErrorCode =
   | 'overloaded'           // 529 / 503
   | 'context_too_long'     // 400 with context length error
   | 'invalid_request'      // 400 other
-  | 'authentication'       // 401 / 403
+  | 'authentication'       // 401 / credential-related 403
+  | 'content_policy'       // 403 rejected by an upstream content-safety policy
   | 'not_found'            // 404
   | 'server_error'         // 500 / 502
   | 'network_error'        // fetch/connection failures
@@ -136,17 +137,43 @@ export type LLMErrorCode =
   | 'cancelled'            // user abort
   | 'unknown';
 
+const LLM_ERROR_CODES: ReadonlySet<string> = new Set<LLMErrorCode>([
+  'rate_limit',
+  'overloaded',
+  'context_too_long',
+  'invalid_request',
+  'authentication',
+  'content_policy',
+  'not_found',
+  'server_error',
+  'network_error',
+  'network_blocked',
+  'cancelled',
+  'unknown',
+]);
+
+export function isLLMErrorCode(value: unknown): value is LLMErrorCode {
+  return typeof value === 'string' && LLM_ERROR_CODES.has(value);
+}
+
 export class LLMError extends Error {
   code: LLMErrorCode;
   retryable: boolean;
   retryAfterMs?: number;
   statusCode?: number;
   rawBody?: string;
+  upstream?: UpstreamErrorDetails;
 
   constructor(
     message: string,
     code: LLMErrorCode,
-    options?: { retryable?: boolean; retryAfterMs?: number; statusCode?: number; rawBody?: string }
+    options?: {
+      retryable?: boolean;
+      retryAfterMs?: number;
+      statusCode?: number;
+      rawBody?: string;
+      upstream?: UpstreamErrorDetails;
+    }
   ) {
     super(message);
     this.name = 'LLMError';
@@ -155,7 +182,209 @@ export class LLMError extends Error {
     this.retryAfterMs = options?.retryAfterMs;
     this.statusCode = options?.statusCode;
     this.rawBody = options?.rawBody;
+    this.upstream = normalizeUpstreamErrorDetails(options?.upstream);
   }
+}
+
+const UPSTREAM_ERROR_SUMMARY_MAX_CHARS = 500;
+const UPSTREAM_ERROR_IDENTIFIER_MAX_CHARS = 256;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stripProviderStatusPrefix(body: string): string {
+  return body.replace(/^\s*(?:HTTP\s+)?\d{3}(?:\s*:\s*|\s+|(?=[{[<]))/i, '');
+}
+
+/**
+ * Bound an error string received from an older/untrusted process without ever
+ * promoting a raw JSON or HTML provider response into renderer-visible text.
+ * Known wrappers are inspected only for classification; safe plain text keeps
+ * its original wording for compatibility.
+ */
+export function sanitizeUntrustedLlmErrorText(value: unknown, fallback: string): string {
+  const safeFallback = fallback.trim().slice(0, UPSTREAM_ERROR_SUMMARY_MAX_CHARS) || 'unknown';
+  if (typeof value !== 'string') return safeFallback;
+  const trimmed = value.trim();
+  if (!trimmed) return safeFallback;
+
+  return isUnsafeStructuredLlmErrorText(trimmed)
+    ? safeFallback
+    : trimmed.slice(0, UPSTREAM_ERROR_SUMMARY_MAX_CHARS);
+}
+
+/** True when an error/stack's first payload line is JSON-like or markup. */
+export function isUnsafeStructuredLlmErrorText(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  let candidate = trimmed
+    .replace(/^sidecar error\s+-?\d+\s*:\s*/i, '')
+    .replace(/^(?:[A-Za-z_$][\w$]*Error|Error)\s*:\s*/, '');
+  candidate = stripProviderStatusPrefix(candidate).trimStart();
+  return candidate.split(/\r?\n/).some((line) => {
+    const payload = stripProviderStatusPrefix(
+      line.trim().replace(/^(?:[A-Za-z_$][\w$]*Error|Error)\s*:\s*/, ''),
+    ).trimStart();
+    if (!payload) return false;
+    if (payload.startsWith('<')) return true;
+    try {
+      JSON.parse(payload);
+      return true;
+    } catch {
+      // A truncated/pretty-printed JSON object or array is still a raw
+      // provider body even though one line cannot be parsed in isolation.
+      return /^[{[]/.test(payload);
+    }
+  });
+}
+
+/** Validate the bounded provider projection before trusting cross-process data. */
+export function isUpstreamErrorDetails(value: unknown): value is UpstreamErrorDetails {
+  if (!isRecord(value)) return false;
+  const allowedKeys = new Set(['status', 'error_type', 'traceId', 'summary']);
+  if (Object.keys(value).some((key) => !allowedKeys.has(key))) return false;
+  if (!Number.isInteger(value.status) || (value.status as number) < 100 || (value.status as number) > 599) {
+    return false;
+  }
+  for (const [key, maxChars] of [
+    ['error_type', UPSTREAM_ERROR_IDENTIFIER_MAX_CHARS],
+    ['traceId', UPSTREAM_ERROR_IDENTIFIER_MAX_CHARS],
+    ['summary', UPSTREAM_ERROR_SUMMARY_MAX_CHARS],
+  ] as const) {
+    const field = value[key];
+    if (field === undefined) continue;
+    if (typeof field !== 'string' || field.length > maxChars || field.trim().length === 0) return false;
+  }
+  return true;
+}
+
+/** Return a fresh allowlisted projection for store/export boundaries. */
+export function normalizeUpstreamErrorDetails(value: unknown): UpstreamErrorDetails | undefined {
+  if (!isUpstreamErrorDetails(value)) return undefined;
+  const summary = value.summary && !isUnsafeStructuredLlmErrorText(value.summary)
+    ? value.summary.trim()
+    : undefined;
+  return {
+    status: value.status,
+    ...(value.error_type ? { error_type: value.error_type.trim() } : {}),
+    ...(value.traceId ? { traceId: value.traceId.trim() } : {}),
+    ...(summary ? { summary } : {}),
+  };
+}
+
+function parseProviderErrorBody(rawBody: string): Record<string, unknown> | undefined {
+  const stripped = stripProviderStatusPrefix(rawBody);
+  try {
+    const parsed: unknown = JSON.parse(stripped);
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parsesAsJson(rawBody: string): boolean {
+  const stripped = stripProviderStatusPrefix(rawBody);
+  try {
+    JSON.parse(stripped);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function providerErrorRecords(rawBody: string): Record<string, unknown>[] {
+  const root = parseProviderErrorBody(rawBody);
+  if (!root) return [];
+  const nestedError = isRecord(root.error) ? root.error : undefined;
+  const nestedDetail = isRecord(root.detail) ? root.detail : undefined;
+  const errorDetail = nestedError && isRecord(nestedError.detail) ? nestedError.detail : undefined;
+  return [nestedError, errorDetail, nestedDetail, root].filter(isRecord);
+}
+
+function firstBoundedString(
+  records: Record<string, unknown>[],
+  keys: readonly string[],
+  maxChars: number,
+): string | undefined {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = record[key];
+      if (typeof value !== 'string') continue;
+      const trimmed = value.trim();
+      if (trimmed) return trimmed.slice(0, maxChars);
+    }
+  }
+  return undefined;
+}
+
+/** Build the only provider-error projection allowed to cross the terminal wire. */
+export function extractUpstreamErrorDetails(
+  statusCode: number,
+  rawBody: string,
+  fallbackMessage: string,
+): UpstreamErrorDetails {
+  const records = providerErrorRecords(rawBody);
+  const errorType = firstBoundedString(records, ['error_type', 'errorType'], UPSTREAM_ERROR_IDENTIFIER_MAX_CHARS);
+  const traceId = firstBoundedString(records, ['traceId', 'trace_id'], UPSTREAM_ERROR_IDENTIFIER_MAX_CHARS);
+  const structuredSummary = firstBoundedString(records, ['message', 'detail'], UPSTREAM_ERROR_SUMMARY_MAX_CHARS);
+  // For a parsed JSON body with no human-readable message/detail, omit the
+  // summary instead of copying the whole JSON object into the UI card. Plain
+  // text provider bodies still use the bounded fallback.
+  const fallbackSummary = records.length === 0 && !parsesAsJson(rawBody)
+    ? fallbackMessage.trim().slice(0, UPSTREAM_ERROR_SUMMARY_MAX_CHARS)
+    : '';
+  return {
+    status: statusCode,
+    ...(errorType ? { error_type: errorType } : {}),
+    ...(traceId ? { traceId } : {}),
+    ...(structuredSummary || fallbackSummary
+      ? { summary: structuredSummary || fallbackSummary }
+      : {}),
+  };
+}
+
+/**
+ * Produce a bounded terminal/store message without ever falling back to the
+ * adapter's raw JSON response body. Detailed raw data remains diagnostic-only.
+ */
+export function formatLlmTerminalError(err: LLMError): string {
+  const upstream = normalizeUpstreamErrorDetails(err.upstream);
+  const summary = upstream?.summary?.trim();
+  if (summary) return summary.slice(0, UPSTREAM_ERROR_SUMMARY_MAX_CHARS);
+  const message = err.message.trim();
+  // Hand-constructed local errors have no raw provider body and may carry a
+  // useful safe message. Classified HTTP errors either have the bounded
+  // upstream projection or retain rawBody, so they take the status/code path.
+  if (!upstream && !err.rawBody && message) {
+    return message.slice(0, UPSTREAM_ERROR_SUMMARY_MAX_CHARS);
+  }
+  const status = upstream?.status ?? err.statusCode;
+  if (status !== undefined) return `HTTP ${status} · ${err.code}`;
+  return err.rawBody ? err.code : message ? message.slice(0, UPSTREAM_ERROR_SUMMARY_MAX_CHARS) : err.code;
+}
+
+function isContentPolicyRejection(rawBody: string): boolean {
+  const records = providerErrorRecords(rawBody);
+  const errorType = firstBoundedString(records, ['error_type', 'errorType'], UPSTREAM_ERROR_IDENTIFIER_MAX_CHARS);
+  if (errorType && /governance\.|content[_-]safety|content[_-]policy/i.test(errorType)) {
+    return true;
+  }
+  const detail = firstBoundedString(records, ['detail'], UPSTREAM_ERROR_SUMMARY_MAX_CHARS);
+  if (detail && /safety[\s_-]*system/i.test(detail)) {
+    return true;
+  }
+  // A valid JSON body has already been inspected structurally above. Do not
+  // regex its serialized message strings: quoted user text can contain
+  // fragments such as `'error_type':'content_policy'` without being a
+  // provider error field.
+  if (parsesAsJson(rawBody)) return false;
+  // Some providers prefix the JSON with the status code or return a shape we
+  // do not otherwise understand. Keep the fallback precise to the error_type
+  // field so quoted user input cannot turn an unrelated 403 into this class.
+  return /["']error_type["']\s*:\s*["'][^"']*(?:governance\.|content[_-]safety|content[_-]policy)/i.test(rawBody)
+    || /["']detail["']\s*:\s*["'][^"']*safety[\s_-]*system/i.test(rawBody);
 }
 
 /**
@@ -165,7 +394,7 @@ export class LLMError extends Error {
  */
 export function extractApiErrorMessage(rawBody: string): string {
   // Some providers (e.g. mimo) prefix body with status code: "403 {json}"
-  const stripped = rawBody.replace(/^\d{3}\s+/, '');
+  const stripped = stripProviderStatusPrefix(rawBody);
   try {
     const parsed = JSON.parse(stripped) as {
       error?: { message?: string };
@@ -188,8 +417,29 @@ export function extractApiErrorMessage(rawBody: string): string {
  * because some WAFs forge application/json in the Content-Type header.
  */
 function isHtmlBody(body: string): boolean {
-  const trimmed = body.trimStart().toLowerCase();
-  return trimmed.startsWith('<!doctype') || trimmed.startsWith('<html');
+  let candidate = stripProviderStatusPrefix(body.slice(0, 8192)).trimStart();
+
+  // HTML documents may omit the <html> element, and proxy pages sometimes
+  // prepend an XML declaration or one or more comments. Peel off only those
+  // document-level prolog nodes, then require a document root rather than
+  // treating arbitrary angle-bracket text in a provider message as HTML.
+  while (candidate) {
+    if (candidate.startsWith('<!--')) {
+      const commentEnd = candidate.indexOf('-->');
+      if (commentEnd === -1) return false;
+      candidate = candidate.slice(commentEnd + 3).trimStart();
+      continue;
+    }
+    if (/^<\?xml\b/i.test(candidate)) {
+      const declarationEnd = candidate.indexOf('?>');
+      if (declarationEnd === -1) return false;
+      candidate = candidate.slice(declarationEnd + 2).trimStart();
+      continue;
+    }
+    break;
+  }
+
+  return /^(?:<!doctype\b|<html\b|<head\b|<body\b)/i.test(candidate);
 }
 
 /**
@@ -200,49 +450,65 @@ export function classifyError(statusCode: number, rawBody: string): LLMError {
   // Detect HTML response before any JSON parsing — a WAF / reverse-proxy
   // intercepted the request and returned an error page instead of an API response.
   if (isHtmlBody(rawBody)) {
+    const message = '请求被网络防火墙或代理拦截（返回了 HTML 页面而非 API 响应）';
     return new LLMError(
-      '请求被网络防火墙或代理拦截（返回了 HTML 页面而非 API 响应）',
+      message,
       'network_blocked',
-      { retryable: false, statusCode, rawBody: rawBody.slice(0, 500) },
+      {
+        retryable: false,
+        statusCode,
+        rawBody: rawBody.slice(0, 500),
+        upstream: extractUpstreamErrorDetails(statusCode, '', message),
+      },
     );
   }
 
   const message = extractApiErrorMessage(rawBody);
   const stored = rawBody.slice(0, 1000);
+  const upstream = extractUpstreamErrorDetails(statusCode, rawBody, message);
 
   // Rate limiting
   if (statusCode === 429) {
     const retryAfter = extractRetryAfter(message);
     return new LLMError(message, 'rate_limit', {
-      retryable: true, retryAfterMs: retryAfter, statusCode, rawBody: stored,
+      retryable: true, retryAfterMs: retryAfter, statusCode, rawBody: stored, upstream,
     });
   }
 
   // Overloaded
   if (statusCode === 529 || statusCode === 503) {
     return new LLMError(message, 'overloaded', {
-      retryable: true, retryAfterMs: 5000, statusCode, rawBody: stored,
+      retryable: true, retryAfterMs: 5000, statusCode, rawBody: stored, upstream,
     });
   }
 
   // Server errors (retryable)
   if (statusCode === 500 || statusCode === 502) {
     return new LLMError(message, 'server_error', {
-      retryable: true, retryAfterMs: 2000, statusCode, rawBody: stored,
+      retryable: true, retryAfterMs: 2000, statusCode, rawBody: stored, upstream,
+    });
+  }
+
+  // A provider policy rejection is not a credential failure. Check only 403;
+  // 401 remains authentication even if an unusual body mentions safety.
+  if (statusCode === 403 && isContentPolicyRejection(rawBody)) {
+    const policyMessage = upstream.summary ?? `HTTP ${statusCode} · content_policy`;
+    return new LLMError(policyMessage, 'content_policy', {
+      retryable: false, statusCode, rawBody: stored, upstream,
     });
   }
 
   // Auth errors (not retryable)
   if (statusCode === 401 || statusCode === 403) {
     return new LLMError(message, 'authentication', {
-      retryable: false, statusCode, rawBody: stored,
+      retryable: false, statusCode, rawBody: stored, upstream,
     });
   }
 
   // Not found
   if (statusCode === 404) {
     return new LLMError(message, 'not_found', {
-      retryable: false, statusCode, rawBody: stored,
+      retryable: false, statusCode, rawBody: stored, upstream,
     });
   }
 
@@ -251,15 +517,15 @@ export function classifyError(statusCode: number, rawBody: string): LLMError {
     const isContextTooLong = /prompt.is.too.long|token.*exceed|too.many.tokens|max.tokens.exceeded|context.window|context.length/i.test(message);
     if (isContextTooLong) {
       return new LLMError(message, 'context_too_long', {
-        retryable: false, statusCode, rawBody: stored,
+        retryable: false, statusCode, rawBody: stored, upstream,
       });
     }
     return new LLMError(message, 'invalid_request', {
-      retryable: false, statusCode, rawBody: stored,
+      retryable: false, statusCode, rawBody: stored, upstream,
     });
   }
 
-  return new LLMError(message, 'unknown', { retryable: false, statusCode, rawBody: stored });
+  return new LLMError(message, 'unknown', { retryable: false, statusCode, rawBody: stored, upstream });
 }
 
 function extractRetryAfter(message: string): number | undefined {
@@ -279,25 +545,19 @@ function extractRetryAfter(message: string): number | undefined {
  * empty-body fallback string is a caller-supplied parameter rather than an
  * internal `getI18n()` call. Callers should pass `getI18n().chat.errorEmptyBody`.
  *
- * Note: we deliberately do NOT append an `rawBody` snippet. `classifyError`
- * already surfaces any non-empty body through `err.message` (via
- * `extractApiErrorMessage`), so an empty `fallbackMessage` implies an empty body —
- * a snippet would never add signal and would only risk leaking an opaque
- * intercept page into the chat surface.
+ * For classified LLM errors, always format from the bounded upstream
+ * projection. `err.message` can still contain a raw JSON fallback for local
+ * diagnostics and must not be copied into the chat surface.
  */
 export function formatLlmDisplayError(
   err: unknown,
   fallbackMessage: string,
   emptyBodyFallback: string,
 ): string {
+  if (err instanceof LLMError) {
+    return formatLlmTerminalError(err) || emptyBodyFallback;
+  }
   const msg = fallbackMessage.trim();
   if (msg) return msg;
-  if (err instanceof LLMError) {
-    const parts: string[] = [];
-    if (err.statusCode) parts.push(`HTTP ${err.statusCode}`);
-    if (err.code) parts.push(err.code);
-    return parts.join(' · ') || emptyBodyFallback;
-  }
   return emptyBodyFallback;
 }
-

--- a/src/core/llm/providerCallHealth.test.ts
+++ b/src/core/llm/providerCallHealth.test.ts
@@ -47,7 +47,7 @@ describe('providerCallHealth', () => {
     });
 
     it('does NOT flag transient / non-config codes', () => {
-      for (const code of ['rate_limit', 'overloaded', 'server_error', 'network_error', 'network_blocked', 'context_too_long', 'cancelled', 'unknown'] as const) {
+      for (const code of ['content_policy', 'rate_limit', 'overloaded', 'server_error', 'network_error', 'network_blocked', 'context_too_long', 'cancelled', 'unknown'] as const) {
         expect(isConfigFailureCode(code)).toBe(false);
       }
     });

--- a/src/core/llm/providerCallHealth.ts
+++ b/src/core/llm/providerCallHealth.ts
@@ -21,7 +21,7 @@ export interface ProviderCallOutcome {
  * Error codes that indicate a persistent provider / model / endpoint
  * misconfiguration — the kind a user can act on via Settings → Models, and the
  * kind a cheap connectivity probe can miss. Transient conditions (rate limits,
- * upstream 5xx, network blips, user cancels) are deliberately excluded: recording
+ * upstream 5xx, network blips, content-policy rejections, user cancels) are deliberately excluded: recording
  * them would mislabel a correctly-configured provider as broken and steer the
  * user to change settings that are actually fine.
  */

--- a/src/core/llm/sidecarAdapter.test.ts
+++ b/src/core/llm/sidecarAdapter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { StreamEvent } from '../../types';
-import { LLMError } from './adapter';
+import { formatLlmTerminalError, LLMError } from './adapter';
 
 // Fake pub/sub + request/notify surface for sidecarManager — lets tests fire
 // llm.event/llm.chatMeta notifications and control what request() does,
@@ -168,6 +168,78 @@ describe('SidecarLLMAdapter', () => {
       });
     });
 
+    it('reconstructs status and upstream details without a raw provider body', async () => {
+      const upstream = {
+        status: 403,
+        error_type: 'governance.alicloud_content_safety_input_rejected',
+        traceId: 'sidecar-adapter-trace-403',
+        summary: 'The content safety system rejected the request.',
+      } as const;
+      requestMock.mockRejectedValue(
+        new SidecarRpcError(-32000, upstream.summary, {
+          name: 'LLMError',
+          code: 'content_policy',
+          retryable: false,
+          statusCode: 403,
+          message: upstream.summary,
+          upstream,
+        }),
+      );
+      const adapter = new SidecarLLMAdapter('claude');
+
+      await expect(adapter.chat([], { model: 'm', apiKey: 'k' }, () => {})).rejects.toMatchObject({
+        code: 'content_policy',
+        statusCode: 403,
+        upstream,
+        rawBody: undefined,
+      });
+    });
+
+    it.each([
+      '{"private":"legacy provider body"}',
+      '<html><body>legacy proxy response</body></html>',
+    ])('does not promote a legacy structured RPC message into terminal text: %s', async (message) => {
+      requestMock.mockRejectedValue(
+        new SidecarRpcError(-32000, message, {
+          name: 'LLMError',
+          code: 'authentication',
+          retryable: false,
+          message,
+        }),
+      );
+      const adapter = new SidecarLLMAdapter('claude');
+
+      const caught = await adapter.chat([], { model: 'm', apiKey: 'k' }, () => {}).catch((error) => error);
+      expect(caught).toMatchObject({ code: 'authentication', retryable: false, message: 'authentication' });
+      expect(formatLlmTerminalError(caught)).toBe('authentication');
+      expect(JSON.stringify(caught)).not.toContain('legacy provider body');
+      expect(JSON.stringify(caught)).not.toContain('legacy proxy response');
+    });
+
+    it.each([
+      ['unknown code', { code: 'made_up', retryable: false }],
+      ['content policy marked retryable', { code: 'content_policy', retryable: true }],
+      ['network-blocked marked retryable', { code: 'network_blocked', retryable: true }],
+      ['negative retry delay', { code: 'rate_limit', retryable: true, retryAfterMs: -1 }],
+      ['invalid status', { code: 'authentication', retryable: false, statusCode: 403.5 }],
+      ['content policy with 401 status', { code: 'content_policy', retryable: false, statusCode: 401, upstream: { status: 401 } }],
+      ['rate limit with 403 status', { code: 'rate_limit', retryable: true, statusCode: 403, upstream: { status: 403 } }],
+      ['unknown field', { code: 'authentication', retryable: false, rawBody: 'private' }],
+    ])('rejects malformed LLM wire data: %s', async (_label, fields) => {
+      requestMock.mockRejectedValue(new SidecarRpcError(-32000, 'untrusted', {
+        name: 'LLMError',
+        message: 'untrusted',
+        ...fields,
+      }));
+      const adapter = new SidecarLLMAdapter('claude');
+
+      await expect(adapter.chat([], { model: 'm', apiKey: 'k' }, () => {})).rejects.toMatchObject({
+        code: 'unknown',
+        retryable: false,
+        message: 'Invalid sidecar LLM error response',
+      });
+    });
+
     it('a SidecarRpcError without LLMError-shaped data becomes a retryable network_error', async () => {
       requestMock.mockRejectedValue(new SidecarRpcError(-32603, 'Internal error', { name: 'TypeError', message: 'boom' }));
       const adapter = new SidecarLLMAdapter('claude');
@@ -183,6 +255,16 @@ describe('SidecarLLMAdapter', () => {
         code: 'network_error', retryable: true,
       });
       await expect(adapter.chat([], { model: 'm', apiKey: 'k' }, () => {})).rejects.toBeInstanceOf(LLMError);
+    });
+
+    it('sanitizes a structured plain transport Error before it reaches terminal formatting', async () => {
+      requestMock.mockRejectedValue(new Error('{"private":"plain transport body"}'));
+      const adapter = new SidecarLLMAdapter('claude');
+
+      const caught = await adapter.chat([], { model: 'm', apiKey: 'k' }, () => {}).catch((error) => error);
+      expect(caught).toMatchObject({ code: 'network_error', retryable: true, message: 'Sidecar transport failed' });
+      expect(formatLlmTerminalError(caught)).toBe('Sidecar transport failed');
+      expect(JSON.stringify(caught)).not.toContain('plain transport body');
     });
   });
 

--- a/src/core/llm/sidecarAdapter.ts
+++ b/src/core/llm/sidecarAdapter.ts
@@ -15,8 +15,14 @@
  */
 
 import type { LLMAdapter, ChatOptions, LLMErrorCode, AdapterKind } from './adapter';
-import { LLMError } from './adapter';
-import type { Message, StreamEvent } from '../../types';
+import {
+  isLLMErrorCode,
+  isUpstreamErrorDetails,
+  LLMError,
+  normalizeUpstreamErrorDetails,
+  sanitizeUntrustedLlmErrorText,
+} from './adapter';
+import type { Message, StreamEvent, UpstreamErrorDetails } from '../../types';
 import { request, notifySidecar, onSidecarNotification, SidecarRpcError } from '../sidecar/sidecarManager';
 import { createLogger } from '../logging/logger';
 
@@ -43,11 +49,72 @@ interface LlmChatMetaNotificationParams {
 }
 
 interface SidecarLlmErrorData {
-  name?: string;
-  code?: string;
+  name: 'LLMError';
+  code?: LLMErrorCode;
   retryable?: boolean;
   retryAfterMs?: number;
+  statusCode?: number;
+  upstream?: UpstreamErrorDetails;
   message?: string;
+}
+
+const SIDECAR_LLM_ERROR_DATA_KEYS = new Set([
+  'name',
+  'code',
+  'retryable',
+  'retryAfterMs',
+  'statusCode',
+  'upstream',
+  'message',
+]);
+const WIRE_RETRYABLE_LLM_CODES: ReadonlySet<LLMErrorCode> = new Set([
+  'rate_limit',
+  'overloaded',
+  'server_error',
+  'network_error',
+]);
+const WIRE_HTTP_STATUS_BY_CODE: Partial<Record<LLMErrorCode, ReadonlySet<number>>> = {
+  authentication: new Set([401, 403]),
+  content_policy: new Set([403]),
+  context_too_long: new Set([400]),
+  invalid_request: new Set([400]),
+  not_found: new Set([404]),
+  overloaded: new Set([503, 529]),
+  rate_limit: new Set([429]),
+  server_error: new Set([500, 502]),
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isSidecarLlmErrorData(value: unknown): value is SidecarLlmErrorData {
+  if (!isRecord(value) || value.name !== 'LLMError') return false;
+  if (Object.keys(value).some((key) => !SIDECAR_LLM_ERROR_DATA_KEYS.has(key))) return false;
+  if (value.code !== undefined && !isLLMErrorCode(value.code)) return false;
+  if (value.retryable !== undefined && typeof value.retryable !== 'boolean') return false;
+  if (value.retryable === true && (!value.code || !WIRE_RETRYABLE_LLM_CODES.has(value.code))) return false;
+  if (value.retryAfterMs !== undefined
+    && (!Number.isFinite(value.retryAfterMs as number) || (value.retryAfterMs as number) < 0 || value.retryable !== true)) {
+    return false;
+  }
+  if (value.statusCode !== undefined
+    && (!Number.isInteger(value.statusCode) || (value.statusCode as number) < 100 || (value.statusCode as number) > 599)) {
+    return false;
+  }
+  if (value.upstream !== undefined && !isUpstreamErrorDetails(value.upstream)) return false;
+  if (value.statusCode !== undefined && isUpstreamErrorDetails(value.upstream)
+    && value.statusCode !== value.upstream.status) {
+    return false;
+  }
+  const effectiveStatus = typeof value.statusCode === 'number'
+    ? value.statusCode
+    : isUpstreamErrorDetails(value.upstream) ? value.upstream.status : undefined;
+  if (value.code && effectiveStatus !== undefined) {
+    const allowedStatuses = WIRE_HTTP_STATUS_BY_CODE[value.code];
+    if (allowedStatuses && !allowedStatuses.has(effectiveStatus)) return false;
+  }
+  return value.message === undefined || typeof value.message === 'string';
 }
 
 function isLlmEventParams(v: unknown): v is LlmEventNotificationParams {
@@ -75,22 +142,36 @@ function reconstructError(err: unknown): LLMError {
   // re-wrap it as a generic network_error.
   if (err instanceof LLMError) return err;
   if (err instanceof SidecarRpcError) {
-    const data = err.data as SidecarLlmErrorData | undefined;
-    if (data?.name === 'LLMError') {
-      return new LLMError(data.message ?? err.message, (data.code as LLMErrorCode | undefined) ?? 'unknown', {
+    const data = err.data;
+    if (isSidecarLlmErrorData(data)) {
+      const upstream = normalizeUpstreamErrorDetails(data.upstream);
+      const code = data.code ?? 'unknown';
+      const message = upstream?.summary
+        ?? sanitizeUntrustedLlmErrorText(data.message, code);
+      return new LLMError(message, code, {
         retryable: data.retryable,
         retryAfterMs: data.retryAfterMs,
+        statusCode: typeof data.statusCode === 'number' ? data.statusCode : undefined,
+        upstream,
       });
+    }
+    if (isRecord(data) && data.name === 'LLMError') {
+      // A malformed LLM-shaped response is protocol corruption, not a basis
+      // for trusting retryability or provider text supplied by the wire.
+      return new LLMError('Invalid sidecar LLM error response', 'unknown', { retryable: false });
     }
     // The sidecar threw something that wasn't an LLMError (e.g. a bug in the
     // adapter, an unexpected exception) — surface as a retryable transport
     // failure rather than silently losing the shape withRetry expects.
-    return new LLMError(data?.message ?? err.message, 'network_error', { retryable: true });
+    return new LLMError('Sidecar request failed', 'network_error', { retryable: true });
   }
   // Not even a SidecarRpcError — e.g. the manager's request() rejected for a
   // transport reason (see the close-mid-stream case handled in chat() below,
   // and this is the generic fallback for anything else unexpected).
-  const message = err instanceof Error ? err.message : String(err);
+  const message = sanitizeUntrustedLlmErrorText(
+    err instanceof Error ? err.message : String(err),
+    'Sidecar transport failed',
+  );
   return new LLMError(message, 'network_error', { retryable: true });
 }
 

--- a/src/core/session/shareBundle.test.ts
+++ b/src/core/session/shareBundle.test.ts
@@ -116,6 +116,71 @@ describe('buildShareBundle', () => {
     expect(JSON.stringify(bundle)).toContain('[REDACTED:anthropic-key]');
   });
 
+  it('allowlists and redacts provider error details before sharing', async () => {
+    const secret = 'sk-ant-abcdefghijklmnopqrstuvwxyz123456';
+    const conv = makeConv([
+      {
+        id: 'failed-valid',
+        role: 'user',
+        content: 'fixed fixture input',
+        timestamp: 1,
+        runState: 'failed',
+        runError: `provider echoed ${secret}`,
+        runErrorDetails: {
+          status: 403,
+          error_type: `governance.${secret}`,
+          traceId: secret,
+          summary: `provider echoed ${secret}`,
+        },
+      },
+      {
+        id: 'failed-malformed',
+        role: 'user',
+        content: 'fixed fixture input',
+        timestamp: 2,
+        runState: 'failed',
+        runErrorDetails: {
+          status: 403,
+          rawBody: `private prompt and ${secret}`,
+        } as never,
+      },
+      {
+        id: 'failed-legacy-raw-error',
+        role: 'user',
+        content: 'fixed fixture input',
+        timestamp: 3,
+        runState: 'failed',
+        runError: '{"private":"legacy provider body without a credential pattern"}',
+      },
+      {
+        id: 'completed-with-stale-error',
+        role: 'user',
+        content: 'fixed fixture input',
+        timestamp: 4,
+        runState: 'completed',
+        runError: 'must not survive a completed row',
+        runErrorDetails: { status: 403 },
+      },
+    ]);
+
+    const bundle = await buildShareBundle(conv);
+    const serialized = JSON.stringify(bundle);
+
+    expect(serialized).not.toContain(secret);
+    expect(serialized).not.toContain('private prompt');
+    expect(serialized).not.toContain('rawBody');
+    expect(serialized).not.toContain('legacy provider body without a credential pattern');
+    expect(bundle.messages[0].runError).toContain('[REDACTED:anthropic-key]');
+    expect(bundle.messages[0].runErrorDetails?.error_type).toContain('[REDACTED:anthropic-key]');
+    expect(bundle.messages[0].runErrorDetails?.traceId).toContain('[REDACTED:anthropic-key]');
+    expect(bundle.messages[0].runErrorDetails?.summary).toContain('[REDACTED:anthropic-key]');
+    expect(bundle.messages[1].runErrorDetails).toBeUndefined();
+    expect(bundle.messages[2].runError).toBe('Provider request failed');
+    expect(bundle.messages[3].runError).toBeUndefined();
+    expect(bundle.messages[3].runErrorDetails).toBeUndefined();
+    expect(bundle.stats.redactionCount).toBeGreaterThanOrEqual(4);
+  });
+
   it('clears isStreaming flags and tool-call execution state', async () => {
     const conv = makeConv([
       {

--- a/src/core/session/shareBundle.ts
+++ b/src/core/session/shareBundle.ts
@@ -24,6 +24,7 @@ import { normalizeSeparators } from '@/utils/pathUtils';
 import { listSnapshots, readSnapshotBytes, type SnapshotEntry, type SnapshotSource } from './outputSnapshots';
 import { redactText, redactDeep, type RedactionSample } from './shareRedactor';
 import { isCompactBoundary } from '@/core/context/compactBoundary';
+import { normalizeUpstreamErrorDetails, sanitizeUntrustedLlmErrorText } from '@/core/llm/adapter';
 
 export const SHARE_SCHEMA_VERSION = 1 as const;
 
@@ -204,6 +205,37 @@ async function prepareMessage(
     const r = redactText(clone.thinking);
     onRedaction(r);
     clone.thinking = r.text;
+  }
+  if (clone.runState !== 'failed' && clone.runState !== 'connection-failed') {
+    delete clone.runError;
+    delete clone.runErrorDetails;
+  }
+  if (clone.runError) {
+    const r = redactText(clone.runError);
+    onRedaction(r);
+    clone.runError = sanitizeUntrustedLlmErrorText(r.text, 'Provider request failed');
+  }
+  const runErrorDetails = normalizeUpstreamErrorDetails(clone.runErrorDetails);
+  if (!runErrorDetails) {
+    delete clone.runErrorDetails;
+  } else {
+    const redactOptionalField = (value: string | undefined): string | undefined => {
+      if (!value) return undefined;
+      const redacted = redactText(value);
+      onRedaction(redacted);
+      return redacted.text;
+    };
+    // Every provider-controlled string can echo credentials, including fields
+    // normally used as identifiers. Re-normalize after redaction so a replaced
+    // value can never escape the bounded share-contract projection.
+    const redactedDetails = normalizeUpstreamErrorDetails({
+      status: runErrorDetails.status,
+      error_type: redactOptionalField(runErrorDetails.error_type),
+      traceId: redactOptionalField(runErrorDetails.traceId),
+      summary: redactOptionalField(runErrorDetails.summary),
+    });
+    if (redactedDetails) clone.runErrorDetails = redactedDetails;
+    else delete clone.runErrorDetails;
   }
   return clone;
 }

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -250,6 +250,7 @@ const enUS: TranslationDict = {
     runRecovering: 'Connection interrupted. Recovering…',
     runFailed: 'Send failed',
     runConnectionFailed: 'Connection recovery failed',
+    contentPolicyRejected: 'The upstream content-safety system rejected the request (often triggered by conversation history; try continuing in a new conversation)',
     runInterrupted: 'Stopped',
     runRecoveredAfterRestart: 'The task did not finish before the app restarted. Please retry.',
     runRetry: 'Retry',
@@ -1129,6 +1130,7 @@ const enUS: TranslationDict = {
     detailHide: 'Hide details',
     errMap: {
       aiAuth: 'API key is invalid or expired',
+      aiContentPolicy: 'The upstream content-safety system rejected the request (often triggered by conversation history; try continuing in a new conversation)',
       aiRateLimit: 'Rate limit exceeded, try again shortly',
       aiOverloaded: 'Provider is busy, try again shortly',
       aiServerError: 'Provider returned a server error',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -250,6 +250,7 @@ const zhCN: TranslationDict = {
     runRecovering: '连接中断，正在恢复…',
     runFailed: '发送失败',
     runConnectionFailed: '连接恢复失败',
+    contentPolicyRejected: '上游内容安全系统拒绝了请求（通常由对话历史触发，可尝试新开会话继续）',
     runInterrupted: '已停止',
     runRecoveredAfterRestart: '应用重启前任务未完成，请重试。',
     runRetry: '重试',
@@ -1129,6 +1130,7 @@ const zhCN: TranslationDict = {
     detailHide: '收起详情',
     errMap: {
       aiAuth: 'API Key 无效或已过期',
+      aiContentPolicy: '上游内容安全系统拒绝了请求（通常由对话历史触发，可尝试新开会话继续）',
       aiRateLimit: '请求频率超限，稍后再试',
       aiOverloaded: 'provider 服务繁忙，稍后再试',
       aiServerError: 'provider 服务异常，稍后再试',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -283,6 +283,7 @@ export interface TranslationDict {
     runRecovering: string;
     runFailed: string;
     runConnectionFailed: string;
+    contentPolicyRejected: string;
     runInterrupted: string;
     runRecoveredAfterRestart: string;
     runRetry: string;
@@ -1291,6 +1292,7 @@ export interface TranslationDict {
     errMap: {
       // AI service codes
       aiAuth: string;
+      aiContentPolicy: string;
       aiRateLimit: string;
       aiOverloaded: string;
       aiServerError: string;

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -605,6 +605,149 @@ describe('chatStore', () => {
       }
     });
 
+    it('keeps structured upstream error details on the durable failed user row', async () => {
+      const terminalTimestamp = new Date('2026-08-29T00:00:00.000Z').getTime();
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(terminalTimestamp);
+      const id = useChatStore.getState().createConversation();
+      const message = {
+        id: 'client-msg-upstream-failure',
+        role: 'user',
+        content: 'fixed fixture input',
+        timestamp: FIXED_TIMESTAMP,
+        runState: 'running',
+      } as const;
+      const errorDetails = {
+        status: 403,
+        error_type: 'governance.alicloud_content_safety_input_rejected',
+        traceId: 'store-trace-403',
+        summary: 'The content safety system rejected the request.',
+      } as const;
+      useChatStore.getState().addMessage(id, message);
+      vi.mocked(exists).mockResolvedValue(true);
+      vi.mocked(readTextFile).mockResolvedValue(`${JSON.stringify(message)}\n`);
+
+      try {
+        useChatStore.getState().updateUserMessageRun(id, message.id, {
+          state: 'failed',
+          error: errorDetails.summary,
+          errorDetails,
+        });
+        await waitForConversationPersistence(id);
+
+        expect(useChatStore.getState().conversations[id].messages[0]).toMatchObject({
+          runState: 'failed',
+          runError: errorDetails.summary,
+          runErrorDetails: errorDetails,
+          runEndedAt: terminalTimestamp,
+        });
+      } finally {
+        vi.mocked(exists).mockReset();
+        vi.mocked(exists).mockResolvedValue(false);
+        vi.mocked(readTextFile).mockReset();
+        vi.mocked(readTextFile).mockResolvedValue('');
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('rejects privacy-unsafe upstream fields at the store action boundary', async () => {
+      const id = useChatStore.getState().createConversation();
+      const message = {
+        id: 'client-msg-unsafe-upstream',
+        role: 'user',
+        content: 'fixed fixture input',
+        timestamp: FIXED_TIMESTAMP,
+        runState: 'running',
+      } as const;
+      useChatStore.getState().addMessage(id, message);
+      vi.mocked(exists).mockResolvedValue(true);
+      vi.mocked(readTextFile).mockResolvedValue(`${JSON.stringify(message)}\n`);
+
+      try {
+        useChatStore.getState().updateUserMessageRun(id, message.id, {
+          state: 'failed',
+          error: 'HTTP 403 · content_policy',
+          errorDetails: {
+            status: 403,
+            rawBody: 'private prompt text',
+          } as never,
+        });
+        await waitForConversationPersistence(id);
+
+        const stored = useChatStore.getState().conversations[id].messages[0];
+        expect(stored.runError).toBe('HTTP 403 · content_policy');
+        expect(stored.runErrorDetails).toBeUndefined();
+      } finally {
+        vi.mocked(exists).mockReset();
+        vi.mocked(exists).mockResolvedValue(false);
+        vi.mocked(readTextFile).mockReset();
+        vi.mocked(readTextFile).mockResolvedValue('');
+      }
+    });
+
+    it('sanitizes a structured run error at the store action boundary', async () => {
+      const id = useChatStore.getState().createConversation();
+      const message = {
+        id: 'client-msg-unsafe-run-error',
+        role: 'user',
+        content: 'fixed fixture input',
+        timestamp: FIXED_TIMESTAMP,
+        runState: 'running',
+      } as const;
+      useChatStore.getState().addMessage(id, message);
+      vi.mocked(exists).mockResolvedValue(true);
+      vi.mocked(readTextFile).mockResolvedValue(`${JSON.stringify(message)}\n`);
+
+      try {
+        useChatStore.getState().updateUserMessageRun(id, message.id, {
+          state: 'failed',
+          error: '{"private":"provider body at store boundary"}',
+        });
+        await waitForConversationPersistence(id);
+
+        const stored = useChatStore.getState().conversations[id].messages[0];
+        expect(stored.runError).toBe(getI18n().chat.errorEmptyBody);
+        expect(JSON.stringify(stored)).not.toContain('provider body at store boundary');
+      } finally {
+        vi.mocked(exists).mockReset();
+        vi.mocked(exists).mockResolvedValue(false);
+        vi.mocked(readTextFile).mockReset();
+        vi.mocked(readTextFile).mockResolvedValue('');
+      }
+    });
+
+    it('drops failure fields when the store action completes a run', async () => {
+      const id = useChatStore.getState().createConversation();
+      const message = {
+        id: 'client-msg-completed-with-error',
+        role: 'user',
+        content: 'fixed fixture input',
+        timestamp: FIXED_TIMESTAMP,
+        runState: 'running',
+      } as const;
+      useChatStore.getState().addMessage(id, message);
+      vi.mocked(exists).mockResolvedValue(true);
+      vi.mocked(readTextFile).mockResolvedValue(`${JSON.stringify(message)}\n`);
+
+      try {
+        useChatStore.getState().updateUserMessageRun(id, message.id, {
+          state: 'completed',
+          error: 'must not survive',
+          errorDetails: { status: 403 },
+        });
+        await waitForConversationPersistence(id);
+
+        const stored = useChatStore.getState().conversations[id].messages[0];
+        expect(stored.runState).toBe('completed');
+        expect(stored.runError).toBeUndefined();
+        expect(stored.runErrorDetails).toBeUndefined();
+      } finally {
+        vi.mocked(exists).mockReset();
+        vi.mocked(exists).mockResolvedValue(false);
+        vi.mocked(readTextFile).mockReset();
+        vi.mocked(readTextFile).mockResolvedValue('');
+      }
+    });
+
     it('persists a terminal timestamp with the interrupted reliable-run state', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-08-13T06:30:00.000Z'));
@@ -3129,5 +3272,97 @@ describe('sanitizeImportedMessage — same completion inference as disk load', (
       id: 'u1', role: 'user', content: 'x', timestamp: 1, runState: 'pending', loopId: 'loop-z',
     } as never);
     expect((sanitized as { runState?: string }).runState).toBe('failed');
+  });
+
+  it.each([
+    ['unknown raw field', { status: 403, rawBody: 'private prompt text' }],
+    ['oversized summary', { status: 403, summary: 'x'.repeat(501) }],
+  ])('drops an invalid imported upstream projection: %s', (_label, runErrorDetails) => {
+    const sanitized = sanitizeImportedMessage({
+      id: 'u-invalid-import',
+      role: 'user',
+      content: 'x',
+      timestamp: 1,
+      runState: 'failed',
+      runErrorDetails,
+    } as never);
+
+    expect(sanitized.runErrorDetails).toBeUndefined();
+  });
+
+  it('sanitizes a legacy imported JSON runError', () => {
+    const sanitized = sanitizeImportedMessage({
+      id: 'u-unsafe-import-error',
+      role: 'user',
+      content: 'x',
+      timestamp: 1,
+      runState: 'failed',
+      runError: 'Error: {"private":"imported provider body"}',
+    } as never);
+
+    expect(sanitized.runError).toBe(getI18n().chat.errorEmptyBody);
+    expect(JSON.stringify(sanitized)).not.toContain('imported provider body');
+  });
+
+  it('drops failure fields from an imported completed row', () => {
+    const sanitized = sanitizeImportedMessage({
+      id: 'u-completed-import-error',
+      role: 'user',
+      content: 'x',
+      timestamp: 1,
+      runState: 'completed',
+      runError: 'must not survive',
+      runErrorDetails: { status: 403 },
+    } as never);
+
+    expect(sanitized.runError).toBeUndefined();
+    expect(sanitized.runErrorDetails).toBeUndefined();
+  });
+});
+
+describe('sanitizeLoadedMessages — upstream privacy boundary', () => {
+  it.each([
+    ['unknown raw field', { status: 403, rawBody: 'private prompt text' }],
+    ['oversized summary', { status: 403, summary: 'x'.repeat(501) }],
+  ])('drops an invalid persisted upstream projection: %s', (_label, runErrorDetails) => {
+    const [sanitized] = sanitizeLoadedMessages([{
+      id: 'u-invalid-ledger',
+      role: 'user',
+      content: 'x',
+      timestamp: 1,
+      runState: 'failed',
+      runErrorDetails,
+    } as never]);
+
+    expect(sanitized.runErrorDetails).toBeUndefined();
+  });
+
+  it('sanitizes a legacy persisted HTML runError', () => {
+    const [sanitized] = sanitizeLoadedMessages([{
+      id: 'u-unsafe-ledger-error',
+      role: 'user',
+      content: 'x',
+      timestamp: 1,
+      runState: 'failed',
+      runError: '<html><body>persisted proxy body</body></html>',
+    } as never]);
+
+    expect(sanitized.runError).toBe(getI18n().chat.errorEmptyBody);
+    expect(JSON.stringify(sanitized)).not.toContain('persisted proxy body');
+  });
+
+  it('drops failure fields from a persisted completed row', () => {
+    const [sanitized] = sanitizeLoadedMessages([{
+      id: 'u-completed-ledger-error',
+      role: 'user',
+      content: 'x',
+      timestamp: 1,
+      runState: 'completed',
+      runError: 'must not survive',
+      runErrorDetails: { status: 403 },
+    } as never]);
+
+    expect(sanitized.runError).toBeUndefined();
+    expect(sanitized.runErrorDetails).toBeUndefined();
   });
 });

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import { current, enableMapSet } from 'immer';
-import type { Message, Conversation, AgentStatus, RetryInfo, TokenUsage, ConversationStatus, ToolCallForContext, ToolResultContent, ToolCall, NoticeCardAction, SandboxRecoveryAction, ToolExecutionMetadata, UserQuestionResult } from '../types';
+import type { Message, Conversation, AgentStatus, RetryInfo, TokenUsage, ConversationStatus, ToolCallForContext, ToolResultContent, ToolCall, NoticeCardAction, SandboxRecoveryAction, ToolExecutionMetadata, UserQuestionResult, UpstreamErrorDetails } from '../types';
 import type { ExecutionStepSnapshot, PlannedStep } from '../types/execution';
 import { useWorkspaceStore } from './workspaceStore';
 import { useProjectStore } from './projectStore';
@@ -33,6 +33,7 @@ import { useWorkProcessFoldStore } from './workProcessFoldStore';
 import { useBatchProgressStore } from './batchProgressStore';
 import { usePreviewStore } from './previewStore';
 import { appendBoundedSubagentToolCall } from '../core/session/durableToolResultContent';
+import { normalizeUpstreamErrorDetails, sanitizeUntrustedLlmErrorText } from '../core/llm/adapter';
 
 enableMapSet();
 
@@ -55,6 +56,7 @@ const TERMINAL_RUN_STATES = new Set<Message['runState']>([
   'connection-failed',
   'interrupted',
 ]);
+const RUN_FAILURE_STATES = new Set<Message['runState']>(['failed', 'connection-failed']);
 
 function toolCallHasNonSuccessMetadata(tc: ToolCall): boolean {
   return tc.subagentStopReason !== undefined && tc.subagentStopReason !== 'completed'
@@ -78,14 +80,43 @@ function recoverInterruptedUserRun(msg: Message, answeredLoopIds?: ReadonlySet<s
   };
 }
 
+function safeRunErrorFallback(errorDetails?: UpstreamErrorDetails): string {
+  const statusFallback = errorDetails
+    ? `HTTP ${errorDetails.status}`
+    : getI18n().chat.errorEmptyBody;
+  return errorDetails?.summary
+    ? sanitizeUntrustedLlmErrorText(errorDetails.summary, statusFallback)
+    : statusFallback;
+}
+
+function sanitizeRunError(value: unknown, errorDetails?: UpstreamErrorDetails): string | undefined {
+  if (typeof value !== 'string' || value.trim() === '') return undefined;
+  return sanitizeUntrustedLlmErrorText(value, safeRunErrorFallback(errorDetails));
+}
+
+function enforceRunErrorState(message: Message): Message {
+  if (RUN_FAILURE_STATES.has(message.runState)) return message;
+  const { runError: _runError, runErrorDetails: _runErrorDetails, ...withoutRunError } = message;
+  return withoutRunError as Message;
+}
+
 /** Extra safety net for messages coming in via import — ensures no streaming
  * flag survives even if the source bundle was built by a broken exporter.
  * Pass the bundle's `collectAnsweredLoopIds` so a stale-active row whose loop
  * demonstrably replied is inferred completed here too — without it, the same
  * ledger that loads clean from disk imports branded "发送失败". */
 export function sanitizeImportedMessage(msg: Message, answeredLoopIds?: ReadonlySet<string>): Message {
-  return recoverInterruptedUserRun({
-    ...msg,
+  const {
+    runErrorDetails: untrustedRunErrorDetails,
+    runError: untrustedRunError,
+    ...messageWithoutErrorDetails
+  } = msg;
+  const runErrorDetails = normalizeUpstreamErrorDetails(untrustedRunErrorDetails);
+  const runError = sanitizeRunError(untrustedRunError, runErrorDetails);
+  return enforceRunErrorState(recoverInterruptedUserRun({
+    ...messageWithoutErrorDetails,
+    ...(runError ? { runError } : {}),
+    ...(runErrorDetails ? { runErrorDetails } : {}),
     isStreaming: false,
     toolCalls: msg.toolCalls?.map((tc) => {
       const {
@@ -95,7 +126,7 @@ export function sanitizeImportedMessage(msg: Message, answeredLoopIds?: Readonly
       } = tc;
       return { ...safeToolCall, isExecuting: false };
     }),
-  }, answeredLoopIds);
+  }, answeredLoopIds));
 }
 
 /** A non-ghost assistant row: real text, tool activity, or thinking. Shared
@@ -136,6 +167,13 @@ export function sanitizeLoadedMessages(messages: Message[]): Message[] {
   const answeredLoopIds = collectAnsweredLoopIds(messages);
   return messages
     .map((msg) => {
+      const {
+        runErrorDetails: untrustedRunErrorDetails,
+        runError: untrustedRunError,
+        ...messageWithoutErrorDetails
+      } = msg;
+      const runErrorDetails = normalizeUpstreamErrorDetails(untrustedRunErrorDetails);
+      const runError = sanitizeRunError(untrustedRunError, runErrorDetails);
       const toolCalls = msg.toolCalls?.map((tc) => {
         const safeToRetryRecovery =
           tc.sandboxRecoveryAction === 'pending'
@@ -150,11 +188,13 @@ export function sanitizeLoadedMessages(messages: Message[]): Message[] {
             : tc.sandboxRecoveryAction,
         };
       });
-      return recoverInterruptedUserRun({
-        ...msg,
+      return enforceRunErrorState(recoverInterruptedUserRun({
+        ...messageWithoutErrorDetails,
+        ...(runError ? { runError } : {}),
+        ...(runErrorDetails ? { runErrorDetails } : {}),
         isStreaming: false,
         toolCalls,
-      }, answeredLoopIds);
+      }, answeredLoopIds));
     })
     .filter(msg => msg.role !== 'assistant' || isSubstantiveAssistant(msg));
 }
@@ -611,6 +651,7 @@ interface ChatActions {
     patch: {
       state: NonNullable<Message['runState']>;
       error?: string;
+      errorDetails?: UpstreamErrorDetails;
       content?: Message['content'];
       skill?: Message['skill'];
       delegateAgent?: Message['delegateAgent'];
@@ -1444,8 +1485,13 @@ export const useChatStore = create<ChatStore>()(
           } else {
             delete message.runEndedAt;
           }
-          if (patch.error) message.runError = patch.error;
+          const errorDetails = normalizeUpstreamErrorDetails(patch.errorDetails);
+          const isFailure = RUN_FAILURE_STATES.has(patch.state);
+          const runError = isFailure ? sanitizeRunError(patch.error, errorDetails) : undefined;
+          if (runError) message.runError = runError;
           else delete message.runError;
+          if (isFailure && errorDetails) message.runErrorDetails = errorDetails;
+          else delete message.runErrorDetails;
           if ('content' in patch && patch.content !== undefined) message.content = patch.content;
           if ('skill' in patch) message.skill = patch.skill;
           if ('delegateAgent' in patch) message.delegateAgent = patch.delegateAgent;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -325,6 +325,18 @@ export interface ThinkingBlock {
   thinking: string;
 }
 
+/**
+ * Bounded, user-visible projection of an upstream provider error. The raw
+ * response body stays inside the adapter/diagnostic path and must never cross
+ * the sidecar terminal wire or be persisted on a chat message.
+ */
+export interface UpstreamErrorDetails {
+  status: number;
+  error_type?: string;
+  traceId?: string;
+  summary?: string;
+}
+
 export interface Message {
   id: string;
   role: 'user' | 'assistant' | 'system';
@@ -347,6 +359,8 @@ export interface Message {
   clientMessageId?: string;
   /** User-facing detail retained when dispatch reaches a failed terminal. */
   runError?: string;
+  /** Structured provider fields retained for the failed-run error card. */
+  runErrorDetails?: UpstreamErrorDetails;
   toolCalls?: ToolCall[];
   // Extended thinking content
   thinking?: string;

--- a/tests/e2e/content-policy-error.spec.ts
+++ b/tests/e2e/content-policy-error.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * Real-Electron acceptance for a provider content-policy 403. The mock binds
+ * only to loopback, receives a fixed synthetic prompt, and the app runs with
+ * an isolated Chromium profile + app-data root.
+ */
+import { expect, test } from '@playwright/test';
+import { createServer, type Server } from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { ElectronApplication } from 'playwright';
+import {
+  closeAbuElectron,
+  configureLocalMockProvider,
+  createElectronDataRoot,
+  launchAbuElectron,
+  removeElectronDataRoot,
+  REPO_ROOT,
+  type ElectronDataRoot,
+} from './electronHelpers';
+
+const READY_TIMEOUT = 45_000;
+const CHAT_PLACEHOLDER = '想让阿布帮你做点什么？';
+const ERROR_TYPE = 'governance.alicloud_content_safety_input_rejected';
+const TRACE_ID = 'e2e-governance-trace-403';
+const PROVIDER_SUMMARY = 'Input rejected by the upstream content-safety policy.';
+const RAW_ONLY_MARKER = 'raw-provider-body-must-not-render';
+const SCREENSHOT_PATH = path.join(REPO_ROOT, 'test-results', 'content-policy-error-card.png');
+
+interface ContentPolicyMock {
+  baseUrl: string;
+  close: () => Promise<void>;
+  requestCount: () => number;
+}
+
+async function startContentPolicyMock(): Promise<ContentPolicyMock> {
+  let requests = 0;
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    for await (const _chunk of req) {
+      // Drain the fixed synthetic request before responding.
+    }
+    if (req.method !== 'POST' || url.pathname !== '/v1/chat/completions') {
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'unexpected E2E route' }));
+      return;
+    }
+    requests += 1;
+    res.writeHead(403, { 'content-type': 'application/json; charset=utf-8' });
+    res.end(JSON.stringify({
+      error: { message: PROVIDER_SUMMARY },
+      error_type: ERROR_TYPE,
+      traceId: TRACE_ID,
+      private: RAW_ONLY_MARKER,
+    }));
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await closeServer(server);
+    throw new Error('Content-policy mock did not receive a TCP port');
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    close: () => closeServer(server),
+    requestCount: () => requests,
+  };
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+    server.closeAllConnections?.();
+  });
+}
+
+let app: ElectronApplication | undefined;
+let dataRoot: ElectronDataRoot | undefined;
+let mock: ContentPolicyMock | undefined;
+
+test.describe.serial('Content-policy error card — real Electron', () => {
+  test.afterEach(async () => {
+    if (app) {
+      await closeAbuElectron(app);
+      app = undefined;
+    }
+    if (mock) {
+      await mock.close();
+      mock = undefined;
+    }
+    if (dataRoot) {
+      removeElectronDataRoot(dataRoot);
+      dataRoot = undefined;
+    }
+  });
+
+  test('shows bounded structured fields without rendering the raw 403 body', async () => {
+    mock = await startContentPolicyMock();
+    dataRoot = createElectronDataRoot();
+    const launched = await launchAbuElectron(dataRoot);
+    app = launched.app;
+    const page = await app.firstWindow({ timeout: READY_TIMEOUT });
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.getByPlaceholder(CHAT_PLACEHOLDER)).toBeVisible({ timeout: READY_TIMEOUT });
+    await configureLocalMockProvider(page, mock.baseUrl);
+
+    const input = page.getByPlaceholder(CHAT_PLACEHOLDER);
+    await input.fill('fixed synthetic E2E prompt for a controlled 403');
+    await input.press('Enter');
+
+    await expect.poll(() => mock!.requestCount(), { timeout: READY_TIMEOUT }).toBe(1);
+    const card = page.getByRole('alert').filter({ hasText: TRACE_ID });
+    await expect(card).toBeVisible({ timeout: READY_TIMEOUT });
+    await expect(card).toContainText('HTTP 403');
+    await expect(card).toContainText(`error_type: ${ERROR_TYPE}`);
+    await expect(card).toContainText(`traceId: ${TRACE_ID}`);
+    await expect(card).toContainText(PROVIDER_SUMMARY);
+    await expect(page.getByText(/上游内容安全系统拒绝了请求/)).toBeVisible();
+    await expect(page.locator('body')).not.toContainText(RAW_ONLY_MARKER);
+    await expect.poll(() => mock!.requestCount()).toBe(1);
+
+    fs.mkdirSync(path.dirname(SCREENSHOT_PATH), { recursive: true });
+    await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
+  });
+});


### PR DESCRIPTION
## 改动

- 新增 `content_policy` 结构化分类，并统一 403 / WAF / HTML 响应判定与不可重试语义。
- 将有界、脱敏的上游错误详情贯穿 sidecar、agent、store、share 与错误卡片。
- 修复 Electron 启动竞态下首轮 in-process 路径丢失错误生命周期与详情的问题。
- 新增真实 Electron content-policy 错误卡 E2E；未纳入 balance-error retryability，按任务书留待后续。

## 验证

- 受影响测试：20 files / 920 tests passed
- `npm run verify`：467 files / 7160 passed / 1 skipped，覆盖率门禁通过
- `npm run electron:dev:check`：通过
- 真实 Electron content-policy E2E：3/3 passed，单次请求且原始响应正文不外泄
- 独立复审：`gpt-5.6-sol + xhigh`，无可复现 P0/P1/P2

## 实现

- 实现：`gpt-5.6-terra + medium`
- 已 rebase 到含 #314 的最新 `origin/dev`（`1560fd4f`）