### PR TITLE
fix(chat): 工作过程状态行对齐 Codex——消除 mid-run 插入跳 + 读秒 + 文案语义归位

### DIFF
--- a/e2e/preview-workspace.spec.ts
+++ b/e2e/preview-workspace.spec.ts
@@ -237,7 +237,7 @@ test.describe('Preview and workspace journey', () => {
   test('renders a completed batch aggregate and opens a deduped subagent workspace tab', async ({ page }) => {
     await seedBatchConversation(page, 'completed');
 
-    const processHeader = page.getByRole('button', { name: /已处理 4s · 2 个 Agent：2 成功/ });
+    const processHeader = page.getByRole('button', { name: /用时 4s · 2 个 Agent：2 成功/ });
     await expect(processHeader).toHaveAttribute('aria-expanded', 'false');
     await processHeader.click();
     await expect(processHeader).toHaveAttribute('aria-expanded', 'true');

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -100,7 +100,7 @@ const VirtuosoTypingFooter: NonNullable<Components<Message[], MessageListContext
   if (!context?.showTypingIndicator) return null;
   // Layout mirrors a MessageGroup's assistant row (shared AssistantRowAvatar,
   // gap-3, shared ThinkingStatusLine) so the hand-off from this footer to the
-  // real assistant placeholder — and then to the TaskBlock header / "已处理
+  // real assistant placeholder — and then to the TaskBlock header / "用时
   // Xs" fold header — keeps the label on the same baseline at the same size
   // instead of hopping between typographies ("错行"). The negative top margin
   // bridges the item-pad vs in-group-gap difference — see chatSpacing.ts.

--- a/src/components/chat/MessageGroup.segments.test.ts
+++ b/src/components/chat/MessageGroup.segments.test.ts
@@ -655,8 +655,11 @@ describe('computeWorkProcessFold', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const seg = (kind: string): any => (kind === 'text' ? { kind, text: 'x', message: { id: 't' }, isLastTurn: true } : { kind, executionSteps: [], legacySteps: [], isLastGroup: false, stepsMsgs: [] });
 
-  it('allows running work to be manually folded (streamed text stays visible via the collapsed-render filter)', () => {
-    expect(computeWorkProcessFold([seg('steps'), seg('text')], false)).toBe(2);
+  it('never folds while the run is in progress (header would insert mid-run and say "worked for")', () => {
+    expect(computeWorkProcessFold([seg('steps'), seg('text')], false)).toBeNull();
+    expect(computeWorkProcessFold([seg('steps'), seg('steps')], false)).toBeNull();
+    const batch = { kind: 'batch', toolCall: { id: 'b', name: 'run_agent_batch', input: {} }, message: { id: 'm' } } as Extract<Segment, { kind: 'batch' }>;
+    expect(computeWorkProcessFold([batch], false)).toBeNull();
   });
   it('folds everything before the final text answer', () => {
     // [thinking, plan, tool, text] → foldEnd = 3

--- a/src/components/chat/MessageGroup.status.test.tsx
+++ b/src/components/chat/MessageGroup.status.test.tsx
@@ -164,7 +164,7 @@ describe('MessageGroup stopped terminal', () => {
     expect(screen.getByText('I will inspect the workspace first.')).toBeInTheDocument();
   });
 
-  it('keeps streaming assistant text visible after manually collapsing preceding work', () => {
+  it('renders running work inline without a fold header, keeping streaming text visible', () => {
     const userMessage: Message = {
       id: 'user-streaming-text',
       role: 'user',
@@ -213,9 +213,13 @@ describe('MessageGroup stopped terminal', () => {
 
     render(<MessageGroup conversationId={conversation.id} messages={conversation.messages} isLastGroup />);
 
-    const foldButton = screen.getByRole('button', { name: /1 agents: 1 running/ });
-    fireEvent.click(foldButton);
-    expect(foldButton).toHaveAttribute('aria-expanded', 'false');
+    // In-progress runs render their work inline: no fold wrapper exists yet
+    // (the "Worked for" header is a settled-turn summary — see
+    // computeWorkProcessFold), so the live batch card and the streaming text
+    // are both directly visible.
+    expect(screen.queryByRole('button', { name: /1 agents: 1 running/ })).toBeNull();
+    expect(screen.queryByText(/Worked for/)).toBeNull();
+    expect(screen.getByRole('button', { name: /Open inspect live state.*Running/ })).toBeInTheDocument();
     expect(screen.getByText('The first result is already available.')).toBeInTheDocument();
   });
 
@@ -517,7 +521,7 @@ describe('MessageGroup stopped terminal', () => {
     expect(screen.getAllByText('✓ 1 sub-tasks completed')).toHaveLength(1);
   });
 
-  it('keeps process-only running work visible without offering a destructive fold', () => {
+  it('keeps process-only running work visible with no fold header until the run settles', () => {
     const userMessage: Message = {
       id: 'user-running-fold',
       role: 'user',
@@ -557,15 +561,95 @@ describe('MessageGroup stopped terminal', () => {
     useBatchProgressStore.getState().setTaskRunning(identity, 0);
 
     const view = render(<MessageGroup conversationId={conversation.id} messages={messages} isLastGroup />);
-    // Running work offers a manual fold but never auto-collapses: the live
-    // batch card must stay visible by default, across remounts.
-    expect(screen.getByRole('button', { name: /1 agents: 1 running/ })).toHaveAttribute('aria-expanded', 'true');
+    // Running work renders inline — no fold header exists until the run
+    // settles, and the live batch card stays visible, across remounts.
+    expect(screen.queryByRole('button', { name: /1 agents: 1 running/ })).toBeNull();
     expect(screen.getByRole('button', { name: /Open inspect running/ })).toBeInTheDocument();
 
     view.unmount();
     render(<MessageGroup conversationId={conversation.id} messages={messages} isLastGroup />);
-    expect(screen.getByRole('button', { name: /1 agents: 1 running/ })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.queryByRole('button', { name: /1 agents: 1 running/ })).toBeNull();
     expect(screen.getByRole('button', { name: /Open inspect running/ })).toBeInTheDocument();
+  });
+
+  it('never shows the "Worked for" header mid-run; it appears only once the run settles', () => {
+    const userMessage: Message = {
+      id: 'user-lifecycle',
+      role: 'user',
+      content: 'run the lifecycle batch',
+      timestamp: 1_000,
+      loopId: 'loop-lifecycle',
+      runState: 'running',
+    };
+    const placeholder: Message = {
+      id: 'assistant-lifecycle',
+      role: 'assistant',
+      content: '',
+      timestamp: 1_100,
+      loopId: 'loop-lifecycle',
+      isStreaming: true,
+    };
+    const conversation: Conversation = {
+      id: 'conversation-lifecycle',
+      title: 'Lifecycle',
+      messages: [userMessage, placeholder],
+      createdAt: 1_000,
+      updatedAt: 1_100,
+      status: 'running',
+    };
+    setConversationState(conversation);
+
+    // Phase 1 — fresh placeholder: typing dots only, no fold header row.
+    const view = render(
+      <MessageGroup conversationId={conversation.id} messages={[userMessage, placeholder]} isLastGroup />,
+    );
+    expect(document.querySelector('.typing-dot')).not.toBeNull();
+    expect(screen.queryByText(/Worked for/)).toBeNull();
+
+    // Phase 2 — first process content arrives: the work renders inline and
+    // STILL no header row mounts above it (the mid-run "已处理 0s" insertion
+    // was the reported one-frame jump).
+    const batchMessage: Message = {
+      ...placeholder,
+      toolCalls: [{
+        id: 'lifecycle-batch',
+        name: TOOL_NAMES.RUN_AGENT_BATCH,
+        input: { tasks: [{ task: 'inspect lifecycle' }] },
+        isExecuting: true,
+      }],
+    };
+    const identity = {
+      conversationId: conversation.id,
+      assistantMessageId: batchMessage.id,
+      batchToolCallId: 'lifecycle-batch',
+    };
+    useBatchProgressStore.getState().initBatch(identity, ['inspect lifecycle']);
+    useBatchProgressStore.getState().setTaskRunning(identity, 0);
+    view.rerender(
+      <MessageGroup conversationId={conversation.id} messages={[userMessage, batchMessage]} isLastGroup />,
+    );
+    expect(screen.getByRole('button', { name: /Open inspect lifecycle.*Running/ })).toBeInTheDocument();
+    expect(screen.queryByText(/Worked for/)).toBeNull();
+
+    // Phase 3 — run settles: the fold header appears, now truthfully in the
+    // past tense, together with the completion collapse.
+    useBatchProgressStore.getState().setTaskTerminal(identity, 0, { status: 'succeeded', reason: 'completed' });
+    const settledUser: Message = { ...userMessage, runState: 'completed', runEndedAt: 3_000 };
+    const settledBatch: Message = { ...batchMessage, isStreaming: false };
+    const finalMessage: Message = {
+      id: 'assistant-lifecycle-final',
+      role: 'assistant',
+      content: 'Lifecycle finished.',
+      timestamp: 2_900,
+      loopId: 'loop-lifecycle',
+    };
+    useChatStore.setState({
+      conversations: { [conversation.id]: { ...conversation, status: 'idle' } },
+    });
+    view.rerender(
+      <MessageGroup conversationId={conversation.id} messages={[settledUser, settledBatch, finalMessage]} isLastGroup />,
+    );
+    expect(screen.getByText(/Worked for/)).toBeInTheDocument();
   });
 
   it('does not re-auto-collapse after the user manually expands a successful fold', async () => {

--- a/src/components/chat/MessageGroup.status.test.tsx
+++ b/src/components/chat/MessageGroup.status.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 /// <reference types="@testing-library/jest-dom" />
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { initLanguage } from '@/i18n';
 import { useChatStore } from '@/stores/chatStore';
 import { useBatchProgressStore } from '@/stores/batchProgressStore';
@@ -216,9 +216,10 @@ describe('MessageGroup stopped terminal', () => {
     // In-progress runs render their work inline: no fold wrapper exists yet
     // (the "Worked for" header is a settled-turn summary — see
     // computeWorkProcessFold), so the live batch card and the streaming text
-    // are both directly visible.
+    // are both directly visible, under the non-interactive ticking divider.
     expect(screen.queryByRole('button', { name: /1 agents: 1 running/ })).toBeNull();
     expect(screen.queryByText(/Worked for/)).toBeNull();
+    expect(screen.getByText(/Working/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Open inspect live state.*Running/ })).toBeInTheDocument();
     expect(screen.getByText('The first result is already available.')).toBeInTheDocument();
   });
@@ -562,8 +563,10 @@ describe('MessageGroup stopped terminal', () => {
 
     const view = render(<MessageGroup conversationId={conversation.id} messages={messages} isLastGroup />);
     // Running work renders inline — no fold header exists until the run
-    // settles, and the live batch card stays visible, across remounts.
+    // settles (only the non-interactive ticking divider), and the live batch
+    // card stays visible, across remounts.
     expect(screen.queryByRole('button', { name: /1 agents: 1 running/ })).toBeNull();
+    expect(screen.getByText(/Working/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Open inspect running/ })).toBeInTheDocument();
 
     view.unmount();
@@ -573,6 +576,16 @@ describe('MessageGroup stopped terminal', () => {
   });
 
   it('never shows the "Worked for" header mid-run; it appears only once the run settles', () => {
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval', 'Date'] });
+    vi.setSystemTime(5_000);
+    try {
+      runFoldLifecycle();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  function runFoldLifecycle() {
     const userMessage: Message = {
       id: 'user-lifecycle',
       role: 'user',
@@ -599,16 +612,18 @@ describe('MessageGroup stopped terminal', () => {
     };
     setConversationState(conversation);
 
-    // Phase 1 — fresh placeholder: typing dots only, no fold header row.
+    // Phase 1 — fresh placeholder: typing dots only, no divider and no fold
+    // header row yet.
     const view = render(
       <MessageGroup conversationId={conversation.id} messages={[userMessage, placeholder]} isLastGroup />,
     );
     expect(document.querySelector('.typing-dot')).not.toBeNull();
     expect(screen.queryByText(/Worked for/)).toBeNull();
+    expect(screen.queryByText(/Working/)).toBeNull();
 
-    // Phase 2 — first process content arrives: the work renders inline and
-    // STILL no header row mounts above it (the mid-run "已处理 0s" insertion
-    // was the reported one-frame jump).
+    // Phase 2 — first process content arrives: the ticking in-run divider
+    // takes the dots' slot (progressive wording, not a button), and the
+    // settled "Worked for" header still does not exist.
     const batchMessage: Message = {
       ...placeholder,
       toolCalls: [{
@@ -630,9 +645,16 @@ describe('MessageGroup stopped terminal', () => {
     );
     expect(screen.getByRole('button', { name: /Open inspect lifecycle.*Running/ })).toBeInTheDocument();
     expect(screen.queryByText(/Worked for/)).toBeNull();
+    // Divider: elapsed = now(5s) - workStart(1s) = 4s, ticking every second.
+    expect(screen.getByText('Working for 4s')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Working for/ })).toBeNull();
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+    expect(screen.getByText('Working for 6s')).toBeInTheDocument();
 
-    // Phase 3 — run settles: the fold header appears, now truthfully in the
-    // past tense, together with the completion collapse.
+    // Phase 3 — run settles: the ticking divider hands its slot to the fold
+    // header, now truthfully in the past tense, with the completion collapse.
     useBatchProgressStore.getState().setTaskTerminal(identity, 0, { status: 'succeeded', reason: 'completed' });
     const settledUser: Message = { ...userMessage, runState: 'completed', runEndedAt: 3_000 };
     const settledBatch: Message = { ...batchMessage, isStreaming: false };
@@ -650,7 +672,8 @@ describe('MessageGroup stopped terminal', () => {
       <MessageGroup conversationId={conversation.id} messages={[settledUser, settledBatch, finalMessage]} isLastGroup />,
     );
     expect(screen.getByText(/Worked for/)).toBeInTheDocument();
-  });
+    expect(screen.queryByText(/Working for/)).toBeNull();
+  }
 
   it('does not re-auto-collapse after the user manually expands a successful fold', async () => {
     const userMessage: Message = {

--- a/src/components/chat/MessageGroup.tsx
+++ b/src/components/chat/MessageGroup.tsx
@@ -128,17 +128,18 @@ function useRunElapsedMs(startMs: number | undefined, active: boolean): number {
  * text, not a button — no fold exists until the run settles, when the fold
  * header button takes this exact slot as a 1:1 row swap.
  *
- * animateOnMount is FROZEN at mount (a later class change would replay the
- * animation mid-run): the common path — typing dots hand off to the first
- * process segment — is a same-slot row swap and must NOT animate (a grow-in
- * would dip the region height for 200ms), while the text-first path inserts
- * this row above already-visible content and needs the grow-in to avoid the
- * one-frame insertion jump this whole change exists to kill.
+ * ALWAYS grows in on mount (Codex animates its "Working for" divider the same
+ * way). The dots slot is NOT this row's to take: when the first process
+ * segment lands, TaskBlock's own header row is the dots row's designated
+ * same-slot successor (see ThinkingStatusLine), so at that commit the instant
+ * height budget is already spent (dots out, TaskBlock header in, net zero) —
+ * a non-animated divider on top was measured as the same one-frame +46px jump
+ * as the original bug. Growing in keeps every frame continuous: the thinking
+ * row slides down one row-height over 200ms instead of teleporting.
  */
-function RunStatusDivider({ label, animateOnMount }: { label: string; animateOnMount: boolean }) {
-  const [animate] = useState(animateOnMount);
+function RunStatusDivider({ label }: { label: string }) {
   return (
-    <div className={cn(animate && 'block-expand block-expand-open block-expand-enter')}>
+    <div className="block-expand block-expand-open block-expand-enter">
       <div className="mb-2 text-body text-[var(--abu-text-muted)] tabular-nums">
         {label}
       </div>
@@ -868,13 +869,6 @@ export default function MessageGroup({ conversationId, messages, isLastGroup: is
     (seg) => seg.kind === 'steps' || seg.kind === 'plan' || seg.kind === 'batch');
   const showRunStatusLine = !isGroupDone && !isStopped && hasProcessSegments;
   const runElapsedMs = useRunElapsedMs(workStart, showRunStatusLine);
-  // Entry-animation decision for the divider, derived from render data alone:
-  // when the group has no text yet, the divider mounts exactly as the typing
-  // dots leave — a same-slot row swap, no animation. When authored text is
-  // already visible (text-first turns), the divider is a genuine insertion
-  // above content the user is reading, so it grows in instead of landing in
-  // one frame.
-  const runStatusLineAnimates = segments.some((seg) => seg.kind === 'text');
   // Sub-second elapsed shows the plain "处理中" (Codex: "Working") so the very
   // first paint never reads "已处理 0s".
   const runStatusLabel = runElapsedMs >= 1000
@@ -1155,10 +1149,7 @@ export default function MessageGroup({ conversationId, messages, isLastGroup: is
                 the focus-deferred auto-collapse below relies on). */}
             <div ref={workProcessRef}>
               {showRunStatusLine && (
-                <RunStatusDivider
-                  label={runStatusLabel}
-                  animateOnMount={runStatusLineAnimates}
-                />
+                <RunStatusDivider label={runStatusLabel} />
               )}
               {workFoldEnd != null && (
                 /* Lightweight fold header — matches the thinking/step block

--- a/src/components/chat/MessageGroup.tsx
+++ b/src/components/chat/MessageGroup.tsx
@@ -425,13 +425,22 @@ export function buildRenderSegments(
 // Index (exclusive) up to which segments fold into the collapsible "工作过程"
 // group. Segments [0, foldEnd) fold; [foldEnd, end) render inline. When the
 // turn is done and ends in a text answer, the fold stops at that answer;
-// otherwise (streaming, text-first with no closing answer, process after the
-// last text) the whole group folds. Authored content is still never hidden:
-// the collapsed render branch filters segments by kind and keeps text/user
-// segments visible unconditionally — the swallow bug this replaced lived in
-// that filter, not in the fold range.
+// otherwise (text-first with no closing answer, process after the last text)
+// the whole group folds. Authored content is still never hidden: the collapsed
+// render branch filters segments by kind and keeps text/user segments visible
+// unconditionally — the swallow bug this replaced lived in that filter, not in
+// the fold range.
+//
+// While the run is still in progress the fold does not exist at all (null):
+// the header's "已处理 Xs" wording is a settled-turn summary, and mounting the
+// header row mid-run inserted ~28px above the live thinking/step block — under
+// SmoothHeight's 40px threshold, so it landed as a one-frame jump. Deferring
+// the whole wrapper keeps the in-run row structure stable (the typing dots
+// swap 1:1 with TaskBlock's first row) and the header only appears together
+// with the completion collapse, which SmoothHeight bridges.
 // eslint-disable-next-line react-refresh/only-export-components
 export function computeWorkProcessFold(segments: RenderSegment[], isDone: boolean): number | null {
+  if (!isDone) return null;
   const hasProcess = segments.some((segment) =>
     segment.kind === 'steps' || segment.kind === 'plan' || segment.kind === 'batch');
   if (!hasProcess) return null;
@@ -442,7 +451,7 @@ export function computeWorkProcessFold(segments: RenderSegment[], isDone: boolea
   const hasProcessAfterLastText = lastTextIdx >= 0 && segments
     .slice(lastTextIdx + 1)
     .some((segment) => segment.kind === 'steps' || segment.kind === 'plan' || segment.kind === 'batch');
-  if (isDone && lastTextIdx > 0 && !hasProcessAfterLastText) return lastTextIdx;
+  if (lastTextIdx > 0 && !hasProcessAfterLastText) return lastTextIdx;
   return segments.length;
 }
 
@@ -1078,50 +1087,50 @@ export default function MessageGroup({ conversationId, messages, isLastGroup: is
             {/* Render segments: text blocks and merged step groups.
                 When the turn is done and has a final text answer, all
                 intermediate segments (thinking/plan/steps) are folded
-                behind a single collapsible "工作过程" row (Codex-style). */}
-            {workFoldEnd == null ? (
-              <>
-                {segments.map(renderSegment)}
-              </>
-            ) : (
-              <>
-                <div ref={workProcessRef}>
-                  {/* Lightweight fold header — matches the thinking/step block
-                      style (muted text + trailing chevron, no card background). */}
-                  <button
-                    type="button"
-                    aria-expanded={workExpanded}
-                    onClick={() => {
-                      useWorkProcessFoldStore.getState().setMode(
-                        conversationId,
-                        foldKey,
-                        workExpanded ? 'collapsed' : 'expanded',
-                      );
-                    }}
-                    className="flex items-center gap-1 text-body text-[var(--abu-text-muted)] hover:text-[var(--abu-text-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--abu-focus-ring)] rounded-sm transition-colors mb-2"
-                  >
-                    <span>{foldHeaderLabel}</span>
-                    <ChevronDown
-                      aria-hidden="true"
-                      className={cn('h-3.5 w-3.5 transition-transform', !workExpanded && '-rotate-90')}
-                    />
-                  </button>
-                  {workExpanded
-                    ? segments.slice(0, workFoldEnd).map((seg, i) => renderSegment(seg, i))
-                    : segments.slice(0, workFoldEnd)
-                        /* Collapsing hides PROCESS segments only. Assistant text
-                           and mid-loop user messages are authored conversation
-                           content and must survive any fold state — hiding them
-                           here was the "collapse swallows the answer" bug. Keep
-                           the original segment index so keys stay stable across
-                           fold toggles. */
-                        .map((seg, i) => ({ seg, i }))
-                        .filter(({ seg }) => seg.kind === 'widget' || seg.kind === 'text' || seg.kind === 'user')
-                        .map(({ seg, i }) => renderSegment(seg, i))}
-                </div>
-                {segments.slice(workFoldEnd).map((seg, i) => renderSegment(seg, workFoldEnd + i))}
-              </>
-            )}
+                behind a single collapsible "工作过程" row (Codex-style).
+                While the run is in progress workFoldEnd is null: everything
+                renders inline and no header row exists yet — but the
+                workProcessRef wrapper stays mounted either way, so the
+                process subtree keeps its DOM parent when the fold appears
+                at completion (no remount = keyboard focus survives, which
+                the focus-deferred auto-collapse below relies on). */}
+            <div ref={workProcessRef}>
+              {workFoldEnd != null && (
+                /* Lightweight fold header — matches the thinking/step block
+                    style (muted text + trailing chevron, no card background). */
+                <button
+                  type="button"
+                  aria-expanded={workExpanded}
+                  onClick={() => {
+                    useWorkProcessFoldStore.getState().setMode(
+                      conversationId,
+                      foldKey,
+                      workExpanded ? 'collapsed' : 'expanded',
+                    );
+                  }}
+                  className="flex items-center gap-1 text-body text-[var(--abu-text-muted)] hover:text-[var(--abu-text-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--abu-focus-ring)] rounded-sm transition-colors mb-2"
+                >
+                  <span>{foldHeaderLabel}</span>
+                  <ChevronDown
+                    aria-hidden="true"
+                    className={cn('h-3.5 w-3.5 transition-transform', !workExpanded && '-rotate-90')}
+                  />
+                </button>
+              )}
+              {workFoldEnd == null || workExpanded
+                ? segments.slice(0, workFoldEnd ?? segments.length).map((seg, i) => renderSegment(seg, i))
+                : segments.slice(0, workFoldEnd)
+                    /* Collapsing hides PROCESS segments only. Assistant text
+                       and mid-loop user messages are authored conversation
+                       content and must survive any fold state — hiding them
+                       here was the "collapse swallows the answer" bug. Keep
+                       the original segment index so keys stay stable across
+                       fold toggles. */
+                    .map((seg, i) => ({ seg, i }))
+                    .filter(({ seg }) => seg.kind === 'widget' || seg.kind === 'text' || seg.kind === 'user')
+                    .map(({ seg, i }) => renderSegment(seg, i))}
+            </div>
+            {workFoldEnd != null && segments.slice(workFoldEnd).map((seg, i) => renderSegment(seg, workFoldEnd + i))}
             </SmoothHeight>
 
             {/* Interactive notice cards (Module I) — skill proposals etc.

--- a/src/components/chat/MessageGroup.tsx
+++ b/src/components/chat/MessageGroup.tsx
@@ -107,6 +107,45 @@ function SkillPatchSummaryRow({ skillName, calls }: { skillName: string; calls: 
   );
 }
 
+// Elapsed time for the in-run status divider ("已处理 Ns"), ticking once per
+// second while `active` — the same 1s-interval + wall-clock pattern Codex uses
+// for its "Working for {time}" divider. Inert (0, no interval) when inactive,
+// so settled groups and pure-text runs pay nothing.
+function useRunElapsedMs(startMs: number | undefined, active: boolean): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [active]);
+  if (!active || startMs == null) return 0;
+  return Math.max(0, now - startMs);
+}
+
+/**
+ * In-run ticking status divider ("处理中" / "已处理 Ns"), Codex-aligned: plain
+ * text, not a button — no fold exists until the run settles, when the fold
+ * header button takes this exact slot as a 1:1 row swap.
+ *
+ * animateOnMount is FROZEN at mount (a later class change would replay the
+ * animation mid-run): the common path — typing dots hand off to the first
+ * process segment — is a same-slot row swap and must NOT animate (a grow-in
+ * would dip the region height for 200ms), while the text-first path inserts
+ * this row above already-visible content and needs the grow-in to avoid the
+ * one-frame insertion jump this whole change exists to kill.
+ */
+function RunStatusDivider({ label, animateOnMount }: { label: string; animateOnMount: boolean }) {
+  const [animate] = useState(animateOnMount);
+  return (
+    <div className={cn(animate && 'block-expand block-expand-open block-expand-enter')}>
+      <div className="mb-2 text-body text-[var(--abu-text-muted)] tabular-nums">
+        {label}
+      </div>
+    </div>
+  );
+}
+
 // Codex-style compact duration for the work-process fold label: "1m 4s" / "39s".
 function formatWorkDuration(ms: number): string {
   const totalSec = Math.max(0, Math.round(ms / 1000));
@@ -432,7 +471,7 @@ export function buildRenderSegments(
 // the fold range.
 //
 // While the run is still in progress the fold does not exist at all (null):
-// the header's "已处理 Xs" wording is a settled-turn summary, and mounting the
+// the settled "用时 Xs" header is a completed-turn summary, and mounting the
 // header row mid-run inserted ~28px above the live thinking/step block — under
 // SmoothHeight's 40px threshold, so it landed as a one-frame jump. Deferring
 // the whole wrapper keeps the in-run row structure stable (the typing dots
@@ -803,7 +842,7 @@ export default function MessageGroup({ conversationId, messages, isLastGroup: is
   // generation isn't captured — its timestamp is set at creation — and the live
   // execution with the accurate endTime is usually evicted by the time this
   // settled fold renders). Floor the total at the sum of visible step durations
-  // so "已处理 X" is never less than the thinking/tool times the user can add up.
+  // so "用时 X" is never less than the thinking/tool times the user can add up.
   const workStepsSec =
     assistantMsgs.reduce((a, m) => a + (m.thinkingDuration ?? 0), 0) +
     activeExecSteps.filter((s) => s.type !== 'thinking').reduce((a, s) => a + (s.duration ?? 0), 0);
@@ -821,6 +860,26 @@ export default function MessageGroup({ conversationId, messages, isLastGroup: is
     })
     : '';
   const foldHeaderLabel = batchAggregateLabel ? `${workLabel} · ${batchAggregateLabel}` : workLabel;
+  // Codex-aligned in-run status divider: appears (animated) with the first
+  // process segment, ticks every second, and is NOT interactive — collapse
+  // only exists once the run settles and the fold header takes this exact
+  // slot ("已处理 Ns" → "用时 Ns" as a 1:1 row swap, no layout change).
+  const hasProcessSegments = segments.some(
+    (seg) => seg.kind === 'steps' || seg.kind === 'plan' || seg.kind === 'batch');
+  const showRunStatusLine = !isGroupDone && !isStopped && hasProcessSegments;
+  const runElapsedMs = useRunElapsedMs(workStart, showRunStatusLine);
+  // Entry-animation decision for the divider, derived from render data alone:
+  // when the group has no text yet, the divider mounts exactly as the typing
+  // dots leave — a same-slot row swap, no animation. When authored text is
+  // already visible (text-first turns), the divider is a genuine insertion
+  // above content the user is reading, so it grows in instead of landing in
+  // one frame.
+  const runStatusLineAnimates = segments.some((seg) => seg.kind === 'text');
+  // Sub-second elapsed shows the plain "处理中" (Codex: "Working") so the very
+  // first paint never reads "已处理 0s".
+  const runStatusLabel = runElapsedMs >= 1000
+    ? format(t.chat.workingFor, { duration: formatWorkDuration(runElapsedMs) })
+    : t.chat.working;
   const foldMode = foldEntry?.mode ?? 'auto';
   const workExpanded = foldMode === 'expanded' || (foldMode === 'auto' && !(foldEntry?.autoCollapseHandled ?? false));
   const hasFinalAnswerOutsideFold = workFoldEnd !== null && workFoldEnd < segments.length && segments[workFoldEnd]?.kind === 'text';
@@ -1063,7 +1122,7 @@ export default function MessageGroup({ conversationId, messages, isLastGroup: is
 
             {/* SmoothHeight bridges the layout SWAPS inside this region — most
                 importantly the completion fold: the expanded thinking/step
-                block unmounts and the one-line "已处理 Xs" header takes its
+                block unmounts and the one-line "用时 Xs" header takes its
                 place in the same render, a -100~200px one-frame shrink that
                 (while pinned to the bottom) used to clamp scrollTop and jump
                 the whole view down. Streamed token growth stays instant (it's
@@ -1078,7 +1137,7 @@ export default function MessageGroup({ conversationId, messages, isLastGroup: is
                 itself, so a plan card from an earlier turn in the same group does
                 not suppress the dots for the fresh empty turn that follows. */}
             {isStreaming && !streamingHasContent && (
-              /* mb-2 matches the TaskBlock header / "已处理 Xs" fold header
+              /* mb-2 matches the TaskBlock header / "用时 Xs" fold header
                  buttons that replace this row in later states; the label
                  geometry itself lives in the shared ThinkingStatusLine. */
               <ThinkingStatusLine label={t.status.thinking} className="mb-2" />
@@ -1095,6 +1154,12 @@ export default function MessageGroup({ conversationId, messages, isLastGroup: is
                 at completion (no remount = keyboard focus survives, which
                 the focus-deferred auto-collapse below relies on). */}
             <div ref={workProcessRef}>
+              {showRunStatusLine && (
+                <RunStatusDivider
+                  label={runStatusLabel}
+                  animateOnMount={runStatusLineAnimates}
+                />
+              )}
               {workFoldEnd != null && (
                 /* Lightweight fold header — matches the thinking/step block
                     style (muted text + trailing chevron, no card background). */

--- a/src/components/chat/SmoothHeight.tsx
+++ b/src/components/chat/SmoothHeight.tsx
@@ -21,7 +21,7 @@ const DURATION_MS = 280;
  * the last message group (the completion fold replacing the expanded thinking
  * block) clamps scrollTop instantly — the whole view visibly jumps DOWN. The
  * mount direction is covered by .block-expand-enter, but the fold is a
- * component *swap* (TaskBlock unmounts, the "已处理 Xs" header mounts), so no
+ * component *swap* (TaskBlock unmounts, the "用时 Xs" header mounts), so no
  * CSS enter/exit animation on either component can bridge it. Animating the
  * measured height of the region that contains the swap can.
  *

--- a/src/components/chat/ThinkingStatusLine.tsx
+++ b/src/components/chat/ThinkingStatusLine.tsx
@@ -42,7 +42,7 @@ export function TypingDots({
 
 /** One status row: tertiary text-body label + bouncing dots. text-body (not
  *  text-minor) and no vertical padding of its own — successors (TaskBlock
- *  active header, "已处理 Xs" fold header) are text-body buttons with mb-2,
+ *  active header, "已处理 Ns" divider / "用时 Xs" fold header) are text-body buttons with mb-2,
  *  so callers that need the mb-2 pass it via className. */
 export function ThinkingStatusLine({
   label,

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -449,6 +449,8 @@ const enUS: TranslationDict = {
       invalidDisallowedToolsField: 'Error: Cannot start agent “{agentName}”: AGENT.md disallowed-tools must be a list of strings, not a scalar value or object. Fix the tool configuration and retry.',
       invalidEmptyDisallowedToolDeclarations: 'Error: Cannot start agent “{agentName}”: entries {positions} in the AGENT.md disallowed-tools list are blank. Remove or replace the blank entries and retry.',
     },
+    working: 'Working',
+    workingFor: 'Working for {duration}',
     workedFor: 'Worked for {duration}',
     stoppedAfter: 'You stopped after {duration}',
     usageChipInput: 'Input',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -449,7 +449,10 @@ const zhCN: TranslationDict = {
       invalidDisallowedToolsField: 'Error: 无法启动代理“{agentName}”：AGENT.md 的 disallowed-tools 必须是字符串列表，不能写成单个值或对象。请修正工具配置后重试。',
       invalidEmptyDisallowedToolDeclarations: 'Error: 无法启动代理“{agentName}”：AGENT.md 的 disallowed-tools 列表中第 {positions} 项为空。请删除或补全这些条目后重试。',
     },
-    workedFor: '已处理 {duration}',
+    // 与 Codex 官方 zh-CN 对齐：进行中读秒用「已处理」，完成态用「用时」。
+    working: '处理中',
+    workingFor: '已处理 {duration}',
+    workedFor: '用时 {duration}',
     stoppedAfter: '你在 {duration} 后停止了',
     usageChipInput: '输入',
     usageChipOutput: '输出',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -480,7 +480,10 @@ export interface TranslationDict {
       /** Agent disallowed-tools frontmatter contains blank entries. {agentName} {positions} */
       invalidEmptyDisallowedToolDeclarations: string;
     };
-    // Work-process fold label (Codex-style turn collapse). {duration} = e.g. "1m 4s"
+    // Work-process status line / fold label (Codex-style). {duration} = e.g. "1m 4s".
+    // working/workingFor = in-run divider (ticking); workedFor = settled fold header.
+    working: string;
+    workingFor: string;
     workedFor: string;
     stoppedAfter: string;
     // Usage chip


### PR DESCRIPTION
## 背景

用户录屏报障（v0.42 与 dev 均复现，属既有缺陷）：发送消息约 0.5s 后「已处理 0s」折叠头一帧插入到「思考中」上方把内容顶跳，且整个 run 期间「已处理 Ns」（过去时）与下方「思考中/执行中」并存，语义矛盾。

根因：`computeWorkProcessFold` 不等 `isGroupDone` 就返回非 null，fold 头 mid-run 渲染；其 ~46px 插入低于 SmoothHeight 40px 动画阈值，一帧落地。

## 方案（对齐 Codex 客户端，firsthand 逆向 ChatGPT.app 26.825.32147 + codex-rs）

三个 commit 递进：

1. **`01e4320c` 折叠推迟到 run 结束**：`computeWorkProcessFold` 在 `!isDone` 时返回 null；`workProcessRef` 容器改为常挂载（完成瞬间 process 子树不重挂、键盘焦点保留，focus-deferred auto-collapse 依赖此）。取舍：run 进行中不再提供手动折叠（Codex 同样门控到回答开始才允许折叠）。
2. **`541f9eba` 读秒 divider + 文案分家**：run 中 fold 槽位渲染只读 divider——不足 1s「处理中」，之后「已处理 Ns」每秒 tick（1s interval + 墙钟，`tabular-nums` 防抖宽）；完成态文案改「**用时 {duration}**」（en 不变 "Worked for"）。依据：Codex 官方 zh-CN 里 `workingFor`（进行中读秒）恰为「已处理 {time}」、`workedFor` 为「用时 {time}」——旧实现把进行态文案借去当完成态标签正是语义错位之源。
3. **`bd6eb343` divider 永远动画长入**：50ms 帧级 A/B 采样（dev 基线 vs 非动画 divider）实测两者过渡瞬间同为 +46px 一帧砸落——TaskBlock 头部行是 dots 行的同位继任者且瞬时挂载，静态 divider 压其上等于整行瞬移。改为无条件 `block-expand-enter` 长入（Codex 对其 "Working for" divider 同样无条件 height 0→auto 动画）后，实测过渡降为 ≤20px 瞬态、思考行 8px 起步 200ms 平滑下滑。

## 最终行为

`思考中 ●●●` → `已处理 Ns`（平滑展开 + 每秒读秒，非按钮）→ 结束 `用时 Ns ▾`（同槽换位，自动折叠）/ 停止 `你在 Ns 后停止了`。纯文本问答全程无计时行，行为不变。

## 验证

- `npm run verify` exit 0 本地亲跑（lint + typecheck + 7k+ 全量测试 + 覆盖率门禁，覆盖率微升）
- 组件测试钉住生命周期不变量：run 中不出现「用时/Worked for」、divider 假时钟下逐秒 tick（4s→6s）、结束换折叠头；`computeWorkProcessFold` 纯函数测试改钉「run 中一律不折叠」
- e2e `preview-workspace.spec.ts` 折叠头断言同步改「用时 4s · 2 个 Agent：2 成功」
- 真机 Electron（隔离 appdata + mock SSE + CDP 50ms 逐帧采样）三轮实证：run 中 0 帧含完成态文案、读秒逐秒跳、过渡无一帧砸落；A/B GIF 对比已由用户目验
- 用户真机验收通过

## 备注

- 逆向结论已存 memory（`reference-codex-turn-status-divider-firsthand`），含 Codex worked-for 一等 item 数据模型、折叠门控、计时语义等，供后续迭代参考
- 锚定分支 `codex/fix/thinking-jump-root`（滚动 spacer 重构，解决的是另一机制的 scroll 跳）合入 dev 时，需重跑其 e2e 与本改动互验

🤖 Generated with [Claude Code](https://claude.com/claude-code)