### PR TITLE
fix(chat): eliminate active-turn scroll jumps

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -50,6 +50,26 @@ import {
   VIRTUOSO_ITEM_TRAILING_PAD,
   TYPING_FOOTER_GAP_COMPENSATION,
 } from './chatSpacing';
+import { emitChatScrollTrace, type ChatScrollFollowSource } from './chatScrollTrace';
+import {
+  announceChatTurnScrollIntent,
+  subscribeChatTurnScrollIntent,
+} from './chatTurnScrollIntent';
+import {
+  VIRTUOSO_AT_BOTTOM_THRESHOLD_PX,
+  armTurnScrollAnchor,
+  canArmTurnScrollAnchor,
+  exitTurnScrollAnchor,
+  findUserMessageAnchor,
+  getAnchorScrollCorrection,
+  isAtBottomFromGeometry,
+  isChapterRailAtBottom,
+  reconcileTurnScrollAnchor,
+  selectLatestUserAnchor,
+  shouldFollowOutput,
+  type TurnScrollAnchor,
+  type TurnScrollAnchorExitReason,
+} from './turnScrollAnchor';
 
 /**
  * Context passed to the Virtuoso `Footer` component (the streaming typing
@@ -64,6 +84,7 @@ interface MessageListContext {
   showTypingIndicator: boolean;
   retryingLabel: string | null;
   thinkingLabel: string;
+  registerTurnSpacer: (element: HTMLDivElement | null) => void;
 }
 
 // Row wrapper for each virtualized message group. Spacing between groups
@@ -97,7 +118,6 @@ const VirtuosoMessageItem: NonNullable<Components<Message[], MessageListContext>
 const VirtuosoTypingFooter: NonNullable<Components<Message[], MessageListContext>['Footer']> = ({
   context,
 }) => {
-  if (!context?.showTypingIndicator) return null;
   // Layout mirrors a MessageGroup's assistant row (shared AssistantRowAvatar,
   // gap-3, shared ThinkingStatusLine) so the hand-off from this footer to the
   // real assistant placeholder — and then to the TaskBlock header / "用时
@@ -105,12 +125,43 @@ const VirtuosoTypingFooter: NonNullable<Components<Message[], MessageListContext
   // instead of hopping between typographies ("错行"). The negative top margin
   // bridges the item-pad vs in-group-gap difference — see chatSpacing.ts.
   return (
-    <div className={cn(TYPING_FOOTER_GAP_COMPENSATION, 'flex gap-3')}>
-      <AssistantRowAvatar />
-      <ThinkingStatusLine label={context.retryingLabel ?? context.thinkingLabel} />
-    </div>
+    <>
+      {context?.showTypingIndicator && (
+        <div className={cn(TYPING_FOOTER_GAP_COMPENSATION, 'flex gap-3')}>
+          <AssistantRowAvatar />
+          <ThinkingStatusLine label={context.retryingLabel ?? context.thinkingLabel} />
+        </div>
+      )}
+      <div
+        ref={context?.registerTurnSpacer}
+        data-turn-bottom-spacer
+        aria-hidden="true"
+        style={{ height: 0 }}
+      />
+    </>
   );
 };
+
+interface PendingTurnAnchor {
+  conversationId: string;
+  previousMessageId: string | null;
+  /** Follow events this pending gate may still suppress before self-clearing. */
+  suppressionBudget: number;
+}
+
+const TURN_ANCHOR_TARGET_TOP_PX = 20;
+// An announced intent whose dispatch fails (message never persisted) leaves no
+// owner to clear the pending gate, and the arm effect's frame timeout never
+// starts. Budget how many follow events the gate may eat: a successful arm
+// clears pending within a couple of height events, so a spent budget can only
+// mean the turn never materialized.
+const PENDING_TURN_ANCHOR_SUPPRESSION_BUDGET = 30;
+
+function syncElementToBottom(element: HTMLElement): number {
+  const previousScrollTop = element.scrollTop;
+  element.scrollTop = element.scrollHeight;
+  return element.scrollTop - previousScrollTop;
+}
 
 // Declared at module scope (not inline in the component) — react-virtuoso
 // requires stable `components` object/function references, otherwise it
@@ -279,14 +330,167 @@ export default function ChatView({
     pinnedRef.current = v;
     setPinned(v);
   }, []);
+  // Mirrors Virtuoso's own atBottomStateChange callback. Geometry-sensitive
+  // exits update this from the real distance instead of forcing a stale value.
+  const [isAtBottom, setIsAtBottom] = useState(true);
+  // Active-turn geometry is intentionally transient and ref-backed. Streamed
+  // tokens can resize the final Virtuoso row several times per frame; mirroring
+  // those measurements through React state would add another render/measure
+  // loop on top of Virtuoso's own one.
+  const turnAnchorRef = useRef<TurnScrollAnchor | null>(null);
+  const pendingTurnAnchorRef = useRef<PendingTurnAnchor | null>(null);
+  const turnSpacerElementRef = useRef<HTMLDivElement | null>(null);
+  const turnSpacerHeightRef = useRef(0);
+  const armAnchorRafRef = useRef(0);
+  const runningConversationRef = useRef<string | null>(null);
+  const dismissedTurnAnchorRef = useRef<{ conversationId: string; messageId: string } | null>(null);
+  const writeTurnSpacerHeight = useCallback((height: number) => {
+    const nextHeight = Number.isFinite(height) ? Math.max(0, height) : 0;
+    turnSpacerHeightRef.current = nextHeight;
+    const element = turnSpacerElementRef.current;
+    if (!element) return;
+    element.style.height = `${nextHeight}px`;
+    element.dataset.spacerHeight = String(nextHeight);
+  }, []);
+  const writeTurnSpacerWithCompensation = useCallback((
+    element: HTMLElement | null,
+    height: number,
+    mode: 'preserve-position' | 'sync-bottom',
+  ) => {
+    const previousHeight = turnSpacerHeightRef.current;
+    const previousScrollTop = element?.scrollTop ?? 0;
+    writeTurnSpacerHeight(height);
+    if (!element || height !== 0 || previousHeight === 0) return;
+
+    // Clearing physical spacer can clamp scrollTop immediately. Pair the DOM
+    // write with an explicit scroll decision in this layout pass so no later
+    // Virtuoso height callback can deliver the old one-frame hard jump.
+    void element.scrollHeight;
+    if (mode === 'sync-bottom') {
+      element.scrollTop = element.scrollHeight;
+      return;
+    }
+    const maximumScrollTop = Math.max(0, element.scrollHeight - element.clientHeight);
+    element.scrollTop = Math.min(previousScrollTop, maximumScrollTop);
+  }, [writeTurnSpacerHeight]);
+  const registerTurnSpacer = useCallback((element: HTMLDivElement | null) => {
+    turnSpacerElementRef.current = element;
+    if (!element) return;
+    element.style.height = `${turnSpacerHeightRef.current}px`;
+    element.dataset.spacerHeight = String(turnSpacerHeightRef.current);
+  }, []);
+  const readTurnSpacerHeight = useCallback(() => {
+    const element = turnSpacerElementRef.current;
+    return element ? element.getBoundingClientRect().height : turnSpacerHeightRef.current;
+  }, []);
+  const measureActiveTailHeight = useCallback((anchorElement: HTMLElement) => {
+    const messageRow = anchorElement.closest<HTMLElement>('[data-index]');
+    const spacerElement = turnSpacerElementRef.current;
+    if (!messageRow || !spacerElement) return null;
+    // Both values come from the same painted coordinate space. Unlike
+    // Virtuoso's total-height callback versus the scroll parent's scrollHeight,
+    // their difference cannot feed the spacer's own height back into the next
+    // measurement. The spacer's top also captures footer/typing hand-offs while
+    // excluding the spacer height itself.
+    return Math.max(
+      0,
+      spacerElement.getBoundingClientRect().top - messageRow.getBoundingClientRect().top,
+    );
+  }, []);
+  const reconcileActiveTurnGeometry = useCallback((el: HTMLElement, totalListHeight?: number) => {
+    const anchor = turnAnchorRef.current;
+    if (anchor?.phase !== 'armed') return;
+    const anchorElement = findUserMessageAnchor(el, anchor.messageId);
+    const contentHeight = anchorElement ? measureActiveTailHeight(anchorElement) : null;
+    const reconciled = reconcileTurnScrollAnchor(anchor, {
+      contentHeight: contentHeight ?? anchor.baselineContentHeight,
+      anchorPresent: anchorElement != null,
+    });
+    turnAnchorRef.current = reconciled.anchor;
+    if (reconciled.handoff === 'sync-bottom') {
+      const previousScrollTop = el.scrollTop;
+      writeTurnSpacerWithCompensation(el, 0, 'sync-bottom');
+      emitChatScrollTrace('turn-anchor', 'applied', el, {
+        totalListHeight,
+        scrollDelta: el.scrollTop - previousScrollTop,
+        spacerHeight: 0,
+        contentHeight: reconciled.contentHeight,
+        baselineContentHeight: anchor.baselineContentHeight,
+      });
+      updatePinned(true);
+      setIsAtBottom(true);
+      return;
+    }
+    writeTurnSpacerHeight(reconciled.spacerHeight);
+    if (!anchorElement) return;
+
+    const currentTop = anchorElement.getBoundingClientRect().top - el.getBoundingClientRect().top;
+    const correction = getAnchorScrollCorrection(anchor.targetTop, currentTop);
+    if (correction === 0) return;
+    const previousScrollTop = el.scrollTop;
+    emitChatScrollTrace('turn-anchor', 'scheduled', el, {
+      totalListHeight,
+      anchorTop: currentTop,
+      spacerHeight: reconciled.spacerHeight,
+      contentHeight: reconciled.contentHeight,
+      baselineContentHeight: anchor.baselineContentHeight,
+    });
+    el.scrollTop += correction;
+    emitChatScrollTrace('turn-anchor', 'applied', el, {
+      totalListHeight,
+      scrollDelta: el.scrollTop - previousScrollTop,
+      anchorTop: anchorElement.getBoundingClientRect().top - el.getBoundingClientRect().top,
+      spacerHeight: readTurnSpacerHeight(),
+      contentHeight: measureActiveTailHeight(anchorElement) ?? undefined,
+      baselineContentHeight: anchor.baselineContentHeight,
+    });
+  }, [
+    measureActiveTailHeight,
+    readTurnSpacerHeight,
+    updatePinned,
+    writeTurnSpacerHeight,
+    writeTurnSpacerWithCompensation,
+  ]);
   // Fade timer for the search-hit highlight. Kept in a ref (NOT an effect
   // cleanup) — consuming the pending jump re-runs the effect, and a cleanup
   // would cancel the fade, leaving the highlight stuck on.
   const highlightFadeTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  // Mirrors Virtuoso's own atBottomStateChange callback — drives the
-  // "jump to latest" floating button. Starts true so the button doesn't
-  // flash on first mount before Virtuoso reports its initial state.
-  const [isAtBottom, setIsAtBottom] = useState(true);
+  const leaveTurnAnchor = useCallback((reason: TurnScrollAnchorExitReason) => {
+    const activeAnchor = turnAnchorRef.current;
+    const state = useChatStore.getState();
+    const activeConversationId = state.activeConversationId;
+    const latestCandidate = activeConversationId
+      ? selectLatestUserAnchor(
+          activeConversationId,
+          state.conversations[activeConversationId]?.messages ?? [],
+        )
+      : null;
+    dismissedTurnAnchorRef.current = activeAnchor ?? latestCandidate;
+    const exit = exitTurnScrollAnchor(turnAnchorRef.current, reason);
+    turnAnchorRef.current = exit.anchor;
+    pendingTurnAnchorRef.current = null;
+    if (exit.spacerHeight === 0) {
+      writeTurnSpacerWithCompensation(
+        scrollParentEl,
+        0,
+        exit.pinned ? 'sync-bottom' : 'preserve-position',
+      );
+    } else {
+      writeTurnSpacerHeight(exit.spacerHeight);
+    }
+    updatePinned(exit.pinned);
+    if (reason === 'user-scroll-intent') {
+      const element = scrollParentEl;
+      const distanceToBottom = element
+        ? element.scrollHeight - element.scrollTop - element.clientHeight
+        : Number.POSITIVE_INFINITY;
+      setIsAtBottom(isAtBottomFromGeometry(distanceToBottom));
+    } else if (reason === 'search-jump' || reason === 'chapter-jump') {
+      setIsAtBottom(false);
+    } else {
+      setIsAtBottom(true);
+    }
+  }, [scrollParentEl, updatePinned, writeTurnSpacerHeight, writeTurnSpacerWithCompensation]);
   // Message id to briefly highlight after a search-hit jump (see effect below).
   const [highlightedMessageId, setHighlightedMessageId] = useState<string | null>(null);
   // Index of the message group at the top of the viewport — what the chapter
@@ -304,21 +508,78 @@ export default function ChatView({
   // event re-corrects the position. Raw scrollTop = scrollHeight bypasses
   // virtualization state entirely and always lands on the true bottom.
   const stickRafRef = useRef(0);
-  const stickToBottom = useCallback((el: HTMLElement | null) => {
+  const stickToBottom = useCallback((
+    el: HTMLElement | null,
+    source: Exclude<ChatScrollFollowSource, 'virtuoso-follow-output'>,
+    totalListHeight?: number,
+  ) => {
     if (!el) return;
     cancelAnimationFrame(stickRafRef.current);
+    emitChatScrollTrace(source, 'scheduled', el, { totalListHeight });
     stickRafRef.current = requestAnimationFrame(() => {
+      const previousScrollTop = el.scrollTop;
       el.scrollTop = el.scrollHeight;
+      emitChatScrollTrace(source, 'applied', el, {
+        totalListHeight,
+        scrollDelta: el.scrollTop - previousScrollTop,
+      });
     });
   }, []);
 
   const scrollToLatest = useCallback((behavior: 'smooth' | 'auto' = 'smooth') => {
     // Explicit "go to bottom" — re-engage the bottom lock.
-    updatePinned(true);
+    leaveTurnAnchor('explicit-latest');
     virtuosoRef.current?.scrollToIndex({ index: 'LAST', align: 'end', behavior });
     // Optimistic — atBottomStateChange will confirm once the scroll settles.
     setIsAtBottom(true);
-  }, [updatePinned]);
+  }, [leaveTurnAnchor]);
+
+  const prepareTurnAnchorIntent = useCallback((conversationId: string) => {
+    const state = useChatStore.getState();
+    if (state.activeConversationId !== conversationId) return;
+    const conversation = state.conversations[conversationId];
+    // A composer send during an active run is only staged. Keep the current
+    // anchor until the queue actually persists its own user row; message-id
+    // rebinding below will then hand ownership to that turn.
+    if (conversation?.status === 'running') return;
+    const previousAnchor = selectLatestUserAnchor(conversationId, conversation?.messages ?? []);
+    leaveTurnAnchor('explicit-latest');
+    pendingTurnAnchorRef.current = {
+      conversationId,
+      previousMessageId: previousAnchor?.messageId ?? null,
+      suppressionBudget: PENDING_TURN_ANCHOR_SUPPRESSION_BUDGET,
+    };
+  }, [leaveTurnAnchor]);
+
+  useEffect(() => subscribeChatTurnScrollIntent((intent) => {
+    prepareTurnAnchorIntent(intent.conversationId);
+  }), [prepareTurnAnchorIntent]);
+
+  useEffect(() => {
+    const observeTerminalState = () => {
+      const state = useChatStore.getState();
+      const conversationId = state.activeConversationId;
+      const status = conversationId ? state.conversations[conversationId]?.status : undefined;
+      if (conversationId && status === 'running') {
+        runningConversationRef.current = conversationId;
+        return;
+      }
+      if (conversationId && runningConversationRef.current === conversationId) {
+        runningConversationRef.current = null;
+        // User/navigation exits already terminated the anchor. Preserve their
+        // frozen spacer and viewport ownership when the background run later
+        // reaches idle; terminal cleanup is only for a still-live lifecycle.
+        if (
+          turnAnchorRef.current != null
+          || pendingTurnAnchorRef.current?.conversationId === conversationId
+        ) {
+          leaveTurnAnchor('run-terminal');
+        }
+      }
+    };
+    observeTerminalState();
+    return useChatStore.subscribe(observeTerminalState);
+  }, [leaveTurnAnchor]);
 
   // Conversation switch: engage the bottom lock (unless a search jump is about
   // to position the view on a hit) and reset the jump-button state so it doesn't
@@ -327,10 +588,11 @@ export default function ChatView({
   // previous conversation paints for one frame (the button flash).
   useLayoutEffect(() => {
     const jumpPending = useChatStore.getState().pendingSearchJump?.convId === activeConvId;
+    leaveTurnAnchor(jumpPending ? 'search-jump' : 'conversation-switch');
     updatePinned(!jumpPending);
     setIsAtBottom(true);
-    if (pinnedRef.current) stickToBottom(scrollParentEl);
-  }, [activeConvId, scrollParentEl, stickToBottom, updatePinned]);
+    if (pinnedRef.current) stickToBottom(scrollParentEl, 'conversation-switch');
+  }, [activeConvId, leaveTurnAnchor, scrollParentEl, stickToBottom, updatePinned]);
 
   // The rail lives inside the transcript column's own left padding (40px from
   // `md:px-10`, which any desktop viewport gets), and is 26px wide at its
@@ -379,7 +641,13 @@ export default function ChatView({
       // behind and would leave the rail a frame stale on every scroll.
       const distanceToBottom =
         scrollParentEl.scrollHeight - scrollParentEl.scrollTop - scrollParentEl.clientHeight;
-      setFirstVisibleGroup(topVisibleGroup(rows, { atBottom: distanceToBottom <= 24 }));
+      setFirstVisibleGroup(topVisibleGroup(rows, {
+        atBottom: isChapterRailAtBottom(
+          distanceToBottom,
+          turnAnchorRef.current,
+          pinnedRef.current,
+        ),
+      }));
     };
     const onScroll = () => { if (!frame) frame = requestAnimationFrame(measure); };
     // Also measure now: mounting lands on the newest message without any
@@ -392,20 +660,47 @@ export default function ChatView({
     };
   }, [scrollParentEl, activeConvId, messageCount]);
 
-  // Unpin on explicit upward user intent. Content growing under the viewport
-  // must NOT unpin (that's the whole point of the lock), so we listen for user
-  // gestures rather than scroll-position changes.
+  // Any explicit scrolling gesture owns the viewport. While anchored that
+  // includes downward wheel/keys and native scrollbar drags; otherwise only an
+  // upward gesture releases the ordinary bottom lock.
   useEffect(() => {
     if (!scrollParentEl) return;
-    const unpin = () => updatePinned(false);
-    const onWheel = (e: WheelEvent) => { if (e.deltaY < 0) unpin(); };
+    const hasTransientAnchor = () => (
+      turnAnchorRef.current != null
+      || pendingTurnAnchorRef.current?.conversationId === activeConvId
+    );
+    const unpin = () => leaveTurnAnchor('user-scroll-intent');
+    const onWheel = (event: WheelEvent) => {
+      if ((hasTransientAnchor() && event.deltaY !== 0) || event.deltaY < 0) unpin();
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target;
+      if (
+        target instanceof HTMLElement
+        && target.matches('input, textarea, [contenteditable="true"]')
+      ) return;
+      const navigationKeys = new Set(['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' ']);
+      if (!navigationKeys.has(event.key)) return;
+      const upwardKeys = new Set(['ArrowUp', 'PageUp', 'Home']);
+      if (hasTransientAnchor() || upwardKeys.has(event.key)) unpin();
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      if (!hasTransientAnchor()) return;
+      const rect = scrollParentEl.getBoundingClientRect();
+      const scrollbarWidth = Math.max(16, scrollParentEl.offsetWidth - scrollParentEl.clientWidth);
+      if (event.clientX >= rect.right - scrollbarWidth) unpin();
+    };
     scrollParentEl.addEventListener('wheel', onWheel, { passive: true });
     scrollParentEl.addEventListener('touchmove', unpin, { passive: true });
+    scrollParentEl.addEventListener('pointerdown', onPointerDown, { passive: true });
+    window.addEventListener('keydown', onKeyDown, { capture: true });
     return () => {
       scrollParentEl.removeEventListener('wheel', onWheel);
       scrollParentEl.removeEventListener('touchmove', unpin);
+      scrollParentEl.removeEventListener('pointerdown', onPointerDown);
+      window.removeEventListener('keydown', onKeyDown, { capture: true });
     };
-  }, [scrollParentEl, updatePinned]);
+  }, [activeConvId, leaveTurnAnchor, scrollParentEl]);
 
   // Search-jump: when a full-text search hit is picked, scroll to and briefly
   // highlight the first message whose text matches the query. Waits until the
@@ -431,7 +726,7 @@ export default function ChatView({
     if (index < 0) return;
     // Release the bottom lock so late height-measurements don't yank the view
     // from the hit back to the bottom.
-    updatePinned(false);
+    leaveTurnAnchor('search-jump');
     setHighlightedMessageId(target.id);
     // Defer a frame so Virtuoso (freshly remounted via `key`) is mounted and can
     // resolve the index before we scroll.
@@ -440,7 +735,7 @@ export default function ChatView({
     });
     clearTimeout(highlightFadeTimerRef.current);
     highlightFadeTimerRef.current = setTimeout(() => setHighlightedMessageId(null), 2600);
-  }, [pendingSearchJump, activeConvId, messageCount, updatePinned]);
+  }, [pendingSearchJump, activeConvId, leaveTurnAnchor, messageCount]);
 
   const handleSend = async (
     text: string,
@@ -481,6 +776,11 @@ export default function ChatView({
     // freshly-appended item on its own next render, so this doesn't need to
     // wait for a DOM mutation callback the way the old MutationObserver did.
     scrollToLatest('auto');
+    // Suppress both legacy bottom-follow paths during the gap between dispatch
+    // and the new persisted user row mounting. Child Virtuoso layout effects
+    // can report the new total height before ChatView's parent layout effect
+    // has had a chance to arm the DOM anchor.
+    announceChatTurnScrollIntent({ conversationId: convId, source: 'composer' });
     let dispatch: AgentLoopDispatchResult;
     try {
       dispatch = await runAgentLoopDispatched(convId, text, { images });
@@ -490,6 +790,7 @@ export default function ChatView({
       // however, the failed transcript row (and its Retry action) owns
       // recovery; handing the same text back to ChatInput would duplicate it.
       if (!(error instanceof AgentLoopDispatchError) || !error.messageTaken) {
+        pendingTurnAnchorRef.current = null;
         throw error;
       }
       useToastStore.getState().addToast({
@@ -503,6 +804,7 @@ export default function ChatView({
     // images simply vanished with no feedback. Surface it and hand the draft
     // back instead.
     if (dispatch?.reason === 'error') {
+      if (!dispatch.messageTaken) pendingTurnAnchorRef.current = null;
       useToastStore.getState().addToast({
         type: 'error',
         title: dispatch.error || t.chat.conversationBusy,
@@ -552,6 +854,156 @@ export default function ChatView({
   // recovery notices that explain an interrupted task to the user.
   const visibleMessages = messages.filter(m => !m.isSystem || m.isRecoveryNotice);
   const messageGroups = groupMessagesByLoop(visibleMessages);
+  useLayoutEffect(() => {
+    if (!scrollParentEl || !activeConvId) return;
+    const conversation = useChatStore.getState().conversations[activeConvId];
+    const candidate = selectLatestUserAnchor(activeConvId, conversation?.messages ?? []);
+    if (!candidate) return;
+    const dismissed = dismissedTurnAnchorRef.current;
+    if (
+      dismissed?.conversationId === candidate.conversationId
+      && dismissed.messageId === candidate.messageId
+    ) return;
+    let pending = pendingTurnAnchorRef.current;
+    const activeAnchor = turnAnchorRef.current;
+    // Queue auto-handoff happens inside the runner, without another UI click.
+    // A new persisted user id during a live run is therefore the authoritative
+    // rebind signal even when no explicit pending intent exists.
+    if (
+      conversation?.status === 'running'
+      && activeAnchor?.messageId !== candidate.messageId
+      && pending?.conversationId !== activeConvId
+    ) {
+      pending = {
+        conversationId: activeConvId,
+        previousMessageId: activeAnchor?.messageId ?? null,
+        suppressionBudget: PENDING_TURN_ANCHOR_SUPPRESSION_BUDGET,
+      };
+      pendingTurnAnchorRef.current = pending;
+    }
+    if (pending?.conversationId !== activeConvId || candidate.messageId === pending.previousMessageId) return;
+
+    let attempts = 0;
+    const tryArm = () => {
+      armAnchorRafRef.current = 0;
+      const anchorElement = findUserMessageAnchor(scrollParentEl, candidate.messageId);
+      const contentHeight = anchorElement ? measureActiveTailHeight(anchorElement) : null;
+      if (!anchorElement || contentHeight == null) {
+        attempts += 1;
+        if (attempts < 8) {
+          armAnchorRafRef.current = requestAnimationFrame(tryArm);
+        } else {
+          // A virtualized/unmounted candidate must not leave followOutput gated
+          // forever. Abandoning is a complete state transition.
+          leaveTurnAnchor('arm-abandoned');
+        }
+        return;
+      }
+
+      const anchorHeight = anchorElement.getBoundingClientRect().height;
+      if (!canArmTurnScrollAnchor({
+        anchorHeight,
+        viewportHeight: scrollParentEl.clientHeight,
+        targetTop: TURN_ANCHOR_TARGET_TOP_PX,
+      })) {
+        leaveTurnAnchor('arm-abandoned');
+        return;
+      }
+
+      pendingTurnAnchorRef.current = null;
+      dismissedTurnAnchorRef.current = null;
+      const viewportTop = scrollParentEl.getBoundingClientRect().top;
+      const anchorTop = anchorElement.getBoundingClientRect().top - viewportTop;
+      const distanceToBottom =
+        scrollParentEl.scrollHeight - scrollParentEl.scrollTop - scrollParentEl.clientHeight;
+      const anchor = armTurnScrollAnchor({
+        ...candidate,
+        anchorTop,
+        targetTop: TURN_ANCHOR_TARGET_TOP_PX,
+        distanceToBottom,
+        contentHeight,
+      });
+      turnAnchorRef.current = anchor;
+      const previousScrollTop = scrollParentEl.scrollTop;
+      emitChatScrollTrace('turn-anchor', 'scheduled', scrollParentEl, {
+        anchorTop,
+        spacerHeight: anchor.spacerHeight,
+        contentHeight: anchor.baselineContentHeight,
+        baselineContentHeight: anchor.baselineContentHeight,
+      });
+      // Route through the compensated writer: on a queue rebind the previous
+      // anchor's spacer may still be non-zero, and writing 0 bare would clamp
+      // scrollTop before the arm's own scroll math runs.
+      writeTurnSpacerWithCompensation(scrollParentEl, anchor.spacerHeight, 'preserve-position');
+      // Force the spacer write into this layout pass so the initial anchor move
+      // and its newly available scroll range land before paint.
+      void scrollParentEl.scrollHeight;
+      const maximumScrollTop = Math.max(0, scrollParentEl.scrollHeight - scrollParentEl.clientHeight);
+      scrollParentEl.scrollTop = Math.min(
+        maximumScrollTop,
+        scrollParentEl.scrollTop + anchor.initialScrollDelta,
+      );
+      const mountedAnchor = findUserMessageAnchor(scrollParentEl, candidate.messageId);
+      if (mountedAnchor) {
+        const currentTop = mountedAnchor.getBoundingClientRect().top - viewportTop;
+        scrollParentEl.scrollTop += getAnchorScrollCorrection(anchor.targetTop, currentTop);
+      }
+      emitChatScrollTrace('turn-anchor', 'applied', scrollParentEl, {
+        scrollDelta: scrollParentEl.scrollTop - previousScrollTop,
+        anchorTop: mountedAnchor
+          ? mountedAnchor.getBoundingClientRect().top - viewportTop
+          : undefined,
+        spacerHeight: readTurnSpacerHeight(),
+        contentHeight: mountedAnchor ? measureActiveTailHeight(mountedAnchor) ?? undefined : undefined,
+        baselineContentHeight: anchor.baselineContentHeight,
+      });
+      if (anchor.phase === 'exhausted') {
+        // Born-exhausted arm (no absorption capacity): hand off to bottom in
+        // this same layout pass. The compensated writer above has already put
+        // the ref at 0, so its previousHeight guard can never fire here —
+        // sync the scroll explicitly instead of relying on it.
+        void scrollParentEl.scrollHeight;
+        scrollParentEl.scrollTop = scrollParentEl.scrollHeight;
+      }
+    };
+
+    tryArm();
+    return () => cancelAnimationFrame(armAnchorRafRef.current);
+  }, [
+    activeConvId,
+    leaveTurnAnchor,
+    measureActiveTailHeight,
+    messageCount,
+    readTurnSpacerHeight,
+    scrollParentEl,
+    writeTurnSpacerHeight,
+    writeTurnSpacerWithCompensation,
+  ]);
+  useLayoutEffect(() => {
+    const activeAnchor = turnAnchorRef.current;
+    if (!scrollParentEl || activeAnchor?.phase !== 'armed') return;
+    const anchorElement = findUserMessageAnchor(scrollParentEl, activeAnchor.messageId);
+    const messageRow = anchorElement?.closest<HTMLElement>('[data-index]');
+    if (!messageRow) return;
+
+    const observer = new ResizeObserver(() => {
+      // ResizeObserver runs after layout and before paint. Reading geometry
+      // again here closes the same-frame loop: the growing message row and the
+      // shrinking spacer are presented as one constant-height transaction to
+      // Virtuoso instead of two visible total-height changes.
+      reconcileActiveTurnGeometry(scrollParentEl);
+    });
+    observer.observe(messageRow);
+    return () => observer.disconnect();
+  }, [
+    activeConvId,
+    messageCount,
+    reconcileActiveTurnGeometry,
+    scrollParentEl,
+  ]);
+  useLayoutEffect(() => {
+    if (scrollParentEl) reconcileActiveTurnGeometry(scrollParentEl);
+  });
   // Derived from the very array Virtuoso renders, so a chapter's groupIndex is
   // always a valid scroll target — deriving from `messages` instead would let
   // the two drift the next time grouping rules change.
@@ -572,12 +1024,99 @@ export default function ChatView({
   // to the top, not centred — a chapter is read forwards from its first
   // message, and centring would hide the turn that opens it above the fold.
   const jumpToChapter = useCallback((chapter: Chapter) => {
-    updatePinned(false);
+    leaveTurnAnchor('chapter-jump');
     setHighlightedMessageId(chapter.messageId);
     virtuosoRef.current?.scrollToIndex({ index: chapter.groupIndex, align: 'start', behavior: 'auto' });
     clearTimeout(highlightFadeTimerRef.current);
     highlightFadeTimerRef.current = setTimeout(() => setHighlightedMessageId(null), 2600);
-  }, [updatePinned]);
+  }, [leaveTurnAnchor]);
+
+  // Shared by handleFollowOutput / handleTotalListHeightChanged (they must
+  // agree, or one path re-enables the bottom-pin the other is holding off).
+  const shouldSuppressLegacyFollow = useCallback(() => {
+    const pending = pendingTurnAnchorRef.current;
+    if (pending?.conversationId === activeConvId) {
+      pending.suppressionBudget -= 1;
+      if (pending.suppressionBudget > 0) return true;
+      // Spent budget: the announced turn never persisted (failed dispatch).
+      // Drop the gate so ordinary bottom-follow recovers on this very event.
+      pendingTurnAnchorRef.current = null;
+      return false;
+    }
+    if (!activeConvId) return false;
+    const conversation = useChatStore.getState().conversations[activeConvId];
+    const newest = selectLatestUserAnchor(activeConvId, conversation?.messages ?? []);
+    return Boolean(
+      conversation?.status === 'running'
+      && newest
+      && turnAnchorRef.current?.messageId !== newest.messageId
+      && !(
+        dismissedTurnAnchorRef.current?.conversationId === newest.conversationId
+        && dismissedTurnAnchorRef.current.messageId === newest.messageId
+      ),
+    );
+  }, [activeConvId]);
+
+  const handleFollowOutput = useCallback((atBottom: boolean) => {
+    emitChatScrollTrace('virtuoso-follow-output', 'decision', scrollParentEl, { atBottom });
+    if (shouldSuppressLegacyFollow()) return false;
+    return shouldFollowOutput(turnAnchorRef.current);
+  }, [shouldSuppressLegacyFollow, scrollParentEl]);
+
+  const handleAtBottomStateChange = useCallback((atBottom: boolean) => {
+    setIsAtBottom(atBottom);
+    if (!atBottom) return;
+    if (turnAnchorRef.current?.phase === 'armed') {
+      updatePinned(true);
+      return;
+    }
+    // A user who naturally scrolls through a frozen, post-unpin spacer has
+    // explicitly reached "latest" again. Remove that transient tail and restore
+    // the ordinary pinned/follow contract in one state transition.
+    if (turnSpacerHeightRef.current > 0) {
+      leaveTurnAnchor('explicit-latest');
+      return;
+    }
+    updatePinned(true);
+  }, [leaveTurnAnchor, updatePinned]);
+
+  const handleTotalListHeightChanged = useCallback((height: number) => {
+    const el = scrollParentEl;
+    if (!el) return;
+    if (shouldSuppressLegacyFollow()) return;
+
+    const activeAnchor = turnAnchorRef.current;
+    if (activeAnchor?.phase === 'armed') {
+      reconcileActiveTurnGeometry(el, height);
+      return;
+    }
+    if (activeAnchor?.phase === 'exhausted' && pinnedRef.current) {
+      // Exhaustion is a handoff phase, not permission to reintroduce the old
+      // deferred total-height correction. Keep bottom geometry synchronized in
+      // this callback until the run terminal clears the transient anchor.
+      emitChatScrollTrace('turn-anchor', 'scheduled', el, {
+        totalListHeight: height,
+        spacerHeight: 0,
+      });
+      const scrollDelta = syncElementToBottom(el);
+      emitChatScrollTrace('turn-anchor', 'applied', el, {
+        totalListHeight: height,
+        scrollDelta,
+        spacerHeight: 0,
+      });
+      return;
+    }
+
+    if (!pinnedRef.current) return;
+    if (el.scrollHeight - el.scrollTop - el.clientHeight > 2) {
+      stickToBottom(el, 'total-list-height', height);
+    }
+  }, [
+    reconcileActiveTurnGeometry,
+    scrollParentEl,
+    shouldSuppressLegacyFollow,
+    stickToBottom,
+  ]);
 
   // Conversation loading from disk (LRU cache miss) — show skeleton instead of welcome page
   if (activeConvId && !activeConv) {
@@ -826,13 +1365,9 @@ export default function ChatView({
             // text arrives in small, frequent chunks, so instant jumps read
             // as continuous motion without fighting a CSS scroll animation
             // that's still in flight when the next chunk lands.
-            followOutput="auto"
-            atBottomStateChange={(atBottom) => {
-              setIsAtBottom(atBottom);
-              // Reaching the bottom (by any means) re-engages the lock.
-              if (atBottom) updatePinned(true);
-            }}
-            atBottomThreshold={100}
+            followOutput={handleFollowOutput}
+            atBottomStateChange={handleAtBottomStateChange}
+            atBottomThreshold={VIRTUOSO_AT_BOTTOM_THRESHOLD_PX}
             // The bottom lock: whenever late-measured content (widget iframes,
             // images, charts) changes the total list height while the user is
             // pinned, re-stick to the newest message. Event-driven — replaces
@@ -848,14 +1383,7 @@ export default function ChatView({
             // followOutput hasn't already closed the gap (its actual target
             // case: content whose size resolves after layout, like images/
             // iframes finishing their own async measurement).
-            totalListHeightChanged={() => {
-              if (!pinnedRef.current) return;
-              const el = scrollParentEl;
-              if (!el) return;
-              if (el.scrollHeight - el.scrollTop - el.clientHeight > 2) {
-                stickToBottom(el);
-              }
-            }}
+            totalListHeightChanged={handleTotalListHeightChanged}
             // Keep ~one viewport of rows mounted above/below the visible window.
             // Rows still virtualize (far-off messages stay unmounted), but this
             // widens the live band so inline iframe widgets (HtmlWidgetBlock)
@@ -876,6 +1404,7 @@ export default function ChatView({
               // ("思考中…") here made the "…" blink out at the footer →
               // placeholder hand-off, and reads odd before the animated dots.
               thinkingLabel: t.status.thinking,
+              registerTurnSpacer,
             }}
             itemContent={(index, group) =>
               group.length === 1 && isCompactBoundary(group[0]) ? (

--- a/src/components/chat/ChatView.turnScrollAnchor.test.tsx
+++ b/src/components/chat/ChatView.turnScrollAnchor.test.tsx
@@ -1,0 +1,376 @@
+// @vitest-environment happy-dom
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ChatView from './ChatView';
+import { announceChatTurnScrollIntent } from './chatTurnScrollIntent';
+import { useChatStore } from '@/stores/chatStore';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { useEnterpriseStore } from '@/stores/enterpriseStore';
+import type { Message } from '@/types';
+
+interface MockVirtuosoProps {
+  atBottomStateChange?: (atBottom: boolean) => void;
+  components?: { Footer?: React.ComponentType<{ context?: unknown }> };
+  context?: unknown;
+  data?: Message[][];
+  followOutput?: (atBottom: boolean) => 'auto' | false;
+  itemContent?: (index: number, group: Message[]) => React.ReactNode;
+  totalListHeightChanged?: (height: number) => void;
+}
+
+const harness = vi.hoisted(() => ({
+  props: null as MockVirtuosoProps | null,
+  scrollToIndex: vi.fn(),
+}));
+
+vi.mock('@/core/agent/agentLoopRunner', () => ({
+  runAgentLoopDispatched: vi.fn(),
+}));
+
+vi.mock('react-virtuoso', async () => {
+  const React = await import('react');
+  return {
+    Virtuoso: React.forwardRef(function MockVirtuoso(props: MockVirtuosoProps, ref) {
+      harness.props = props;
+      React.useImperativeHandle(ref, () => ({ scrollToIndex: harness.scrollToIndex }));
+      const Footer = props.components?.Footer;
+      return React.createElement(
+        'div',
+        { 'data-testid': 'mock-virtuoso' },
+        ...(props.data ?? []).map((group, index) => React.createElement(
+          'div',
+          { 'data-index': String(index), key: group[0]?.id ?? index },
+          props.itemContent?.(index, group),
+        )),
+        Footer ? React.createElement(Footer, { context: props.context }) : null,
+      );
+    }),
+  };
+});
+
+vi.mock('./MessageGroup', async () => {
+  const React = await import('react');
+  return {
+    default: ({ messages }: { messages: Message[] }) => React.createElement(
+      React.Fragment,
+      null,
+      ...messages.map((message) => React.createElement(
+        'div',
+        {
+          'data-message-id': message.role === 'user' ? message.id : undefined,
+          key: message.id,
+        },
+        typeof message.content === 'string' ? message.content : message.role,
+      )),
+    ),
+  };
+});
+
+vi.mock('./ChatInput', () => ({ default: () => null }));
+vi.mock('./AgentStatusStrip', () => ({ default: () => null }));
+vi.mock('./QueuedMessagesStrip', () => ({ default: () => null }));
+vi.mock('./ScenarioGuide', () => ({ default: () => null }));
+vi.mock('./UsageChip', () => ({ default: () => null }));
+vi.mock('./ChapterRail', async () => {
+  const React = await import('react');
+  return {
+    default: ({ chapters, onJump }: { chapters: Array<{ messageId: string }>; onJump: (chapter: { messageId: string }) => void }) => React.createElement(
+      'button',
+      { 'data-testid': 'chapter-jump', onClick: () => onJump(chapters[0]) },
+      'chapter jump',
+    ),
+  };
+});
+vi.mock('./ChapterMenu', async () => {
+  const React = await import('react');
+  return {
+    default: ({ chapters, onJump }: { chapters: Array<{ messageId: string }>; onJump: (chapter: { messageId: string }) => void }) => React.createElement(
+      'button',
+      { 'data-testid': 'chapter-jump', onClick: () => onJump(chapters[0]) },
+      'chapter jump',
+    ),
+  };
+});
+
+const geometry = {
+  anchorDocumentTop: 220,
+  anchorHeight: 40,
+  baselineContentHeight: 100,
+  contentHeight: 100,
+  scroller: null as HTMLElement | null,
+};
+
+function rect(input: Partial<DOMRect> = {}): DOMRect {
+  return {
+    x: 0,
+    y: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    width: 0,
+    height: 0,
+    toJSON: () => ({}),
+    ...input,
+  };
+}
+
+function message(id: string, role: Message['role'], content: string, loopId: string): Message {
+  return { id, role, content, loopId, timestamp: 1 };
+}
+
+function setupConversation(): string {
+  const store = useChatStore.getState();
+  const conversationId = store.createConversation();
+  store.addMessage(conversationId, message('old-user', 'user', 'old prompt', 'old-loop'));
+  store.addMessage(conversationId, message('old-assistant', 'assistant', 'old answer', 'old-loop'));
+  store.setConversationStatus(conversationId, 'idle');
+  return conversationId;
+}
+
+function installGeometry(scroller: HTMLElement): { getScrollTop: () => number } {
+  geometry.scroller = scroller;
+  let scrollTop = 0;
+  const spacerHeight = () => Number.parseFloat(
+    document.querySelector<HTMLElement>('[data-turn-bottom-spacer]')?.style.height || '0',
+  );
+  const scrollHeight = () => (
+    300
+    + Math.max(0, geometry.contentHeight - geometry.baselineContentHeight)
+    + spacerHeight()
+  );
+  Object.defineProperties(scroller, {
+    clientHeight: { configurable: true, value: 300 },
+    clientWidth: { configurable: true, value: 800 },
+    offsetWidth: { configurable: true, value: 816 },
+    scrollHeight: { configurable: true, get: scrollHeight },
+    scrollTop: {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = Math.max(0, Math.min(value, scrollHeight() - 300));
+      },
+    },
+  });
+  return { getScrollTop: () => scrollTop };
+}
+
+async function armNewTurn(conversationId: string, expectedSpacer: string | null = '200'): Promise<HTMLElement> {
+  announceChatTurnScrollIntent({ conversationId, source: 'composer' });
+  await act(async () => {
+    const store = useChatStore.getState();
+    store.setConversationStatus(conversationId, 'running');
+    store.addMessage(conversationId, message('new-user', 'user', 'new prompt', 'new-loop'));
+  });
+  const spacer = await screen.findByTestId('mock-virtuoso').then(() => (
+    document.querySelector<HTMLElement>('[data-turn-bottom-spacer]')!
+  ));
+  if (expectedSpacer != null) {
+    await waitFor(() => expect(spacer.dataset.spacerHeight).toBe(expectedSpacer));
+  }
+  return spacer;
+}
+
+describe('ChatView active-turn scroll state machine', () => {
+  let rectSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    harness.props = null;
+    harness.scrollToIndex.mockReset();
+    geometry.anchorHeight = 40;
+    geometry.contentHeight = geometry.baselineContentHeight;
+    geometry.scroller = null;
+    useChatStore.setState(useChatStore.getInitialState(), true);
+    useSettingsStore.setState(useSettingsStore.getInitialState(), true);
+    useEnterpriseStore.setState({ mode: { kind: 'personal' }, initialized: true });
+    rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+      const element = this as HTMLElement;
+      const scroller = geometry.scroller;
+      if (element === scroller) return rect({ right: 816, width: 816, height: 300, bottom: 300 });
+      const row = element.closest<HTMLElement>('[data-index]');
+      const rowTop = geometry.anchorDocumentTop - (scroller?.scrollTop ?? 0);
+      if (element.hasAttribute('data-message-id')) {
+        return rect({ top: rowTop, bottom: rowTop + geometry.anchorHeight, height: geometry.anchorHeight });
+      }
+      if (element.hasAttribute('data-turn-bottom-spacer')) {
+        const height = Number.parseFloat(element.style.height || '0');
+        const top = rowTop + geometry.contentHeight;
+        return rect({ top, bottom: top + height, height });
+      }
+      if (row === element) return rect({ top: rowTop, bottom: rowTop + geometry.contentHeight, height: geometry.contentHeight });
+      return rect();
+    });
+  });
+
+  afterEach(() => {
+    rectSpy.mockRestore();
+    cleanup();
+  });
+
+  it('accounts spacer growth and exhausts with scrollTop compensation in the same callback', async () => {
+    const conversationId = setupConversation();
+    render(<ChatView />);
+    const scroller = document.querySelector<HTMLElement>('.overlay-scroll')!;
+    const { getScrollTop } = installGeometry(scroller);
+    const spacer = await armNewTurn(conversationId);
+
+    expect(getScrollTop()).toBe(200);
+    geometry.contentHeight = 180;
+    act(() => harness.props?.totalListHeightChanged?.(380));
+    expect(spacer.dataset.spacerHeight).toBe('120');
+    expect(getScrollTop()).toBe(200);
+
+    geometry.contentHeight = 320;
+    act(() => harness.props?.totalListHeightChanged?.(520));
+    expect(spacer.dataset.spacerHeight).toBe('0');
+    expect(getScrollTop()).toBe(220);
+    expect(harness.props?.followOutput?.(false)).toBe('auto');
+  });
+
+  it('self-clears a pending gate whose dispatch never persisted a message', async () => {
+    const conversationId = setupConversation();
+    render(<ChatView />);
+    const scroller = document.querySelector<HTMLElement>('.overlay-scroll')!;
+    const { getScrollTop } = installGeometry(scroller);
+
+    // Announce, but never persist a new user row: the failed-dispatch shape.
+    announceChatTurnScrollIntent({ conversationId, source: 'regenerate' });
+    // Leave a visible bottom gap so an unsuppressed handler would stick-to-bottom.
+    geometry.contentHeight = geometry.baselineContentHeight - 60;
+    const before = getScrollTop();
+
+    // Inside the suppression budget: follow stays gated, scrollTop untouched.
+    for (let i = 0; i < 20; i += 1) {
+      act(() => harness.props?.totalListHeightChanged?.(400));
+    }
+    expect(harness.props?.followOutput?.(false)).toBe(false);
+    expect(getScrollTop()).toBe(before);
+
+    // Past the budget the gate self-clears and ordinary follow recovers.
+    for (let i = 0; i < 20; i += 1) {
+      act(() => harness.props?.totalListHeightChanged?.(400));
+    }
+    expect(harness.props?.followOutput?.(false)).toBe('auto');
+  });
+
+  it('disarms on a run terminal and clears spacer with a synchronous bottom decision', async () => {
+    const conversationId = setupConversation();
+    render(<ChatView />);
+    const scroller = document.querySelector<HTMLElement>('.overlay-scroll')!;
+    const { getScrollTop } = installGeometry(scroller);
+    const spacer = await armNewTurn(conversationId);
+
+    act(() => useChatStore.getState().setConversationStatus(conversationId, 'idle'));
+
+    expect(spacer.dataset.spacerHeight).toBe('0');
+    expect(getScrollTop()).toBe(0);
+    expect(harness.props?.followOutput?.(false)).toBe('auto');
+  });
+
+  it.each([
+    ['downward wheel', () => geometry.scroller?.dispatchEvent(new WheelEvent('wheel', { deltaY: 12 }))],
+    ['keyboard page-down', () => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'PageDown' }))],
+    ['native scrollbar gutter', () => geometry.scroller?.dispatchEvent(new MouseEvent('pointerdown', { clientX: 815 }))],
+  ])('disarms for %s and preserves the physical bottom state', async (_label, gesture) => {
+    const conversationId = setupConversation();
+    render(<ChatView />);
+    const scroller = document.querySelector<HTMLElement>('.overlay-scroll')!;
+    const { getScrollTop } = installGeometry(scroller);
+    const spacer = await armNewTurn(conversationId);
+    scroller.scrollTop = 195;
+
+    act(gesture);
+
+    expect(spacer.dataset.spacerHeight).toBe('200');
+    expect(getScrollTop()).toBe(195);
+    expect(harness.props?.followOutput?.(false)).toBe('auto');
+    expect(screen.queryByText(/bottom|latest|最新|底部/i)).not.toBeInTheDocument();
+  });
+
+  it('does not steal the viewport again when a user-disarmed run becomes terminal', async () => {
+    const conversationId = setupConversation();
+    render(<ChatView />);
+    const scroller = document.querySelector<HTMLElement>('.overlay-scroll')!;
+    const { getScrollTop } = installGeometry(scroller);
+    const spacer = await armNewTurn(conversationId);
+    scroller.scrollTop = 120;
+    act(() => scroller.dispatchEvent(new WheelEvent('wheel', { deltaY: -12 })));
+
+    act(() => useChatStore.getState().setConversationStatus(conversationId, 'idle'));
+
+    expect(spacer.dataset.spacerHeight).toBe('200');
+    expect(getScrollTop()).toBe(120);
+    expect(harness.props?.followOutput?.(false)).toBe('auto');
+  });
+
+  it('abandons pending cleanly instead of top-anchoring a viewport-height user message', async () => {
+    geometry.anchorHeight = 280;
+    const conversationId = setupConversation();
+    render(<ChatView />);
+    const scroller = document.querySelector<HTMLElement>('.overlay-scroll')!;
+    installGeometry(scroller);
+
+    const spacer = await armNewTurn(conversationId, null);
+
+    await waitFor(() => expect(harness.props?.followOutput?.(false)).toBe('auto'));
+    expect(spacer.dataset.spacerHeight).toBe('0');
+  });
+
+  it('clears a frozen spacer for an explicit latest jump', async () => {
+    const user = userEvent.setup();
+    const conversationId = setupConversation();
+    render(<ChatView />);
+    const scroller = document.querySelector<HTMLElement>('.overlay-scroll')!;
+    installGeometry(scroller);
+    const spacer = await armNewTurn(conversationId);
+    scroller.scrollTop = 0;
+    act(() => scroller.dispatchEvent(new WheelEvent('wheel', { deltaY: -12 })));
+    expect(spacer.dataset.spacerHeight).toBe('200');
+
+    await user.click(screen.getByText(/bottom|latest|最新|底部/i));
+    expect(spacer.dataset.spacerHeight).toBe('0');
+  });
+
+  it('clears spacer before the chapter rail changes the Virtuoso target', async () => {
+    const user = userEvent.setup();
+    const conversationId = setupConversation();
+    for (let index = 1; index <= 2; index += 1) {
+      useChatStore.getState().addMessage(
+        conversationId,
+        message(`chapter-user-${index}`, 'user', `chapter ${index}`, `chapter-loop-${index}`),
+      );
+      useChatStore.getState().addMessage(
+        conversationId,
+        message(`chapter-assistant-${index}`, 'assistant', `answer ${index}`, `chapter-loop-${index}`),
+      );
+    }
+    render(<ChatView />);
+    const scroller = document.querySelector<HTMLElement>('.overlay-scroll')!;
+    installGeometry(scroller);
+    const spacer = await armNewTurn(conversationId);
+    await user.click(screen.getByTestId('chapter-jump'));
+    expect(spacer.dataset.spacerHeight).toBe('0');
+    expect(harness.scrollToIndex).toHaveBeenCalled();
+  });
+
+  it('clears spacer for search navigation and conversation switches', async () => {
+    const conversationId = setupConversation();
+    render(<ChatView />);
+    const scroller = document.querySelector<HTMLElement>('.overlay-scroll')!;
+    installGeometry(scroller);
+    const spacer = await armNewTurn(conversationId);
+
+    act(() => useChatStore.getState().setPendingSearchJump({ convId: conversationId, query: 'old prompt' }));
+    await waitFor(() => expect(harness.scrollToIndex).toHaveBeenCalled());
+    expect(spacer.dataset.spacerHeight).toBe('0');
+
+    const secondConversation = useChatStore.getState().createConversation();
+    useChatStore.getState().addMessage(
+      secondConversation,
+      message('second-user', 'user', 'second conversation', 'second-loop'),
+    );
+    await waitFor(() => expect(useChatStore.getState().activeConversationId).toBe(secondConversation));
+    expect(document.querySelector<HTMLElement>('[data-turn-bottom-spacer]')?.dataset.spacerHeight).toBe('0');
+  });
+});

--- a/src/components/chat/MessageBubble.test.tsx
+++ b/src/components/chat/MessageBubble.test.tsx
@@ -71,6 +71,14 @@ describe('MessageBubble user run status', () => {
     },
   );
 
+  it('exposes a stable DOM anchor for the persisted user message id', () => {
+    setConversation(baseMessage, 'running');
+
+    const { container } = render(<MessageBubble message={baseMessage} />);
+
+    expect(container.querySelector('[data-message-id="message-1"]')).toBeInTheDocument();
+  });
+
   it('keeps an actionable failure and retry control visible', () => {
     const message = { ...baseMessage, runState: 'failed' as const, runError: 'network unavailable' };
     setConversation(message, 'idle');

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -13,6 +13,7 @@ import { useTodosStore } from '@/stores/todosStore';
 import { useLabsFlag } from '@/core/labs/resolve';
 import { LABS_TODOS_INBOX } from '@/core/labs/registry';
 import { runAgentLoopDispatched } from '@/core/agent/agentLoopRunner';
+import { announceChatTurnScrollIntent } from './chatTurnScrollIntent';
 import { useI18n, format } from '@/i18n';
 import { getBaseName, loadLocalImage } from '@/utils/pathUtils';
 import { formatRelativeTime } from '@/utils/messageTime';
@@ -495,6 +496,7 @@ export default function MessageBubble({
       // edited resend stays on the same agent / skill — otherwise the message
       // falls back to the default `general` route and the expert is lost.
       const routedContent = reattachRoutingPrefix(newContent, message);
+      announceChatTurnScrollIntent({ conversationId: convId, source: 'edit-resend' });
       await runAgentLoopDispatched(convId, routedContent, imageAttachments ? { images: imageAttachments } : undefined);
     };
 
@@ -528,6 +530,7 @@ export default function MessageBubble({
 
     const proceed = async () => {
       useChatStore.getState().deleteMessagesFrom(convId, truncateFromId);
+      announceChatTurnScrollIntent({ conversationId: convId, source: 'run-retry' });
       await runAgentLoopDispatched(
         convId,
         routedContent,
@@ -585,6 +588,7 @@ export default function MessageBubble({
       const proceed = async () => {
         // Delete from user message onwards and regenerate
         useChatStore.getState().deleteMessagesFrom(convId, targetUserMsg.id);
+        announceChatTurnScrollIntent({ conversationId: convId, source: 'regenerate' });
         await runAgentLoopDispatched(convId, routedContent, imageAttachments ? { images: imageAttachments } : undefined);
       };
 
@@ -620,7 +624,7 @@ export default function MessageBubble({
     // Extract file attachments from user message text
     const { cleanText: userCleanText, attachmentPaths } = extractAttachments(textContent);
     return (
-      <div className="flex justify-end w-full group">
+      <div className="flex justify-end w-full group" data-message-id={message.id}>
         {rewindConfirmDialog}
         <div className="flex flex-col items-end gap-1.5 max-w-[85%]">
           {/* Image thumbnails — above the text bubble */}

--- a/src/components/chat/MessageGroup.tsx
+++ b/src/components/chat/MessageGroup.tsx
@@ -30,6 +30,7 @@ import { extractWorkflowSteps, extractFileOutputs, extractFilePathsFromText, par
 import { parseSearchResults, stripSourcesBlock, parseSourcesFromText } from '@/utils/searchParser';
 import { backfillDetailBlockImages, snapshotToExecutionSteps } from '@/core/agent/executionSnapshot';
 import { runAgentLoopDispatched } from '@/core/agent/agentLoopRunner';
+import { announceChatTurnScrollIntent } from './chatTurnScrollIntent';
 import { allWorkingDirectories } from '@/core/permissions/workingDirs';
 import { homeDir } from '@tauri-apps/api/path';
 import { cn } from '@/lib/utils';
@@ -757,6 +758,7 @@ export default function MessageGroup({ conversationId, messages, isLastGroup: is
       if (firstAssistantInLoop) {
         useChatStore.getState().deleteMessagesFrom(convId, firstAssistantInLoop.id);
       }
+      announceChatTurnScrollIntent({ conversationId: convId, source: 'run-retry' });
       await runAgentLoopDispatched(convId, userContent, { images: retryImages });
     };
 

--- a/src/components/chat/QueuedMessagesStrip.tsx
+++ b/src/components/chat/QueuedMessagesStrip.tsx
@@ -11,6 +11,7 @@ import {
   resumeUserInputQueue,
 } from '@/core/agent/userInputQueue';
 import { runAgentLoopDispatched } from '@/core/agent/agentLoopRunner';
+import { announceChatTurnScrollIntent } from './chatTurnScrollIntent';
 import { AgentLoopDispatchError } from '@/core/agent/agentLoopDispatchError';
 import { useI18n } from '@/i18n';
 import { Button } from '@/components/ui/button';
@@ -39,6 +40,7 @@ export default function QueuedMessagesStrip({ conversationId }: { conversationId
     const next = dequeueNextUserInput(conversationId);
     try {
       if (next) {
+        announceChatTurnScrollIntent({ conversationId, source: 'queue-resume' });
         const result = await runAgentLoopDispatched(conversationId, next.text);
         if (result.reason === 'error' && !result.messageTaken) {
           restoreDequeuedUserInput(conversationId, next);

--- a/src/components/chat/SandboxRecoveryCard.tsx
+++ b/src/components/chat/SandboxRecoveryCard.tsx
@@ -5,6 +5,7 @@ import { useChatStore } from '@/stores/chatStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { useToastStore } from '@/stores/toastStore';
 import { runAgentLoopDispatched } from '@/core/agent/agentLoopRunner';
+import { announceChatTurnScrollIntent } from './chatTurnScrollIntent';
 import { isConversationRunningInSidecar } from '@/core/agent/sidecarRunPredicate';
 import { TOOL_NAMES } from '@/core/tools/toolNames';
 import { format, useI18n } from '@/i18n';
@@ -108,6 +109,7 @@ export default function SandboxRecoveryCard({
       await setAction(conversationId, messageId, toolCallId, 'started');
       computerUseMayHaveSideEffects = true;
 
+      announceChatTurnScrollIntent({ conversationId, source: 'sandbox-recovery' });
       const result = await runAgentLoopDispatched(
         conversationId,
         format(t.sandbox.appAutomationContinuePrompt, { app }),

--- a/src/components/chat/TaskBlock.test.tsx
+++ b/src/components/chat/TaskBlock.test.tsx
@@ -140,6 +140,27 @@ describe('TaskBlock — thinking pane running → completed', () => {
     expect(toggleSlot(toggle!).classList.contains('block-expand-enter')).toBe(true);
   });
 
+  it('keeps long live thinking inside the max-h-48 scroll pane and follows its internal bottom', () => {
+    const { container, rerender } = render(
+      <TaskBlock executionSteps={[execThinkingStep()]} isActive />,
+    );
+    const pane = container.querySelector<HTMLElement>('.max-h-48.overflow-y-auto');
+    expect(pane).not.toBeNull();
+    Object.defineProperty(pane!, 'scrollHeight', { configurable: true, value: 480 });
+    pane!.scrollTop = 0;
+
+    rerender(
+      <TaskBlock
+        executionSteps={[execThinkingStep({ detail: 'reasoning tokens streaming in\nnext line' })]}
+        isActive
+      />,
+    );
+
+    expect(pane!.classList.contains('max-h-48')).toBe(true);
+    expect(pane!.classList.contains('overflow-y-auto')).toBe(true);
+    expect(pane!.scrollTop).toBe(480);
+  });
+
   it('collapse via the toggle rolls the panel up (closed + inert), not unmounted; history mounts render the button statically', () => {
     const { container } = render(
       <TaskBlock

--- a/src/components/chat/chatScrollTrace.test.ts
+++ b/src/components/chat/chatScrollTrace.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CHAT_SCROLL_TRACE_EVENT,
+  emitChatScrollTrace,
+  type ChatScrollTraceDetail,
+} from './chatScrollTrace';
+
+describe('chat scroll trace', () => {
+  it('is disabled by default and avoids reading layout geometry', () => {
+    const listener = vi.fn<(event: Event) => void>();
+    window.addEventListener(CHAT_SCROLL_TRACE_EVENT, listener);
+    const element = document.createElement('div');
+    const scrollHeight = vi.fn(() => 900);
+    Object.defineProperty(element, 'scrollHeight', { configurable: true, get: scrollHeight });
+
+    emitChatScrollTrace('total-list-height', 'applied', element);
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(scrollHeight).not.toHaveBeenCalled();
+    window.removeEventListener(CHAT_SCROLL_TRACE_EVENT, listener);
+  });
+
+  it('marks the exact follow source when the runtime switch is enabled', () => {
+    (window as Window & { __ABU_CHAT_SCROLL_TRACE__?: boolean }).__ABU_CHAT_SCROLL_TRACE__ = true;
+    const listener = vi.fn<(event: Event) => void>();
+    window.addEventListener(CHAT_SCROLL_TRACE_EVENT, listener);
+    const element = document.createElement('div');
+    Object.defineProperties(element, {
+      scrollHeight: { configurable: true, value: 900 },
+      clientHeight: { configurable: true, value: 400 },
+    });
+    element.scrollTop = 440;
+
+    emitChatScrollTrace('total-list-height', 'applied', element, {
+      totalListHeight: 880,
+      scrollDelta: 56,
+    });
+
+    expect(listener).toHaveBeenCalledOnce();
+    const event = listener.mock.calls[0][0] as CustomEvent<ChatScrollTraceDetail>;
+    expect(event.detail).toEqual({
+      source: 'total-list-height',
+      phase: 'applied',
+      totalListHeight: 880,
+      scrollTop: 440,
+      scrollHeight: 900,
+      clientHeight: 400,
+      distanceToBottom: 60,
+      scrollDelta: 56,
+    });
+
+    window.removeEventListener(CHAT_SCROLL_TRACE_EVENT, listener);
+    delete (window as Window & { __ABU_CHAT_SCROLL_TRACE__?: boolean }).__ABU_CHAT_SCROLL_TRACE__;
+  });
+});

--- a/src/components/chat/chatScrollTrace.ts
+++ b/src/components/chat/chatScrollTrace.ts
@@ -1,0 +1,65 @@
+export const CHAT_SCROLL_TRACE_EVENT = 'abu:chat-scroll-trace';
+export const CHAT_SCROLL_TRACE_RUNTIME_FLAG = '__ABU_CHAT_SCROLL_TRACE__';
+
+export type ChatScrollFollowSource =
+  | 'conversation-switch'
+  | 'turn-anchor'
+  | 'total-list-height'
+  | 'virtuoso-follow-output';
+
+export type ChatScrollTracePhase = 'decision' | 'scheduled' | 'applied';
+
+export interface ChatScrollTraceDetail {
+  source: ChatScrollFollowSource;
+  phase: ChatScrollTracePhase;
+  atBottom?: boolean;
+  totalListHeight?: number;
+  scrollTop?: number;
+  scrollHeight?: number;
+  clientHeight?: number;
+  distanceToBottom?: number;
+  scrollDelta?: number;
+  anchorTop?: number;
+  spacerHeight?: number;
+  contentHeight?: number;
+  baselineContentHeight?: number;
+}
+
+function scrollGeometry(element: HTMLElement | null): Pick<
+  ChatScrollTraceDetail,
+  'scrollTop' | 'scrollHeight' | 'clientHeight' | 'distanceToBottom'
+> {
+  if (!element) return {};
+  return {
+    scrollTop: element.scrollTop,
+    scrollHeight: element.scrollHeight,
+    clientHeight: element.clientHeight,
+    distanceToBottom: element.scrollHeight - element.scrollTop - element.clientHeight,
+  };
+}
+
+/**
+ * Renderer-observable timing marker for scroll-follow decisions and writes.
+ * Electron E2E attaches a listener before app mount so a visible correction can
+ * be attributed to the exact caller without enabling production telemetry.
+ */
+export function emitChatScrollTrace(
+  source: ChatScrollFollowSource,
+  phase: ChatScrollTracePhase,
+  element: HTMLElement | null,
+  detail: Omit<ChatScrollTraceDetail, 'source' | 'phase'> = {},
+): void {
+  if (typeof window === 'undefined') return;
+  const traceWindow = window as Window & { __ABU_CHAT_SCROLL_TRACE__?: boolean };
+  // Opt-in diagnostics only. This guard intentionally precedes every geometry
+  // read so production streaming does not force layout when no one is tracing.
+  if (traceWindow[CHAT_SCROLL_TRACE_RUNTIME_FLAG] !== true) return;
+  window.dispatchEvent(new CustomEvent<ChatScrollTraceDetail>(CHAT_SCROLL_TRACE_EVENT, {
+    detail: {
+      source,
+      phase,
+      ...scrollGeometry(element),
+      ...detail,
+    },
+  }));
+}

--- a/src/components/chat/chatTurnScrollIntent.test.ts
+++ b/src/components/chat/chatTurnScrollIntent.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  announceChatTurnScrollIntent,
+  subscribeChatTurnScrollIntent,
+  type ChatTurnScrollIntentSource,
+} from './chatTurnScrollIntent';
+
+describe('chat turn scroll intent', () => {
+  it.each([
+    'composer',
+    'edit-resend',
+    'regenerate',
+    'run-retry',
+    'queue-resume',
+    'sandbox-recovery',
+  ] satisfies ChatTurnScrollIntentSource[])('covers the %s dispatch entry', (source) => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeChatTurnScrollIntent(listener);
+
+    announceChatTurnScrollIntent({ conversationId: 'conversation-1', source });
+
+    expect(listener).toHaveBeenCalledWith({ conversationId: 'conversation-1', source });
+    unsubscribe();
+  });
+});

--- a/src/components/chat/chatTurnScrollIntent.ts
+++ b/src/components/chat/chatTurnScrollIntent.ts
@@ -1,0 +1,30 @@
+export type ChatTurnScrollIntentSource =
+  | 'composer'
+  | 'edit-resend'
+  | 'regenerate'
+  | 'run-retry'
+  | 'queue-resume'
+  | 'sandbox-recovery';
+
+export interface ChatTurnScrollIntent {
+  conversationId: string;
+  source: ChatTurnScrollIntentSource;
+}
+
+type Listener = (intent: ChatTurnScrollIntent) => void;
+
+const listeners = new Set<Listener>();
+
+/**
+ * Announces a user-visible run before its dispatcher can append the new user
+ * row. ChatView uses this narrow renderer-local signal to close the one-commit
+ * pending gap for every resend surface, not only the main composer.
+ */
+export function announceChatTurnScrollIntent(intent: ChatTurnScrollIntent): void {
+  for (const listener of listeners) listener(intent);
+}
+
+export function subscribeChatTurnScrollIntent(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/src/components/chat/turnScrollAnchor.test.ts
+++ b/src/components/chat/turnScrollAnchor.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import type { Message } from '@/types';
+import {
+  ANCHOR_TOLERANCE_PX,
+  CHAPTER_RAIL_BOTTOM_THRESHOLD_PX,
+  VIRTUOSO_AT_BOTTOM_THRESHOLD_PX,
+  armTurnScrollAnchor,
+  canArmTurnScrollAnchor,
+  exitTurnScrollAnchor,
+  getAnchorScrollCorrection,
+  isAtBottomFromGeometry,
+  isChapterRailAtBottom,
+  reconcileTurnScrollAnchor,
+  selectLatestUserAnchor,
+  shouldFollowOutput,
+} from './turnScrollAnchor';
+
+const BASE_CONTENT_HEIGHT = 1_000;
+
+function arm(overrides: Partial<Parameters<typeof armTurnScrollAnchor>[0]> = {}) {
+  return armTurnScrollAnchor({
+    conversationId: 'conversation-1',
+    messageId: 'user-1',
+    anchorTop: 420,
+    targetTop: 20,
+    distanceToBottom: 0,
+    contentHeight: BASE_CONTENT_HEIGHT,
+    ...overrides,
+  });
+}
+
+describe('turn scroll anchor invariants', () => {
+  it('keeps correction inside the 2px anchor tolerance at zero', () => {
+    expect(ANCHOR_TOLERANCE_PX).toBe(2);
+    expect(getAnchorScrollCorrection(20, 21.9)).toBe(0);
+    expect(getAnchorScrollCorrection(20, 22.1)).toBeCloseTo(2.1);
+    expect(getAnchorScrollCorrection(20, 17)).toBe(-3);
+  });
+
+  it('allocates exactly the missing scroll range without a physical measurement reserve', () => {
+    expect(arm()).toMatchObject({
+      phase: 'armed',
+      targetTop: 20,
+      initialScrollDelta: 400,
+      initialSpacerHeight: 400,
+      spacerHeight: 400,
+      baselineContentHeight: BASE_CONTENT_HEIGHT,
+    });
+    expect(arm({ distanceToBottom: 75 })).toMatchObject({
+      initialScrollDelta: 400,
+      initialSpacerHeight: 325,
+    });
+  });
+
+  it('absorbs active-tail growth into the footer spacer with zero net list-height change', () => {
+    const initial = arm();
+    const afterGrowth = reconcileTurnScrollAnchor(initial, {
+      contentHeight: 1_120,
+      anchorPresent: true,
+    });
+
+    expect(afterGrowth.anchor).toMatchObject({ phase: 'armed', spacerHeight: 280 });
+    expect(afterGrowth.contentHeight + afterGrowth.spacerHeight).toBe(1_400);
+    expect(afterGrowth.handoff).toBe('none');
+  });
+
+  it('risk B — counteracts SmoothHeight growth and shrink without spacer oscillation', () => {
+    let anchor = arm();
+    let spacerHeight = anchor.spacerHeight;
+
+    for (const contentHeight of [1_120, 1_080, 1_160, 1_040, 1_200]) {
+      const result = reconcileTurnScrollAnchor(anchor, {
+        contentHeight,
+        anchorPresent: true,
+      });
+      anchor = result.anchor;
+      spacerHeight = result.spacerHeight;
+      expect(contentHeight + spacerHeight).toBe(1_400);
+      expect(anchor.phase).toBe('armed');
+    }
+    expect(spacerHeight).toBe(anchor.spacerHeight);
+  });
+
+  it('risk C — requests a same-layout-pass bottom handoff when the spacer exhausts', () => {
+    const result = reconcileTurnScrollAnchor(arm(), {
+      contentHeight: 1_400,
+      anchorPresent: true,
+    });
+
+    expect(result.anchor).toMatchObject({ phase: 'exhausted', spacerHeight: 0 });
+    expect(result.handoff).toBe('sync-bottom');
+    expect(shouldFollowOutput(result.anchor)).toBe('auto');
+  });
+
+  it('risk C — an unmounted anchor also requests a synchronous handoff', () => {
+    expect(reconcileTurnScrollAnchor(arm(), {
+      contentHeight: BASE_CONTENT_HEIGHT,
+      anchorPresent: false,
+    }).handoff).toBe('sync-bottom');
+  });
+
+  it('risk E — never follows content after explicit upward intent and preserves the frozen spacer', () => {
+    const anchor = arm();
+    const exit = exitTurnScrollAnchor(anchor, 'user-scroll-intent');
+
+    expect(exit).toEqual({
+      anchor: null,
+      spacerHeight: 400,
+      pinned: false,
+    });
+  });
+
+  it('risk E — clears spacer and restores pinned bottom state for an explicit latest jump', () => {
+    expect(exitTurnScrollAnchor(arm(), 'explicit-latest')).toEqual({
+      anchor: null,
+      spacerHeight: 0,
+      pinned: true,
+    });
+  });
+
+  it.each([
+    ['conversation-switch', true],
+    ['run-terminal', true],
+    ['arm-abandoned', true],
+    ['search-jump', false],
+    ['chapter-jump', false],
+  ] as const)('resets anchor state for %s', (reason, pinned) => {
+    expect(exitTurnScrollAnchor(arm(), reason)).toEqual({
+      anchor: null,
+      spacerHeight: 0,
+      pinned,
+    });
+  });
+
+  it('risk F7 — derives bottom state from geometry instead of forcing false on unpin', () => {
+    expect(VIRTUOSO_AT_BOTTOM_THRESHOLD_PX).toBe(100);
+    expect(isAtBottomFromGeometry(1)).toBe(true);
+    expect(isAtBottomFromGeometry(99.9)).toBe(true);
+    expect(isAtBottomFromGeometry(100.1)).toBe(false);
+  });
+
+  it('risk F8 — declines a top anchor when the user bubble would consume the viewport', () => {
+    expect(canArmTurnScrollAnchor({ anchorHeight: 240, viewportHeight: 600, targetTop: 20 })).toBe(true);
+    expect(canArmTurnScrollAnchor({ anchorHeight: 580, viewportHeight: 600, targetTop: 20 })).toBe(false);
+  });
+});
+
+describe('risk A — chapter rail geometry', () => {
+  it('treats an armed pinned spacer as the newest chapter despite its physical distance', () => {
+    expect(CHAPTER_RAIL_BOTTOM_THRESHOLD_PX).toBe(24);
+    expect(isChapterRailAtBottom(300, arm(), true)).toBe(true);
+    expect(isChapterRailAtBottom(300, arm(), false)).toBe(false);
+    expect(isChapterRailAtBottom(23.9, null, false)).toBe(true);
+    expect(isChapterRailAtBottom(24.1, null, false)).toBe(false);
+  });
+});
+
+describe('risk D — anchor rebinding', () => {
+  it('selects the newest persisted user id even when legacy turns reused one loop id', () => {
+    const messages: Message[] = [
+      { id: 'user-1', role: 'user', content: 'first', timestamp: 1, loopId: 'loop-1' },
+      { id: 'assistant-1', role: 'assistant', content: 'answer', timestamp: 2, loopId: 'loop-1' },
+      { id: 'user-2', role: 'user', content: 'queued', timestamp: 3, loopId: 'loop-1' },
+      { id: 'assistant-2', role: 'assistant', content: '', timestamp: 4, loopId: 'loop-1', isStreaming: true },
+    ];
+
+    expect(selectLatestUserAnchor('conversation-1', messages)).toEqual({
+      conversationId: 'conversation-1',
+      messageId: 'user-2',
+    });
+    expect(messages.map((message) => message.id)).toEqual([
+      'user-1',
+      'assistant-1',
+      'user-2',
+      'assistant-2',
+    ]);
+  });
+});

--- a/src/components/chat/turnScrollAnchor.ts
+++ b/src/components/chat/turnScrollAnchor.ts
@@ -1,0 +1,166 @@
+import type { Message } from '@/types';
+
+export const ANCHOR_TOLERANCE_PX = 2;
+export const CHAPTER_RAIL_BOTTOM_THRESHOLD_PX = 24;
+export const VIRTUOSO_AT_BOTTOM_THRESHOLD_PX = 100;
+
+export interface TurnAnchorCandidate {
+  conversationId: string;
+  messageId: string;
+}
+
+export interface TurnScrollAnchor extends TurnAnchorCandidate {
+  phase: 'armed' | 'exhausted';
+  targetTop: number;
+  initialScrollDelta: number;
+  initialSpacerHeight: number;
+  spacerHeight: number;
+  baselineContentHeight: number;
+}
+
+export interface TurnScrollAnchorExit {
+  anchor: null;
+  spacerHeight: number;
+  pinned: boolean;
+}
+
+export type TurnScrollAnchorExitReason =
+  | 'user-scroll-intent'
+  | 'explicit-latest'
+  | 'conversation-switch'
+  | 'run-terminal'
+  | 'arm-abandoned'
+  | 'search-jump'
+  | 'chapter-jump';
+
+function nonNegative(value: number): number {
+  return Math.max(0, value);
+}
+
+export function selectLatestUserAnchor(
+  conversationId: string,
+  messages: readonly Message[],
+): TurnAnchorCandidate | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index].role === 'user') {
+      return { conversationId, messageId: messages[index].id };
+    }
+  }
+  return null;
+}
+
+export function findUserMessageAnchor(root: ParentNode, messageId: string): HTMLElement | null {
+  for (const element of root.querySelectorAll<HTMLElement>('[data-message-id]')) {
+    if (element.dataset.messageId === messageId) return element;
+  }
+  return null;
+}
+
+export function armTurnScrollAnchor(input: {
+  conversationId: string;
+  messageId: string;
+  anchorTop: number;
+  targetTop: number;
+  distanceToBottom: number;
+  contentHeight: number;
+}): TurnScrollAnchor {
+  const initialScrollDelta = nonNegative(input.anchorTop - input.targetTop);
+  const existingScrollRange = nonNegative(input.distanceToBottom);
+  // The spacer is real scrollable geometry, so every pixel must correspond to
+  // range that is actually missing. A former +96px measurement reserve left a
+  // matching blind gap and merely delayed the hard return to bottom.
+  const initialSpacerHeight = nonNegative(initialScrollDelta - existingScrollRange);
+  return {
+    conversationId: input.conversationId,
+    messageId: input.messageId,
+    phase: initialSpacerHeight > 0 ? 'armed' : 'exhausted',
+    targetTop: input.targetTop,
+    initialScrollDelta,
+    initialSpacerHeight,
+    spacerHeight: initialSpacerHeight,
+    baselineContentHeight: input.contentHeight,
+  };
+}
+
+export function reconcileTurnScrollAnchor(
+  anchor: TurnScrollAnchor,
+  input: {
+    contentHeight: number;
+    anchorPresent: boolean;
+  },
+): {
+  anchor: TurnScrollAnchor;
+  contentHeight: number;
+  spacerHeight: number;
+  handoff: 'none' | 'sync-bottom';
+} {
+  const contentHeight = input.contentHeight;
+  const contentDelta = contentHeight - anchor.baselineContentHeight;
+  const computedSpacerHeight = nonNegative(anchor.initialSpacerHeight - contentDelta);
+  const spacerHeight = input.anchorPresent ? computedSpacerHeight : 0;
+  const phase = spacerHeight > 0 ? 'armed' : 'exhausted';
+  return {
+    anchor: { ...anchor, phase, spacerHeight },
+    contentHeight,
+    spacerHeight,
+    handoff: phase === 'exhausted' ? 'sync-bottom' : 'none',
+  };
+}
+
+export function canArmTurnScrollAnchor(input: {
+  anchorHeight: number;
+  viewportHeight: number;
+  targetTop: number;
+}): boolean {
+  if (input.anchorHeight <= 0 || input.viewportHeight <= 0) return false;
+  // Keep one target-sized breathing band below the user bubble. Otherwise a
+  // viewport-height prompt anchored at the top hides the assistant response.
+  return input.anchorHeight <= input.viewportHeight - (input.targetTop * 2);
+}
+
+export function getAnchorScrollCorrection(targetTop: number, currentTop: number): number {
+  const delta = currentTop - targetTop;
+  return Math.abs(delta) <= ANCHOR_TOLERANCE_PX ? 0 : delta;
+}
+
+export function shouldFollowOutput(anchor: TurnScrollAnchor | null): 'auto' | false {
+  return anchor?.phase === 'armed' ? false : 'auto';
+}
+
+export function isChapterRailAtBottom(
+  distanceToBottom: number,
+  anchor: TurnScrollAnchor | null,
+  pinned: boolean,
+): boolean {
+  if (anchor?.phase === 'armed' && pinned) return true;
+  return distanceToBottom <= CHAPTER_RAIL_BOTTOM_THRESHOLD_PX;
+}
+
+export function isAtBottomFromGeometry(distanceToBottom: number): boolean {
+  return distanceToBottom <= VIRTUOSO_AT_BOTTOM_THRESHOLD_PX;
+}
+
+export function exitTurnScrollAnchor(
+  anchor: TurnScrollAnchor | null,
+  reason: TurnScrollAnchorExitReason,
+): TurnScrollAnchorExit {
+  if (reason === 'user-scroll-intent') {
+    return {
+      anchor: null,
+      spacerHeight: anchor?.spacerHeight ?? 0,
+      pinned: false,
+    };
+  }
+  if (reason === 'search-jump' || reason === 'chapter-jump') {
+    return {
+      anchor: null,
+      spacerHeight: 0,
+      pinned: false,
+    };
+  }
+  return {
+    anchor: null,
+    spacerHeight: 0,
+    pinned: true,
+  };
+}

--- a/tests/e2e/thinking-scroll-anchor.spec.ts
+++ b/tests/e2e/thinking-scroll-anchor.spec.ts
@@ -1,0 +1,424 @@
+/**
+ * Real-Electron regression for the active-turn scroll anchor. The mock stream
+ * is advanced by the test one animation frame at a time, so failures identify
+ * renderer geometry rather than timer or network scheduling noise.
+ */
+import { expect, test } from '@playwright/test';
+import { createServer, type Server, type ServerResponse } from 'node:http';
+import type { ElectronApplication, Page } from 'playwright';
+import {
+  closeAbuElectron,
+  configureLocalMockProvider,
+  createElectronDataRoot,
+  launchAbuElectron,
+  removeElectronDataRoot,
+  type ElectronDataRoot,
+} from './electronHelpers';
+
+const READY_TIMEOUT = 45_000;
+const CHAT_PLACEHOLDER = '想让阿布帮你做点什么？';
+const PRELUDE_PROMPT = 'THINKING_SCROLL_PRELUDE_20260829';
+const PRELUDE_MARKER = 'THINKING_SCROLL_PRELUDE_COMPLETE';
+const WARMUP_PROMPT = 'THINKING_SCROLL_WARMUP_20260829';
+const WARMUP_MARKER = 'THINKING_SCROLL_WARMUP_COMPLETE';
+const PROBE_PROMPT = 'THINKING_SCROLL_PROBE_20260829';
+const ANSWER_MARKER = 'THINKING_SCROLL_PROBE_COMPLETE';
+const TRACE_EVENT = 'abu:chat-scroll-trace';
+
+interface ProbeMock {
+  baseUrl: string;
+  close: () => Promise<void>;
+  finishProbe: () => void;
+  waitForProbe: () => Promise<void>;
+  writeAnswer: (content: string) => void;
+  writeReasoning: (content: string) => void;
+}
+
+interface ScrollTrace {
+  distanceToBottom?: number;
+  phase: string;
+  source: string;
+  scrollDelta?: number;
+  spacerHeight?: number;
+}
+
+interface AnchorSample {
+  anchorTop: number;
+  distanceToBottom: number;
+  spacerHeight: number;
+  scrollTop: number;
+}
+
+function sseDelta(delta: Record<string, string>, finishReason: string | null = null): string {
+  return `data: ${JSON.stringify({
+    id: 'chatcmpl-thinking-scroll',
+    object: 'chat.completion.chunk',
+    created: 0,
+    model: 'abu-thinking-scroll-e2e',
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  })}\n\n`;
+}
+
+function responseContains(body: string, marker: string): boolean {
+  try {
+    return JSON.stringify(JSON.parse(body)).includes(marker);
+  } catch {
+    return body.includes(marker);
+  }
+}
+
+async function startProbeMock(): Promise<ProbeMock> {
+  let probeResponse: ServerResponse | null = null;
+  let resolveProbe: (() => void) | null = null;
+  const probeReady = new Promise<void>((resolve) => {
+    resolveProbe = resolve;
+  });
+  const activeResponses = new Set<ServerResponse>();
+  const server = createServer(async (req, res) => {
+    activeResponses.add(res);
+    res.once('close', () => activeResponses.delete(res));
+    let body = '';
+    for await (const chunk of req) body += String(chunk);
+
+    if (req.method !== 'POST' || req.url !== '/v1/chat/completions') {
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'unexpected route' }));
+      return;
+    }
+
+    res.writeHead(200, {
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+      'content-type': 'text/event-stream; charset=utf-8',
+    });
+
+    if (responseContains(body, PROBE_PROMPT)) {
+      probeResponse = res;
+      resolveProbe?.();
+      return;
+    }
+
+    if (responseContains(body, WARMUP_PROMPT)) {
+      const lines = Array.from({ length: 35 }, (_, index) => `warmup line ${index + 1}`).join('\n');
+      res.write(sseDelta({ content: `${lines}\n${WARMUP_MARKER}` }));
+      res.write(sseDelta({}, 'stop'));
+      res.end('data: [DONE]\n\n');
+      return;
+    }
+
+    if (responseContains(body, PRELUDE_PROMPT)) {
+      res.write(sseDelta({ content: `prelude answer\n${PRELUDE_MARKER}` }));
+      res.write(sseDelta({}, 'stop'));
+      res.end('data: [DONE]\n\n');
+      return;
+    }
+
+    // Memory extraction and other background bookkeeping must not introduce a
+    // real network dependency into this journey.
+    res.write(sseDelta({ content: '[]' }));
+    res.write(sseDelta({}, 'stop'));
+    res.end('data: [DONE]\n\n');
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('loopback mock did not bind a port');
+
+  const requireProbeResponse = (): ServerResponse => {
+    if (!probeResponse) throw new Error('probe response is not ready');
+    return probeResponse;
+  };
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    waitForProbe: () => probeReady,
+    writeReasoning: (content) => requireProbeResponse().write(sseDelta({ reasoning_content: content })),
+    writeAnswer: (content) => requireProbeResponse().write(sseDelta({ content })),
+    finishProbe: () => {
+      const response = requireProbeResponse();
+      response.write(sseDelta({}, 'stop'));
+      response.end('data: [DONE]\n\n');
+    },
+    close: () => closeServer(server, activeResponses),
+  };
+}
+
+function closeServer(server: Server, activeResponses: ReadonlySet<ServerResponse>): Promise<void> {
+  for (const response of activeResponses) response.destroy();
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+    server.closeAllConnections?.();
+  });
+}
+
+async function advanceFrames(page: Page, count: number): Promise<void> {
+  await page.evaluate(async (frameCount) => {
+    for (let index = 0; index < frameCount; index += 1) {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    }
+  }, count);
+}
+
+async function send(page: Page, text: string): Promise<void> {
+  const input = page.getByPlaceholder(CHAT_PLACEHOLDER).first();
+  await expect(input).toBeVisible({ timeout: READY_TIMEOUT });
+  await input.fill(text);
+  await page.keyboard.press('Enter');
+}
+
+async function waitForTurnCompletion(page: Page, marker: string): Promise<void> {
+  await expect(page.getByText(marker, { exact: false })).toBeVisible({ timeout: READY_TIMEOUT });
+  await expect(page.getByLabel(/^(停止|Stop)$/)).toBeHidden({ timeout: READY_TIMEOUT });
+}
+
+let app: ElectronApplication | undefined;
+let dataRoot: ElectronDataRoot | undefined;
+let mock: ProbeMock | undefined;
+
+test.describe.serial('Thinking scroll anchor — real Electron', () => {
+  test.afterEach(async () => {
+    if (app) {
+      await closeAbuElectron(app);
+      app = undefined;
+    }
+    if (dataRoot) {
+      removeElectronDataRoot(dataRoot);
+      dataRoot = undefined;
+    }
+    if (mock) {
+      await mock.close();
+      mock = undefined;
+    }
+  });
+
+  test('keeps the active user anchor stable without a raw total-height correction', async ({ browserName: _browserName }, testInfo) => {
+    mock = await startProbeMock();
+    const launched = await launchAbuElectron(createElectronDataRoot());
+    app = launched.app;
+    dataRoot = launched;
+    const page = await app.firstWindow({ timeout: READY_TIMEOUT });
+    await page.waitForLoadState('domcontentloaded');
+    // Wait for Zustand persistence to finish hydrating before replacing its
+    // provider state; configuring immediately after domcontentloaded can race
+    // the initial empty-store write and leave the composer with no model.
+    await expect(page.getByPlaceholder(CHAT_PLACEHOLDER).first()).toBeVisible({ timeout: READY_TIMEOUT });
+    await configureLocalMockProvider(page, mock.baseUrl, {
+      contextWindowSize: 200_000,
+      maxOutputTokens: 8_192,
+      modelId: 'abu-thinking-scroll-e2e',
+      supportsReasoning: true,
+    });
+
+    await send(page, PRELUDE_PROMPT);
+    await waitForTurnCompletion(page, PRELUDE_MARKER);
+    await send(page, WARMUP_PROMPT);
+    await waitForTurnCompletion(page, WARMUP_MARKER);
+
+    await page.evaluate((eventName) => {
+      const target = window as Window & {
+        __ABU_CHAT_SCROLL_TRACE__?: boolean;
+        __abuAnchorSamples?: AnchorSample[];
+        __abuCollectAnchorSamples?: boolean;
+        __abuScrollTraces?: ScrollTrace[];
+      };
+      target.__ABU_CHAT_SCROLL_TRACE__ = true;
+      target.__abuScrollTraces = [];
+      window.addEventListener(eventName, (event) => {
+        target.__abuScrollTraces?.push((event as CustomEvent<ScrollTrace>).detail);
+      });
+    }, TRACE_EVENT);
+
+    await send(page, PROBE_PROMPT);
+    await mock.waitForProbe();
+    const anchor = page.locator(`[data-message-id]`, { hasText: PROBE_PROMPT }).last();
+    await expect(anchor).toBeVisible({ timeout: READY_TIMEOUT });
+    await advanceFrames(page, 4);
+    mock.writeReasoning('rail geometry seed keeps the measured active tail live\n');
+    await advanceFrames(page, 6);
+    const railEvidence = await page.evaluate((probe) => {
+      const scroller = document.querySelector<HTMLElement>('.overlay-scroll');
+      const currentTick = document.querySelector<HTMLButtonElement>('nav button[aria-current="true"]');
+      const spacer = document.querySelector<HTMLElement>('[data-turn-bottom-spacer]');
+      const anchorElement = Array.from(document.querySelectorAll<HTMLElement>('[data-message-id]'))
+        .find((element) => element.textContent?.includes(probe));
+      const messageRow = anchorElement?.closest<HTMLElement>('[data-index]');
+      if (!scroller || !currentTick || !messageRow || !spacer) {
+        throw new Error('chapter rail or active-turn geometry was not available');
+      }
+      return {
+        currentLabel: currentTick.getAttribute('aria-label'),
+        distanceToBottom: scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight,
+        spacerHeight: spacer?.getBoundingClientRect().height ?? 0,
+        tickCount: document.querySelectorAll('nav button[aria-current]').length,
+        isProbeChapter: currentTick.getAttribute('aria-label')?.includes(probe.slice(0, 20)) ?? false,
+        initialTailHeight: spacer.getBoundingClientRect().top - messageRow.getBoundingClientRect().top,
+      };
+    }, PROBE_PROMPT);
+    expect(railEvidence.tickCount).toBe(3);
+    expect(railEvidence.spacerHeight).toBeGreaterThan(0);
+    expect(railEvidence.isProbeChapter, railEvidence.currentLabel ?? 'missing label').toBe(true);
+    await page.evaluate((probe) => {
+      const target = window as Window & {
+        __abuAnchorSamples?: AnchorSample[];
+        __abuCollectAnchorSamples?: boolean;
+      };
+      const anchorElement = Array.from(document.querySelectorAll<HTMLElement>('[data-message-id]'))
+        .find((element) => element.textContent?.includes(probe));
+      const scroller = document.querySelector<HTMLElement>('.overlay-scroll');
+      if (!anchorElement || !scroller) throw new Error('active user anchor or chat scroller not found');
+      target.__abuAnchorSamples = [];
+      target.__abuCollectAnchorSamples = true;
+      const sample = () => {
+        if (!target.__abuCollectAnchorSamples) return;
+        target.__abuAnchorSamples?.push({
+          anchorTop: anchorElement.getBoundingClientRect().top - scroller.getBoundingClientRect().top,
+          distanceToBottom: scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight,
+          spacerHeight: document.querySelector<HTMLElement>('[data-turn-bottom-spacer]')
+            ?.getBoundingClientRect().height ?? 0,
+          scrollTop: scroller.scrollTop,
+        });
+        requestAnimationFrame(sample);
+      };
+      requestAnimationFrame(sample);
+    }, PROBE_PROMPT);
+
+    for (let index = 0; index < 22; index += 1) {
+      mock.writeReasoning(`reasoning line ${String(index + 1).padStart(2, '0')} keeps growing the active task pane\n`);
+      await advanceFrames(page, 3);
+    }
+    mock.writeAnswer(`${ANSWER_MARKER} first answer line.\n`);
+    await advanceFrames(page, 4);
+    // Deliberately exceed the initial spacer. The previous regression sampled
+    // only spacer>0 frames and used a short reply, so it never observed the
+    // delayed +96px correction after exhaustion.
+    for (let chunk = 0; chunk < 14; chunk += 1) {
+      const lines = Array.from(
+        { length: 8 },
+        (_, index) => `long answer ${String((chunk * 8) + index + 1).padStart(3, '0')} keeps growing after spacer exhaustion`,
+      ).join('\n');
+      mock.writeAnswer(`${lines}\n`);
+      await advanceFrames(page, 3);
+    }
+    mock.writeAnswer('Final answer line settles the completion fold.');
+    mock.finishProbe();
+    await expect(page.getByText(ANSWER_MARKER, { exact: false })).toBeVisible({ timeout: READY_TIMEOUT });
+    await advanceFrames(page, 24);
+
+    const evidence = await page.evaluate((probe) => {
+      const target = window as Window & {
+        __abuAnchorSamples?: AnchorSample[];
+        __abuCollectAnchorSamples?: boolean;
+        __abuScrollTraces?: ScrollTrace[];
+      };
+      target.__abuCollectAnchorSamples = false;
+      const anchorElement = Array.from(document.querySelectorAll<HTMLElement>('[data-message-id]'))
+        .find((element) => element.textContent?.includes(probe)) ?? null;
+      const messageRow = anchorElement?.closest<HTMLElement>('[data-index]');
+      const spacer = document.querySelector<HTMLElement>('[data-turn-bottom-spacer]');
+      const scroller = document.querySelector<HTMLElement>('.overlay-scroll');
+      return {
+        samples: target.__abuAnchorSamples ?? [],
+        traces: target.__abuScrollTraces ?? [],
+        finalDistanceToBottom: scroller
+          ? scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight
+          : Number.POSITIVE_INFINITY,
+        finalTailHeight: messageRow && spacer
+          ? spacer.getBoundingClientRect().top - messageRow.getBoundingClientRect().top
+          : 0,
+      };
+    }, PROBE_PROMPT);
+    const armedSamples = evidence.samples.filter((sample) => sample.spacerHeight > 0);
+    const anchorTops = armedSamples.map((sample) => sample.anchorTop);
+    const anchorDrift = Math.max(...anchorTops) - Math.min(...anchorTops);
+    const firstExhaustedIndex = evidence.samples.findIndex((sample) => sample.spacerHeight === 0);
+    const postExhaustionSamples = firstExhaustedIndex >= 0
+      ? evidence.samples.slice(firstExhaustedIndex + 1)
+      : [];
+    const maxArmedBottomGap = Math.max(
+      0,
+      ...armedSamples.map((sample) => Math.abs(sample.distanceToBottom)),
+    );
+    const anchorStart = evidence.traces.findIndex((trace) => trace.source === 'turn-anchor');
+    const anchorHandoff = evidence.traces.findIndex((trace, index) => (
+      index >= anchorStart
+      && trace.source === 'turn-anchor'
+      && trace.phase === 'applied'
+      && trace.spacerHeight === 0
+    ));
+    // The sampler and the scroll correction are both rAF callbacks. Depending
+    // on callback registration order, a sample can observe the intermediate
+    // layout before the correction later in the same frame. Applied traces are
+    // emitted after scrollTop is written, so they are the authoritative
+    // same-layout-pass handoff evidence.
+    const handoffAppliedTraces = anchorHandoff >= 0
+      ? evidence.traces
+          .slice(anchorHandoff)
+          .filter((trace) => trace.source === 'turn-anchor' && trace.phase === 'applied')
+          .slice(0, 4)
+      : [];
+    const maxHandoffGap = Math.max(
+      0,
+      ...handoffAppliedTraces.map((trace) => Math.abs(
+        trace.distanceToBottom ?? Number.POSITIVE_INFINITY,
+      )),
+    );
+    const finalBottomGap = Math.abs(evidence.finalDistanceToBottom);
+    const tailGrowth = evidence.finalTailHeight - railEvidence.initialTailHeight;
+    const anchoredTraces = anchorStart >= 0
+      ? evidence.traces.slice(anchorStart, anchorHandoff >= 0 ? anchorHandoff + 1 : undefined)
+      : evidence.traces;
+    const rawHeightCorrection = anchoredTraces.find((trace) =>
+      trace.source === 'total-list-height'
+      && trace.phase === 'applied'
+      && Math.abs(trace.scrollDelta ?? 0) > 2,
+    );
+    await testInfo.attach('scroll-anchor-evidence.json', {
+      body: Buffer.from(JSON.stringify({
+        anchorDrift,
+        anchorHandoff,
+        anchoredTraces,
+        firstExhaustedIndex,
+        finalBottomGap,
+        maxArmedBottomGap,
+        maxHandoffGap,
+        handoffAppliedTraces,
+        railEvidence,
+        tailGrowth,
+        ...evidence,
+      }, null, 2)),
+      contentType: 'application/json',
+    });
+
+    expect(
+      rawHeightCorrection,
+      `total-list-height performed a raw correction: ${JSON.stringify(evidence.traces)}`,
+    ).toBeUndefined();
+    expect(anchorHandoff, 'no synchronous spacer-exhaustion handoff was traced').toBeGreaterThan(anchorStart);
+    expect(
+      anchorDrift,
+      `active user anchor drifted across ${armedSamples.length} armed frames: ${JSON.stringify(evidence)}`,
+    ).toBeLessThanOrEqual(2);
+    expect(tailGrowth).toBeGreaterThan(railEvidence.spacerHeight);
+    expect(firstExhaustedIndex, 'the long answer never exhausted the initial spacer').toBeGreaterThanOrEqual(0);
+    expect(postExhaustionSamples.length, 'no frames were sampled after spacer exhaustion').toBeGreaterThan(0);
+    expect(
+      maxArmedBottomGap,
+      `armed frames exposed a physical bottom blind spot: ${JSON.stringify(armedSamples)}`,
+    ).toBeLessThanOrEqual(2);
+    expect(
+      maxHandoffGap,
+      `spacer exhaustion left a delayed handoff gap: ${JSON.stringify(handoffAppliedTraces)}`,
+    ).toBeLessThanOrEqual(8);
+    expect(handoffAppliedTraces).toHaveLength(4);
+    expect(
+      finalBottomGap,
+      `long reply did not settle at bottom: ${JSON.stringify(postExhaustionSamples.slice(-8))}`,
+    ).toBeLessThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## 问题

流式思考/回答增长期间，Virtuoso 高度回调、章节 rail 与多处回底逻辑会竞争 `scrollTop`，导致当前用户消息和思考块发生可见跳动；旧的 96px reserve 还会把跳动延迟到 spacer 耗尽时。

## 修复

- 为当前 user turn 建立稳定的 DOM anchor 与精确 spacer 记账，耗尽时在同一 layout pass 完成 `sync-bottom` handoff。
- 用统一 scroll intent 覆盖 composer、编辑重发、regenerate、run retry、队列恢复和 sandbox recovery，并补齐 terminal / 用户导航的终止语义。
- 移除 96px 物理预备金与 raw total-height correction；trace 改为默认关闭的运行时诊断开关。
- 增加 `data-message-id` DOM 锚点、组件级状态机测试和真实 Electron 长回复回归，覆盖章节 rail 几何及 A–E 风险面。
- 与已合入的 #318 联合验证，保留 in-run divider 与“用时”行为。

## 验证

- `npm run verify`：472 test files passed；7218 passed / 1 skipped；coverage 门禁通过。
- 定向联合测试：8 files / 110 tests passed；query-js 子包 2 files / 24 tests passed。
- `npm run test:e2e:electron -- tests/e2e/thinking-scroll-anchor.spec.ts`：真实 Electron 1 passed；112 行长回复穿过 spacer exhaustion，chapter rail/anchor/handoff/final-bottom 几何阈值均通过。
- `npm run electron:dev:check`：通过。
- `git diff --check`：通过。

## 复审重点

- anchor 在 run terminal 与用户 wheel/keyboard/scrollbar/navigation 接管后的终止语义。
- spacer 清零与 `scrollTop` 补偿是否始终处于同一 layout pass。
- #318 divider 增长期间章节 rail current tick 与 active turn anchor 是否保持一致。
