### PR TITLE
chore: sync package-lock version field to 0.42.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "abu",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "abu",
-      "version": "0.41.0",
+      "version": "0.42.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.95.2",


### PR DESCRIPTION
package.json 已是 0.42.0，但 lockfile 顶部两处 version 字段仍停在 0.41.0——任何人跑一次 `npm install` 都会产生这 2 行无关 churn 混进自己的 PR（本次 Windows 沙箱 UI 分支就撞上了）。

用 `npm install --package-lock-only` 生成，无任何依赖变化，diff 仅 2 行版本号。

🤖 Generated with [Claude Code](https://claude.com/claude-code)