### PR TITLE
fix(setup): install sub-package deps during electron dev bootstrap

### DIFF
--- a/scripts/setup-electron-dev.mjs
+++ b/scripts/setup-electron-dev.mjs
@@ -30,10 +30,10 @@ const args = npmExecPath
 console.log('[Abu Electron] 正在按 package-lock.json 安装当前 worktree 的完整依赖...');
 const childEnv = { ...process.env, NODE_ENV: 'development' };
 
-function run(commandArgs, label) {
+function run(commandArgs, label, cwd = repoRoot) {
   console.log(`\n[Abu Electron] ${label}...`);
   const result = spawnSync(command, commandArgs, {
-    cwd: repoRoot,
+    cwd,
     env: childEnv,
     stdio: 'inherit',
   });
@@ -51,6 +51,12 @@ function npmArgs(...npmArguments) {
 }
 
 run(args, '安装锁定依赖');
+// 子包各有独立的 package-lock/node_modules，CI 也是分别 npm ci
+// （.github/workflows/ci.yml）。漏装时 bootstrap 显示成功，但 verify 里
+// abu-browser-bridge 的测试会因 esbuild 解析不到子包依赖（如 linkedom）而失败。
+for (const subPackage of ['abu-browser-bridge', 'abu-chrome-extension']) {
+  run(args, `安装 ${subPackage} 子包依赖`, path.join(repoRoot, subPackage));
+}
 run(npmArgs('run', 'setup:electron-runtimes'), '准备内置 Node 和 Python');
 run(npmArgs('run', 'verify:electron-runtimes'), '校验内置运行时');
 run(npmArgs('run', 'build:electron-browser-runtime'), '构建浏览器能力');


### PR DESCRIPTION
## 问题

`npm run setup:electron-dev` 只在仓库根跑 `npm ci`，不装 `abu-browser-bridge/`、`abu-chrome-extension/` 各自的 node_modules。新 worktree bootstrap 显示「开发环境已准备完成」，但 `npm run verify` 会在 abu-browser-bridge 挂 8 个测试（esbuild 报 `Could not resolve .../abu-browser-bridge/node_modules/linkedom/worker.js`），需要手动进子包补 `npm install` 才能修复。今晚 Windows 沙箱 UI 分支的全新 worktree 实际踩到。

## 修复

照搬 CI 的做法（`.github/workflows/ci.yml` 里两个子包分别 `npm ci`），在根安装后对两个子包各跑一次锁定安装。

## 验证

- 全新 worktree 跑 `npm run setup:electron-dev`：exit 0，两个子包 node_modules 就位
- 原先失败的 `queryJs.test.ts` + `tools.test.ts`：24/24 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)