### PR TITLE
fix(chat): stop dropping sends made while the previous dispatch is settling

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,3 +40,62 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+
+  # Real-Electron E2E (tests/e2e/, playwright.electron.config.ts). Until this
+  # job existed, the Electron suite ran nowhere in CI — a green "E2E Tests"
+  # check only covered the browser suite above, so desktop-only regressions
+  # (e.g. the composer pending-send drop fixed in 03c35086) shipped invisibly.
+  # `continue-on-error` keeps it advisory while it builds a track record on
+  # hosted macOS runners; drop that line once it has been reliably green.
+  e2e-electron:
+    runs-on: macos-14
+    timeout-minutes: 60
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Setup Rust (native helper + sandbox launcher)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache pinned Electron runtimes
+        uses: actions/cache@v4
+        with:
+          path: electron/.runtime
+          key: electron-runtimes-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/setup-electron-runtimes.mjs') }}
+
+      - name: Cache cargo builds
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            electron/native-helper/target
+            electron/sandbox-launcher/target
+          key: cargo-electron-e2e-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('electron/native-helper/Cargo.lock', 'electron/sandbox-launcher/Cargo.lock') }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Not covered by the suite's global-setup (which prepares runtimes,
+      # sidecar, and renderer) but required by the tool-approval specs.
+      - name: Build sandbox launcher
+        run: npm run build:sandbox-launcher
+
+      - name: Run Electron E2E tests
+        run: npm run test:e2e:electron
+        env:
+          CI: true
+
+      - name: Upload Electron E2E traces
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: electron-e2e-test-results
+          path: test-results/
+          retention-days: 7

--- a/src/components/chat/ChatInput.agentMention.test.tsx
+++ b/src/components/chat/ChatInput.agentMention.test.tsx
@@ -160,7 +160,7 @@ describe('ChatInput inline @mention boundaries', () => {
 
     fireEvent.keyDown(textarea, { key: 'Enter' });
 
-    expect(onSend).toHaveBeenCalledWith('hello@publisher', undefined, null);
+    expect(onSend).toHaveBeenCalledWith('hello@publisher', undefined, null, expect.any(Function));
     expect(textarea.value).toBe('');
   });
 
@@ -273,7 +273,7 @@ describe('ChatInput inline @mention boundaries', () => {
       await Promise.resolve();
     });
 
-    expect(onSend).toHaveBeenCalledWith('@publisher write this', undefined, null);
+    expect(onSend).toHaveBeenCalledWith('@publisher write this', undefined, null, expect.any(Function));
     expect(screen.getByRole('button', { name: '@publisher' })).toBeTruthy();
     expect(textarea.value).toBe('write this');
   });
@@ -292,7 +292,7 @@ describe('ChatInput inline @mention boundaries', () => {
       await Promise.resolve();
     });
 
-    expect(onSend).toHaveBeenCalledWith('@publisher write this', undefined, undefined);
+    expect(onSend).toHaveBeenCalledWith('@publisher write this', undefined, undefined, expect.any(Function));
     expect(screen.getByRole('button', { name: '@publisher' })).toBeTruthy();
     expect(textarea).toHaveValue('');
   });
@@ -432,6 +432,7 @@ describe('ChatInput inline @mention boundaries', () => {
       '@publisher [Attachment: `/private/project/plan.docx`]\n\nreview this',
       undefined,
       null,
+      expect.any(Function),
     );
   });
 

--- a/src/components/chat/ChatInput.test.tsx
+++ b/src/components/chat/ChatInput.test.tsx
@@ -196,7 +196,7 @@ describe('ChatInput per-conversation drafts', () => {
       await Promise.resolve();
     });
 
-    expect(onSend).toHaveBeenCalledWith('hello', undefined, null);
+    expect(onSend).toHaveBeenCalledWith('hello', undefined, null, expect.any(Function));
     expect(textarea.value).toBe('');
     expect(readComposerDraft(WELCOME_COMPOSER_DRAFT_KEY).text).toBe('');
   });
@@ -251,7 +251,7 @@ describe('ChatInput per-conversation drafts', () => {
     ['returns false', (deferredSend: ReturnType<typeof deferred<boolean | void>>) => deferredSend.resolve(false)],
     ['rejects', (deferredSend: ReturnType<typeof deferred<boolean | void>>) => deferredSend.reject(new Error('send failed'))],
   ])('does not clobber new same-conversation typing or dispatch concurrently when a send %s', async (_outcome, settle) => {
-    useChatStore.getState().createConversation();
+    const conversationId = useChatStore.getState().createConversation();
     const send = deferred<boolean | void>();
     const onSend = vi.fn(() => send.promise);
     render(<ChatInput variant="chat" onSend={onSend} />);
@@ -262,9 +262,14 @@ describe('ChatInput per-conversation drafts', () => {
     expect(onSend).toHaveBeenCalledTimes(1);
     expect(textarea.value).toBe('');
 
+    // Typed while the initial send is still pending — staged for the queue
+    // rather than dispatched concurrently or dropped.
     fireEvent.change(textarea, { target: { value: 'new draft while pending' } });
     fireEvent.keyDown(textarea, { key: 'Enter' });
     expect(onSend).toHaveBeenCalledTimes(1);
+    expect(getQueuedInputs(conversationId).map((entry) => entry.text))
+      .toEqual(['new draft while pending']);
+    expect(textarea.value).toBe('');
 
     await act(async () => {
       settle(send);
@@ -276,9 +281,14 @@ describe('ChatInput per-conversation drafts', () => {
       await Promise.resolve();
     });
 
-    expect(textarea.value).toBe('new draft while pending\nfirst message');
+    // The failed initial send hands its own draft back; the staged follow-up
+    // stays in the queue untouched.
+    expect(textarea.value).toBe('first message');
     expect(readComposerDraft(getComposerDraftKey(useChatStore.getState().activeConversationId)).text)
-      .toBe('new draft while pending\nfirst message');
+      .toBe('first message');
+    expect(getQueuedInputs(conversationId).map((entry) => entry.text))
+      .toEqual(['new draft while pending']);
+    clearInputQueue(conversationId);
   });
 
   it('queues a pure-text follow-up while a previous initial send promise is still pending and the chat is running', async () => {
@@ -307,8 +317,77 @@ describe('ChatInput per-conversation drafts', () => {
     clearInputQueue(conversationId);
   });
 
-  it('blocks a second non-running initial dispatch with an accurate pending-send warning', () => {
+  it('releases the pending-send lock at acceptance so a new draft can dispatch mid-run', async () => {
+    // Mirrors the welcome composer's shared draft key: task A's run may take
+    // minutes, and the "new task" composer must not silently drop task B for
+    // that whole time. Once A's message is accepted (onAccepted fired), B
+    // dispatches immediately.
     useChatStore.getState().createConversation();
+    const firstRun = deferred<boolean | void>();
+    const onSend = vi.fn((
+      _message: string,
+      _images?: unknown,
+      _workspace?: unknown,
+      onAccepted?: () => void,
+    ) => {
+      onAccepted?.();
+      return firstRun.promise;
+    });
+    render(<ChatInput variant="chat" onSend={onSend} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: 'task A' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onSend).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(textarea, { target: { value: 'task B' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onSend).toHaveBeenCalledTimes(2);
+    expect(onSend.mock.calls[1][0]).toBe('task B');
+    expect(textarea.value).toBe('');
+
+    await act(async () => {
+      firstRun.resolve(true);
+      await firstRun.promise;
+    });
+  });
+
+  it('stages a follow-up typed in the post-run settling window instead of dropping it', async () => {
+    // Reproduces the task-lifecycle e2e race: the run has already published its
+    // terminal (status left 'running'), but the initial dispatch promise has
+    // not resolved yet, so the composer's pending-send guard is still held.
+    // An Enter in that window must stage the message for the live dispatcher's
+    // final queue drain — not vanish behind a toast with the draft left behind.
+    const conversationId = useChatStore.getState().createConversation();
+    const pending = deferred<boolean | void>();
+    const onSend = vi.fn(() => pending.promise);
+    render(<ChatInput variant="chat" onSend={onSend} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: 'start work' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onSend).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useChatStore.getState().setConversationStatus(conversationId, 'running');
+      useChatStore.getState().setConversationStatus(conversationId, 'completed');
+    });
+    fireEvent.change(textarea, { target: { value: 'follow up in settling window' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(getQueuedInputs(conversationId).map((entry) => entry.text))
+      .toEqual(['follow up in settling window']);
+    expect(textarea.value).toBe('');
+    await act(async () => {
+      pending.resolve(true);
+      await pending.promise;
+    });
+    clearInputQueue(conversationId);
+  });
+
+  it('stages a second non-running dispatch attempt while the first send is still pending', () => {
+    const conversationId = useChatStore.getState().createConversation();
     const pending = deferred<boolean | void>();
     const onSend = vi.fn(() => pending.promise);
     render(<ChatInput variant="chat" onSend={onSend} />);
@@ -320,14 +399,10 @@ describe('ChatInput per-conversation drafts', () => {
     fireEvent.keyDown(textarea, { key: 'Enter' });
 
     expect(onSend).toHaveBeenCalledTimes(1);
-    expect(useToastStore.getState().toasts).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: 'info',
-          title: 'A previous send is still being accepted. Wait a moment, then try again.',
-        }),
-      ]),
-    );
+    expect(getQueuedInputs(conversationId).map((entry) => entry.text)).toEqual(['second']);
+    expect(textarea.value).toBe('');
+    expect(useToastStore.getState().toasts).toEqual([]);
+    clearInputQueue(conversationId);
   });
 
   it('refuses to queue a PDF attachment while the conversation is running and preserves the draft', () => {
@@ -378,6 +453,7 @@ describe('ChatInput per-conversation drafts', () => {
       '[Attachment: `/workspace/notes.txt`]\n\nsummarize this file',
       undefined,
       undefined,
+      expect.any(Function),
     );
   });
 });
@@ -486,7 +562,7 @@ describe('ChatInput Electron attachment picker and clipboard boundary', () => {
     fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
 
     expect(onSend).toHaveBeenCalledTimes(1);
-    expect(onSend.mock.calls[0][3]).toBeUndefined();
+    expect(onSend.mock.calls[0][3]).toEqual(expect.any(Function));
     expect(electronHostMocks.authorizeElectronUserAttachment).not.toHaveBeenCalled();
   });
 
@@ -515,7 +591,7 @@ describe('ChatInput Electron attachment picker and clipboard boundary', () => {
     expect(onSend.mock.calls[0][1]).toEqual([
       expect.objectContaining({ mediaType: 'image/png' }),
     ]);
-    expect(onSend.mock.calls[0][3]).toBeUndefined();
+    expect(onSend.mock.calls[0][3]).toEqual(expect.any(Function));
   });
 
   it('releases an Electron image token after the selected image is materialized', async () => {
@@ -558,7 +634,7 @@ describe('ChatInput Electron attachment picker and clipboard boundary', () => {
 
     expect(onSend).toHaveBeenCalledTimes(1);
     expect(onSend.mock.calls[0][1]).toBeUndefined();
-    expect(onSend.mock.calls[0][3]).toBeUndefined();
+    expect(onSend.mock.calls[0][3]).toEqual(expect.any(Function));
   });
 
 
@@ -750,7 +826,7 @@ describe('ChatInput async attachment admission ownership', () => {
   });
 
   it('keeps the pending-send lock for a draft across unmount and remount', async () => {
-    useChatStore.getState().createConversation();
+    const conversationId = useChatStore.getState().createConversation();
     const send = deferred<boolean | void>();
     const onSend = vi.fn(() => send.promise);
     const rendered = render(<ChatInput variant="chat" onSend={onSend} />);
@@ -764,20 +840,16 @@ describe('ChatInput async attachment admission ownership', () => {
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'second' } });
     fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
 
+    // The lock survives the remount: no concurrent dispatch. The blocked
+    // attempt is staged for the live dispatcher instead of dropped.
     expect(onSend).toHaveBeenCalledTimes(1);
-    expect(useToastStore.getState().toasts).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: 'info',
-          title: 'A previous send is still being accepted. Wait a moment, then try again.',
-        }),
-      ]),
-    );
+    expect(getQueuedInputs(conversationId).map((entry) => entry.text)).toEqual(['second']);
 
     await act(async () => {
       send.resolve(true);
       await send.promise;
     });
+    clearInputQueue(conversationId);
   });
 
 
@@ -837,7 +909,7 @@ describe('ChatInput inline agent selection', () => {
     expect(screen.getByRole('button', { name: '@publisher' })).toBeTruthy();
 
     fireEvent.keyDown(textarea, { key: 'Enter' });
-    expect(onSend).toHaveBeenCalledWith('@publisher 请帮我优化这段文字', undefined, null);
+    expect(onSend).toHaveBeenCalledWith('@publisher 请帮我优化这段文字', undefined, null, expect.any(Function));
   });
 
   it('gives the suggestion listbox a localized accessible name', () => {

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -122,12 +122,17 @@ interface ChatInputProps {
   /**
    * Deliver the composed message. Resolving to `false` means the send was not
    * accepted (no API key, conversation busy) and the composer restores the
-   * draft it optimistically cleared.
+   * draft it optimistically cleared. `onAccepted` fires as soon as the message
+   * is durably taken (its transcript row exists) — the composer releases its
+   * pending-send lock there instead of holding it for the whole run, so a new
+   * draft under the same key (welcome composer, post-run follow-up) can send
+   * while the previous run is still executing.
    */
   onSend: (
     message: string,
     images?: ImageAttachment[],
     workspacePath?: string | null,
+    onAccepted?: () => void,
   ) => void | Promise<boolean | void>;
   disabled?: boolean;
   /** Custom placeholder from scenario guide (welcome variant only) */
@@ -1227,6 +1232,19 @@ export default function ChatInput({ variant, onSend, disabled, scenarioPlacehold
     const sentDraftKey = draftKey;
     const finishPendingSend = tryBeginComposerDraftSend(sentDraftKey);
     if (!finishPendingSend) {
+      // The guard is released only when the previous dispatch PROMISE settles,
+      // which happens after the run's visible terminal (reply rendered,
+      // status no longer 'running', send button back). An Enter in that
+      // settling window misses the isRunning staging branch above, so stage it
+      // here instead of dropping it: a held guard proves the previous dispatch
+      // chain is still live, and that chain's final queue drain runs in the
+      // same microtask turn as the guard release — a keydown can never land
+      // between them, so a message staged now is always picked up.
+      if (activeConv?.id && message && !hasRuntimeAttachments) {
+        enqueueUserInput(activeConv.id, message);
+        resetInput();
+        return;
+      }
       useToastStore.getState().addToast({
         type: 'info',
         title: t.chat.sendAlreadyPending,
@@ -1250,6 +1268,13 @@ export default function ChatInput({ variant, onSend, disabled, scenarioPlacehold
         message,
         images.length > 0 ? images : undefined,
         isWelcome ? localWorkspace : undefined,
+        // Release the lock at acceptance: once the message is in the
+        // transcript it can never be handed back (see
+        // shouldRestoreComposerAfterDispatch), so double-send protection is no
+        // longer needed and holding on would drop sends made while the run is
+        // still executing. finishPendingSend is idempotent — the .finally
+        // below stays as the release path for never-accepted sends.
+        () => finishPendingSend(),
       );
     } catch (error) {
       finishPendingSend();

--- a/src/components/chat/ChatView.composerDispatch.test.tsx
+++ b/src/components/chat/ChatView.composerDispatch.test.tsx
@@ -113,7 +113,7 @@ describe('ChatView welcome composer dispatch ownership', () => {
     expect(dispatchMock).toHaveBeenCalledWith(
       expect.any(String),
       'hello',
-      { images: undefined },
+      { images: undefined, onMessageTaken: expect.any(Function) },
     );
     await waitFor(() => expect(textarea).toHaveValue(''));
     expect(readComposerDraft(WELCOME_COMPOSER_DRAFT_KEY).text).toBe('');

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -741,6 +741,7 @@ export default function ChatView({
     text: string,
     images?: ImageAttachment[],
     workspacePath?: string | null,
+    onAccepted?: () => void,
   ) => {
     // Block sending if API key is not configured (Ollama doesn't need one).
     // Returning false hands the text back to the composer — opening settings
@@ -783,7 +784,10 @@ export default function ChatView({
     announceChatTurnScrollIntent({ conversationId: convId, source: 'composer' });
     let dispatch: AgentLoopDispatchResult;
     try {
-      dispatch = await runAgentLoopDispatched(convId, text, { images });
+      dispatch = await runAgentLoopDispatched(convId, text, {
+        images,
+        onMessageTaken: () => onAccepted?.(),
+      });
     } catch (error) {
       // The runner deliberately keeps persistence/transport failures as
       // rejections for non-UI callers. Once it has appended the user message,

--- a/src/core/agent/agentLoopRunner.ts
+++ b/src/core/agent/agentLoopRunner.ts
@@ -2712,6 +2712,10 @@ async function runSingleAgentLoopDispatchedWithOwnership(
     loopId: runId,
   });
   ownership.messageTaken = true;
+  // The documented onMessageTaken contract ("invoked once the initial user
+  // message is present in the transcript") applies to the sidecar path too —
+  // the shell row was just added above.
+  options?.onMessageTaken?.(clientMessageId);
   shellChatDelta.setConversationStatus(conversationId, 'running');
   try {
     await waitForConversationPersistence(conversationId);


### PR DESCRIPTION
## 问题

composer 的 pending-send 守卫（`tryBeginComposerDraftSend`）持有到**整条 dispatch promise 收尾**才释放，而 UI 早已宣告就绪（回复渲染完、状态 idle、发送按钮恢复）。落在这个窗口里的 Enter 被静默丢弃，只剩一条 info toast，草稿滞留在输入框。两个变体：

- **chat 视图（settling window）**：上一轮 run 刚结束、promise 未 settle 时的跟进消息被吞。`tests/e2e/task-lifecycle.spec.ts:530` 在快机器上因此确定性失败（本机 5/5，失败位置随时序在 index 2~5 漂移）。
- **welcome 视图（更严重）**：welcome composer 的 draftKey 全局共享，上一条从 welcome 发出的任务**整个首轮 run 期间**都占着守卫——「开新任务→发送」在此期间整段被吞。`tests/e2e/infra-hygiene.spec.ts:438` 因此在本机从未通过过。多任务并行是核心工作流，这是真实用户可踩的产品 bug。

CI 一直是绿的，因为 `e2e.yml` 只跑浏览器版 `e2e/`（Vite dev server），`tests/e2e/` 的真 Electron suite **在 CI 里从未执行过**。

## 修复（两层）

1. **acceptance 即释放**：消息进 transcript 时通过既有的 `onMessageTaken` 钩子释放守卫（幂等，`.finally` 兜底）。该钩子在 sidecar 派发路径此前从未被调用（文档契约覆盖但没接线，且此前零消费者），本 PR 在 shell 落消息行处补上。释放条件与草稿恢复条件严格互补（`shouldRestoreComposerAfterDispatch` 只在 `messageTaken === false` 时恢复），语义无冲突。
2. **守卫被占时入队而非丢弃**：守卫被占证明上一条 dispatch 链还活着，其最终队列排空与守卫释放在同一 microtask turn 内完成，keydown（宏任务）不可能插入其间——所以此时入队的消息必然被消费。

## 顺带

- **ci(e2e)**：新增 `e2e-electron` job（macos-14 跑 `test:e2e:electron`，缓存 pinned runtimes + cargo，失败上传 traces）。先挂 `continue-on-error: true` 观察期，稳定后删掉那行转正。
- **chore(setup)**：`setup-electron-dev.mjs` 补装 `abu-browser-bridge` 依赖（ci.yml 早已如此；本地缺口导致 fresh worktree 8 个单测报 linkedom 解析失败）。

## 验证（真 Electron 壳，macOS 本机）

- `npm run build` / `npm run lint` / `npm test` 全绿（7220 passed / 472 files）
- `task-lifecycle:530` 连续 **7 次**通过（修前 5/5 失败）
- `infra-hygiene:438` 连续 **4 次**通过（修前本机从未通过）
- 两个 spec 文件完整 3 轮 9/9 全绿，含此前因失败从未执行到的 4 个用例
- 新增 2 条组件测试钉住新契约（settling-window 入队、acceptance 即释放）；3 条钉死旧丢弃行为的测试按新契约更新，若干 onSend 实参断言补第 4 参

🤖 Generated with [Claude Code](https://claude.com/claude-code)