### PR TITLE
test(e2e): isolate ~/.abu state from the developer's real home

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -101,6 +101,23 @@ if (allowE2EAppDataRedirect && Object.hasOwn(process.env, E2E_APP_DATA_ROOT_ENV)
   // Keep its Downloads write inside the launch-specific temp root so the
   // test never leaves artifacts in a developer's real ~/Downloads folder.
   app.setPath('downloads', path.join(appDataRoot, 'Downloads'));
+  // ~/.abu is Abu's own state root (memdir memories, skills, agents, plugins,
+  // canvas history, task log, plus the managed ~/Abu default workspace), and
+  // every renderer path under it resolves through tauriHost's
+  // BaseDirectory.Home → app.getPath('home'). Left unredirected, an E2E run
+  // reads the developer's REAL memory index into its LLM requests and can
+  // write extracted junk memories back into the real store. Redirecting
+  // 'home' here — inside the same gate — moves ALL of those composition
+  // sites at once, so this stays the single decision point instead of a
+  // per-module state-root override. Documents/Desktop/Downloads resolve from
+  // their own app.getPath keys and are deliberately NOT moved by this:
+  // tests/e2e/infra-hygiene.spec.ts exercises permission scoping against
+  // fixtures in the real ~/Documents (accepted team design). The sidecar's
+  // twin resolution follows via the ABU_HOME_DIR bootstrap env var that
+  // sidecarManager passes at spawn time (see sidecar/src/bootstrap.ts).
+  const e2eHomeDir = path.join(appDataRoot, 'Home');
+  fs.mkdirSync(e2eHomeDir, { recursive: true });
+  app.setPath('home', e2eHomeDir);
   e2eTauriStorageRoot = path.join(appDataRoot, 'tauri-webview-user-data');
 }
 

--- a/sidecar/src/bootstrap.ts
+++ b/sidecar/src/bootstrap.ts
@@ -20,10 +20,21 @@
  * to handle a "bootstrap hasn't arrived yet" state during the process's
  * early lifetime). Smallest-diff, and structurally race-free by
  * construction — chosen over a `bootstrap`-style notification for this
- * reason. `homeDir()` needs NO bootstrap at all — `node:os.homedir()`
- * resolves it directly, same as `shims/memdirPaths.ts`'s established
- * pattern (copied here for `tauriPathRun.ts`'s `homeDir()`, not
- * reinvented).
+ * reason.
+ *
+ * ── Home (`ABU_HOME_DIR`, resolved by `resolveHomeDir()` below) ──────────
+ * Home IS derivable in plain Node (`node:os.homedir()`), and that used to be
+ * the whole story here. But the SHELL's home can legitimately differ from
+ * the OS home: `electron/main.cjs`'s gated E2E block redirects
+ * `app.getPath('home')` into the launch-scoped data root so isolated E2E
+ * runs never read or write the developer's real `~/.abu` state (memdir
+ * memories leaked into LLM requests otherwise — observed 2026-09-01). The
+ * shell therefore also passes its own resolved `homeDir()` down as
+ * `ABU_HOME_DIR`, so both processes compose identical `~/.abu/...` paths in
+ * every mode. Unlike the two vars above this one is fail-SOFT at read time:
+ * `os.homedir()` is a correct fallback (equal to the shell's value in every
+ * non-redirected run), so a spawn that omitted the var keeps the exact
+ * pre-existing behavior instead of throwing.
  *
  * ── Fail-loud discipline ──────────────────────────────────────────────────
  * If the shell failed to resolve `appDataDir()`/`resourceDir()` before
@@ -55,6 +66,9 @@
  * message-handler registration required.
  */
 
+import { homedir } from 'node:os';
+import { isAbsolute } from 'node:path';
+
 export interface SidecarBootstrap {
   appDataDir: string;
   resourceDir: string;
@@ -81,6 +95,21 @@ export function getBootstrap(): SidecarBootstrap {
     };
   }
   return cached;
+}
+
+/**
+ * The user home directory as the SHELL resolves it — `ABU_HOME_DIR` when the
+ * spawn provided a usable (absolute) value, else `node:os.homedir()`. Every
+ * sidecar-side `~/...` composition (memdir state in `shims/memdirPaths.ts`,
+ * `shims/tauriPathRun.ts`'s `homeDir()`) MUST go through this so renderer and
+ * sidecar resolve identical `~/.abu/...` paths even when the shell's home is
+ * redirected (E2E isolation). A malformed value is ignored, not thrown on:
+ * the fallback is exactly the pre-`ABU_HOME_DIR` behavior.
+ */
+export function resolveHomeDir(): string {
+  const v = process.env.ABU_HOME_DIR;
+  if (v && isAbsolute(v)) return v;
+  return homedir();
 }
 
 /** Test-only reset. */

--- a/sidecar/src/shims/memdirPaths.ts
+++ b/sidecar/src/shims/memdirPaths.ts
@@ -13,13 +13,15 @@
  * left unshimmed — that's a silent, total feature loss, not an acceptable
  * degradation. So this gets a real shim, not a stub.
  *
- * `os.homedir()` is the direct Node equivalent of Tauri's `homeDir()` —
- * both resolve to the OS user home directory on the same machine (the
- * sidecar and the webview are separate PROCESSES but always run on the
- * SAME machine as siblings under one Tauri app instance), so both sides
- * resolve to the identical `~/.abu/...` paths for the same workspace,
- * which matters because the shell and the sidecar may both read/write the
- * same memory files across different runs.
+ * Home comes from `bootstrap.ts`'s `resolveHomeDir()` — the shell's own
+ * resolved home passed down as the `ABU_HOME_DIR` spawn env var, falling
+ * back to `os.homedir()` (the direct Node equivalent of Tauri's `homeDir()`
+ * — sidecar and webview are separate PROCESSES but always siblings on the
+ * SAME machine). The env var matters because the shell's home is NOT always
+ * the OS home: E2E launches redirect `app.getPath('home')` into an isolated
+ * data root (see electron/main.cjs), and both sides must keep resolving the
+ * identical `~/.abu/...` paths for the same workspace — the shell and the
+ * sidecar both read/write the same memory files across different runs.
  *
  * `sanitizePath`/`djb2Hash`/directory-composition logic is copied
  * VERBATIM from the real `paths.ts` (not reimplemented from scratch) to
@@ -33,7 +35,7 @@
  * `getMemoryDir`), so they're intentionally omitted rather than
  * speculatively duplicated.
  */
-import { homedir } from 'node:os';
+import { resolveHomeDir } from '../bootstrap';
 
 const MAX_SANITIZED_LENGTH = 200;
 
@@ -75,7 +77,7 @@ export function sanitizePath(name: string): string {
 }
 
 export async function getMemoryDir(workspacePath?: string | null): Promise<string> {
-  const home = homedir();
+  const home = resolveHomeDir();
   if (workspacePath) {
     const normalized = normalizeSeparators(workspacePath);
     const key = sanitizePath(normalized);

--- a/sidecar/src/shims/tauriPathRun.ts
+++ b/sidecar/src/shims/tauriPathRun.ts
@@ -56,10 +56,23 @@
  */
 import { homedir, tmpdir } from 'node:os';
 import { resolve as nodeResolve, join as nodeJoin } from 'node:path';
-import { getBootstrap } from '../bootstrap';
+import { getBootstrap, resolveHomeDir } from '../bootstrap';
 
+/**
+ * Shell-aligned home, not raw `os.homedir()`: the shell's tauriHost resolves
+ * `BaseDirectory.Home` via `app.getPath('home')`, which E2E launches redirect
+ * into an isolated data root — `resolveHomeDir()` follows it through the
+ * `ABU_HOME_DIR` spawn env var (falling back to `os.homedir()`, the identical
+ * value in every non-redirected run). Keeps sidecar-side `~/.abu` consumers
+ * (skill/loader.ts, outputSnapshots.ts) resolving the same paths as the
+ * renderer. The Desktop/Documents/Downloads helpers below intentionally stay
+ * on raw `os.homedir()`: tauriHost resolves those from their own
+ * `app.getPath('desktop'|'documents'|'downloads')` keys, which the E2E home
+ * redirect deliberately does NOT move (tests/e2e/infra-hygiene.spec.ts
+ * exercises permission scoping against the real ~/Documents).
+ */
 export async function homeDir(): Promise<string> {
-  return homedir();
+  return resolveHomeDir();
 }
 
 export async function appDataDir(): Promise<string> {

--- a/src/core/sidecar/sidecarManager.ts
+++ b/src/core/sidecar/sidecarManager.ts
@@ -117,7 +117,7 @@
 
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
-import { resolveResource, appDataDir, resourceDir } from '@tauri-apps/api/path';
+import { resolveResource, appDataDir, homeDir, resourceDir } from '@tauri-apps/api/path';
 import { isTauriEnv } from '@/utils/tauriEnv';
 import { createLogger } from '@/core/logging/logger';
 import { useEnterpriseStore } from '@/stores/enterpriseStore';
@@ -693,6 +693,21 @@ async function attemptSpawn(kind: 'initial' | 'restart'): Promise<void> {
     spawnEnv.ABU_RESOURCE_DIR = await resourceDir();
   } catch (err) {
     logger.warn('Failed to resolve resourceDir for sidecar bootstrap', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  // Home is derivable in plain Node (os.homedir()), but the SHELL's home can
+  // legitimately differ from it: electron/main.cjs redirects
+  // app.getPath('home') into the launch-scoped E2E data root so isolated runs
+  // never touch the developer's real ~/.abu state. Passing the shell-resolved
+  // value keeps sidecar-side ~/.abu paths (memdir, skills) identical to the
+  // renderer's BY CONSTRUCTION in every mode — in a normal run it equals
+  // os.homedir(), so behavior is unchanged. Fail-soft like the two above:
+  // sidecar/src/bootstrap.ts falls back to os.homedir() when absent.
+  try {
+    spawnEnv.ABU_HOME_DIR = await homeDir();
+  } catch (err) {
+    logger.warn('Failed to resolve homeDir for sidecar bootstrap', {
       error: err instanceof Error ? err.message : String(err),
     });
   }


### PR DESCRIPTION
## 问题

E2E 启动重定向了 appData/userData/downloads，但没重定向 `home`——所有 `~/.abu` 消费者（memdir 记忆、skills、agents、plugins、canvas-history）在 E2E 里都读写开发者的**真实**状态：

- 记忆提取请求把真实记忆索引（含具体条目名）发给测试配置的任意 endpoint（实测抓到 5/5 条请求携带真实条目）；
- E2E 跑动过程还可能把 mock 对话提取出的垃圾记忆**写回**真实存储；
- 测试行为依赖开发机上碰巧存在的记忆/skills 内容，本机与 CI（干净 runner）条件不一致。

## 方案

在 `main.cjs` 既有的 `ABU_E2E_APP_DATA_ROOT` 门控块内重定向 `app.getPath('home')`——renderer 所有 `~/.abu` 组合点都汇聚在 tauriHost `BaseDirectory.Home` 这一个咽喉，单点即可隔离全部状态。sidecar 侧通过 spawn 时传 `ABU_HOME_DIR`（沿用 `ABU_APP_DATA_DIR` 既有模式）+ `bootstrap.ts` 新增 fail-soft 的 `resolveHomeDir()`，两进程按构造解析出相同的 `~/.abu` 路径。

刻意**不动** Documents/Desktop/Downloads——它们走各自独立的 `app.getPath` key，infra-hygiene 针对真实 `~/Documents` fixture 的权限作用域测试（既定团队设计）不受影响。正常/打包构建行为不变：env 值等于 `os.homedir()`，缺省时回落为改动前的原行为。

## 验证（基于合并 #324 后的 dev，真 Electron 壳）

- `npm run build` / `npm run lint` / `npm run typecheck:sidecar` / `npm test`（7220 passed）全绿
- 完整 Electron E2E：**35 passed / 0 failed**（含 task-lifecycle 6/6、infra-hygiene 3/3——`~/Documents` 权限流不受 home 重定向影响的实证）
- 泄漏前后对照：改动前 5/5 条 memory 提取请求携带真实记忆索引条目；改动后逐条检查 `hasRealEntry=false`、索引清单段不存在（消息里仅剩提取指令的固定引用话术）。事后确认真实 `~/.abu/memory` 逐字节未动。
- 附带收益：无工作区会话不再写进开发者真实的 `~/Abu` 默认工作区。

🤖 Generated with [Claude Code](https://claude.com/claude-code)