### PR TITLE
feat(browser): stop propagation, takeover & rate-limit backoff (批次2.5 PR-B)

### DIFF
--- a/abu-browser-bridge/src/abortSignal.test.ts
+++ b/abu-browser-bridge/src/abortSignal.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import { linkAbortSignal } from './abortSignal.js';
+
+describe('linkAbortSignal', () => {
+  it('does nothing and returns a no-op cleanup when no signal is given', () => {
+    const onAbort = vi.fn();
+    const cleanup = linkAbortSignal(undefined, onAbort);
+
+    expect(onAbort).not.toHaveBeenCalled();
+    expect(() => cleanup()).not.toThrow();
+  });
+
+  it('fires onAbort synchronously when the signal is already aborted', () => {
+    const controller = new AbortController();
+    controller.abort();
+    const onAbort = vi.fn();
+
+    const cleanup = linkAbortSignal(controller.signal, onAbort);
+
+    expect(onAbort).toHaveBeenCalledTimes(1);
+    // Nothing left to detach — calling cleanup must still be safe.
+    expect(() => cleanup()).not.toThrow();
+  });
+
+  it('fires onAbort when the signal aborts later', () => {
+    const controller = new AbortController();
+    const onAbort = vi.fn();
+
+    linkAbortSignal(controller.signal, onAbort);
+    expect(onAbort).not.toHaveBeenCalled();
+
+    controller.abort();
+    expect(onAbort).toHaveBeenCalledTimes(1);
+  });
+
+  it('never fires onAbort again after cleanup runs first', () => {
+    const controller = new AbortController();
+    const onAbort = vi.fn();
+
+    const cleanup = linkAbortSignal(controller.signal, onAbort);
+    cleanup();
+    controller.abort();
+
+    expect(onAbort).not.toHaveBeenCalled();
+  });
+
+  it('only fires once even if abort fires multiple listeners scenario', () => {
+    const controller = new AbortController();
+    const onAbort = vi.fn();
+    linkAbortSignal(controller.signal, onAbort);
+
+    controller.abort();
+    // Aborting an already-aborted controller is a no-op in the DOM spec, but
+    // guard the assumption explicitly since AbortController has no "abort
+    // twice" API to invoke directly.
+    expect(onAbort).toHaveBeenCalledTimes(1);
+  });
+});

--- a/abu-browser-bridge/src/abortSignal.ts
+++ b/abu-browser-bridge/src/abortSignal.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared helper for wiring an external `AbortSignal` into a transport's own
+ * cancellation mechanism (a WS request's pending-map entry, an internal
+ * `AbortController` backing a `fetch`, ...).
+ *
+ * Both browser transports (`chromeWsTransport` in tools.ts/wsServer.ts, and
+ * `HttpBrowserTransport` in electron/browser-runtime/server.ts) need the same
+ * three behaviors — trigger a callback on abort, do it synchronously if the
+ * signal is already aborted before we start waiting, and never leak the
+ * listener once the operation settles by any other means (success, timeout,
+ * disconnect) — so the logic lives here once instead of being duplicated (and
+ * drifting) in each transport.
+ */
+
+/**
+ * Attach `onAbort` to `signal`. If `signal` is already aborted, `onAbort`
+ * fires synchronously before this function returns (so the caller can skip
+ * ever starting the underlying operation) and the returned cleanup is a
+ * no-op. Otherwise `onAbort` fires at most once, and the returned cleanup
+ * detaches the listener so it never fires after the operation has already
+ * settled some other way.
+ *
+ * Returns a no-op cleanup (and never calls `onAbort`) when `signal` is
+ * `undefined`, so callers can use this unconditionally.
+ */
+export function linkAbortSignal(signal: AbortSignal | undefined, onAbort: () => void): () => void {
+  if (!signal) {
+    return () => {};
+  }
+  if (signal.aborted) {
+    onAbort();
+    return () => {};
+  }
+  signal.addEventListener('abort', onAbort, { once: true });
+  return () => signal.removeEventListener('abort', onAbort);
+}

--- a/abu-browser-bridge/src/tools.test.ts
+++ b/abu-browser-bridge/src/tools.test.ts
@@ -148,11 +148,12 @@ describe('tool surface', () => {
 
     await snapshot.handler({ tabId: 7, selector: '.ant-form', maxChars: 5000 });
 
-    expect(transport.send).toHaveBeenCalledWith('snapshot', {
-      tabId: 7,
-      selector: '.ant-form',
-      maxChars: 5000,
-    });
+    expect(transport.send).toHaveBeenCalledWith(
+      'snapshot',
+      { tabId: 7, selector: '.ant-form', maxChars: 5000 },
+      undefined,
+      { signal: undefined }
+    );
   });
 
   it('reads HTML first, then evaluates query_js outside the page transport', async () => {
@@ -169,7 +170,12 @@ describe('tool surface', () => {
       code: '({ title: document.querySelector("h1").textContent, count: document.querySelectorAll("[data-kind]").length })',
     }) as { content: Array<{ text: string }> };
 
-    expect(transport.send).toHaveBeenCalledWith('get_html', { tabId: 9, selector: 'main' });
+    expect(transport.send).toHaveBeenCalledWith(
+      'get_html',
+      { tabId: 9, selector: 'main' },
+      undefined,
+      { signal: undefined }
+    );
     expect(result.content[0].text).toContain('"title": "Hello"');
     expect(result.content[0].text).toContain('"count": 1');
     expect(result.content[0].text).toContain('note: this ran against a read-only copy');
@@ -185,10 +191,15 @@ describe('ownerId forwarding', () => {
 
     // get_tabs takes no input schema, so its only parameter is `extra`.
     await getTabs.handler({});
-    expect(transport.send).toHaveBeenLastCalledWith('get_tabs', {});
+    expect(transport.send).toHaveBeenLastCalledWith('get_tabs', {}, undefined, { signal: undefined });
 
     await getTabs.handler(metaWithOwner);
-    expect(transport.send).toHaveBeenLastCalledWith('get_tabs', { ownerId: 'conv-42' });
+    expect(transport.send).toHaveBeenLastCalledWith(
+      'get_tabs',
+      { ownerId: 'conv-42' },
+      undefined,
+      { signal: undefined }
+    );
   });
 
   it('get_tabs forwards createIfEmpty:false only when the caller opted out of provisioning', async () => {
@@ -203,10 +214,12 @@ describe('ownerId forwarding', () => {
         [ABU_CREATE_IF_EMPTY_META_KEY]: false,
       },
     });
-    expect(transport.send).toHaveBeenLastCalledWith('get_tabs', {
-      ownerId: 'conv-42',
-      createIfEmpty: false,
-    });
+    expect(transport.send).toHaveBeenLastCalledWith(
+      'get_tabs',
+      { ownerId: 'conv-42', createIfEmpty: false },
+      undefined,
+      { signal: undefined }
+    );
 
     // Anything other than an explicit `false` keeps the historical payload
     // shape, so the host keeps its create-when-empty default.
@@ -216,7 +229,12 @@ describe('ownerId forwarding', () => {
         [ABU_CREATE_IF_EMPTY_META_KEY]: true,
       },
     });
-    expect(transport.send).toHaveBeenLastCalledWith('get_tabs', { ownerId: 'conv-42' });
+    expect(transport.send).toHaveBeenLastCalledWith(
+      'get_tabs',
+      { ownerId: 'conv-42' },
+      undefined,
+      { signal: undefined }
+    );
   });
 
   it('click omits ownerId without a conversation id, and includes it with one', async () => {
@@ -224,14 +242,20 @@ describe('ownerId forwarding', () => {
     const click = registered.find((t) => t.name === 'click')!;
 
     await click.handler({ tabId: 1, locator: '{"css":"#a"}' });
-    expect(transport.send).toHaveBeenLastCalledWith('click', { tabId: 1, locator: { css: '#a' } });
+    expect(transport.send).toHaveBeenLastCalledWith(
+      'click',
+      { tabId: 1, locator: { css: '#a' } },
+      undefined,
+      { signal: undefined }
+    );
 
     await click.handler({ tabId: 1, locator: '{"css":"#a"}' }, metaWithOwner);
-    expect(transport.send).toHaveBeenLastCalledWith('click', {
-      tabId: 1,
-      locator: { css: '#a' },
-      ownerId: 'conv-42',
-    });
+    expect(transport.send).toHaveBeenLastCalledWith(
+      'click',
+      { tabId: 1, locator: { css: '#a' }, ownerId: 'conv-42' },
+      undefined,
+      { signal: undefined }
+    );
   });
 
   it('navigate omits ownerId without a conversation id, and includes it with one', async () => {
@@ -239,19 +263,20 @@ describe('ownerId forwarding', () => {
     const navigate = registered.find((t) => t.name === 'navigate')!;
 
     await navigate.handler({ tabId: 2, url: 'https://example.com', action: 'goto' });
-    expect(transport.send).toHaveBeenLastCalledWith('navigate', {
-      tabId: 2,
-      url: 'https://example.com',
-      action: 'goto',
-    });
+    expect(transport.send).toHaveBeenLastCalledWith(
+      'navigate',
+      { tabId: 2, url: 'https://example.com', action: 'goto' },
+      undefined,
+      { signal: undefined }
+    );
 
     await navigate.handler({ tabId: 2, url: 'https://example.com', action: 'goto' }, metaWithOwner);
-    expect(transport.send).toHaveBeenLastCalledWith('navigate', {
-      tabId: 2,
-      url: 'https://example.com',
-      action: 'goto',
-      ownerId: 'conv-42',
-    });
+    expect(transport.send).toHaveBeenLastCalledWith(
+      'navigate',
+      { tabId: 2, url: 'https://example.com', action: 'goto', ownerId: 'conv-42' },
+      undefined,
+      { signal: undefined }
+    );
   });
 
   it('screenshot omits ownerId without a conversation id, and includes it with one', async () => {
@@ -259,10 +284,20 @@ describe('ownerId forwarding', () => {
     const screenshot = registered.find((t) => t.name === 'screenshot')!;
 
     await screenshot.handler({ tabId: 3 });
-    expect(transport.send).toHaveBeenLastCalledWith('screenshot', { tabId: 3 });
+    expect(transport.send).toHaveBeenLastCalledWith(
+      'screenshot',
+      { tabId: 3 },
+      undefined,
+      { signal: undefined }
+    );
 
     await screenshot.handler({ tabId: 3 }, metaWithOwner);
-    expect(transport.send).toHaveBeenLastCalledWith('screenshot', { tabId: 3, ownerId: 'conv-42' });
+    expect(transport.send).toHaveBeenLastCalledWith(
+      'screenshot',
+      { tabId: 3, ownerId: 'conv-42' },
+      undefined,
+      { signal: undefined }
+    );
   });
 
   it('query_js omits ownerId without a conversation id, and includes it with one on the get_html call', async () => {
@@ -276,14 +311,92 @@ describe('ownerId forwarding', () => {
     vi.mocked(transport.send).mockResolvedValue({ success: true, data: '<html></html>' });
 
     await query.handler({ tabId: 9, code: '1' }).catch(() => {});
-    expect(transport.send).toHaveBeenLastCalledWith('get_html', { tabId: 9, selector: undefined });
+    expect(transport.send).toHaveBeenLastCalledWith(
+      'get_html',
+      { tabId: 9, selector: undefined },
+      undefined,
+      { signal: undefined }
+    );
 
     await query.handler({ tabId: 9, code: '1' }, metaWithOwner).catch(() => {});
-    expect(transport.send).toHaveBeenLastCalledWith('get_html', {
-      tabId: 9,
-      selector: undefined,
-      ownerId: 'conv-42',
+    expect(transport.send).toHaveBeenLastCalledWith(
+      'get_html',
+      { tabId: 9, selector: undefined, ownerId: 'conv-42' },
+      undefined,
+      { signal: undefined }
+    );
+  });
+});
+
+// Task B2: `extra.signal` is the MCP SDK's per-request AbortSignal
+// (RequestHandlerExtra.signal), which fires when the client cancels the tool
+// call (see B1: the conversation's abort signal reaches the SDK's callTool()
+// options). Every handler must forward it into transport.send()'s 4th param
+// so an aborted conversation stops a browser action from hanging until its
+// own (sometimes 120s) timeout.
+describe('abort signal forwarding', () => {
+  it('forwards extra.signal as the 4th transport.send() argument', async () => {
+    const { registered, transport } = collectTools();
+    const controller = new AbortController();
+    const click = registered.find((t) => t.name === 'click')!;
+
+    await click.handler({ tabId: 1, locator: '{"css":"#a"}' }, { signal: controller.signal });
+
+    expect(transport.send).toHaveBeenLastCalledWith(
+      'click',
+      { tabId: 1, locator: { css: '#a' } },
+      undefined,
+      { signal: controller.signal }
+    );
+  });
+
+  it('forwards the signal alongside a custom timeout for wait_for', async () => {
+    const { registered, transport } = collectTools();
+    const controller = new AbortController();
+    const waitFor = registered.find((t) => t.name === 'wait_for')!;
+
+    await waitFor.handler(
+      { tabId: 1, condition: '{"type":"appear","locator":{"css":"#a"}}', timeout: 1000 },
+      { signal: controller.signal }
+    );
+
+    expect(transport.send).toHaveBeenLastCalledWith(
+      'wait_for',
+      { tabId: 1, condition: { type: 'appear', locator: { css: '#a' } }, timeout: 1000 },
+      6000,
+      { signal: controller.signal }
+    );
+  });
+
+  it('ignores a non-AbortSignal value under extra.signal rather than forwarding garbage', async () => {
+    const { registered, transport } = collectTools();
+    const click = registered.find((t) => t.name === 'click')!;
+
+    await click.handler({ tabId: 1, locator: '{"css":"#a"}' }, { signal: 'not-a-signal' });
+
+    expect(transport.send).toHaveBeenLastCalledWith(
+      'click',
+      { tabId: 1, locator: { css: '#a' } },
+      undefined,
+      { signal: undefined }
+    );
+  });
+
+  it('rejects the tool call when the transport rejects because the signal was aborted mid-flight', async () => {
+    const { registered, transport } = collectTools();
+    const controller = new AbortController();
+    const click = registered.find((t) => t.name === 'click')!;
+    const abortError = new DOMException('The operation was aborted.', 'AbortError');
+    vi.mocked(transport.send).mockImplementationOnce(() => {
+      // Simulates chromeWsTransport/HttpBrowserTransport rejecting once the
+      // signal they were handed fires while the request is still in flight.
+      controller.abort();
+      return Promise.reject(abortError);
     });
+
+    await expect(
+      click.handler({ tabId: 1, locator: '{"css":"#a"}' }, { signal: controller.signal })
+    ).rejects.toThrow('The operation was aborted');
   });
 });
 

--- a/abu-browser-bridge/src/tools.ts
+++ b/abu-browser-bridge/src/tools.ts
@@ -37,7 +37,8 @@ export interface BrowserTransport {
   send(
     action: string,
     payload?: Record<string, unknown>,
-    timeoutMs?: number
+    timeoutMs?: number,
+    opts?: { signal?: AbortSignal }
   ): Promise<BrowserTransportResponse>;
   isConnected(): boolean | Promise<boolean>;
   getConnectionError(): string;
@@ -48,10 +49,10 @@ const BROWSER_EXTENSION_NOT_CONNECTED =
   'Browser extension is not connected. Please install and enable the Abu Browser Extension, then check the connection status in the extension popup.';
 
 const chromeWsTransport: BrowserTransport = {
-  send: async (action, payload = {}, timeoutMs = 30_000) => {
+  send: async (action, payload = {}, timeoutMs = 30_000, opts) => {
     const { sendToExtension, isExtensionConnected } = await import('./wsServer.js');
     try {
-      return await sendToExtension(action, payload, timeoutMs);
+      return await sendToExtension(action, payload, timeoutMs, opts?.signal);
     } catch (err) {
       if (!isExtensionConnected()) {
         throw new Error(BROWSER_EXTENSION_NOT_CONNECTED, { cause: err });
@@ -111,6 +112,36 @@ function createIfEmptyFromExtra(extra: unknown): false | undefined {
   return meta?.[ABU_CREATE_IF_EMPTY_META_KEY] === false ? false : undefined;
 }
 
+/**
+ * Pull the per-request `AbortSignal` out of a tool handler's `extra` (the MCP
+ * SDK's `RequestHandlerExtra.signal`, set for every request). The SDK fires
+ * this when the client sends a `notifications/cancelled` for the request
+ * (see B1: the desktop client passes the conversation's abort signal into
+ * `callTool`'s SDK options), so a handler that forwards it into
+ * `transport.send()` lets an aborted run stop waiting on the extension/host
+ * instead of hanging until the tool's own timeout.
+ */
+function signalFromExtra(extra: unknown): AbortSignal | undefined {
+  const signal = (extra as { signal?: unknown } | undefined)?.signal;
+  return signal instanceof AbortSignal ? signal : undefined;
+}
+
+/**
+ * Every handler's `transport.send()` call, with the caller's abort signal
+ * always forwarded as the 4th param. Centralized so "pass extra.signal
+ * through" isn't repeated (and can't silently drift) at each of the 19 call
+ * sites below.
+ */
+function sendWithSignal(
+  transport: BrowserTransport,
+  action: string,
+  payload: Record<string, unknown>,
+  extra: unknown,
+  timeoutMs?: number
+): Promise<BrowserTransportResponse> {
+  return transport.send(action, payload, timeoutMs, { signal: signalFromExtra(extra) });
+}
+
 function formatResult(response: BrowserTransportResponse): string {
   if (!response.success) {
     return `Error: ${response.error ?? 'Unknown error'}`;
@@ -165,10 +196,10 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
       await ensureConnected(transport);
       const ownerId = ownerFromExtra(extra);
       const createIfEmpty = createIfEmptyFromExtra(extra);
-      const res = await transport.send('get_tabs', {
+      const res = await sendWithSignal(transport, 'get_tabs', {
         ...(ownerId ? { ownerId } : {}),
         ...(createIfEmpty === false ? { createIfEmpty: false } : {}),
-      });
+      }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -185,7 +216,7 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     async ({ tabId, selector, maxChars }, extra) => {
       await ensureConnected(transport);
       const ownerId = ownerFromExtra(extra);
-      const res = await transport.send('snapshot', { tabId, selector, maxChars, ...(ownerId ? { ownerId } : {}) });
+      const res = await sendWithSignal(transport, 'snapshot', { tabId, selector, maxChars, ...(ownerId ? { ownerId } : {}) }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -202,7 +233,7 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
       await ensureConnected(transport);
       const parsed = parseLocator(locator);
       const ownerId = ownerFromExtra(extra);
-      const res = await transport.send('click', { tabId, locator: parsed, ...(ownerId ? { ownerId } : {}) });
+      const res = await sendWithSignal(transport, 'click', { tabId, locator: parsed, ...(ownerId ? { ownerId } : {}) }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -220,7 +251,7 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
       await ensureConnected(transport);
       const parsed = parseLocator(locator);
       const ownerId = ownerFromExtra(extra);
-      const res = await transport.send('fill', { tabId, locator: parsed, value, ...(ownerId ? { ownerId } : {}) });
+      const res = await sendWithSignal(transport, 'fill', { tabId, locator: parsed, value, ...(ownerId ? { ownerId } : {}) }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -238,7 +269,7 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
       await ensureConnected(transport);
       const parsed = parseLocator(locator);
       const ownerId = ownerFromExtra(extra);
-      const res = await transport.send('select', { tabId, locator: parsed, value, ...(ownerId ? { ownerId } : {}) });
+      const res = await sendWithSignal(transport, 'select', { tabId, locator: parsed, value, ...(ownerId ? { ownerId } : {}) }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -263,9 +294,11 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
       await ensureConnected(transport);
       const parsed = parseCondition(condition);
       const ownerId = ownerFromExtra(extra);
-      const res = await transport.send(
+      const res = await sendWithSignal(
+        transport,
         'wait_for',
         { tabId, condition: parsed, timeout, ...(ownerId ? { ownerId } : {}) },
+        extra,
         timeout + 5000
       );
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
@@ -283,7 +316,7 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     async ({ tabId, selector }, extra) => {
       await ensureConnected(transport);
       const ownerId = ownerFromExtra(extra);
-      const res = await transport.send('extract_text', { tabId, selector, ...(ownerId ? { ownerId } : {}) });
+      const res = await sendWithSignal(transport, 'extract_text', { tabId, selector, ...(ownerId ? { ownerId } : {}) }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -299,7 +332,7 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     async ({ tabId, selector }, extra) => {
       await ensureConnected(transport);
       const ownerId = ownerFromExtra(extra);
-      const res = await transport.send('extract_table', { tabId, selector, ...(ownerId ? { ownerId } : {}) });
+      const res = await sendWithSignal(transport, 'extract_table', { tabId, selector, ...(ownerId ? { ownerId } : {}) }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -317,7 +350,7 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     async ({ tabId, direction, amount, selector }, extra) => {
       await ensureConnected(transport);
       const ownerId = ownerFromExtra(extra);
-      const res = await transport.send('scroll', { tabId, direction, amount, selector, ...(ownerId ? { ownerId } : {}) });
+      const res = await sendWithSignal(transport, 'scroll', { tabId, direction, amount, selector, ...(ownerId ? { ownerId } : {}) }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -334,7 +367,7 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     async ({ tabId, url, action }, extra) => {
       await ensureConnected(transport);
       const ownerId = ownerFromExtra(extra);
-      const res = await transport.send('navigate', { tabId, url, action, ...(ownerId ? { ownerId } : {}) });
+      const res = await sendWithSignal(transport, 'navigate', { tabId, url, action, ...(ownerId ? { ownerId } : {}) }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -351,7 +384,7 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     async ({ tabId, key, modifiers }, extra) => {
       await ensureConnected(transport);
       const ownerId = ownerFromExtra(extra);
-      const res = await transport.send('keyboard', { tabId, key, modifiers, ...(ownerId ? { ownerId } : {}) });
+      const res = await sendWithSignal(transport, 'keyboard', { tabId, key, modifiers, ...(ownerId ? { ownerId } : {}) }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -367,7 +400,7 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     async ({ tabId, code }, extra) => {
       await ensureConnected(transport);
       const ownerId = ownerFromExtra(extra);
-      const res = await transport.send('execute_js', { tabId, code, ...(ownerId ? { ownerId } : {}) }, 60_000);
+      const res = await sendWithSignal(transport, 'execute_js', { tabId, code, ...(ownerId ? { ownerId } : {}) }, extra, 60_000);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -384,7 +417,7 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     async ({ tabId, code, selector }, extra) => {
       await ensureConnected(transport);
       const ownerId = ownerFromExtra(extra);
-      const htmlResponse = await transport.send('get_html', { tabId, selector, ...(ownerId ? { ownerId } : {}) });
+      const htmlResponse = await sendWithSignal(transport, 'get_html', { tabId, selector, ...(ownerId ? { ownerId } : {}) }, extra);
       if (!htmlResponse.success) {
         throw new Error(htmlResponse.error ?? 'Failed to read page HTML');
       }
@@ -406,7 +439,7 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     async ({ tabId }, extra) => {
       await ensureConnected(transport);
       const ownerId = ownerFromExtra(extra);
-      const res = await transport.send('screenshot', { tabId, ...(ownerId ? { ownerId } : {}) });
+      const res = await sendWithSignal(transport, 'screenshot', { tabId, ...(ownerId ? { ownerId } : {}) }, extra);
       if (res.success && typeof res.data === 'string') {
         return {
           content: [{
@@ -431,7 +464,7 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
       await ensureConnected(transport);
       const ownerId = ownerFromExtra(extra);
       // Full-page capture needs more time: scroll + multiple captures + stitch
-      const res = await transport.send('screenshot_full_page', { tabId, ...(ownerId ? { ownerId } : {}) }, 120_000);
+      const res = await sendWithSignal(transport, 'screenshot_full_page', { tabId, ...(ownerId ? { ownerId } : {}) }, extra, 120_000);
       if (res.success && typeof res.data === 'string') {
         return {
           content: [{
@@ -468,7 +501,7 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     async (extra) => {
       await ensureConnected(transport);
       const ownerId = ownerFromExtra(extra);
-      const res = await transport.send('get_downloads', ownerId ? { ownerId } : {});
+      const res = await sendWithSignal(transport, 'get_downloads', ownerId ? { ownerId } : {}, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -483,7 +516,7 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     async ({ tabId }, extra) => {
       await ensureConnected(transport);
       const ownerId = ownerFromExtra(extra);
-      const res = await transport.send('start_recording', { tabId, ...(ownerId ? { ownerId } : {}) });
+      const res = await sendWithSignal(transport, 'start_recording', { tabId, ...(ownerId ? { ownerId } : {}) }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -498,7 +531,7 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     async ({ tabId }, extra) => {
       await ensureConnected(transport);
       const ownerId = ownerFromExtra(extra);
-      const res = await transport.send('stop_recording', { tabId, ...(ownerId ? { ownerId } : {}) });
+      const res = await sendWithSignal(transport, 'stop_recording', { tabId, ...(ownerId ? { ownerId } : {}) }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );

--- a/abu-browser-bridge/src/types.ts
+++ b/abu-browser-bridge/src/types.ts
@@ -21,6 +21,17 @@ export interface BridgeResponse {
   error?: string;
 }
 
+/**
+ * Sent Bridge → Extension when the caller aborts before a response for
+ * `requestId` arrived. The extension is not required to act on it (this PR
+ * only asks it not to crash on an unrecognized message shape); it exists so a
+ * future extension version can stop in-flight work early.
+ */
+export interface BridgeCancelMessage {
+  type: 'cancel';
+  requestId: string;
+}
+
 // --- Element Locator (multi-strategy targeting) ---
 // All fields optional — only one strategy should be specified per locator.
 

--- a/abu-browser-bridge/src/wsServer.test.ts
+++ b/abu-browser-bridge/src/wsServer.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Task B2: `sendToExtension`'s abort handling — stop waiting for the
+ * extension's response and tell it to stop working via a
+ * `{type:'cancel', requestId}` message, without leaking the timeout timer or
+ * the abort listener.
+ *
+ * No real sockets: per this repo's determinism rule (no real network in
+ * tests), both `ws` and `node:http` are mocked with in-memory EventEmitters
+ * standing in for the WebSocketServer and the discovery HTTP server. This
+ * still drives the real `wsServer.ts` connection-handling code (the
+ * `wss.on('connection', ...)` closure that sets the module's private
+ * `extensionSocket`), just without opening an OS socket.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `vi.mock` factories are hoisted above this file's imports, so they can't
+// close over an `import { EventEmitter } from 'node:events'` declared below
+// them (that produced a "Cannot access before initialization" TDZ error).
+// `vi.hoisted()` runs before the mocks too, so a tiny inline emitter defined
+// there is safe to use from both the mock factories and the test bodies.
+const { MiniEmitter, capturedWsServers, capturedHttpServers } = vi.hoisted(() => {
+  class MiniEmitterImpl {
+    private listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+    on(event: string, fn: (...args: unknown[]) => void): this {
+      if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+      this.listeners.get(event)!.add(fn);
+      return this;
+    }
+    emit(event: string, ...args: unknown[]): void {
+      for (const fn of this.listeners.get(event) ?? []) fn(...args);
+    }
+  }
+  return {
+    MiniEmitter: MiniEmitterImpl,
+    capturedWsServers: [] as InstanceType<typeof MiniEmitterImpl>[],
+    capturedHttpServers: [] as InstanceType<typeof MiniEmitterImpl>[],
+  };
+});
+
+vi.mock('ws', () => {
+  class FakeWebSocketServer extends MiniEmitter {
+    constructor(_opts: unknown) {
+      super();
+      capturedWsServers.push(this);
+      // Defer so the constructor's caller can attach .on('listening') etc.
+      // first — emitting synchronously here would fire before any listener
+      // is registered.
+      queueMicrotask(() => this.emit('listening'));
+    }
+    close(): void {}
+  }
+  class FakeWebSocket {
+    static readonly OPEN = 1;
+  }
+  return { WebSocketServer: FakeWebSocketServer, WebSocket: FakeWebSocket };
+});
+
+vi.mock('http', () => {
+  class FakeHttpServer extends MiniEmitter {
+    listen(_port: number, _host: string, cb?: () => void): this {
+      cb?.();
+      return this;
+    }
+    close(): void {}
+  }
+  return {
+    createServer: (_handler: unknown) => {
+      const server = new FakeHttpServer();
+      capturedHttpServers.push(server);
+      return server;
+    },
+  };
+});
+
+/** A fake extension WebSocket: an emitter with the methods wsServer.ts calls on it. */
+function makeFakeSocket() {
+  const socket = new MiniEmitter() as InstanceType<typeof MiniEmitter> & {
+    readyState: number;
+    send: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+    terminate: ReturnType<typeof vi.fn>;
+    ping: ReturnType<typeof vi.fn>;
+  };
+  socket.readyState = 1; // WebSocket.OPEN
+  socket.send = vi.fn();
+  socket.close = vi.fn();
+  socket.terminate = vi.fn();
+  socket.ping = vi.fn();
+  return socket;
+}
+
+describe('sendToExtension abort handling', () => {
+  let fakeExtension: ReturnType<typeof makeFakeSocket>;
+
+  beforeEach(async () => {
+    capturedWsServers.length = 0;
+    capturedHttpServers.length = 0;
+    vi.resetModules();
+
+    const { startWSServer } = await import('./wsServer.js');
+    await startWSServer(9876);
+
+    const wss = capturedWsServers[0];
+    fakeExtension = makeFakeSocket();
+    wss.emit('connection', fakeExtension, { headers: { origin: 'chrome-extension://fake' } });
+  });
+
+  afterEach(async () => {
+    const { stopWSServer } = await import('./wsServer.js');
+    stopWSServer();
+  });
+
+  it('sends the request once, with no cancel message, when nothing aborts', async () => {
+    const { sendToExtension } = await import('./wsServer.js');
+    const controller = new AbortController();
+
+    const pending = sendToExtension('click', { tabId: 1 }, 5000, controller.signal);
+    expect(fakeExtension.send).toHaveBeenCalledTimes(1);
+    const sent = JSON.parse(fakeExtension.send.mock.calls[0][0] as string);
+    expect(sent).toMatchObject({ action: 'click', payload: { tabId: 1 } });
+
+    // Extension answers normally.
+    fakeExtension.emit('message', JSON.stringify({ id: sent.id, success: true, data: 'ok' }));
+    await expect(pending).resolves.toMatchObject({ success: true, data: 'ok' });
+
+    // Aborting after the fact must be a no-op: the abort listener was
+    // detached on resolve, so this must not send a stray cancel message.
+    controller.abort();
+    expect(fakeExtension.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops waiting and sends {type:"cancel", requestId} when the signal aborts mid-flight', async () => {
+    const { sendToExtension } = await import('./wsServer.js');
+    const controller = new AbortController();
+
+    const pending = sendToExtension('click', { tabId: 1 }, 30_000, controller.signal);
+    expect(fakeExtension.send).toHaveBeenCalledTimes(1);
+    const sent = JSON.parse(fakeExtension.send.mock.calls[0][0] as string);
+
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(fakeExtension.send).toHaveBeenCalledTimes(2);
+    const cancelMsg = JSON.parse(fakeExtension.send.mock.calls[1][0] as string);
+    expect(cancelMsg).toEqual({ type: 'cancel', requestId: sent.id });
+  });
+
+  it('does not crash if the extension later answers a request that was already cancelled', async () => {
+    const { sendToExtension } = await import('./wsServer.js');
+    const controller = new AbortController();
+
+    const pending = sendToExtension('click', { tabId: 1 }, 30_000, controller.signal);
+    const sent = JSON.parse(fakeExtension.send.mock.calls[0][0] as string);
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+
+    // A late response for the now-forgotten request id must be tolerated
+    // (logged, not thrown) rather than resolving/rejecting anything.
+    expect(() => {
+      fakeExtension.emit('message', JSON.stringify({ id: sent.id, success: true, data: 'late' }));
+    }).not.toThrow();
+  });
+
+  it('rejects immediately without sending anything when the signal is already aborted', async () => {
+    const { sendToExtension } = await import('./wsServer.js');
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      sendToExtension('click', { tabId: 1 }, 5000, controller.signal)
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(fakeExtension.send).not.toHaveBeenCalled();
+  });
+});

--- a/abu-browser-bridge/src/wsServer.ts
+++ b/abu-browser-bridge/src/wsServer.ts
@@ -13,8 +13,9 @@
 import { WebSocketServer, WebSocket } from 'ws';
 import { createServer, type Server as HTTPServer } from 'http';
 import { randomBytes } from 'crypto';
-import type { BridgeRequest, BridgeResponse } from './types.js';
+import type { BridgeCancelMessage, BridgeRequest, BridgeResponse } from './types.js';
 import { PKG_VERSION } from './version.js';
+import { linkAbortSignal } from './abortSignal.js';
 
 const DEFAULT_WS_PORT = 9876;
 const DISCOVERY_PORT = 9875;
@@ -236,11 +237,19 @@ function handleResponse(msg: BridgeResponse): void {
 
 /**
  * Send a request to the Chrome Extension and wait for response.
+ *
+ * `signal`, when given, lets the caller stop waiting before the extension
+ * responds (e.g. the conversation run was stopped): the pending request is
+ * dropped immediately, a best-effort `{type:'cancel', requestId}` message is
+ * sent so the extension can stop working on it, and the promise rejects with
+ * an `AbortError` instead of hanging until `timeoutMs`. If `signal` is
+ * already aborted, the request is never sent at all.
  */
 export function sendToExtension(
   action: string,
   payload: Record<string, unknown> = {},
-  timeoutMs: number = 30_000
+  timeoutMs: number = 30_000,
+  signal?: AbortSignal
 ): Promise<BridgeResponse> {
   return new Promise((resolve, reject) => {
     if (!extensionSocket || extensionSocket.readyState !== WebSocket.OPEN) {
@@ -250,15 +259,48 @@ export function sendToExtension(
       return;
     }
 
+    if (signal?.aborted) {
+      reject(new DOMException('The operation was aborted.', 'AbortError'));
+      return;
+    }
+
     const id = generateId();
     const request: BridgeRequest = { id, action, payload };
 
+    const unlink = linkAbortSignal(signal, () => {
+      const pending = pendingRequests.get(id);
+      if (pending) {
+        clearTimeout(pending.timer);
+        pendingRequests.delete(id);
+      }
+      if (extensionSocket && extensionSocket.readyState === WebSocket.OPEN) {
+        const cancel: BridgeCancelMessage = { type: 'cancel', requestId: id };
+        try {
+          extensionSocket.send(JSON.stringify(cancel));
+        } catch (err) {
+          console.error('[abu-bridge] Failed to send cancel to extension:', err);
+        }
+      }
+      reject(new DOMException('The operation was aborted.', 'AbortError'));
+    });
+
     const timer = setTimeout(() => {
       pendingRequests.delete(id);
+      unlink();
       reject(new Error(`Request timed out after ${timeoutMs}ms (action: ${action})`));
     }, timeoutMs);
 
-    pendingRequests.set(id, { resolve, reject, timer });
+    pendingRequests.set(id, {
+      resolve: (response) => {
+        unlink();
+        resolve(response);
+      },
+      reject: (error) => {
+        unlink();
+        reject(error);
+      },
+      timer,
+    });
 
     extensionSocket.send(JSON.stringify(request));
   });

--- a/abu-browser-shared/types.ts
+++ b/abu-browser-shared/types.ts
@@ -21,6 +21,17 @@ export interface BridgeResponse {
   error?: string;
 }
 
+/**
+ * Sent Bridge → Extension when the caller aborts before a response for
+ * `requestId` arrived. The extension is not required to act on it (this PR
+ * only asks it not to crash on an unrecognized message shape); it exists so a
+ * future extension version can stop in-flight work early.
+ */
+export interface BridgeCancelMessage {
+  type: 'cancel';
+  requestId: string;
+}
+
 // --- Element Locator (multi-strategy targeting) ---
 // All fields optional — only one strategy should be specified per locator.
 

--- a/abu-chrome-extension/src/shared/types.ts
+++ b/abu-chrome-extension/src/shared/types.ts
@@ -21,6 +21,17 @@ export interface BridgeResponse {
   error?: string;
 }
 
+/**
+ * Sent Bridge → Extension when the caller aborts before a response for
+ * `requestId` arrived. The extension is not required to act on it (this PR
+ * only asks it not to crash on an unrecognized message shape); it exists so a
+ * future extension version can stop in-flight work early.
+ */
+export interface BridgeCancelMessage {
+  type: 'cancel';
+  requestId: string;
+}
+
 // --- Element Locator (multi-strategy targeting) ---
 // All fields optional — only one strategy should be specified per locator.
 

--- a/electron/browser-runtime/server.ts
+++ b/electron/browser-runtime/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { registerTools, type BrowserTransport, type BrowserTransportResponse } from '../../abu-browser-bridge/src/tools.ts';
+import { linkAbortSignal } from '../../abu-browser-bridge/src/abortSignal.ts';
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '[::1]']);
@@ -83,12 +84,18 @@ class HttpBrowserTransport implements BrowserTransport {
   async send(
     action: string,
     payload: Record<string, unknown> = {},
-    timeoutMs: number = DEFAULT_REQUEST_TIMEOUT_MS
+    timeoutMs: number = DEFAULT_REQUEST_TIMEOUT_MS,
+    opts?: { signal?: AbortSignal }
   ): Promise<BrowserTransportResponse> {
     const id = nextRequestId();
     const body: RuntimeRequest = { id, action, payload };
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
+    // Fires immediately (before the fetch below ever starts) if opts.signal
+    // is already aborted, and is always detached in `finally` so an
+    // unrelated later abort on the caller's signal can't fire into a
+    // settled/reused controller.
+    const unlink = linkAbortSignal(opts?.signal, () => controller.abort());
 
     try {
       const response = await fetch(this.config.endpoint, {
@@ -117,6 +124,7 @@ class HttpBrowserTransport implements BrowserTransport {
       throw new Error(errorMessage(err), { cause: err });
     } finally {
       clearTimeout(timer);
+      unlink();
     }
   }
 }

--- a/electron/browserAutomationHost.cjs
+++ b/electron/browserAutomationHost.cjs
@@ -116,9 +116,15 @@ async function handleRequest(req, res) {
     const { performBrowserAutomation } = require('./browserHost.cjs');
     const data = await performBrowserAutomation(action, payload, { signal: controller.signal });
     res.off('close', onClose);
-    // A request whose client already disconnected has no socket left to
-    // write a response to; writing anyway would throw from inside this
-    // handler (e.g. ERR_STREAM_WRITE_AFTER_END).
+    // On a premature disconnect `res.writableEnded` is actually still FALSE
+    // here (the response body was never written), so this guard does not
+    // block that case — it passes, and `sendJson()` runs. That write is a
+    // harmless no-op: Node's `http.ServerResponse` routes a write on an
+    // already-destroyed socket to an internal no-op callback rather than
+    // throwing, so nothing inside this handler can be surprised by it. The
+    // guard is kept for the normal-path case — symmetry with the catch
+    // branch below, and skipping a JSON.stringify + header build whose result
+    // would just be discarded.
     if (!res.writableEnded) sendJson(res, 200, { success: true, data });
   } catch (error) {
     res.off('close', onClose);

--- a/electron/browserAutomationHost.cjs
+++ b/electron/browserAutomationHost.cjs
@@ -81,6 +81,20 @@ function readJsonBody(req) {
   });
 }
 
+/**
+ * Abort-to-main: cancel the in-flight browser action when the client
+ * connection closes before a response was ever sent (the run was stopped).
+ *
+ * This listens on the RESPONSE's `close`, not the request's. Verified with a
+ * raw TCP client: `req`'s `close` event fires immediately once the request
+ * body has been fully read — while the socket is still open and long before
+ * the response is written — so it fires on every ordinary request and cannot
+ * distinguish "client vanished" from "client is just waiting for the reply."
+ * `res`'s `close` only fires early (`res.writableEnded === false`) on a
+ * genuine premature disconnect; on a normal round trip it fires once, after
+ * `res.end()`, with `writableEnded === true`. That flag is therefore both
+ * necessary and sufficient — no extra local "did we finish" flag needed.
+ */
 async function handleRequest(req, res) {
   if (req.method !== 'POST' || req.url !== '/action') {
     sendJson(res, 404, { success: false, error: 'Not found' });
@@ -91,16 +105,29 @@ async function handleRequest(req, res) {
     return;
   }
 
+  const controller = new AbortController();
+  const onClose = () => {
+    if (!res.writableEnded) controller.abort();
+  };
+  res.on('close', onClose);
+
   try {
     const { action, payload } = await readJsonBody(req);
     const { performBrowserAutomation } = require('./browserHost.cjs');
-    const data = await performBrowserAutomation(action, payload);
-    sendJson(res, 200, { success: true, data });
+    const data = await performBrowserAutomation(action, payload, { signal: controller.signal });
+    res.off('close', onClose);
+    // A request whose client already disconnected has no socket left to
+    // write a response to; writing anyway would throw from inside this
+    // handler (e.g. ERR_STREAM_WRITE_AFTER_END).
+    if (!res.writableEnded) sendJson(res, 200, { success: true, data });
   } catch (error) {
-    sendJson(res, 200, {
-      success: false,
-      error: error instanceof Error ? error.message : String(error),
-    });
+    res.off('close', onClose);
+    if (!res.writableEnded) {
+      sendJson(res, 200, {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 }
 

--- a/electron/browserAutomationHost.test.cjs
+++ b/electron/browserAutomationHost.test.cjs
@@ -1,20 +1,27 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const http = require('node:http');
 const path = require('node:path');
 const { afterEach, test } = require('node:test');
 
 const browserHostPath = path.join(__dirname, 'browserHost.cjs');
 const calls = [];
+/**
+ * Reassignable so individual tests (the abort-to-main ones below) can swap in
+ * a double that inspects the `opts.signal` `handleRequest` passes as the 3rd
+ * arg, then restore this default in `afterEach`.
+ */
+let performBrowserAutomationImpl = async (action, payload) => {
+  calls.push({ action, payload });
+  return { action, payload };
+};
 require.cache[browserHostPath] = {
   id: browserHostPath,
   filename: browserHostPath,
   loaded: true,
   exports: {
-    performBrowserAutomation: async (action, payload) => {
-      calls.push({ action, payload });
-      return { action, payload };
-    },
+    performBrowserAutomation: (...args) => performBrowserAutomationImpl(...args),
   },
 };
 
@@ -26,6 +33,10 @@ const {
 
 afterEach(() => {
   calls.length = 0;
+  performBrowserAutomationImpl = async (action, payload) => {
+    calls.push({ action, payload });
+    return { action, payload };
+  };
   stopBrowserAutomationServer();
 });
 
@@ -80,4 +91,86 @@ test('browser runtime launch uses bundled Node and keeps credentials in child en
   assert.match(launch.args[0], /electron[/\\]browser-runtime[/\\]dist[/\\]server\.mjs$/);
   assert.match(launch.env.ABU_BROWSER_RUNTIME_ENDPOINT, /^http:\/\/127\.0\.0\.1:\d+\/action$/);
   assert.match(launch.env.ABU_BROWSER_RUNTIME_TOKEN, /^[a-f0-9]{64}$/);
+});
+
+/**
+ * Abort-to-main: `handleRequest` builds an `AbortController` per request and
+ * aborts it when the client connection closes early (the run being stopped),
+ * passing `{ signal }` as `performBrowserAutomation`'s 3rd argument. These
+ * tests exercise the real HTTP layer (unlike the mocked `performBrowserAutomation`
+ * calls above) since the behavior under test lives entirely in the request
+ * lifecycle, not in browserHost.cjs.
+ */
+test('closing the client connection mid-action aborts the signal passed to performBrowserAutomation', async () => {
+  let capturedSignal = null;
+  let resolveAction;
+  performBrowserAutomationImpl = (action, payload, opts) => {
+    capturedSignal = opts && opts.signal;
+    return new Promise((resolve) => {
+      resolveAction = resolve;
+    });
+  };
+
+  const { endpoint, token } = await ensureBrowserAutomationServer();
+  const url = new URL(endpoint);
+
+  await new Promise((resolve) => {
+    const req = http.request({
+      hostname: url.hostname,
+      port: url.port,
+      path: url.pathname,
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    // The client vanishing (run stopped) surfaces locally as a socket error —
+    // that is the scenario under test, not a bug in the request.
+    req.on('error', () => {});
+    req.end(JSON.stringify({ action: 'click', payload: {} }));
+    // Let the server start handling the request (readJsonBody resolves, then
+    // performBrowserAutomation is invoked and captures the signal) before the
+    // client disappears out from under it.
+    setImmediate(() => setImmediate(() => {
+      req.destroy();
+      resolve();
+    }));
+  });
+
+  // Give the server's `req.on('close', ...)` handler a tick to fire.
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.ok(capturedSignal, 'performBrowserAutomation must have been called with a signal');
+  assert.equal(capturedSignal.aborted, true, 'the signal must abort when the client connection closes early');
+
+  // The action "finishes" long after the client is gone — nothing should throw.
+  resolveAction({ ok: true });
+});
+
+test('a request that completes normally never aborts its own action signal', async () => {
+  let capturedSignal = null;
+  performBrowserAutomationImpl = async (action, payload, opts) => {
+    capturedSignal = opts && opts.signal;
+    return { action, payload };
+  };
+
+  const { endpoint, token } = await ensureBrowserAutomationServer();
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ action: 'snapshot', payload: {} }),
+  });
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { success: true, data: { action: 'snapshot', payload: {} } });
+
+  // The request's socket also emits `close` right after a normal response —
+  // give that a tick, then confirm it did NOT get mistaken for an abort.
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.ok(capturedSignal, 'performBrowserAutomation must have been called with a signal');
+  assert.equal(capturedSignal.aborted, false, 'a normal completion must not misfire the abort signal');
 });

--- a/electron/browserHost.cjs
+++ b/electron/browserHost.cjs
@@ -261,15 +261,103 @@ function userIsInteracting(viewId, ownerKey) {
   return typeof last === 'number' && clock.now() - last < USER_INTERACT_QUIET_MS;
 }
 
-async function awaitUserIdle(viewId) {
+async function awaitUserIdle(viewId, signal) {
   const ownerKey = ownerKeyOf(viewId);
   if (!userIsInteracting(viewId, ownerKey)) return;
+  assertNotAborted(signal);
   const deadline = clock.now() + TAKEOVER_WAIT_MS;
   while (clock.now() < deadline) {
     await clock.sleep(TAKEOVER_POLL_MS);
+    assertNotAborted(signal);
     if (!userIsInteracting(viewId, ownerKey)) return;
   }
   throw new Error(USER_TAKEOVER_MESSAGE);
+}
+
+/**
+ * ## Backing off after HTTP 429 (R5)
+ *
+ * A site that starts answering with 429 is telling the automation to slow
+ * down, not to keep hammering it — but nothing upstream of `execute_js`/
+ * `click`/etc previously read the response status at all, so the model would
+ * see a rate-limit page and immediately retry the same action, making the
+ * block worse. `originBackoff` tracks one exponential window PER ORIGIN (not
+ * per tab — a site rate-limits the client, not one specific view), doubling
+ * 1s→2s→4s… and capping at 30s; a 2xx main-frame response clears it, since
+ * that is the site telling us it is no longer objecting. Only main-frame
+ * responses are inspected — a 429 from a third-party subresource (an ad, an
+ * analytics ping) is not "this site" rate-limiting the automated action.
+ *
+ * Gated exactly where the takeover backoff (R4) is gated — reusing
+ * `TAKEOVER_GATED_ACTIONS` rather than a second list — because both guards
+ * answer the same question ("is it safe to act on this page right now?"),
+ * just for a different hazard. Read-only actions are exactly as safe to run
+ * against a rate-limiting origin as against any other page: no retry, no
+ * additional load. There is deliberately no retry-after-backoff path here
+ * either: the caller (the model) decides whether to wait, tell the user, or
+ * give up on this step.
+ */
+const BACKOFF_BASE_MS = 1000;
+const BACKOFF_CAP_MS = 30000;
+
+/** origin -> { until: ts, level: n }. Absent/expired ⇒ no backoff in effect. */
+const originBackoff = new Map();
+
+function backoffDelayForLevel(level) {
+  return Math.min(BACKOFF_BASE_MS * 2 ** (level - 1), BACKOFF_CAP_MS);
+}
+
+function originOf(urlString) {
+  try {
+    return new URL(String(urlString || '')).origin;
+  } catch {
+    return null;
+  }
+}
+
+function registerRateLimitHit(origin) {
+  if (!origin) return;
+  const existing = originBackoff.get(origin);
+  const level = existing ? existing.level + 1 : 1;
+  originBackoff.set(origin, { until: clock.now() + backoffDelayForLevel(level), level });
+}
+
+function clearRateLimit(origin) {
+  if (!origin) return;
+  originBackoff.delete(origin);
+}
+
+/**
+ * Remaining backoff time for `origin` in ms; 0 when there is none, or once it
+ * has expired (an expired entry is pruned here so the map does not grow
+ * forever across origins that got rate-limited once and moved on).
+ */
+function backoffRemainingMs(origin) {
+  if (!origin) return 0;
+  const entry = originBackoff.get(origin);
+  if (!entry) return 0;
+  const remaining = entry.until - clock.now();
+  if (remaining <= 0) {
+    originBackoff.delete(origin);
+    return 0;
+  }
+  return remaining;
+}
+
+/**
+ * ## Abort-to-main (Stop button propagation)
+ *
+ * `browserAutomationHost.cjs` builds an `AbortController` per MCP request and
+ * aborts it when the client connection closes early (the run was stopped).
+ * The signal is threaded down through `performBrowserAutomation` into every
+ * wait loop a gated action can be sitting in — the takeover backoff's poll
+ * loop above, and the rate-limit gate below — so a stopped run does not sit
+ * out someone else's 10-second wait before it notices.
+ */
+function assertNotAborted(signal) {
+  if (signal && signal.aborted) {
+    throw new Error('Browser action cancelled because the run was stopped.');
+  }
 }
 
 function resolveOwnerKey(payload) {
@@ -371,6 +459,22 @@ function browserSessionForViews() {
   if (typeof browserSession.setDisplayMediaRequestHandler === 'function') {
     browserSession.setDisplayMediaRequestHandler((_request, callback) => callback({}));
   }
+
+  // R5: watch main-frame responses for the 429/2xx signals that drive the
+  // per-origin backoff above. Registered once per session (this function is
+  // memoized via the `browserSession` singleton), covering every automation
+  // view and every pane tab, since they all share `BROWSER_SESSION_PARTITION`.
+  browserSession.webRequest.onHeadersReceived({ urls: ['<all_urls>'] }, (details, callback) => {
+    if (details.resourceType === 'mainFrame') {
+      const origin = originOf(details.url);
+      if (details.statusCode === 429) {
+        registerRateLimitHit(origin);
+      } else if (details.statusCode >= 200 && details.statusCode < 300) {
+        clearRateLimit(origin);
+      }
+    }
+    callback({ cancel: false });
+  });
 
   browserSession.on('will-download', (_event, item) => {
     const record = {
@@ -746,18 +850,27 @@ async function screenshotAutomation(view, fullPage) {
   }
 }
 
-async function performBrowserAutomation(action, payload = {}) {
+/**
+ * @param {string} action
+ * @param {Record<string, unknown>} [payload]
+ * @param {{ signal?: AbortSignal }} [opts] `signal` aborts when the run that
+ *   requested this action was stopped (see browserAutomationHost.cjs's
+ *   `handleRequest`) — optional, so the existing 2-arg call sites (and their
+ *   tests) are unaffected.
+ */
+async function performBrowserAutomation(action, payload = {}, opts) {
+  const signal = opts && opts.signal;
   // Everything this call does — including creating and loading views — is
   // automation, so nothing it triggers may be mistaken for the user.
   aiActionDepth += 1;
   try {
-    return await runBrowserAutomation(action, payload);
+    return await runBrowserAutomation(action, payload, signal);
   } finally {
     aiActionDepth -= 1;
   }
 }
 
-async function runBrowserAutomation(action, payload) {
+async function runBrowserAutomation(action, payload, signal) {
   const ownerKey = resolveOwnerKey(payload);
 
   if (action === 'get_tabs') {
@@ -799,12 +912,22 @@ async function runBrowserAutomation(action, payload) {
   const { view } = match;
 
   if (TAKEOVER_GATED_ACTIONS.has(action)) {
+    assertNotAborted(signal);
+
+    const remainingMs = backoffRemainingMs(originOf(view.webContents.getURL()));
+    if (remainingMs > 0) {
+      throw new Error(
+        `This site is rate-limiting automated actions (HTTP 429). Backing off for ${Math.ceil(remainingMs / 1000)}s — ` +
+          'retrying immediately would make it worse. Tell the user, wait, or suggest they do this step manually.'
+      );
+    }
+
     // Step outside the AI-attribution window for the wait itself: observing the
     // user is the entire point of it, and at depth>0 their keystrokes would be
     // filed as automation's own and the wait would end after one quiet poll.
     aiActionDepth -= 1;
     try {
-      await awaitUserIdle(match.id);
+      await awaitUserIdle(match.id, signal);
     } finally {
       aiActionDepth += 1;
     }

--- a/electron/browserHost.cjs
+++ b/electron/browserHost.cjs
@@ -464,7 +464,14 @@ function browserSessionForViews() {
   // per-origin backoff above. Registered once per session (this function is
   // memoized via the `browserSession` singleton), covering every automation
   // view and every pane tab, since they all share `BROWSER_SESSION_PARTITION`.
-  browserSession.webRequest.onHeadersReceived({ urls: ['<all_urls>'] }, (details, callback) => {
+  // `types: ['mainFrame']` (Electron 43's WebRequestFilter) narrows the native
+  // event stream itself, on top of the `resourceType === 'mainFrame'` check
+  // below — belt-and-braces, since the JS check alone still means every
+  // subresource response on every page marshals into this process first.
+  // NOTE: Electron allows only ONE `onHeadersReceived` listener per session —
+  // registering a second one on `BROWSER_SESSION_PARTITION` anywhere else
+  // would silently REPLACE this one (last registration wins), not add to it.
+  browserSession.webRequest.onHeadersReceived({ urls: ['<all_urls>'], types: ['mainFrame'] }, (details, callback) => {
     if (details.resourceType === 'mainFrame') {
       const origin = originOf(details.url);
       if (details.statusCode === 429) {
@@ -871,6 +878,11 @@ async function performBrowserAutomation(action, payload = {}, opts) {
 }
 
 async function runBrowserAutomation(action, payload, signal) {
+  // Checked before EVERYTHING else — including get_tabs/get_downloads, which
+  // bypass every per-tab gate below — so a stopped run cannot still provision
+  // and open a brand-new tab (or leak any other side effect) after Stop.
+  assertNotAborted(signal);
+
   const ownerKey = resolveOwnerKey(payload);
 
   if (action === 'get_tabs') {
@@ -914,7 +926,24 @@ async function runBrowserAutomation(action, payload, signal) {
   if (TAKEOVER_GATED_ACTIONS.has(action)) {
     assertNotAborted(signal);
 
-    const remainingMs = backoffRemainingMs(originOf(view.webContents.getURL()));
+    // A `navigate` to a NEW page (the default `goto`, or an explicit one) is
+    // rate-limit-checked against the URL it is ABOUT TO LOAD, not the tab's
+    // current origin — otherwise a tab sitting on a backed-off site could
+    // never navigate away (false block), and a tab sitting on a clean site
+    // could freely navigate INTO a backed-off one (missed block: the escape
+    // hatch away from a bad origin must stay open, but a fresh navigation
+    // INTO it must not). Every other gated action (click/fill/.../reload/
+    // back/forward) acts on the page already loaded, so it keeps checking the
+    // view's current origin. An unparseable target URL yields no origin
+    // (`originOf` returns null on a parse failure), so `backoffRemainingMs`
+    // sees nothing to check and this gate falls through — the malformed URL
+    // is still caught by `allowedAutomationUrl()` inside
+    // `navigateAutomationTab()`, which is the right place to report it.
+    const isGotoNavigate = action === 'navigate' && (payload.action || 'goto') === 'goto';
+    const backoffOrigin = isGotoNavigate
+      ? originOf(payload.url)
+      : originOf(view.webContents.getURL());
+    const remainingMs = backoffRemainingMs(backoffOrigin);
     if (remainingMs > 0) {
       throw new Error(
         `This site is rate-limiting automated actions (HTTP 429). Backing off for ${Math.ceil(remainingMs / 1000)}s — ` +

--- a/electron/browserHost.cjs
+++ b/electron/browserHost.cjs
@@ -177,6 +177,101 @@ function ownerKeyOf(id) {
   return meta ? meta.ownerKey : LEGACY_OWNER;
 }
 
+/**
+ * ## Backing off while the user takes over (R4)
+ *
+ * Agent tabs are adopted into the visible browser pane, so the user can grab
+ * the keyboard mid-task — and used to lose: automation kept clicking and
+ * filling under their hands, and the model then reasoned about a page state
+ * that neither side had produced alone.
+ *
+ * Attribution is a plain time window. `before-input-event` and `focus` on a
+ * view are the USER only while `aiActionDepth === 0`; every automation action
+ * runs with that depth raised, so `keyboardAutomation`'s own
+ * `webContents.focus()` + `sendInputEvent()` are excluded without needing to
+ * tag individual events. The depth is deliberately GLOBAL, not per owner:
+ * during owner A's action, owner B's real input is misread as automation. That
+ * error is one-directional (a missed backoff, never a new block) and the window
+ * is milliseconds wide, so it is accepted rather than tracked per owner.
+ *
+ * State-changing actions then wait for a quiet window before running. Read-only
+ * ones (snapshot, get_html, the extract_ pair, screenshots, get_tabs, wait_for)
+ * never wait — they are exactly what a model should do while the user works.
+ */
+const USER_INTERACT_QUIET_MS = 3000;
+const TAKEOVER_WAIT_MS = 10000;
+const TAKEOVER_POLL_MS = 500;
+
+/** Fixed text: it tells the model to re-read the page, not to retry blindly. */
+const USER_TAKEOVER_MESSAGE =
+  'The user is currently interacting with this browser tab. Automation paused to avoid ' +
+  'conflicting with their input. Wait for them to finish, then re-read the page state ' +
+  '(snapshot) before continuing.';
+
+const TAKEOVER_GATED_ACTIONS = new Set([
+  'click',
+  'fill',
+  'select',
+  'keyboard',
+  'navigate',
+  'execute_js',
+  'scroll',
+  'start_recording',
+]);
+
+/** ownerKey -> ts of the last input the USER landed on one of that owner's views. */
+const userInteractionAt = new Map();
+
+/** >0 while an automation action is executing — its own events are not the user. */
+let aiActionDepth = 0;
+
+/**
+ * The backoff is a wall-clock wait of up to 10 seconds, which no test can sit
+ * through. Both reads of "now" and the poll sleep go through this one seam so a
+ * test can drive virtual time (see `__testing.setClock`).
+ */
+const REAL_CLOCK = {
+  now: () => Date.now(),
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+};
+let clock = REAL_CLOCK;
+
+/**
+ * Drop an owner's interaction record once none of its views survive, so a long
+ * session does not accumulate one timestamp per conversation that ever typed.
+ */
+function forgetOwnerInteractionIfUnused(ownerKey) {
+  for (const id of views.keys()) {
+    if (ownerKeyOf(id) === ownerKey) return;
+  }
+  userInteractionAt.delete(ownerKey);
+}
+
+/**
+ * @param {string} viewId the view the action is about to touch
+ * @param {string} ownerKey that view's owner (NOT necessarily the caller's —
+ *   an agent may be driving the user's own legacy pane tab, and it is the pane
+ *   tab's user we must yield to)
+ */
+function userIsInteracting(viewId, ownerKey) {
+  // Picking an element is a live, multi-second user gesture that never emits an
+  // input event of its own — treat the armed session itself as "hands on".
+  if (inspectSessions.has(viewId)) return true;
+  const last = userInteractionAt.get(ownerKey);
+  return typeof last === 'number' && clock.now() - last < USER_INTERACT_QUIET_MS;
+}
+
+async function awaitUserIdle(viewId) {
+  const ownerKey = ownerKeyOf(viewId);
+  if (!userIsInteracting(viewId, ownerKey)) return;
+  const deadline = clock.now() + TAKEOVER_WAIT_MS;
+  while (clock.now() < deadline) {
+    await clock.sleep(TAKEOVER_POLL_MS);
+    if (!userIsInteracting(viewId, ownerKey)) return;
+  }
+  throw new Error(USER_TAKEOVER_MESSAGE);
+}
+
 function resolveOwnerKey(payload) {
   const raw = payload && typeof payload.ownerId === 'string' ? payload.ownerId.trim() : '';
   return raw || LEGACY_OWNER;
@@ -354,7 +449,15 @@ function configureBrowserView(id, view) {
   contents.on('did-start-navigation', (_event, _url, _isInPlace, isMainFrame) => {
     if (isMainFrame) resetAutomationRuntime();
   });
+  // Attribution for the takeover backoff: outside an automation action, input
+  // landing here is the user working in this view's owner's tab.
+  const recordUserInteraction = () => {
+    if (aiActionDepth > 0) return;
+    userInteractionAt.set(ownerKeyOf(id), clock.now());
+  };
+  contents.on('before-input-event', recordUserInteraction);
   contents.on('focus', () => {
+    recordUserInteraction();
     // The user focusing a view makes it that view OWNER's current tab, never
     // anyone else's.
     activeTabIdByOwner.set(ownerKeyOf(id), automationTabId);
@@ -371,8 +474,10 @@ function configureBrowserView(id, view) {
     // wiped — that would silently downgrade the live new view to legacy and
     // hand it to every other conversation.
     if (views.get(id) === view) {
+      const ownerKey = ownerKeyOf(id);
       viewMeta.delete(id);
       views.delete(id);
+      forgetOwnerInteractionIfUnused(ownerKey);
     }
   });
 }
@@ -642,6 +747,17 @@ async function screenshotAutomation(view, fullPage) {
 }
 
 async function performBrowserAutomation(action, payload = {}) {
+  // Everything this call does — including creating and loading views — is
+  // automation, so nothing it triggers may be mistaken for the user.
+  aiActionDepth += 1;
+  try {
+    return await runBrowserAutomation(action, payload);
+  } finally {
+    aiActionDepth -= 1;
+  }
+}
+
+async function runBrowserAutomation(action, payload) {
   const ownerKey = resolveOwnerKey(payload);
 
   if (action === 'get_tabs') {
@@ -681,6 +797,19 @@ async function performBrowserAutomation(action, payload = {}) {
   const match = findViewByTabId(targetTabId, ownerKey);
   if (!match) throw new Error(`Browser tab not found: ${String(targetTabId)}`);
   const { view } = match;
+
+  if (TAKEOVER_GATED_ACTIONS.has(action)) {
+    // Step outside the AI-attribution window for the wait itself: observing the
+    // user is the entire point of it, and at depth>0 their keystrokes would be
+    // filed as automation's own and the wait would end after one quiet poll.
+    aiActionDepth -= 1;
+    try {
+      await awaitUserIdle(match.id);
+    } finally {
+      aiActionDepth += 1;
+    }
+  }
+
   activeTabIdByOwner.set(ownerKey, view.webContents.id);
 
   if (action === 'navigate') return navigateAutomationTab(view, payload);
@@ -898,11 +1027,13 @@ function closeView(id, view) {
   } catch {
     /* already gone — best-effort */
   }
+  const ownerKey = ownerKeyOf(id);
   views.delete(id);
   // `destroyed` also clears these, but it never fires when the window is torn
   // down under us (app quit) — don't leak the ownership record.
   viewMeta.delete(id);
   pendingAutomationOwners.delete(id);
+  forgetOwnerInteractionIfUnused(ownerKey);
 }
 
 function browserClose({ id }) {
@@ -965,4 +1096,8 @@ module.exports = {
   BROWSER_MISS,
   closeAllBrowserViews,
   performBrowserAutomation,
+  __testing: {
+    /** Swap the takeover backoff's clock; pass nothing to restore wall time. */
+    setClock(next) { clock = next || REAL_CLOCK; },
+  },
 };

--- a/electron/browserHost.ownership.test.cjs
+++ b/electron/browserHost.ownership.test.cjs
@@ -745,6 +745,44 @@ test('a 2xx main-frame response clears that origin\'s backoff window', async () 
   }
 });
 
+test('a 429 returned after a redirect is attributed to the post-redirect origin, not the pre-redirect one', async () => {
+  // Electron's webRequest fires onHeadersReceived once per hop of a
+  // navigation, each carrying THAT hop's own response URL — a redirect
+  // Y -> X therefore fires twice: once for Y's 3xx, once for X's final
+  // response. Simulate exactly that shape and confirm the backoff lands on
+  // X (the origin that actually answered 429), not Y (the one the agent
+  // originally asked to visit).
+  const { host, fireHeadersReceived, restore } = loadHost();
+  try {
+    const { clock } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+    await navigate(host, OWNER_A, aTab, 'https://y.example.com/start');
+
+    respond(fireHeadersReceived, 'https://y.example.com/start', 302); // redirect hop from Y
+    respond(fireHeadersReceived, 'https://x.example.com/final', 429); // final hop from X
+
+    // The redirect landed the tab on X.
+    await navigate(host, OWNER_A, aTab, 'https://x.example.com/final');
+
+    // A further gated action on that (now X-origin) tab is blocked.
+    await assert.rejects(
+      navigate(host, OWNER_A, aTab, 'https://x.example.com/final?retry=1'),
+      /Backing off for 1s/
+    );
+    assert.equal(contentsFor(aTab).url, 'https://x.example.com/final', 'no retry landed');
+
+    // A second, unrelated tab still on Y's origin is unaffected — the backoff
+    // must be keyed by X, not by Y (nor by anything else the redirect touched).
+    const bTab = tabIds(await getTabs(host, OWNER_B))[0];
+    await navigate(host, OWNER_B, bTab, 'https://y.example.com/other-page');
+    await navigate(host, OWNER_B, bTab, 'https://y.example.com/still-fine');
+    assert.equal(contentsFor(bTab).url, 'https://y.example.com/still-fine');
+  } finally {
+    restore();
+  }
+});
+
 test('a 429 on a subresource (non-main-frame) is not treated as the page rate-limiting', async () => {
   const { host, fireHeadersReceived, restore } = loadHost();
   try {

--- a/electron/browserHost.ownership.test.cjs
+++ b/electron/browserHost.ownership.test.cjs
@@ -1,7 +1,8 @@
 'use strict';
 
 /**
- * browserHost — per-conversation tab ownership.
+ * browserHost — per-conversation tab ownership, and backing off when the user
+ * takes the page over.
  *
  * Before this suite, `browserHost.cjs` kept ONE global `activeAutomationTabId`
  * and `get_tabs` returned every live view, so two conversations running browser
@@ -17,6 +18,15 @@
  *  4. The "current tab" is per owner, not global.
  *  5. Touching another owner's tab fails loud with a next-step hint.
  *  6. An empty (filtered) tab set creates a view for THAT owner.
+ *
+ * The takeover contract (R4) is layered on top of the same ownership keys:
+ *  7. Keyboard input / focus landing on a view while no automation action is
+ *     running is the USER, recorded against that view's owner; the same events
+ *     fired by automation itself (keyboard's focus + sendInputEvent) are not.
+ *  8. A state-changing action (click/fill/select/keyboard/navigate/execute_js/
+ *     scroll/start_recording) waits for a 3s quiet window before running, and
+ *     gives up after 10s with a fixed "the user is interacting" message.
+ *     Read-only actions never wait.
  *
  * browserHost.cjs is a main-process module (`require('electron')` +
  * `require('./tauriHost.cjs')`), so this runs it under plain Node with both of
@@ -47,6 +57,13 @@ class FakeWebContents {
     this.destroyed = false;
     this.listeners = new Map();
     this.navigationHistory = { goBack() {}, goForward() {} };
+    this.isolatedScripts = [];
+    this.debugger = {
+      isAttached: () => false,
+      attach() {},
+      detach() {},
+      async sendCommand() { return { data: 'AAAA', cssContentSize: { width: 10, height: 10 } }; },
+    };
   }
 
   on(event, handler) {
@@ -67,13 +84,24 @@ class FakeWebContents {
   isDestroyed() { return this.destroyed; }
   getURL() { return this.url; }
   getTitle() { return this.title; }
-  focus() {}
+
+  /** Electron focuses the real webContents here, which fires its `focus` event. */
+  focus() { this.fire('focus'); }
+
+  sendInputEvent() {}
   reload() {}
   close() { this.destroyed = true; }
 
   async loadURL(url) {
     this.url = url;
     return undefined;
+  }
+
+  async executeJavaScriptInIsolatedWorld(_worldId, scripts) {
+    this.isolatedScripts.push(scripts);
+    // `drainSelections` is the only inspect call whose return value matters
+    // here; an empty drain keeps the session armed without emitting.
+    return [];
   }
 }
 
@@ -191,6 +219,34 @@ function contentsFor(tabId) {
   const found = contentsRegistry.get(tabId);
   assert.ok(found, `no fake webContents for tab ${tabId}`);
   return found;
+}
+
+/**
+ * The takeover backoff is a real-time wait (up to 10s), so the tests drive it
+ * through the module's injectable clock instead: `sleep()` advances virtual
+ * time by exactly the polling interval and records it, and `onSleep` lets a
+ * test simulate the user typing straight through the wait.
+ */
+function fakeClock(start = 1_000_000) {
+  const state = { t: start, sleeps: [], onSleep: null };
+  const clock = {
+    now: () => state.t,
+    async sleep(ms) {
+      state.t += ms;
+      state.sleeps.push(ms);
+      if (state.onSleep) state.onSleep();
+    },
+  };
+  return { state, clock };
+}
+
+const USER_TAKEOVER_MESSAGE =
+  'The user is currently interacting with this browser tab. Automation paused to avoid ' +
+  'conflicting with their input. Wait for them to finish, then re-read the page state ' +
+  '(snapshot) before continuing.';
+
+function typeInto(tabId) {
+  contentsFor(tabId).fire('before-input-event', {}, { type: 'keyDown', key: 'a' });
 }
 
 test('get_tabs isolates two conversations from each other', async () => {
@@ -399,6 +455,122 @@ test('a headless fallback view still belongs to the requesting conversation', as
     const legacyTabs = await getTabs(host);
     assert.equal(tabIds(legacyTabs).length, 1);
     assert.equal(legacyTabs.windows[0].tabs[0].url, 'https://example.com/');
+  } finally {
+    restore();
+  }
+});
+
+test('a state-changing action waits out the user\'s input, then proceeds', async () => {
+  const { host, restore } = loadHost();
+  try {
+    const { clock, state } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+
+    typeInto(aTab);
+    state.t += 2000; // 2s into the 3s quiet window — still "hands on keyboard"
+
+    await navigate(host, OWNER_A, aTab, 'https://example.com/');
+
+    assert.deepEqual(state.sleeps, [500, 500], 'polled twice, then the window went quiet');
+    assert.equal(contentsFor(aTab).url, 'https://example.com/', 'the action ran after the wait');
+  } finally {
+    restore();
+  }
+});
+
+test('a state-changing action gives up with the pause message if the user never stops', async () => {
+  const { host, restore } = loadHost();
+  try {
+    const { clock, state } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+
+    typeInto(aTab);
+    // The user keeps typing through every poll — the recording must survive the
+    // wait, i.e. the wait itself must not be inside the AI-attribution window.
+    state.onSleep = () => typeInto(aTab);
+
+    await assert.rejects(navigate(host, OWNER_A, aTab, 'https://example.com/'), (error) => {
+      assert.equal(error.message, USER_TAKEOVER_MESSAGE);
+      return true;
+    });
+
+    assert.equal(state.sleeps.length, 20, '10s of 500ms polls, then it stops trying');
+    assert.equal(contentsFor(aTab).url, 'about:blank', 'the action never ran');
+  } finally {
+    restore();
+  }
+});
+
+test('read-only actions are never held back by user interaction', async () => {
+  const { host, restore } = loadHost();
+  try {
+    const { clock, state } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+
+    typeInto(aTab); // the user is mid-keystroke right now
+
+    const shot = await host.performBrowserAutomation('screenshot', {
+      ownerId: OWNER_A,
+      tabId: aTab,
+    });
+    assert.match(shot, /^data:image\/png;base64,/);
+    const tabs = await getTabs(host, OWNER_A);
+    assert.deepEqual(tabIds(tabs), [aTab]);
+
+    assert.deepEqual(state.sleeps, [], 'reading the page never waits on the user');
+  } finally {
+    restore();
+  }
+});
+
+test('automation\'s own focus and input do not count as user interaction', async () => {
+  const { host, restore } = loadHost();
+  try {
+    const { clock, state } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+
+    // `keyboard` focuses the webContents and injects key events — all of it
+    // inside the AI-attribution window, so none of it is the user.
+    await host.performBrowserAutomation('keyboard', { ownerId: OWNER_A, tabId: aTab, key: 'a' });
+    await navigate(host, OWNER_A, aTab, 'https://example.com/');
+    assert.deepEqual(state.sleeps, [], 'automation must not back off from itself');
+
+    // The same event, fired while no action is running, IS the user.
+    contentsFor(aTab).fire('focus');
+    await navigate(host, OWNER_A, aTab, 'https://example.org/');
+    assert.equal(state.sleeps.length, 6, 'waited out the full 3s quiet window');
+    assert.equal(contentsFor(aTab).url, 'https://example.org/');
+  } finally {
+    restore();
+  }
+});
+
+test('an armed inspect session backs automation off like live input', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    const { clock, state } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+    const viewId = emitted.find((entry) => entry.event === 'browser://automation-open').payload.id;
+
+    // The user is picking an element in this very view.
+    await host.browserDispatch(null, 'browser_inspect_set', { id: viewId, enabled: true });
+
+    await assert.rejects(navigate(host, OWNER_A, aTab, 'https://example.com/'), (error) => {
+      assert.equal(error.message, USER_TAKEOVER_MESSAGE);
+      return true;
+    });
+    assert.equal(state.sleeps.length, 20);
+
+    // Disarmed (also clears the poll timer, which would otherwise outlive the test).
+    await host.browserDispatch(null, 'browser_inspect_set', { id: viewId, enabled: false });
+    state.sleeps.length = 0;
+    await navigate(host, OWNER_A, aTab, 'https://example.com/');
+    assert.deepEqual(state.sleeps, []);
   } finally {
     restore();
   }

--- a/electron/browserHost.ownership.test.cjs
+++ b/electron/browserHost.ownership.test.cjs
@@ -762,8 +762,14 @@ test('a 429 returned after a redirect is attributed to the post-redirect origin,
     respond(fireHeadersReceived, 'https://y.example.com/start', 302); // redirect hop from Y
     respond(fireHeadersReceived, 'https://x.example.com/final', 429); // final hop from X
 
-    // The redirect landed the tab on X.
-    await navigate(host, OWNER_A, aTab, 'https://x.example.com/final');
+    // The redirect landed the tab on X — driven directly on the fake
+    // webContents, exactly like a real redirect: Chromium's OWN navigation
+    // engine follows a 3xx without ever re-entering the automation gate (only
+    // the ORIGINAL `goto` call from the agent goes through it). Routing this
+    // through another `navigate()` call would (correctly, per I-1) get
+    // blocked as a fresh navigation INTO the now-backed-off X — which is not
+    // what is being simulated here.
+    await contentsFor(aTab).loadURL('https://x.example.com/final');
 
     // A further gated action on that (now X-origin) tab is blocked.
     await assert.rejects(
@@ -795,6 +801,75 @@ test('a 429 on a subresource (non-main-frame) is not treated as the page rate-li
 
     await navigate(host, OWNER_A, aTab, 'https://example.com/still-fine');
     assert.equal(contentsFor(aTab).url, 'https://example.com/still-fine');
+  } finally {
+    restore();
+  }
+});
+
+/**
+ * I-1 — the R5 gate must check the NAVIGATION TARGET's origin, not the tab's
+ * current origin, for a `navigate`/`goto` action. Checking the current origin
+ * (the pre-fix behavior) gets both directions wrong: it lets automation
+ * navigate FROM a clean tab INTO a backed-off origin (missed block), and it
+ * traps a tab that happens to be sitting ON a backed-off origin so it can
+ * never navigate away to safety (false block, and the escape hatch — leaving
+ * the bad site — is exactly what should NOT be gated).
+ */
+test('navigating INTO a backed-off origin is blocked, even from a clean tab', async () => {
+  const { host, fireHeadersReceived, restore } = loadHost();
+  try {
+    const { clock } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+    await navigate(host, OWNER_A, aTab, 'https://y.example.com/');
+
+    respond(fireHeadersReceived, 'https://x.example.com/', 429);
+
+    await assert.rejects(
+      navigate(host, OWNER_A, aTab, 'https://x.example.com/'),
+      /Backing off for 1s/
+    );
+    assert.equal(contentsFor(aTab).url, 'https://y.example.com/', 'the navigation to x.com never happened');
+  } finally {
+    restore();
+  }
+});
+
+test('navigating AWAY FROM a backed-off origin is the escape hatch and is never gated', async () => {
+  const { host, fireHeadersReceived, restore } = loadHost();
+  try {
+    const { clock } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+    await navigate(host, OWNER_A, aTab, 'https://x.example.com/');
+
+    respond(fireHeadersReceived, 'https://x.example.com/', 429);
+
+    await navigate(host, OWNER_A, aTab, 'https://y.example.com/');
+    assert.equal(contentsFor(aTab).url, 'https://y.example.com/', 'leaving the backed-off origin is allowed');
+  } finally {
+    restore();
+  }
+});
+
+test('an in-page action on a backed-off origin still uses the current-origin check', async () => {
+  const { host, fireHeadersReceived, restore } = loadHost();
+  try {
+    const { clock } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+    await navigate(host, OWNER_A, aTab, 'https://x.example.com/');
+
+    respond(fireHeadersReceived, 'https://x.example.com/', 429);
+
+    await assert.rejects(
+      host.performBrowserAutomation('click', {
+        ownerId: OWNER_A,
+        tabId: aTab,
+        selector: '#submit',
+      }),
+      /Backing off for 1s/
+    );
   } finally {
     restore();
   }
@@ -854,6 +929,39 @@ test('a pre-aborted signal is honored even before the rate-limit gate runs', asy
       /Browser action cancelled because the run was stopped\./
     );
     assert.equal(contentsFor(aTab).url, 'about:blank');
+  } finally {
+    restore();
+  }
+});
+
+/**
+ * I-3 — `get_tabs`/`get_downloads` sit entirely outside `TAKEOVER_GATED_ACTIONS`
+ * (they are read-only, and `get_tabs` is the one action that PROVISIONS a tab
+ * for an owner that has none), so the per-gate `assertNotAborted` never ran for
+ * them. A Stop mid-flight could still land after the abort, opening a brand new
+ * tab for a run that no longer exists. `assertNotAborted` at the very top of
+ * `runBrowserAutomation` closes that gap for every action, gated or not.
+ */
+test('a pre-aborted signal stops get_tabs before it can provision or open a tab', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    const controller = new AbortController();
+    controller.abort();
+
+    await assert.rejects(
+      host.performBrowserAutomation('get_tabs', { ownerId: OWNER_A }, { signal: controller.signal }),
+      /Browser action cancelled because the run was stopped\./
+    );
+
+    assert.equal(
+      emitted.some((entry) => entry.event === 'browser://automation-open'),
+      false,
+      'an aborted get_tabs must not open a new automation view'
+    );
+    // Confirm no view exists for OWNER_A at all (a live, un-aborted get_tabs
+    // would have provisioned exactly one).
+    const probe = await probeTabs(host, OWNER_A);
+    assert.deepEqual(tabIds(probe), []);
   } finally {
     restore();
   }

--- a/electron/browserHost.ownership.test.cjs
+++ b/electron/browserHost.ownership.test.cjs
@@ -116,13 +116,25 @@ class FakeWebContentsView {
   setVisible(visible) { this.visible = visible; }
 }
 
-function fakeSession() {
+/**
+ * `onHeadersReceived` is invoked once per loadHost() (browserSessionForViews()
+ * is memoized inside the fresh module instance), and the real signature is
+ * `(filter, listener)` where the listener takes `(details, callback)`. The
+ * `capture` hook lets a test grab that listener so it can fire synthetic
+ * main-frame 429/2xx responses without a real network round trip.
+ */
+function fakeSession(capture) {
   return {
     setPermissionCheckHandler() {},
     setPermissionRequestHandler() {},
     setDevicePermissionHandler() {},
     setDisplayMediaRequestHandler() {},
     on() {},
+    webRequest: {
+      onHeadersReceived(_filter, listener) {
+        if (capture) capture(listener);
+      },
+    },
   };
 }
 
@@ -144,6 +156,7 @@ function loadHost({ adopt = true } = {}) {
     contentView: { addChildView() {}, removeChildView() {} },
   };
   let host = null;
+  let webRequestListener = null;
 
   require.cache[electronId] = {
     id: electronId,
@@ -151,7 +164,9 @@ function loadHost({ adopt = true } = {}) {
     loaded: true,
     exports: {
       WebContentsView: FakeWebContentsView,
-      session: { fromPartition: () => fakeSession() },
+      session: {
+        fromPartition: () => fakeSession((listener) => { webRequestListener = listener; }),
+      },
     },
   };
   require.cache[tauriHostId] = {
@@ -186,7 +201,18 @@ function loadHost({ adopt = true } = {}) {
     delete require.cache[browserHostId];
   };
 
-  return { host, emitted, restore };
+  /**
+   * Fire a synthetic `webRequest.onHeadersReceived` event, as if `browserSession`
+   * had just observed a real response. `webRequestListener` is only populated
+   * once something has actually created the browser session (e.g. a `get_tabs`
+   * call has provisioned a view) — callers must do that first.
+   */
+  const fireHeadersReceived = (details) => {
+    if (!webRequestListener) throw new Error('webRequest listener not registered yet');
+    webRequestListener({ resourceType: 'mainFrame', ...details }, () => {});
+  };
+
+  return { host, emitted, restore, fireHeadersReceived };
 }
 
 function getTabs(host, ownerId) {
@@ -588,6 +614,208 @@ test('a destroyed view drops its ownership record', async () => {
     assert.equal(tabIds(aAfter).length, 1);
     assert.notEqual(tabIds(aAfter)[0], aTab, 'a fresh owned view replaces the destroyed one');
     assert.equal(aAfter.summary.currentTabId, tabIds(aAfter)[0]);
+  } finally {
+    restore();
+  }
+});
+
+/**
+ * R5 — exponential per-origin backoff after HTTP 429 (docs at the top of
+ * `originBackoff` in browserHost.cjs). All of these fire the fake
+ * `webRequest.onHeadersReceived` listener directly rather than going through
+ * a real navigation, since the fake WebContents has no real network stack.
+ */
+function respond(fireHeadersReceived, url, statusCode, resourceType) {
+  fireHeadersReceived({ url, statusCode, ...(resourceType ? { resourceType } : {}) });
+}
+
+test('a 429 on the current origin blocks a state-changing action with the seconds remaining', async () => {
+  const { host, fireHeadersReceived, restore } = loadHost();
+  try {
+    const { clock } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+    await navigate(host, OWNER_A, aTab, 'https://example.com/checkout');
+
+    respond(fireHeadersReceived, 'https://example.com/checkout', 429);
+
+    await assert.rejects(
+      navigate(host, OWNER_A, aTab, 'https://example.com/checkout?retry=1'),
+      (error) => {
+        assert.equal(
+          error.message,
+          'This site is rate-limiting automated actions (HTTP 429). Backing off for 1s — ' +
+            'retrying immediately would make it worse. Tell the user, wait, or suggest they do this step manually.'
+        );
+        return true;
+      }
+    );
+    // No retry: the action must not have run.
+    assert.equal(contentsFor(aTab).url, 'https://example.com/checkout');
+  } finally {
+    restore();
+  }
+});
+
+test('read-only actions are never blocked by an origin backoff', async () => {
+  const { host, fireHeadersReceived, restore } = loadHost();
+  try {
+    const { clock } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+    await navigate(host, OWNER_A, aTab, 'https://example.com/');
+
+    respond(fireHeadersReceived, 'https://example.com/', 429);
+
+    const shot = await host.performBrowserAutomation('screenshot', { ownerId: OWNER_A, tabId: aTab });
+    assert.match(shot, /^data:image\/png;base64,/);
+  } finally {
+    restore();
+  }
+});
+
+test('a backoff window expires on its own and the action is then allowed', async () => {
+  const { host, fireHeadersReceived, restore } = loadHost();
+  try {
+    const { clock, state } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+    await navigate(host, OWNER_A, aTab, 'https://example.com/');
+
+    respond(fireHeadersReceived, 'https://example.com/', 429);
+    state.t += 1000; // exactly the 1s (level-1) window — now expired
+
+    await navigate(host, OWNER_A, aTab, 'https://example.com/next');
+    assert.equal(contentsFor(aTab).url, 'https://example.com/next', 'the action ran once the window expired');
+  } finally {
+    restore();
+  }
+});
+
+test('consecutive 429s escalate exponentially and cap at 30s', async () => {
+  const { host, fireHeadersReceived, restore } = loadHost();
+  try {
+    const { clock, state } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+    await navigate(host, OWNER_A, aTab, 'https://example.com/');
+
+    // Level 1: 1s.
+    respond(fireHeadersReceived, 'https://example.com/', 429);
+    await assert.rejects(navigate(host, OWNER_A, aTab, 'https://example.com/'), /Backing off for 1s/);
+
+    // Level 2: 2s (a second 429 while still gated, before the first window even expires).
+    respond(fireHeadersReceived, 'https://example.com/', 429);
+    await assert.rejects(navigate(host, OWNER_A, aTab, 'https://example.com/'), /Backing off for 2s/);
+
+    // Level 3: 4s.
+    respond(fireHeadersReceived, 'https://example.com/', 429);
+    await assert.rejects(navigate(host, OWNER_A, aTab, 'https://example.com/'), /Backing off for 4s/);
+
+    // Keep hitting it until the delay would exceed 30s — it must stay capped.
+    respond(fireHeadersReceived, 'https://example.com/', 429); // level 4: 8s
+    respond(fireHeadersReceived, 'https://example.com/', 429); // level 5: 16s
+    respond(fireHeadersReceived, 'https://example.com/', 429); // level 6: would be 32s, capped to 30s
+    await assert.rejects(navigate(host, OWNER_A, aTab, 'https://example.com/'), /Backing off for 30s/);
+
+    state.t += 30000;
+    await navigate(host, OWNER_A, aTab, 'https://example.com/done');
+    assert.equal(contentsFor(aTab).url, 'https://example.com/done');
+  } finally {
+    restore();
+  }
+});
+
+test('a 2xx main-frame response clears that origin\'s backoff window', async () => {
+  const { host, fireHeadersReceived, restore } = loadHost();
+  try {
+    const { clock } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+    await navigate(host, OWNER_A, aTab, 'https://example.com/');
+
+    respond(fireHeadersReceived, 'https://example.com/', 429);
+    await assert.rejects(navigate(host, OWNER_A, aTab, 'https://example.com/'), /Backing off/);
+
+    respond(fireHeadersReceived, 'https://example.com/', 200);
+    await navigate(host, OWNER_A, aTab, 'https://example.com/after-clear');
+    assert.equal(contentsFor(aTab).url, 'https://example.com/after-clear');
+  } finally {
+    restore();
+  }
+});
+
+test('a 429 on a subresource (non-main-frame) is not treated as the page rate-limiting', async () => {
+  const { host, fireHeadersReceived, restore } = loadHost();
+  try {
+    const { clock } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+    await navigate(host, OWNER_A, aTab, 'https://example.com/');
+
+    respond(fireHeadersReceived, 'https://example.com/ads/tracker.js', 429, 'script');
+
+    await navigate(host, OWNER_A, aTab, 'https://example.com/still-fine');
+    assert.equal(contentsFor(aTab).url, 'https://example.com/still-fine');
+  } finally {
+    restore();
+  }
+});
+
+/**
+ * Abort-to-main: the MCP loopback server aborts an AbortController when the
+ * client request closes early (see browserAutomationHost.cjs's `handleRequest`),
+ * and threads it through `performBrowserAutomation(action, payload, { signal })`
+ * into whatever gated wait the action is sitting in.
+ */
+test('an aborted signal stops a gated action during the user-idle wait, within one poll', async () => {
+  const { host, restore } = loadHost();
+  try {
+    const { clock, state } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+
+    typeInto(aTab); // the user is mid-keystroke, so the gated wait actually starts
+    const controller = new AbortController();
+    // Simulate the run being stopped mid-wait — the request closes, which is
+    // exactly what fires between two polls in the real handler.
+    state.onSleep = () => controller.abort();
+
+    await assert.rejects(
+      host.performBrowserAutomation(
+        'navigate',
+        { ownerId: OWNER_A, tabId: aTab, action: 'goto', url: 'https://example.com/' },
+        { signal: controller.signal }
+      ),
+      (error) => {
+        assert.equal(error.message, 'Browser action cancelled because the run was stopped.');
+        return true;
+      }
+    );
+
+    assert.equal(state.sleeps.length, 1, 'stopped after the very next poll, not the full 10s wait');
+    assert.equal(contentsFor(aTab).url, 'about:blank', 'the aborted action never landed');
+  } finally {
+    restore();
+  }
+});
+
+test('a pre-aborted signal is honored even before the rate-limit gate runs', async () => {
+  const { host, restore } = loadHost();
+  try {
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+    const controller = new AbortController();
+    controller.abort();
+
+    await assert.rejects(
+      host.performBrowserAutomation(
+        'navigate',
+        { ownerId: OWNER_A, tabId: aTab, action: 'goto', url: 'https://example.com/' },
+        { signal: controller.signal }
+      ),
+      /Browser action cancelled because the run was stopped\./
+    );
+    assert.equal(contentsFor(aTab).url, 'about:blank');
   } finally {
     restore();
   }

--- a/src/core/mcp/client.test.ts
+++ b/src/core/mcp/client.test.ts
@@ -94,4 +94,119 @@ describe('toCallToolOpts', () => {
   it('returns conversationId: undefined when context itself is undefined', () => {
     expect(toCallToolOpts(undefined)).toEqual({ conversationId: undefined, signal: undefined });
   });
+
+  it('carries abortSignal from context into opts.signal', () => {
+    const controller = new AbortController();
+    expect(toCallToolOpts({ abortSignal: controller.signal })).toEqual({
+      conversationId: undefined,
+      signal: controller.signal,
+    });
+  });
+});
+
+// Task B1: the conversation run's AbortSignal (ToolExecutionContext.abortSignal,
+// threaded through toCallToolOpts()/executeAnyTool's opts) is passed to the MCP
+// SDK's client.callTool() as its RequestOptions.signal (3rd positional param) —
+// see the SDK's client/index.d.ts: callTool(params, resultSchema?, options?).
+// Passing it makes the SDK itself send `notifications/cancelled` and reject
+// promptly when the signal fires; this suite proves the plumbing, not the SDK's
+// internal cancellation (that's the sdk's own tested behavior).
+describe('abort signal propagation into MCP callTool', () => {
+  let manager: MCPClientManager;
+  let mockCallTool: ReturnType<typeof vi.fn>;
+
+  function setFakeServer(name: string): void {
+    const fakeServer: FakeConnectedServer = {
+      config: { name },
+      client: { callTool: mockCallTool },
+      transport: {},
+      tools: new Map(),
+    };
+    (manager as unknown as { servers: Map<string, FakeConnectedServer> }).servers.set(
+      name,
+      fakeServer
+    );
+  }
+
+  beforeEach(() => {
+    manager = new MCPClientManager();
+    mockCallTool = vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+    setFakeServer('test-server');
+  });
+
+  it('passes opts.signal through to the SDK callTool as RequestOptions (3rd param)', async () => {
+    const controller = new AbortController();
+
+    await manager.callTool('test-server', 'some_tool', { a: 1 }, { signal: controller.signal });
+
+    expect(mockCallTool).toHaveBeenCalledWith(
+      { name: 'some_tool', arguments: { a: 1 } },
+      undefined,
+      { signal: controller.signal }
+    );
+  });
+
+  it('does not pass an options object when no signal is given (behavior unchanged)', async () => {
+    await manager.callTool('test-server', 'some_tool', { a: 1 });
+
+    expect(mockCallTool).toHaveBeenCalledWith(
+      { name: 'some_tool', arguments: { a: 1 } },
+      undefined,
+      undefined
+    );
+  });
+
+  it('resolves normally when the signal is provided but never aborted', async () => {
+    const controller = new AbortController();
+
+    const result = await manager.callTool(
+      'test-server',
+      'some_tool',
+      { a: 1 },
+      { signal: controller.signal }
+    );
+
+    expect(result).toBe('ok');
+  });
+
+  it('rejects promptly with the normalized browser-cancel message when the tool belongs to a browser server and the signal is aborted', async () => {
+    setFakeServer('abu-browser');
+    const controller = new AbortController();
+    controller.abort();
+    // Simulates the MCP SDK's own abort handling (protocol.ts): an aborted
+    // signal causes the SDK's callTool() promise to reject promptly.
+    mockCallTool.mockRejectedValue(new DOMException('This operation was aborted', 'AbortError'));
+
+    await expect(
+      manager.callTool('abu-browser', 'click', {}, { signal: controller.signal })
+    ).rejects.toThrow('Browser action cancelled because the run was stopped.');
+  });
+
+  it('applies the same normalization for the abu-browser-bridge server', async () => {
+    setFakeServer('abu-browser-bridge');
+    const controller = new AbortController();
+    controller.abort();
+    mockCallTool.mockRejectedValue(new DOMException('This operation was aborted', 'AbortError'));
+
+    await expect(
+      manager.callTool('abu-browser-bridge', 'click', {}, { signal: controller.signal })
+    ).rejects.toThrow('Browser action cancelled because the run was stopped.');
+  });
+
+  it('keeps the SDK error message unnormalized for non-browser MCP servers even when aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    mockCallTool.mockRejectedValue(new DOMException('This operation was aborted', 'AbortError'));
+
+    await expect(
+      manager.callTool('test-server', 'some_tool', {}, { signal: controller.signal })
+    ).rejects.toThrow(/Tool call failed: This operation was aborted/);
+  });
+
+  it('does not normalize a browser server error when the signal was never aborted (real failure stays real)', async () => {
+    setFakeServer('abu-browser');
+    mockCallTool.mockRejectedValue(new Error('boom'));
+
+    await expect(manager.callTool('abu-browser', 'click', {}, {})).rejects.toThrow(/boom/);
+  });
 });

--- a/src/core/mcp/client.test.ts
+++ b/src/core/mcp/client.test.ts
@@ -142,17 +142,35 @@ describe('abort signal propagation into MCP callTool', () => {
     expect(mockCallTool).toHaveBeenCalledWith(
       { name: 'some_tool', arguments: { a: 1 } },
       undefined,
-      { signal: controller.signal }
+      { signal: controller.signal, timeout: 30000 }
     );
   });
 
-  it('does not pass an options object when no signal is given (behavior unchanged)', async () => {
+  // Task B2 (controller addendum): the SDK's own request/response cycle has
+  // an internal default request timeout (60s, DEFAULT_REQUEST_TIMEOUT_MSEC)
+  // that used to fire independently of the manual Promise.race above it —
+  // for a browser server, whose manual race allows 120s, that meant the
+  // SDK's internal 60s timeout could reject a long `wait_for` first. Passing
+  // `timeout: serverTimeout` aligns the SDK's own timeout with the race.
+  it('always passes options.timeout (serverTimeout) to the SDK, signal or not', async () => {
     await manager.callTool('test-server', 'some_tool', { a: 1 });
 
     expect(mockCallTool).toHaveBeenCalledWith(
       { name: 'some_tool', arguments: { a: 1 } },
       undefined,
-      undefined
+      { timeout: 30000 }
+    );
+  });
+
+  it('passes options.timeout=120000 for a browser server (120s manual race)', async () => {
+    setFakeServer('abu-browser');
+
+    await manager.callTool('abu-browser', 'wait_for', { tabId: 1 });
+
+    expect(mockCallTool).toHaveBeenCalledWith(
+      { name: 'wait_for', arguments: { tabId: 1 } },
+      undefined,
+      { timeout: 120000 }
     );
   });
 

--- a/src/core/mcp/client.ts
+++ b/src/core/mcp/client.ts
@@ -42,10 +42,7 @@ export function toCallToolOpts(
 ): { conversationId?: string; signal?: AbortSignal } {
   return {
     conversationId: context?.conversationId,
-    // `signal` isn't populated from ToolExecutionContext until a later PR adds
-    // an AbortSignal field there; declared now so callTool()'s opts shape
-    // doesn't need to change again once that field lands.
-    signal: undefined,
+    signal: context?.abortSignal,
   };
 }
 
@@ -798,11 +795,15 @@ export class MCPClientManager {
     let timerId: ReturnType<typeof setTimeout>;
     try {
       const client = server.client as {
-        callTool: (params: {
-          name: string;
-          arguments: Record<string, unknown>;
-          _meta?: Record<string, unknown>;
-        }) => Promise<{
+        callTool: (
+          params: {
+            name: string;
+            arguments: Record<string, unknown>;
+            _meta?: Record<string, unknown>;
+          },
+          resultSchema?: undefined,
+          options?: { signal?: AbortSignal }
+        ) => Promise<{
           content?: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
         }>;
       };
@@ -829,7 +830,7 @@ export class MCPClientManager {
         params._meta = meta;
       }
       const result = await Promise.race([
-        client.callTool(params),
+        client.callTool(params, undefined, opts?.signal ? { signal: opts.signal } : undefined),
         timeout,
       ]);
       clearTimeout(timerId!);
@@ -868,6 +869,17 @@ export class MCPClientManager {
       return JSON.stringify(result);
     } catch (err) {
       clearTimeout(timerId!);
+      // The conversation run was stopped: the SDK already cancelled the
+      // in-flight request (see toCallToolOpts/callTool's `signal` param) and
+      // rejected promptly. Only browser automation servers get the friendlier
+      // cancellation message shown to the model/user — other MCP servers keep
+      // whatever error the SDK surfaced for its own abort handling.
+      if (
+        opts?.signal?.aborted &&
+        (serverName === 'abu-browser' || serverName === 'abu-browser-bridge')
+      ) {
+        throw new Error('Browser action cancelled because the run was stopped.', { cause: err });
+      }
       const errorMsg = err instanceof Error ? err.message : String(err);
       console.error(`[MCP] Tool call failed: ${serverName}:${toolName}`, err);
       throw new Error(`Tool call failed: ${errorMsg}`, { cause: err });

--- a/src/core/mcp/client.ts
+++ b/src/core/mcp/client.ts
@@ -802,7 +802,7 @@ export class MCPClientManager {
             _meta?: Record<string, unknown>;
           },
           resultSchema?: undefined,
-          options?: { signal?: AbortSignal }
+          options?: { signal?: AbortSignal; timeout?: number }
         ) => Promise<{
           content?: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
         }>;
@@ -829,8 +829,18 @@ export class MCPClientManager {
       if (Object.keys(meta).length > 0) {
         params._meta = meta;
       }
+      // Always pass `timeout` (not only when a signal is given): the SDK's
+      // own request/response cycle has an internal default request timeout
+      // (60s) that fires independently of the manual `Promise.race` above.
+      // For browser servers, serverTimeout is 120s — without this, the SDK's
+      // 60s default would reject `wait_for`-style long calls before our own
+      // race ever gets a chance to.
       const result = await Promise.race([
-        client.callTool(params, undefined, opts?.signal ? { signal: opts.signal } : undefined),
+        client.callTool(
+          params,
+          undefined,
+          opts?.signal ? { signal: opts.signal, timeout: serverTimeout } : { timeout: serverTimeout }
+        ),
         timeout,
       ]);
       clearTimeout(timerId!);

--- a/src/core/tools/registry.mcpConversationId.test.ts
+++ b/src/core/tools/registry.mcpConversationId.test.ts
@@ -71,4 +71,37 @@ describe('executeAnyTool → mcpManager.callTool → _meta (MCP tool dispatch)',
     const params = mockCallTool.mock.calls[0][0];
     expect(params._meta).toBeUndefined();
   });
+
+  // Task B1: ToolExecutionContext.abortSignal (already injected by toolExecutor
+  // at every dispatch site) must reach the underlying MCP SDK client.callTool()
+  // as its RequestOptions.signal (3rd positional param), the same way
+  // conversationId reaches `_meta` above — this is the real dispatch path a
+  // model tool_use goes through, not just the last-hop unit in client.test.ts.
+  it('forwards the abort signal from ToolExecutionContext into the MCP request options', async () => {
+    const controller = new AbortController();
+
+    await executeAnyTool('test-server__test_tool', { a: 1 }, undefined, undefined, {
+      conversationId: 'c1',
+      abortSignal: controller.signal,
+    });
+
+    expect(mockCallTool).toHaveBeenCalledTimes(1);
+    expect(mockCallTool).toHaveBeenCalledWith(
+      { name: 'test_tool', arguments: { a: 1 }, _meta: { 'abu/conversationId': 'c1' } },
+      undefined,
+      { signal: controller.signal }
+    );
+  });
+
+  it('does not pass an options object when the context has no abort signal', async () => {
+    await executeAnyTool('test-server__test_tool', { a: 1 }, undefined, undefined, {
+      conversationId: 'c1',
+    });
+
+    expect(mockCallTool).toHaveBeenCalledWith(
+      { name: 'test_tool', arguments: { a: 1 }, _meta: { 'abu/conversationId': 'c1' } },
+      undefined,
+      undefined
+    );
+  });
 });

--- a/src/core/tools/registry.mcpConversationId.test.ts
+++ b/src/core/tools/registry.mcpConversationId.test.ts
@@ -89,11 +89,15 @@ describe('executeAnyTool → mcpManager.callTool → _meta (MCP tool dispatch)',
     expect(mockCallTool).toHaveBeenCalledWith(
       { name: 'test_tool', arguments: { a: 1 }, _meta: { 'abu/conversationId': 'c1' } },
       undefined,
-      { signal: controller.signal }
+      { signal: controller.signal, timeout: 30000 }
     );
   });
 
-  it('does not pass an options object when the context has no abort signal', async () => {
+  // Task B2 (controller addendum): `timeout: serverTimeout` is always passed
+  // to the SDK now (not only alongside a signal) — see client.test.ts's
+  // "always passes options.timeout" for why: the SDK's own internal request
+  // timeout otherwise fires ahead of callTool's manual race.
+  it('still passes options.timeout when the context has no abort signal', async () => {
     await executeAnyTool('test-server__test_tool', { a: 1 }, undefined, undefined, {
       conversationId: 'c1',
     });
@@ -101,7 +105,7 @@ describe('executeAnyTool → mcpManager.callTool → _meta (MCP tool dispatch)',
     expect(mockCallTool).toHaveBeenCalledWith(
       { name: 'test_tool', arguments: { a: 1 }, _meta: { 'abu/conversationId': 'c1' } },
       undefined,
-      undefined
+      { timeout: 30000 }
     );
   });
 });

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -933,6 +933,7 @@ export async function executeAnyTool(
     if (mcpManager.isConnected(serverName)) {
       const result = await mcpManager.callTool(serverName, toolName, executionInput, {
         conversationId: toolContext?.conversationId,
+        signal: toolContext?.abortSignal,
       });
       // Only truncate string results; rich content (images) passes through
       if (typeof result === 'string') {


### PR DESCRIPTION
叠在 PR-A（#326）上。停止即中止、用户接管让路、429 指数退避——批次 2.5 的 R3/R4/R5。

## 内容
- R3 停止贯通：会话 AbortSignal → MCP SDK options.signal → server extra.signal → 双 transport 取消（HTTP abort / WS cancel）→ 主进程 res-close AbortController；全动作入口 assertNotAborted
- R4 接管退避：before-input-event/focus 归因（aiActionDepth 窗口排除 AI 自身）、gated 动作 3s 静默窗等待、10s 上限后自然语言报告
- R5 限流退避：main_frame 429 按 origin 指数退避 1s→30s，navigate 按目标 origin 拦、逃离不拦
- 顺手修 dev 既有 bug：MCP SDK 60s 默认超时掐 wait_for（对齐 serverTimeout 120s）

## Stop 链路四场景端到端行为
见交付报告 §六（外层 docs/abu-browser-batch1-b25-delivery-2026-09-01.md）——已派发进页面的单个动作无法撤回（与 Codex 同构的物理边界），其余场景 ≤500ms 停止在集成层证明。

## 证据
- verify=0（477/7266）双确认、electron:test=0、e2e 33 过 1 败（既定环境 flake，同 commit 干净 worktree 2/2 过）
- 逐任务复审（B4 一轮 pin 补测）+ 整分支终审 + 修复波 re-review 全 ADDRESSED
- 账本：worktree `.superpowers/sdd/2026-09-01-browser-abort-backoff-pr-b/progress.md`

## 跟进（已记）
扩展端暂不响应 cancel 中止在途工作；HTTP transport 用户中止误报 timed-out 文案。

🤖 Generated with [Claude Code](https://claude.com/claude-code)