### PR TITLE
feat(browser): view lifecycle decoupling, run-scoped ownership & user reclaim (批次2.5 PR-C)

### DIFF
--- a/abu-browser-bridge/src/tools.test.ts
+++ b/abu-browser-bridge/src/tools.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   ABU_CONVERSATION_META_KEY,
   ABU_CREATE_IF_EMPTY_META_KEY,
+  ABU_RUN_META_KEY,
   registerTools,
   type BrowserTransport,
 } from './tools.js';
@@ -322,6 +323,61 @@ describe('ownerId forwarding', () => {
     expect(transport.send).toHaveBeenLastCalledWith(
       'get_html',
       { tabId: 9, selector: undefined, ownerId: 'conv-42' },
+      undefined,
+      { signal: undefined }
+    );
+  });
+});
+
+// N6: tab ownership in the Abu host is the pair {conversationId, runKey}, so
+// the run half has to ride the same `_meta` channel as the conversation half.
+// Absence must stay absence — the host's "no run ⇒ main loop" default is what
+// keeps every pre-N6 caller byte-compatible, and a defaulted-here payload would
+// take that decision away from it.
+describe('runId forwarding', () => {
+  const metaWithOwner = { _meta: { [ABU_CONVERSATION_META_KEY]: 'conv-42' } };
+
+  it('adds runId alongside ownerId when the caller is a subagent run', async () => {
+    const { registered, transport } = collectTools();
+    const click = registered.find((t) => t.name === 'click')!;
+
+    await click.handler({ tabId: 1, locator: '{"css":"#a"}' }, {
+      _meta: {
+        [ABU_CONVERSATION_META_KEY]: 'conv-42',
+        [ABU_RUN_META_KEY]: 'sar-abc',
+      },
+    });
+    expect(transport.send).toHaveBeenLastCalledWith(
+      'click',
+      { tabId: 1, locator: { css: '#a' }, ownerId: 'conv-42', runId: 'sar-abc' },
+      undefined,
+      { signal: undefined }
+    );
+  });
+
+  it('omits runId entirely for a main-loop caller', async () => {
+    const { registered, transport } = collectTools();
+    const click = registered.find((t) => t.name === 'click')!;
+
+    await click.handler({ tabId: 1, locator: '{"css":"#a"}' }, metaWithOwner);
+    expect(transport.send).toHaveBeenLastCalledWith(
+      'click',
+      { tabId: 1, locator: { css: '#a' }, ownerId: 'conv-42' },
+      undefined,
+      { signal: undefined }
+    );
+  });
+
+  it('ignores a non-string runId rather than forwarding a malformed owner half', async () => {
+    const { registered, transport } = collectTools();
+    const getTabs = registered.find((t) => t.name === 'get_tabs')!;
+
+    await getTabs.handler({
+      _meta: { [ABU_CONVERSATION_META_KEY]: 'conv-42', [ABU_RUN_META_KEY]: 7 },
+    });
+    expect(transport.send).toHaveBeenLastCalledWith(
+      'get_tabs',
+      { ownerId: 'conv-42' },
       undefined,
       { signal: undefined }
     );

--- a/abu-browser-bridge/src/tools.ts
+++ b/abu-browser-bridge/src/tools.ts
@@ -27,6 +27,19 @@ export const ABU_CONVERSATION_META_KEY = 'abu/conversationId';
  */
 export const ABU_CREATE_IF_EMPTY_META_KEY = 'abu/createIfEmpty';
 
+/**
+ * MCP `_meta` key carrying the SUBAGENT RUN that issued the call, alongside
+ * `ABU_CONVERSATION_META_KEY`'s conversation id. Browser tab ownership in the
+ * Abu host is the pair `{conversationId, runKey}` (N6) — one conversation can
+ * drive the browser from its own loop and from several delegated subagent runs
+ * at once, and without the second half they would share one tab pool and one
+ * "current tab" and steal each other's pages. Absent ⇒ the conversation's own
+ * loop, which the host reads as the run key `main`, so a caller that never
+ * sends this key behaves exactly as it did before. Same
+ * `_meta`-not-input-schema and duplication rationale as above.
+ */
+export const ABU_RUN_META_KEY = 'abu/runKey';
+
 export interface BrowserTransportResponse {
   success: boolean;
   data?: unknown;
@@ -89,17 +102,31 @@ async function ensureConnected(transport: BrowserTransport): Promise<void> {
   }
 }
 
-/**
- * Pull the owning conversation id out of a tool handler's `extra` (the MCP SDK's
- * per-request context, `extra._meta?: RequestMeta`), so every handler can merge
- * `{ ownerId }` into its `transport.send()` payload without repeating the
- * `_meta` lookup. `extra` is typed as `unknown` here rather than importing the
- * SDK's `RequestHandlerExtra` type, to stay decoupled from its exact shape.
- */
-function ownerFromExtra(extra: unknown): string | undefined {
+function metaString(extra: unknown, key: string): string | undefined {
   const meta = (extra as { _meta?: Record<string, unknown> } | undefined)?._meta;
-  const owner = meta?.[ABU_CONVERSATION_META_KEY];
-  return typeof owner === 'string' ? owner : undefined;
+  const value = meta?.[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Pull the calling OWNER — conversation id plus subagent run key — out of a tool
+ * handler's `extra` (the MCP SDK's per-request context, `extra._meta?:
+ * RequestMeta`), already shaped as the payload fragment every handler merges
+ * into its `transport.send()` call, so the `_meta` lookup is not repeated at the
+ * 19 call sites below. `extra` is typed as `unknown` here rather than importing
+ * the SDK's `RequestHandlerExtra` type, to stay decoupled from its exact shape.
+ *
+ * Absent keys are OMITTED rather than defaulted: the host owns the "no run id ⇒
+ * the conversation's own loop" default, and a payload that never carries the
+ * field keeps its exact pre-N6 shape for every caller that sends no run.
+ */
+function ownerPayloadFromExtra(extra: unknown): Record<string, string> {
+  const ownerId = metaString(extra, ABU_CONVERSATION_META_KEY);
+  const runId = metaString(extra, ABU_RUN_META_KEY);
+  return {
+    ...(ownerId ? { ownerId } : {}),
+    ...(runId ? { runId } : {}),
+  };
 }
 
 /**
@@ -194,10 +221,10 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     'Get all open browser tabs grouped by window. Returns a summary with the current window/tab info, plus a list of windows each containing their tabs. Use this first to find the target tab ID for other browser actions.',
     async (extra) => {
       await ensureConnected(transport);
-      const ownerId = ownerFromExtra(extra);
+      const owner = ownerPayloadFromExtra(extra);
       const createIfEmpty = createIfEmptyFromExtra(extra);
       const res = await sendWithSignal(transport, 'get_tabs', {
-        ...(ownerId ? { ownerId } : {}),
+        ...owner,
         ...(createIfEmpty === false ? { createIfEmpty: false } : {}),
       }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
@@ -215,8 +242,8 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     },
     async ({ tabId, selector, maxChars }, extra) => {
       await ensureConnected(transport);
-      const ownerId = ownerFromExtra(extra);
-      const res = await sendWithSignal(transport, 'snapshot', { tabId, selector, maxChars, ...(ownerId ? { ownerId } : {}) }, extra);
+      const owner = ownerPayloadFromExtra(extra);
+      const res = await sendWithSignal(transport, 'snapshot', { tabId, selector, maxChars, ...owner }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -232,8 +259,8 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     async ({ tabId, locator }, extra) => {
       await ensureConnected(transport);
       const parsed = parseLocator(locator);
-      const ownerId = ownerFromExtra(extra);
-      const res = await sendWithSignal(transport, 'click', { tabId, locator: parsed, ...(ownerId ? { ownerId } : {}) }, extra);
+      const owner = ownerPayloadFromExtra(extra);
+      const res = await sendWithSignal(transport, 'click', { tabId, locator: parsed, ...owner }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -250,8 +277,8 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     async ({ tabId, locator, value }, extra) => {
       await ensureConnected(transport);
       const parsed = parseLocator(locator);
-      const ownerId = ownerFromExtra(extra);
-      const res = await sendWithSignal(transport, 'fill', { tabId, locator: parsed, value, ...(ownerId ? { ownerId } : {}) }, extra);
+      const owner = ownerPayloadFromExtra(extra);
+      const res = await sendWithSignal(transport, 'fill', { tabId, locator: parsed, value, ...owner }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -268,8 +295,8 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     async ({ tabId, locator, value }, extra) => {
       await ensureConnected(transport);
       const parsed = parseLocator(locator);
-      const ownerId = ownerFromExtra(extra);
-      const res = await sendWithSignal(transport, 'select', { tabId, locator: parsed, value, ...(ownerId ? { ownerId } : {}) }, extra);
+      const owner = ownerPayloadFromExtra(extra);
+      const res = await sendWithSignal(transport, 'select', { tabId, locator: parsed, value, ...owner }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -293,11 +320,11 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     async ({ tabId, condition, timeout }, extra) => {
       await ensureConnected(transport);
       const parsed = parseCondition(condition);
-      const ownerId = ownerFromExtra(extra);
+      const owner = ownerPayloadFromExtra(extra);
       const res = await sendWithSignal(
         transport,
         'wait_for',
-        { tabId, condition: parsed, timeout, ...(ownerId ? { ownerId } : {}) },
+        { tabId, condition: parsed, timeout, ...owner },
         extra,
         timeout + 5000
       );
@@ -315,8 +342,8 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     },
     async ({ tabId, selector }, extra) => {
       await ensureConnected(transport);
-      const ownerId = ownerFromExtra(extra);
-      const res = await sendWithSignal(transport, 'extract_text', { tabId, selector, ...(ownerId ? { ownerId } : {}) }, extra);
+      const owner = ownerPayloadFromExtra(extra);
+      const res = await sendWithSignal(transport, 'extract_text', { tabId, selector, ...owner }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -331,8 +358,8 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     },
     async ({ tabId, selector }, extra) => {
       await ensureConnected(transport);
-      const ownerId = ownerFromExtra(extra);
-      const res = await sendWithSignal(transport, 'extract_table', { tabId, selector, ...(ownerId ? { ownerId } : {}) }, extra);
+      const owner = ownerPayloadFromExtra(extra);
+      const res = await sendWithSignal(transport, 'extract_table', { tabId, selector, ...owner }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -349,8 +376,8 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     },
     async ({ tabId, direction, amount, selector }, extra) => {
       await ensureConnected(transport);
-      const ownerId = ownerFromExtra(extra);
-      const res = await sendWithSignal(transport, 'scroll', { tabId, direction, amount, selector, ...(ownerId ? { ownerId } : {}) }, extra);
+      const owner = ownerPayloadFromExtra(extra);
+      const res = await sendWithSignal(transport, 'scroll', { tabId, direction, amount, selector, ...owner }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -366,8 +393,8 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     },
     async ({ tabId, url, action }, extra) => {
       await ensureConnected(transport);
-      const ownerId = ownerFromExtra(extra);
-      const res = await sendWithSignal(transport, 'navigate', { tabId, url, action, ...(ownerId ? { ownerId } : {}) }, extra);
+      const owner = ownerPayloadFromExtra(extra);
+      const res = await sendWithSignal(transport, 'navigate', { tabId, url, action, ...owner }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -383,8 +410,8 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     },
     async ({ tabId, key, modifiers }, extra) => {
       await ensureConnected(transport);
-      const ownerId = ownerFromExtra(extra);
-      const res = await sendWithSignal(transport, 'keyboard', { tabId, key, modifiers, ...(ownerId ? { ownerId } : {}) }, extra);
+      const owner = ownerPayloadFromExtra(extra);
+      const res = await sendWithSignal(transport, 'keyboard', { tabId, key, modifiers, ...owner }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -399,8 +426,8 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     },
     async ({ tabId, code }, extra) => {
       await ensureConnected(transport);
-      const ownerId = ownerFromExtra(extra);
-      const res = await sendWithSignal(transport, 'execute_js', { tabId, code, ...(ownerId ? { ownerId } : {}) }, extra, 60_000);
+      const owner = ownerPayloadFromExtra(extra);
+      const res = await sendWithSignal(transport, 'execute_js', { tabId, code, ...owner }, extra, 60_000);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -416,8 +443,8 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     },
     async ({ tabId, code, selector }, extra) => {
       await ensureConnected(transport);
-      const ownerId = ownerFromExtra(extra);
-      const htmlResponse = await sendWithSignal(transport, 'get_html', { tabId, selector, ...(ownerId ? { ownerId } : {}) }, extra);
+      const owner = ownerPayloadFromExtra(extra);
+      const htmlResponse = await sendWithSignal(transport, 'get_html', { tabId, selector, ...owner }, extra);
       if (!htmlResponse.success) {
         throw new Error(htmlResponse.error ?? 'Failed to read page HTML');
       }
@@ -438,8 +465,8 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     },
     async ({ tabId }, extra) => {
       await ensureConnected(transport);
-      const ownerId = ownerFromExtra(extra);
-      const res = await sendWithSignal(transport, 'screenshot', { tabId, ...(ownerId ? { ownerId } : {}) }, extra);
+      const owner = ownerPayloadFromExtra(extra);
+      const res = await sendWithSignal(transport, 'screenshot', { tabId, ...owner }, extra);
       if (res.success && typeof res.data === 'string') {
         return {
           content: [{
@@ -462,9 +489,9 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     },
     async ({ tabId }, extra) => {
       await ensureConnected(transport);
-      const ownerId = ownerFromExtra(extra);
+      const owner = ownerPayloadFromExtra(extra);
       // Full-page capture needs more time: scroll + multiple captures + stitch
-      const res = await sendWithSignal(transport, 'screenshot_full_page', { tabId, ...(ownerId ? { ownerId } : {}) }, extra, 120_000);
+      const res = await sendWithSignal(transport, 'screenshot_full_page', { tabId, ...owner }, extra, 120_000);
       if (res.success && typeof res.data === 'string') {
         return {
           content: [{
@@ -500,8 +527,8 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     'Get recent file downloads from the browser. Useful for confirming that a file was downloaded after clicking a download button.',
     async (extra) => {
       await ensureConnected(transport);
-      const ownerId = ownerFromExtra(extra);
-      const res = await sendWithSignal(transport, 'get_downloads', ownerId ? { ownerId } : {}, extra);
+      const owner = ownerPayloadFromExtra(extra);
+      const res = await sendWithSignal(transport, 'get_downloads', owner, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -515,8 +542,8 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     },
     async ({ tabId }, extra) => {
       await ensureConnected(transport);
-      const ownerId = ownerFromExtra(extra);
-      const res = await sendWithSignal(transport, 'start_recording', { tabId, ...(ownerId ? { ownerId } : {}) }, extra);
+      const owner = ownerPayloadFromExtra(extra);
+      const res = await sendWithSignal(transport, 'start_recording', { tabId, ...owner }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );
@@ -530,8 +557,8 @@ export function registerTools(server: McpServer, transport: BrowserTransport = c
     },
     async ({ tabId }, extra) => {
       await ensureConnected(transport);
-      const ownerId = ownerFromExtra(extra);
-      const res = await sendWithSignal(transport, 'stop_recording', { tabId, ...(ownerId ? { ownerId } : {}) }, extra);
+      const owner = ownerPayloadFromExtra(extra);
+      const res = await sendWithSignal(transport, 'stop_recording', { tabId, ...owner }, extra);
       return { content: [{ type: 'text' as const, text: formatResult(res) }] };
     }
   );

--- a/electron/browserHost.cjs
+++ b/electron/browserHost.cjs
@@ -59,6 +59,14 @@
  * navigated-to URL as a plain string (matches `listen<string>` in
  * BrowserTab.tsx:126).
  *
+ * ## Adoption events: `browser://automation-open` / `browser://automation-cancel`
+ * Electron-only (no Tauri counterpart). `-open` invites the renderer to adopt a
+ * new automation view into the workspace; `-cancel {id}` withdraws that
+ * invitation — the run was stopped, or the conversation that owned the view was
+ * deleted — and asks the renderer to drop the tab record again (App.tsx). See
+ * `cancelledAdoptionIds` for why a withdrawal needs both the event and a
+ * main-side tombstone.
+ *
  * ## window.open / target="_blank"
  * browser.rs injects `NEW_WINDOW_SHIM` (an `initialization_script` that
  * redirects `window.open()`/blank-target link clicks into the SAME webview,
@@ -176,6 +184,46 @@ const activeTabIdByOwner = new Map();
  * and `browserCreate()` is where the adopted view's meta gets written.
  */
 const pendingAutomationOwners = new Map();
+
+/**
+ * ## Cancelled adoptions (tombstones)
+ *
+ * `browser://automation-open` is already on its way to the renderer by the time
+ * an adoption can be cancelled (the run was stopped, or the owning conversation
+ * was deleted), and the renderer answers it unconditionally with
+ * `browser_create`. Dropping only the pending-owner entry would let that late
+ * `browser_create` build the view as LEGACY — a live page every OTHER
+ * conversation could see and drive, while the only record that could destroy it
+ * (the renderer tab, still carrying the dead conversation's owner) is invisible
+ * in every tab strip. So a cancelled id is TOMBSTONED here and `browserCreate`
+ * refuses it.
+ *
+ * Refusal is silent (`return null`): `BrowserTab.tsx` treats a throw from
+ * `browser_create` as a transient failure and retries on a timer, which would
+ * turn one refusal into a retry storm.
+ *
+ * The set is capped and evicts oldest-first — it only has to outlive an
+ * in-flight adoption (milliseconds), never the session. Entries are NOT
+ * consumed on the first refusal: React StrictMode can double-mount a
+ * `BrowserTab` and issue `browser_create` twice for the same id.
+ */
+const MAX_CANCELLED_ADOPTIONS = 64;
+const cancelledAdoptionIds = new Set();
+
+/**
+ * Cancel one adoption: stop refusing it into existence, and tell the renderer to
+ * drop the tab record (which also destroys the view if it already made one —
+ * `previewStore` commits every removal through `closeBrowserViews`).
+ */
+function cancelAutomationAdoption(id) {
+  pendingAutomationOwners.delete(id);
+  cancelledAdoptionIds.add(id);
+  while (cancelledAdoptionIds.size > MAX_CANCELLED_ADOPTIONS) {
+    const oldest = cancelledAdoptionIds.values().next().value;
+    cancelledAdoptionIds.delete(oldest);
+  }
+  emit('browser://automation-cancel', { id });
+}
 
 function ownerKeyOf(id) {
   const meta = viewMeta.get(id);
@@ -664,7 +712,7 @@ async function createAutomationView(ownerKey = LEGACY_OWNER, signal) {
     // The run may be stopped at any point during the wait; drop the pending
     // entry before throwing so a cancelled adoption cannot strand one.
     if (signal && signal.aborted) {
-      pendingAutomationOwners.delete(id);
+      cancelAutomationAdoption(id);
       throw new Error(RUN_STOPPED_MESSAGE);
     }
     const adopted = views.get(id);
@@ -683,6 +731,7 @@ async function createAutomationView(ownerKey = LEGACY_OWNER, signal) {
     // one means the owning conversation was deleted while we waited (the only
     // other remover, an adoption, is the branch just above). Building the
     // fallback view now would strand a live view no conversation can close.
+    // The tombstone + cancel event were already published by whoever purged it.
     if (!pendingAutomationOwners.has(id)) throw new Error(RUN_STOPPED_MESSAGE);
     if (Date.now() >= deadline) break;
     await new Promise((resolve) => setTimeout(resolve, 50));
@@ -1070,6 +1119,13 @@ function browserCreate({ id, url, x, y, width, height, visible = true }) {
     throw new Error('main window not found');
   }
 
+  // An adoption cancelled while `browser://automation-open` was already in
+  // flight (see `cancelledAdoptionIds`): the renderer is answering an invitation
+  // main has since withdrawn. Do nothing, quietly — creating the view here is
+  // exactly the LEGACY-ghost bug the tombstone exists to prevent, and throwing
+  // would drive BrowserTab's create-retry loop.
+  if (cancelledAdoptionIds.has(id)) return null;
+
   const existing = views.get(id);
   if (existing) {
     // Already created (e.g. StrictMode double-mount) — reuse it, matching
@@ -1243,26 +1299,38 @@ function browserClose({ id }) {
  * destroys the views it knows about; this command is the belt-and-braces half
  * for main-side state no tab record covers — a headless fallback view (no
  * renderer ever adopted it), or an adoption still pending when the delete
- * landed. Scope is exactly one owner: another conversation's views and the
+ * landed. Every id it reaches is also cancelled (tombstoned + a
+ * `browser://automation-cancel` to the renderer), so an adoption still in
+ * flight cannot come back as a legacy ghost. Scope is exactly one owner: another conversation's views and the
  * LEGACY pool (the user's own pane tabs, which every conversation may see) are
  * never touched, so an unknown/blank/legacy owner is a deliberate no-op rather
  * than an error — like `browser_hide`/`browser_close`, this is a cleanup
  * command whose failure mode must never be "kill someone else's tab".
  */
 function disposeOwnerViews(ownerKey) {
+  const cancelledIds = [];
   // Snapshot: closeView deletes from `views` as we go.
   for (const [id, view] of Array.from(views)) {
-    if (ownerKeyOf(id) === ownerKey) closeView(id, view);
+    if (ownerKeyOf(id) !== ownerKey) continue;
+    closeView(id, view);
+    // Tombstone the closed view's id too: BrowserTab may have a create RETRY in
+    // flight for it (its invoke failed once), which would otherwise rebuild the
+    // view as legacy a moment after this teardown.
+    cancelledIds.push(id);
   }
-  // closeView already drops these per view (and `forgetOwnerInteractionIfUnused`
-  // clears the interaction record once the owner's last view is gone), but the
-  // owner may also hold records with no live view behind them — a current-tab
-  // id whose view was destroyed by the window teardown, or a pending adoption.
+  for (const [pendingId, pendingOwner] of Array.from(pendingAutomationOwners)) {
+    if (pendingOwner === ownerKey) cancelledIds.push(pendingId);
+  }
+  // closeView already drops the per-view records (and
+  // `forgetOwnerInteractionIfUnused` clears the interaction record once the
+  // owner's last view is gone), but the owner may also hold records with no live
+  // view behind them — a current-tab id whose view was destroyed by the window
+  // teardown, or a pending adoption.
   activeTabIdByOwner.delete(ownerKey);
   userInteractionAt.delete(ownerKey);
-  for (const [pendingId, pendingOwner] of Array.from(pendingAutomationOwners)) {
-    if (pendingOwner === ownerKey) pendingAutomationOwners.delete(pendingId);
-  }
+  // Emitted last, so the renderer's reaction (dropping the tab record, which
+  // fires `browser_close`) can never race the teardown above.
+  for (const id of cancelledIds) cancelAutomationAdoption(id);
 }
 
 function browserDisposeOwner({ conversationId }) {

--- a/electron/browserHost.cjs
+++ b/electron/browserHost.cjs
@@ -347,6 +347,42 @@ const USER_INTERACT_QUIET_MS = 3000;
 const TAKEOVER_WAIT_MS = 10000;
 const TAKEOVER_POLL_MS = 500;
 
+/**
+ * ## F1 — navigation-commit focus steal
+ *
+ * Chromium hands a WebContentsView's frame keyboard focus when a navigation
+ * commits — no host code involved (real-device acceptance 2026-09-02: a
+ * page's own redirect fired a genuine `focusout` on the main window's address
+ * bar at exactly the moment the guest landed). Left alone that (a) silently
+ * blurs whatever the user is typing into in the MAIN window, and (b) makes
+ * the guest's `focus` event look like the user being on that tab to the R4
+ * attribution below.
+ *
+ * A steal is told apart from the user really entering the guest by two
+ * signals: the user typed in the main window inside the quiet window, and no
+ * direct input (pointer/keyboard) landed on the guest just before its
+ * `focus`. In exactly that case focus is handed straight back and the event
+ * is not attributed. When nobody is typing in the main window the pre-F1
+ * behavior stands — a missed bounce is harmless with no typing to protect.
+ */
+const GUEST_INPUT_ATTRIBUTION_MS = 1000;
+
+/** ts of the user's last keyboard input in the MAIN window's own webContents. */
+let mainWindowKeyInputAt = 0;
+const mainInputHookedContents = new WeakSet();
+function ensureMainWindowInputHook() {
+  const win = mainWindow();
+  if (!win || win.isDestroyed()) return;
+  const contents = win.webContents;
+  if (!contents || typeof contents.on !== 'function' || mainInputHookedContents.has(contents)) {
+    return;
+  }
+  mainInputHookedContents.add(contents);
+  contents.on('before-input-event', () => {
+    mainWindowKeyInputAt = clock.now();
+  });
+}
+
 /** Fixed text: it tells the model to re-read the page, not to retry blindly. */
 const USER_TAKEOVER_MESSAGE =
   'The user is currently interacting with this browser tab. Automation paused to avoid ' +
@@ -904,14 +940,41 @@ function configureBrowserView(id, view) {
   contents.on('did-start-navigation', (_event, _url, _isInPlace, isMainFrame) => {
     if (isMainFrame) resetAutomationRuntime();
   });
+  ensureMainWindowInputHook();
   // Attribution for the takeover backoff: outside an automation action, input
   // landing here is the user working in this view's owner's tab.
   const recordUserInteraction = () => {
     if (aiActionDepth > 0) return;
     userInteractionAt.set(ownerKeyOf(id), clock.now());
   };
-  contents.on('before-input-event', recordUserInteraction);
+  // Direct input on THIS view (keyboard or pointer) is what separates the
+  // user really entering the guest from a navigation-commit focus steal (F1).
+  let lastDirectGuestInputAt = 0;
+  const recordDirectGuestInput = () => {
+    if (aiActionDepth > 0) return;
+    lastDirectGuestInputAt = clock.now();
+  };
+  contents.on('before-input-event', () => {
+    recordDirectGuestInput();
+    recordUserInteraction();
+  });
+  // `before-input-event` is keyboard-only; a pointer entering the guest is
+  // only visible here.
+  contents.on('input-event', (_event, inputEvent) => {
+    if (inputEvent && inputEvent.type === 'mouseDown') recordDirectGuestInput();
+  });
   contents.on('focus', () => {
+    const now = clock.now();
+    const userTypingInMainUi = now - mainWindowKeyInputAt < USER_INTERACT_QUIET_MS;
+    const enteredGuestDirectly = now - lastDirectGuestInputAt < GUEST_INPUT_ATTRIBUTION_MS;
+    if (userTypingInMainUi && !enteredGuestDirectly) {
+      // Navigation-commit steal (F1): the user is typing in the main window
+      // and never touched this view — hand focus straight back, and do not
+      // let the steal read as the user being on this tab.
+      const win = mainWindow();
+      if (win && !win.isDestroyed()) win.webContents.focus();
+      return;
+    }
     recordUserInteraction();
     // The user focusing a view makes it that view OWNER's current tab, never
     // anyone else's.

--- a/electron/browserHost.cjs
+++ b/electron/browserHost.cjs
@@ -106,6 +106,7 @@ const BROWSER_CMDS = new Set([
   'browser_capture',
   'browser_close',
   'browser_inspect_set',
+  'browser_note_user_interaction',
 ]);
 const BROWSER_MISS = Symbol('browser-dispatch-miss');
 
@@ -1203,6 +1204,28 @@ function browserClose({ id }) {
 }
 
 /**
+ * N3 — React-layer takeover signal.
+ *
+ * The takeover backoff (R4, above) only hears the USER on the guest
+ * webContents itself (`before-input-event` / `focus`): typing in the address
+ * bar or clicking back/forward/reload happens in the MAIN window's React
+ * layer (`BrowserTab.tsx`), which never touches the guest webContents, so
+ * none of it produced a signal — automation could act while the user was
+ * mid-navigation. `BrowserTab.tsx` calls this on address-bar focus/input and
+ * nav-button clicks; it records presence exactly like `recordUserInteraction`
+ * does for real input, reusing the same map/clock rather than adding new
+ * state. An unknown id (a tab that already closed under a stale ref) is a
+ * silent no-op — this is a best-effort presence ping, not a validated
+ * command.
+ */
+function browserNoteUserInteraction({ id }) {
+  const view = getView(id);
+  if (!view) return null;
+  userInteractionAt.set(ownerKeyOf(id), clock.now());
+  return null;
+}
+
+/**
  * @param {import('electron').App} app unused — kept for signature parity
  *   with the other *Dispatch(app, cmd, args) families (e.g. ptyDispatch).
  * @param {string} cmd
@@ -1237,6 +1260,8 @@ function browserDispatch(app, cmd, args) {
       return browserClose(a);
     case 'browser_inspect_set':
       return browserInspectSet(a);
+    case 'browser_note_user_interaction':
+      return browserNoteUserInteraction(a);
     default:
       return BROWSER_MISS;
   }

--- a/electron/browserHost.cjs
+++ b/electron/browserHost.cjs
@@ -632,7 +632,15 @@ async function createAutomationView(ownerKey = LEGACY_OWNER) {
   // into browserCreate() synchronously on the main process, and that is where
   // the pending owner is consumed.
   pendingAutomationOwners.set(id, ownerKey);
-  emit('browser://automation-open', { id, url: 'about:blank' });
+  // Tell the renderer WHOSE view this is: it hangs the adopted tab on that
+  // conversation, so a background task's tab never lands in the conversation
+  // the user happens to be looking at. LEGACY_OWNER sends no ownerId at all —
+  // a legacy view belongs to the shared pool and every conversation may see it.
+  emit('browser://automation-open', {
+    id,
+    url: 'about:blank',
+    ...(ownerKey !== LEGACY_OWNER ? { ownerId: ownerKey } : {}),
+  });
 
   // The production renderer adopts agent-created tabs into its normal browser
   // workspace so the user can watch and intervene. Headless harnesses have no

--- a/electron/browserHost.cjs
+++ b/electron/browserHost.cjs
@@ -45,6 +45,9 @@
  * - `browser_close {id}` → `mainWin.contentView.removeChildView(view)` +
  *   `view.webContents.close()` + delete from the id→view map; also silently
  *   no-ops if unknown.
+ * - `browser_dispose_owner {conversationId}` → close every view that
+ *   conversation owns and drop its ownership records (Electron-only; no Tauri
+ *   counterpart — see `disposeOwnerViews`).
  *
  * ## Navigation event: `browser://nav/{id}`
  * browser.rs's `on_navigation(move |u| { emit(...); true })` fires on every
@@ -107,6 +110,7 @@ const BROWSER_CMDS = new Set([
   'browser_close',
   'browser_inspect_set',
   'browser_note_user_interaction',
+  'browser_dispose_owner',
 ]);
 const BROWSER_MISS = Symbol('browser-dispatch-miss');
 
@@ -355,9 +359,11 @@ function backoffRemainingMs(origin) {
  * loop above, and the rate-limit gate below — so a stopped run does not sit
  * out someone else's 10-second wait before it notices.
  */
+const RUN_STOPPED_MESSAGE = 'Browser action cancelled because the run was stopped.';
+
 function assertNotAborted(signal) {
   if (signal && signal.aborted) {
-    throw new Error('Browser action cancelled because the run was stopped.');
+    throw new Error(RUN_STOPPED_MESSAGE);
   }
 }
 
@@ -624,7 +630,14 @@ function findViewByTabId(tabId, ownerKey = LEGACY_OWNER) {
   return null;
 }
 
-async function createAutomationView(ownerKey = LEGACY_OWNER) {
+/**
+ * @param {string} [ownerKey] the conversation this view is being opened for
+ * @param {AbortSignal} [signal] aborts when the run that asked for this tab was
+ *   stopped — checked on every iteration of the adoption wait below, so a
+ *   stopped run neither sits out the rest of the wait nor ends up owning a
+ *   hidden fallback view it can never close (N8).
+ */
+async function createAutomationView(ownerKey = LEGACY_OWNER, signal) {
   const win = mainWindow();
   if (!win || win.isDestroyed()) throw new Error('main window not found');
 
@@ -647,7 +660,13 @@ async function createAutomationView(ownerKey = LEGACY_OWNER) {
   // workspace so the user can watch and intervene. Headless harnesses have no
   // App listener, so fall back to a hidden view after a short bounded wait.
   const deadline = Date.now() + 2500;
-  while (Date.now() < deadline) {
+  for (;;) {
+    // The run may be stopped at any point during the wait; drop the pending
+    // entry before throwing so a cancelled adoption cannot strand one.
+    if (signal && signal.aborted) {
+      pendingAutomationOwners.delete(id);
+      throw new Error(RUN_STOPPED_MESSAGE);
+    }
     const adopted = views.get(id);
     if (adopted?.webContents && !adopted.webContents.isDestroyed()) {
       // The requesting conversation is the authority on this view's owner —
@@ -660,6 +679,12 @@ async function createAutomationView(ownerKey = LEGACY_OWNER) {
       activeTabIdByOwner.set(ownerKey, adopted.webContents.id);
       return adopted;
     }
+    // N4: `disposeOwnerViews` purges this owner's pending entries, so a missing
+    // one means the owning conversation was deleted while we waited (the only
+    // other remover, an adoption, is the branch just above). Building the
+    // fallback view now would strand a live view no conversation can close.
+    if (!pendingAutomationOwners.has(id)) throw new Error(RUN_STOPPED_MESSAGE);
+    if (Date.now() >= deadline) break;
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
 
@@ -699,8 +724,11 @@ async function createAutomationView(ownerKey = LEGACY_OWNER) {
  *
  * @param {string} [ownerKey]
  * @param {boolean} [createIfEmpty]
+ * @param {AbortSignal} [signal] forwarded to the adoption wait (see
+ *   `createAutomationView`) — provisioning is the one listing path that can
+ *   block for seconds, so a stopped run must not sit it out.
  */
-async function automationTabs(ownerKey = LEGACY_OWNER, createIfEmpty = true) {
+async function automationTabs(ownerKey = LEGACY_OWNER, createIfEmpty = true, signal) {
   const tabs = [];
   for (const [id, view] of views) {
     const contents = view.webContents;
@@ -717,7 +745,7 @@ async function automationTabs(ownerKey = LEGACY_OWNER, createIfEmpty = true) {
     });
   }
   if (tabs.length === 0 && createIfEmpty) {
-    const view = await createAutomationView(ownerKey);
+    const view = await createAutomationView(ownerKey, signal);
     tabs.push({
       id: Array.from(views.entries()).find(([, candidate]) => candidate === view)[0],
       view,
@@ -895,7 +923,7 @@ async function runBrowserAutomation(action, payload, signal) {
   const ownerKey = resolveOwnerKey(payload);
 
   if (action === 'get_tabs') {
-    const tabs = await automationTabs(ownerKey, payload.createIfEmpty !== false);
+    const tabs = await automationTabs(ownerKey, payload.createIfEmpty !== false, signal);
     const win = mainWindow();
     const windowId = win && !win.isDestroyed() ? win.webContents.id : 1;
     const currentTabId = activeTabIdByOwner.get(ownerKey) ?? null;
@@ -1204,6 +1232,47 @@ function browserClose({ id }) {
 }
 
 /**
+ * N4 — tear down everything one conversation owns.
+ *
+ * Deleting a conversation used to leave its agent's browser views running for
+ * the rest of the session: no conversation's tab strip listed them, so nothing
+ * could close them, while main kept a live `WebContentsView` (and the renderer
+ * a mounted `BrowserTab` syncing its bounds) per deleted conversation.
+ *
+ * The renderer's delete cascade removes those tab records, which already
+ * destroys the views it knows about; this command is the belt-and-braces half
+ * for main-side state no tab record covers — a headless fallback view (no
+ * renderer ever adopted it), or an adoption still pending when the delete
+ * landed. Scope is exactly one owner: another conversation's views and the
+ * LEGACY pool (the user's own pane tabs, which every conversation may see) are
+ * never touched, so an unknown/blank/legacy owner is a deliberate no-op rather
+ * than an error — like `browser_hide`/`browser_close`, this is a cleanup
+ * command whose failure mode must never be "kill someone else's tab".
+ */
+function disposeOwnerViews(ownerKey) {
+  // Snapshot: closeView deletes from `views` as we go.
+  for (const [id, view] of Array.from(views)) {
+    if (ownerKeyOf(id) === ownerKey) closeView(id, view);
+  }
+  // closeView already drops these per view (and `forgetOwnerInteractionIfUnused`
+  // clears the interaction record once the owner's last view is gone), but the
+  // owner may also hold records with no live view behind them — a current-tab
+  // id whose view was destroyed by the window teardown, or a pending adoption.
+  activeTabIdByOwner.delete(ownerKey);
+  userInteractionAt.delete(ownerKey);
+  for (const [pendingId, pendingOwner] of Array.from(pendingAutomationOwners)) {
+    if (pendingOwner === ownerKey) pendingAutomationOwners.delete(pendingId);
+  }
+}
+
+function browserDisposeOwner({ conversationId }) {
+  const ownerKey = typeof conversationId === 'string' ? conversationId.trim() : '';
+  if (!ownerKey || ownerKey === LEGACY_OWNER) return null;
+  disposeOwnerViews(ownerKey);
+  return null;
+}
+
+/**
  * N3 — React-layer takeover signal.
  *
  * The takeover backoff (R4, above) only hears the USER on the guest
@@ -1262,6 +1331,8 @@ function browserDispatch(app, cmd, args) {
       return browserInspectSet(a);
     case 'browser_note_user_interaction':
       return browserNoteUserInteraction(a);
+    case 'browser_dispose_owner':
+      return browserDisposeOwner(a);
     default:
       return BROWSER_MISS;
   }

--- a/electron/browserHost.cjs
+++ b/electron/browserHost.cjs
@@ -420,11 +420,23 @@ const userReclaimedAt = new Map();
  * on as though the user had never closed one — the same "the app ignored me"
  * the window exists to prevent, one turn later.
  *
- * So a lift arms a ONE-SHOT notice and the conversation's next MODEL-FACING
- * `get_tabs` carries it and clears it. Keyed to the CONVERSATION, like the
- * window itself: the fact is about the task, not about whichever delegation
- * happens to look first, and exactly one run is told (there is one fact, and
- * repeating it every listing would turn it into noise the model learns to skip).
+ * So a lift arms a ONE-SHOT notice, keyed to the CONVERSATION like the window
+ * itself, and a model-facing `get_tabs` carries it.
+ *
+ * ## Who SPENDS it: the main loop, and only the main loop
+ *
+ * The notice asks the model to confirm with the user before using the browser
+ * again — and a subagent CANNOT do that: `ask_user_question` is in
+ * `ALWAYS_BLOCKED_SUBAGENT_TOOLS`, so a delegation has no channel to the user
+ * at all. Letting whoever listed first consume it therefore lost the notice to
+ * a run structurally unable to obey it, and handed the conversation's own loop
+ * — the one run that can actually ask — a listing that said nothing.
+ *
+ * So every run READS it (a subagent that knows the user just took the browser
+ * back can decline to act and hand the question up to its parent, which costs
+ * nothing and is strictly better than acting blind), and only the MAIN run
+ * CLEARS it. The wording is neutral about whose tab it was for the same reason:
+ * "your browser tab" is simply false told to a sibling run that never owned it.
  *
  * Three paths deliberately arm or consume nothing:
  *  - a `browser_clear_reclaim` that lifted no window. The renderer fires it on
@@ -442,8 +454,8 @@ const userReclaimedAt = new Map();
  * the live refusal outranks a past one — and the owed notice simply waits.
  */
 const RECLAIM_LIFTED_NOTICE =
-  'Note: the user previously closed your browser tab. Confirm they want the browser again '
-  + 'before acting on the page.';
+  "Note: the user previously closed the assistant's browser tab. Confirm they want the "
+  + 'browser again before acting on the page.';
 
 /** conversationIds owed the one-shot notice above. */
 const reclaimNoticePending = new Set();
@@ -531,13 +543,20 @@ function clearUserReclaim(conversationId, runKey, armNotice = false) {
 }
 
 /**
- * Take the one-shot notice owed to `conversationId`, if any. Take-and-clear in
- * one step (`Set.delete` reports whether it was there) so two runs listing back
- * to back cannot both be told.
+ * The one-shot notice owed to `owner`'s conversation, if any.
+ *
+ * Every run READS it; only the MAIN run SPENDS it. A subagent cannot ask the
+ * user anything (`ask_user_question` is blocked for delegations), so spending
+ * the notice on one would retire the request on a run that cannot honour it and
+ * leave the conversation's own loop — the only run with a channel to the user —
+ * told nothing.
  */
-function takeReclaimLiftedNotice(conversationId) {
+function takeReclaimLiftedNotice(owner) {
+  const { conversationId, runKey } = owner;
   if (!conversationId || conversationId === LEGACY_CONVERSATION) return null;
-  return reclaimNoticePending.delete(conversationId) ? RECLAIM_LIFTED_NOTICE : null;
+  if (!reclaimNoticePending.has(conversationId)) return null;
+  if (runKey === MAIN_RUN_KEY) reclaimNoticePending.delete(conversationId);
+  return RECLAIM_LIFTED_NOTICE;
 }
 
 /** >0 while an automation action is executing — its own events are not the user. */
@@ -1295,11 +1314,11 @@ async function runBrowserAutomation(action, payload, signal) {
     const tabs = await automationTabs(owner, modelFacing, signal);
     // One `note` slot, two mutually interesting facts. A window that is open
     // NOW outranks one the user already lifted, and the owed one-shot is only
-    // spent on a listing a model will actually read (see
-    // `RECLAIM_LIFTED_NOTICE`).
+    // read (and, for the main loop, spent) on a listing a model will actually
+    // see — see `RECLAIM_LIFTED_NOTICE`.
     const note = conversationIsReclaimed(owner.conversationId)
       ? USER_RECLAIMED_MESSAGE
-      : (modelFacing ? takeReclaimLiftedNotice(owner.conversationId) : null);
+      : (modelFacing ? takeReclaimLiftedNotice(owner) : null);
     const win = mainWindow();
     const windowId = win && !win.isDestroyed() ? win.webContents.id : 1;
     const currentTabId = activeTabIdByOwner.get(ownerKey) ?? null;

--- a/electron/browserHost.cjs
+++ b/electron/browserHost.cjs
@@ -45,9 +45,10 @@
  * - `browser_close {id}` → `mainWin.contentView.removeChildView(view)` +
  *   `view.webContents.close()` + delete from the id→view map; also silently
  *   no-ops if unknown.
- * - `browser_dispose_owner {conversationId}` → close every view that
- *   conversation owns and drop its ownership records (Electron-only; no Tauri
- *   counterpart — see `disposeOwnerViews`).
+ * - `browser_dispose_owner {conversationId, runKey?}` → close every view that
+ *   conversation owns and drop its ownership records; with `runKey`, only that
+ *   subagent run's (Electron-only; no Tauri counterpart — see
+ *   `disposeOwnerViews`).
  *
  * ## Navigation event: `browser://nav/{id}`
  * browser.rs's `on_navigation(move |u| { emit(...); true })` fires on every
@@ -155,29 +156,105 @@ let browserSession = null;
 let automationRuntime = null;
 
 /**
- * ## Tab ownership (per conversation)
+ * ## Tab ownership (per conversation, per subagent run)
  *
  * Browser automation tabs used to live in one global pool with a single
  * "current tab": two conversations driving the browser at the same time saw
  * each other's tabs in `get_tabs`, and either one's action silently moved the
- * other's current tab. Every automation view now records the conversation that
- * opened it, and every "current tab" record is keyed by that owner.
+ * other's current tab. Every automation view now records the OWNER that opened
+ * it, and every "current tab" record is keyed by that owner.
  *
- * `ownerKey` is `payload.ownerId` (the conversation id threaded down from the
- * MCP tool call) or `LEGACY_OWNER` when a caller sends none — legacy is also
- * what the user's own pane tabs get, and it stays visible to everyone so the
- * single-conversation behavior is unchanged.
+ * An owner is the PAIR `{conversationId, runKey}` (N6), not a bare conversation
+ * id: one conversation can drive the browser from its own loop and from any
+ * number of delegated subagent runs at the same time, and keying on the
+ * conversation alone reproduced the very bug the per-conversation keying fixed
+ * — sibling subagents seeing and stealing each other's tabs — one level down.
+ *
+ * - `conversationId` is `payload.ownerId` (threaded down from the MCP tool call
+ *   via `_meta['abu/conversationId']`).
+ * - `runKey` is `payload.runId` (`_meta['abu/runKey']`, the `sar-*` subagent run
+ *   id). A caller that sends none — the conversation's own main loop, and every
+ *   pre-N6 caller — is `MAIN_RUN_KEY`, so the single-run world is the degenerate
+ *   one-dimensional case of the same code, not a second path.
+ * - A caller that sends no `ownerId` at all is `LEGACY_OWNER`, which is also
+ *   what the user's own pane tabs get: the shared pool, visible to everyone.
+ *
+ * The pair is parsed ONCE per call (`resolveOwnerKey`) into a frozen record that
+ * also carries `key` — the canonical composite string every Map is keyed on.
+ * `makeOwner` is the only place that string is built, and `parseOwnerKey` the
+ * only place it is taken apart, so no call site ever concatenates or splits it.
  */
-const LEGACY_OWNER = 'legacy';
+const LEGACY_CONVERSATION = 'legacy';
+const MAIN_RUN_KEY = 'main';
+/**
+ * Separator inside the canonical composite key. NUL is used rather than a
+ * printable pair like `::` because it cannot appear in any id this app mints
+ * (base36 timestamps, `sar-*` run ids) NOR be typed into one; `makeOwner` also
+ * strips it from both halves, so `{a, b}` and `{a<NUL>b, main}` can never
+ * collapse onto the same key.
+ */
+const OWNER_KEY_SEPARATOR = String.fromCharCode(0);
 
-/** view id -> { ownerKey, createdAt }. Absent ⇒ legacy (see `ownerKeyOf`). */
+function sanitizeOwnerPart(value) {
+  return typeof value === 'string' ? value.split(OWNER_KEY_SEPARATOR).join('').trim() : '';
+}
+
+/**
+ * The one place a composite owner key is built.
+ * @returns {{conversationId: string, runKey: string, key: string}}
+ */
+function makeOwner(conversationId, runKey) {
+  const conversation = sanitizeOwnerPart(conversationId);
+  if (!conversation || conversation === LEGACY_CONVERSATION) return LEGACY_OWNER;
+  const run = sanitizeOwnerPart(runKey) || MAIN_RUN_KEY;
+  return Object.freeze({
+    conversationId: conversation,
+    runKey: run,
+    key: `${conversation}${OWNER_KEY_SEPARATOR}${run}`,
+  });
+}
+
+/** The one place a composite owner key is taken apart. */
+function parseOwnerKey(key) {
+  const at = String(key).indexOf(OWNER_KEY_SEPARATOR);
+  if (at < 0) return { conversationId: String(key), runKey: MAIN_RUN_KEY };
+  return { conversationId: String(key).slice(0, at), runKey: String(key).slice(at + 1) };
+}
+
+/**
+ * The shared pool: the user's own pane tabs, and any caller that sent no owner.
+ * Deliberately a single owner — a caller with a `runId` but no conversation is
+ * folded into it by `makeOwner`, so a stray run id can never mint a private pool
+ * that `browser_dispose_owner` (which refuses the legacy conversation) could
+ * never reap.
+ */
+const LEGACY_OWNER = Object.freeze({
+  conversationId: LEGACY_CONVERSATION,
+  runKey: MAIN_RUN_KEY,
+  key: `${LEGACY_CONVERSATION}${OWNER_KEY_SEPARATOR}${MAIN_RUN_KEY}`,
+});
+
+function isLegacyOwner(owner) {
+  return owner.conversationId === LEGACY_CONVERSATION;
+}
+
+/**
+ * Does `owner` fall inside a dispose request? `runKey === undefined` means the
+ * whole conversation (every run), which is the pre-N6 delete-cascade scope.
+ */
+function ownerInDisposeScope(owner, conversationId, runKey) {
+  if (owner.conversationId !== conversationId) return false;
+  return runKey === undefined || owner.runKey === runKey;
+}
+
+/** view id -> { owner, createdAt }. Absent ⇒ legacy (see `ownerOf`). */
 const viewMeta = new Map();
 
-/** ownerKey -> webContents.id of that owner's most recently touched tab. */
+/** owner key -> webContents.id of that owner's most recently touched tab. */
 const activeTabIdByOwner = new Map();
 
 /**
- * view id -> ownerKey, for automation views awaiting renderer adoption.
+ * view id -> owner record, for automation views awaiting renderer adoption.
  * `createAutomationView()` registers the owner BEFORE emitting
  * `browser://automation-open`, because the renderer answers by calling
  * `browser_create` with the same id — possibly before the emit even returns —
@@ -225,9 +302,15 @@ function cancelAutomationAdoption(id) {
   emit('browser://automation-cancel', { id });
 }
 
-function ownerKeyOf(id) {
+/** @returns {{conversationId: string, runKey: string, key: string}} */
+function ownerOf(id) {
   const meta = viewMeta.get(id);
-  return meta ? meta.ownerKey : LEGACY_OWNER;
+  return meta ? meta.owner : LEGACY_OWNER;
+}
+
+/** The composite key every per-owner Map is keyed on. */
+function ownerKeyOf(id) {
+  return ownerOf(id).key;
 }
 
 /**
@@ -415,9 +498,14 @@ function assertNotAborted(signal) {
   }
 }
 
+/**
+ * The ONE place a wire payload becomes an owner record. `ownerId` carries the
+ * conversation, `runId` the subagent run (absent ⇒ `main`, the conversation's
+ * own loop). Everything downstream passes the record around; nothing re-parses.
+ */
 function resolveOwnerKey(payload) {
-  const raw = payload && typeof payload.ownerId === 'string' ? payload.ownerId.trim() : '';
-  return raw || LEGACY_OWNER;
+  if (!payload) return LEGACY_OWNER;
+  return makeOwner(payload.ownerId, payload.runId);
 }
 
 function isInspectPayload(value) {
@@ -650,42 +738,56 @@ function configureBrowserView(id, view) {
 
 /**
  * @param {unknown} tabId
- * @param {string} ownerKey the calling conversation's owner key
+ * @param {{conversationId: string, runKey: string, key: string}} owner the
+ *   calling run's owner record
  * @returns {{id: string, view: import('electron').WebContentsView} | null}
  *   null when no live view has that webContents id (callers keep their own
  *   "not found" message); THROWS when the tab exists but belongs to another
  *   conversation — a silent miss there would look like "the tab vanished" and
  *   send the model into a retry loop on someone else's tab.
+ *
+ * Reaching a SIBLING RUN's tab inside the same conversation is allowed (N6):
+ * every caller here named the tab EXPLICITLY, and an explicit id is exactly how
+ * a parent hands a tab to a child ("continue on tab 42" in the task text) —
+ * `get_tabs` never lists it, so the id cannot have been guessed from the
+ * listing. It is recorded rather than silent, because it is the one place a run
+ * touches a page it did not open.
  */
-function findViewByTabId(tabId, ownerKey = LEGACY_OWNER) {
+function findViewByTabId(tabId, owner = LEGACY_OWNER) {
   const numeric = Number(tabId);
   if (!Number.isInteger(numeric)) return null;
   for (const [id, view] of views) {
     const contents = view.webContents;
     if (contents && !contents.isDestroyed() && contents.id === numeric) {
-      const tabOwner = ownerKeyOf(id);
+      const tabOwner = ownerOf(id);
       // A legacy tab (the user's own pane tab) may be driven by anyone, and
       // doing so does NOT claim it — ownership stays legacy.
-      if (tabOwner !== ownerKey && tabOwner !== LEGACY_OWNER) {
-        throw new Error(
-          `Browser tab ${tabId} belongs to another conversation's task. ` +
-            'Call get_tabs to see your own tabs, or open a new tab with navigate.'
+      if (tabOwner.key === owner.key || isLegacyOwner(tabOwner)) return { id, view };
+      if (tabOwner.conversationId === owner.conversationId) {
+        console.log(
+          `[browserHost] cross-run tab access: run ${owner.runKey} acting on tab ${tabId} `
+            + `owned by run ${tabOwner.runKey} of the same conversation (explicit tabId hand-over)`
         );
+        return { id, view };
       }
-      return { id, view };
+      throw new Error(
+        `Browser tab ${tabId} belongs to another conversation's task. ` +
+          'Call get_tabs to see your own tabs, or open a new tab with navigate.'
+      );
     }
   }
   return null;
 }
 
 /**
- * @param {string} [ownerKey] the conversation this view is being opened for
+ * @param {{conversationId: string, runKey: string, key: string}} [owner] the
+ *   run this view is being opened for
  * @param {AbortSignal} [signal] aborts when the run that asked for this tab was
  *   stopped — checked on every iteration of the adoption wait below, so a
  *   stopped run neither sits out the rest of the wait nor ends up owning a
  *   hidden fallback view it can never close (N8).
  */
-async function createAutomationView(ownerKey = LEGACY_OWNER, signal) {
+async function createAutomationView(owner = LEGACY_OWNER, signal) {
   const win = mainWindow();
   if (!win || win.isDestroyed()) throw new Error('main window not found');
 
@@ -693,15 +795,21 @@ async function createAutomationView(ownerKey = LEGACY_OWNER, signal) {
   // Register the owner before emitting: the renderer's adoption calls back
   // into browserCreate() synchronously on the main process, and that is where
   // the pending owner is consumed.
-  pendingAutomationOwners.set(id, ownerKey);
+  pendingAutomationOwners.set(id, owner);
   // Tell the renderer WHOSE view this is: it hangs the adopted tab on that
   // conversation, so a background task's tab never lands in the conversation
   // the user happens to be looking at. LEGACY_OWNER sends no ownerId at all —
   // a legacy view belongs to the shared pool and every conversation may see it.
+  //
+  // Deliberately the CONVERSATION only, never the runKey: renderer visibility
+  // stays conversation-granular (C2), because the user watching the pane wants
+  // every tab their conversation opened, whichever run opened it. Run isolation
+  // is a model-facing boundary (get_tabs / current tab / reclaim), not a
+  // user-facing one.
   emit('browser://automation-open', {
     id,
     url: 'about:blank',
-    ...(ownerKey !== LEGACY_OWNER ? { ownerId: ownerKey } : {}),
+    ...(isLegacyOwner(owner) ? {} : { ownerId: owner.conversationId }),
   });
 
   // The production renderer adopts agent-created tabs into its normal browser
@@ -722,9 +830,9 @@ async function createAutomationView(ownerKey = LEGACY_OWNER, signal) {
       // if any other path got there first its guess must not win (that would
       // hand the tab to the wrong owner AND leave this caller without a current
       // tab). Same authority model as the fallback branch below.
-      viewMeta.set(id, { ownerKey, createdAt: Date.now() });
+      viewMeta.set(id, { owner, createdAt: Date.now() });
       pendingAutomationOwners.delete(id);
-      activeTabIdByOwner.set(ownerKey, adopted.webContents.id);
+      activeTabIdByOwner.set(owner.key, adopted.webContents.id);
       return adopted;
     }
     // N4: `disposeOwnerViews` purges this owner's pending entries, so a missing
@@ -748,43 +856,46 @@ async function createAutomationView(ownerKey = LEGACY_OWNER, signal) {
       session: browserSessionForViews(),
     },
   });
-  viewMeta.set(id, { ownerKey, createdAt: Date.now() });
+  viewMeta.set(id, { owner, createdAt: Date.now() });
   configureBrowserView(id, view);
   win.contentView.addChildView(view);
   view.setBounds({ x: 0, y: 0, width: 1024, height: 768 });
   view.setVisible(false);
   views.set(id, view);
-  activeTabIdByOwner.set(ownerKey, view.webContents.id);
+  activeTabIdByOwner.set(owner.key, view.webContents.id);
   void view.webContents.loadURL('about:blank');
   return view;
 }
 
 /**
- * The tabs `ownerKey` is allowed to see: its own plus the legacy pool (the
+ * The tabs `owner` is allowed to see: its OWN RUN's plus the legacy pool (the
  * user's pane tabs and any caller that sent no owner). A legacy caller sees
- * only legacy tabs — never another conversation's.
+ * only legacy tabs — never a conversation's. A sibling run of the same
+ * conversation is NOT listed (N6, user-approved): parent and child agents are
+ * invisible to each other by default, and the only hand-over channel is the
+ * parent naming an explicit tabId in the task description.
  *
  * `createIfEmpty` (default true, the historical behavior) provisions a fresh
- * automation view when the owner has none, so `get_tabs` can bootstrap a task
+ * automation view when THIS RUN has none, so `get_tabs` can bootstrap a task
  * that has not opened a tab yet. Read-only probes — notably the desktop app's
  * browser permission gate, which resolves a tab's origin BEFORE deciding
  * whether the action is even allowed — pass false: a query must not be the
  * thing that opens a tab.
  *
- * @param {string} [ownerKey]
+ * @param {{conversationId: string, runKey: string, key: string}} [owner]
  * @param {boolean} [createIfEmpty]
  * @param {AbortSignal} [signal] forwarded to the adoption wait (see
  *   `createAutomationView`) — provisioning is the one listing path that can
  *   block for seconds, so a stopped run must not sit it out.
  */
-async function automationTabs(ownerKey = LEGACY_OWNER, createIfEmpty = true, signal) {
+async function automationTabs(owner = LEGACY_OWNER, createIfEmpty = true, signal) {
   const tabs = [];
   for (const [id, view] of views) {
     const contents = view.webContents;
     if (!contents || contents.isDestroyed()) continue;
     if (!automationDocumentAllowed(contents.getURL())) continue;
-    const tabOwner = ownerKeyOf(id);
-    if (tabOwner !== ownerKey && tabOwner !== LEGACY_OWNER) continue;
+    const tabOwner = ownerOf(id);
+    if (tabOwner.key !== owner.key && !isLegacyOwner(tabOwner)) continue;
     tabs.push({
       id,
       view,
@@ -794,7 +905,7 @@ async function automationTabs(ownerKey = LEGACY_OWNER, createIfEmpty = true, sig
     });
   }
   if (tabs.length === 0 && createIfEmpty) {
-    const view = await createAutomationView(ownerKey, signal);
+    const view = await createAutomationView(owner, signal);
     tabs.push({
       id: Array.from(views.entries()).find(([, candidate]) => candidate === view)[0],
       view,
@@ -803,8 +914,8 @@ async function automationTabs(ownerKey = LEGACY_OWNER, createIfEmpty = true, sig
       title: view.webContents.getTitle(),
     });
   }
-  if (tabs.length > 0 && !tabs.some((tab) => tab.tabId === activeTabIdByOwner.get(ownerKey))) {
-    activeTabIdByOwner.set(ownerKey, tabs[0].tabId);
+  if (tabs.length > 0 && !tabs.some((tab) => tab.tabId === activeTabIdByOwner.get(owner.key))) {
+    activeTabIdByOwner.set(owner.key, tabs[0].tabId);
   }
   return tabs;
 }
@@ -969,10 +1080,11 @@ async function runBrowserAutomation(action, payload, signal) {
   // and open a brand-new tab (or leak any other side effect) after Stop.
   assertNotAborted(signal);
 
-  const ownerKey = resolveOwnerKey(payload);
+  const owner = resolveOwnerKey(payload);
+  const ownerKey = owner.key;
 
   if (action === 'get_tabs') {
-    const tabs = await automationTabs(ownerKey, payload.createIfEmpty !== false, signal);
+    const tabs = await automationTabs(owner, payload.createIfEmpty !== false, signal);
     const win = mainWindow();
     const windowId = win && !win.isDestroyed() ? win.webContents.id : 1;
     const currentTabId = activeTabIdByOwner.get(ownerKey) ?? null;
@@ -1005,7 +1117,7 @@ async function runBrowserAutomation(action, payload, signal) {
   const targetTabId = payload.tabId === undefined && action === 'get_html'
     ? activeTabIdByOwner.get(ownerKey)
     : payload.tabId;
-  const match = findViewByTabId(targetTabId, ownerKey);
+  const match = findViewByTabId(targetTabId, owner);
   if (!match) throw new Error(`Browser tab not found: ${String(targetTabId)}`);
   const { view } = match;
 
@@ -1152,9 +1264,9 @@ function browserCreate({ id, url, x, y, width, height, visible = true }) {
   // An id the renderer is adopting on behalf of an automation call carries a
   // pending owner (see createAutomationView); anything else — a tab the user
   // opened in the pane — is legacy and stays visible to every caller.
-  const ownerKey = pendingAutomationOwners.get(id) ?? LEGACY_OWNER;
+  const owner = pendingAutomationOwners.get(id) ?? LEGACY_OWNER;
   pendingAutomationOwners.delete(id);
-  viewMeta.set(id, { ownerKey, createdAt: Date.now() });
+  viewMeta.set(id, { owner, createdAt: Date.now() });
 
   configureBrowserView(id, view);
 
@@ -1167,7 +1279,7 @@ function browserCreate({ id, url, x, y, width, height, visible = true }) {
   view.setBounds(toRect(x, y, width, height));
   if (!shouldShow) view.setVisible(false);
   views.set(id, view);
-  activeTabIdByOwner.set(ownerKey, view.webContents.id);
+  activeTabIdByOwner.set(owner.key, view.webContents.id);
 
   const target = url || 'about:blank';
   void view.webContents.loadURL(parseUrl(target));
@@ -1306,12 +1418,21 @@ function browserClose({ id }) {
  * never touched, so an unknown/blank/legacy owner is a deliberate no-op rather
  * than an error — like `browser_hide`/`browser_close`, this is a cleanup
  * command whose failure mode must never be "kill someone else's tab".
+ *
+ * N6 gives it a second, narrower scope. `runKey`:
+ *  - omitted ⇒ EVERY run of that conversation (the delete cascade — unchanged
+ *    from before N6, when a conversation had exactly one owner key);
+ *  - given ⇒ only that run, so a finished subagent releases its own tabs
+ *    without touching a sibling run's or the conversation's own loop (A2).
+ *
+ * @param {string} conversationId
+ * @param {string} [runKey]
  */
-function disposeOwnerViews(ownerKey) {
+function disposeOwnerViews(conversationId, runKey) {
   const cancelledIds = [];
   // Snapshot: closeView deletes from `views` as we go.
   for (const [id, view] of Array.from(views)) {
-    if (ownerKeyOf(id) !== ownerKey) continue;
+    if (!ownerInDisposeScope(ownerOf(id), conversationId, runKey)) continue;
     closeView(id, view);
     // Tombstone the closed view's id too: BrowserTab may have a create RETRY in
     // flight for it (its invoke failed once), which would otherwise rebuild the
@@ -1319,24 +1440,37 @@ function disposeOwnerViews(ownerKey) {
     cancelledIds.push(id);
   }
   for (const [pendingId, pendingOwner] of Array.from(pendingAutomationOwners)) {
-    if (pendingOwner === ownerKey) cancelledIds.push(pendingId);
+    if (ownerInDisposeScope(pendingOwner, conversationId, runKey)) cancelledIds.push(pendingId);
   }
   // closeView already drops the per-view records (and
   // `forgetOwnerInteractionIfUnused` clears the interaction record once the
   // owner's last view is gone), but the owner may also hold records with no live
   // view behind them — a current-tab id whose view was destroyed by the window
-  // teardown, or a pending adoption.
-  activeTabIdByOwner.delete(ownerKey);
-  userInteractionAt.delete(ownerKey);
+  // teardown, or a pending adoption. Both maps are keyed on the composite owner
+  // key, so a conversation-wide dispose has to sweep every run's entry.
+  for (const key of Array.from(activeTabIdByOwner.keys())) {
+    if (ownerInDisposeScope(parseOwnerKey(key), conversationId, runKey)) {
+      activeTabIdByOwner.delete(key);
+    }
+  }
+  for (const key of Array.from(userInteractionAt.keys())) {
+    if (ownerInDisposeScope(parseOwnerKey(key), conversationId, runKey)) {
+      userInteractionAt.delete(key);
+    }
+  }
   // Emitted last, so the renderer's reaction (dropping the tab record, which
   // fires `browser_close`) can never race the teardown above.
   for (const id of cancelledIds) cancelAutomationAdoption(id);
 }
 
-function browserDisposeOwner({ conversationId }) {
-  const ownerKey = typeof conversationId === 'string' ? conversationId.trim() : '';
-  if (!ownerKey || ownerKey === LEGACY_OWNER) return null;
-  disposeOwnerViews(ownerKey);
+function browserDisposeOwner({ conversationId, runKey }) {
+  const conversation = sanitizeOwnerPart(conversationId);
+  if (!conversation || conversation === LEGACY_CONVERSATION) return null;
+  // A blank/non-string runKey is "the whole conversation", not "a run literally
+  // named ''": the delete cascade sends no runKey at all, and a malformed one
+  // must not silently narrow a full teardown into a no-op.
+  const run = sanitizeOwnerPart(runKey) || undefined;
+  disposeOwnerViews(conversation, run);
   return null;
 }
 

--- a/electron/browserHost.cjs
+++ b/electron/browserHost.cjs
@@ -42,13 +42,19 @@
  *   an existing asymmetry in browser.rs, not a divergence introduced here).
  * - `browser_hide/show {id}` → `view.setVisible(false/true)`; silently
  *   no-ops if `id` is unknown (matches Rust's `if let Some(wv) = ...`).
- * - `browser_close {id}` → `mainWin.contentView.removeChildView(view)` +
+ * - `browser_close {id, reason?}` → `mainWin.contentView.removeChildView(view)` +
  *   `view.webContents.close()` + delete from the id→view map; also silently
- *   no-ops if unknown.
+ *   no-ops if unknown. `reason: 'user_close'` additionally records a reclaim
+ *   window for that view's owner (N7 — see `userReclaimedAt`); anything else,
+ *   including an absent or unrecognised value, is a `lifecycle` teardown and
+ *   records nothing.
  * - `browser_dispose_owner {conversationId, runKey?}` → close every view that
  *   conversation owns and drop its ownership records; with `runKey`, only that
  *   subagent run's (Electron-only; no Tauri counterpart — see
  *   `disposeOwnerViews`).
+ * - `browser_clear_reclaim {conversationId}` → lift the reclaim window on every
+ *   run of that conversation (Electron-only; sent when the user posts their next
+ *   message there — see `userReclaimedAt`).
  *
  * ## Navigation event: `browser://nav/{id}`
  * browser.rs's `on_navigation(move |u| { emit(...); true })` fires on every
@@ -120,6 +126,7 @@ const BROWSER_CMDS = new Set([
   'browser_inspect_set',
   'browser_note_user_interaction',
   'browser_dispose_owner',
+  'browser_clear_reclaim',
 ]);
 const BROWSER_MISS = Symbol('browser-dispatch-miss');
 
@@ -357,6 +364,59 @@ const TAKEOVER_GATED_ACTIONS = new Set([
 
 /** ownerKey -> ts of the last input the USER landed on one of that owner's views. */
 const userInteractionAt = new Map();
+
+/**
+ * ## The user closing a tab is a reclaim signal, not just a teardown (N7)
+ *
+ * The takeover backoff above handles "the user is typing here right now". The
+ * stronger gesture — closing the agent's tab outright — used to have no effect
+ * on the run at all: the view died and the very next `get_tabs` silently
+ * provisioned a replacement, so the one action that unambiguously means "stop
+ * using the browser" was the one action the agent could not hear.
+ *
+ * A close therefore carries a REASON. Only a real user gesture (`user_close`,
+ * stamped by `previewStore`'s user-facing close actions) opens a RECLAIM WINDOW
+ * for the closed view's owner; every programmatic teardown — the commit path's
+ * own destroy, the cancel cascade, a conversation delete — is `lifecycle` and
+ * records nothing, as does closing a LEGACY tab (the user closing their own pane
+ * tab is just closing a tab).
+ *
+ * Inside the window, for THAT owner pair (N6 — one subagent's reclaimed tab must
+ * not mute its siblings or the conversation's own loop):
+ *  - `get_tabs` stops provisioning, and its summary carries `note`;
+ *  - a state-changing action or `navigate` left with no tab throws the same
+ *    sentence. Deliberately NOT the run-stopped message: the run is alive, and
+ *    saying otherwise would have the model report something false to the user.
+ *  - anything acting on a tab that IS still open is untouched — the user closed
+ *    one tab, not the whole task.
+ *
+ * The window has no timeout; it is lifted by the user's next message in that
+ * conversation (`browser_clear_reclaim`, every run at once — the user is
+ * addressing the task, not one of its delegations) or by that owner's dispose.
+ * Nothing else reopens it, so a run cannot wait it out.
+ */
+const USER_RECLAIMED_MESSAGE =
+  'The user closed your browser tab. Ask them before opening a new one.';
+
+/** ownerKey -> ts the user closed one of that owner's tabs. Present ⇒ reclaimed. */
+const userReclaimedAt = new Map();
+
+/**
+ * Unknown/absent values are `lifecycle`: a reason that fails to arrive intact
+ * must never be read as a user gesture that gates the run.
+ */
+function isUserCloseReason(reason) {
+  return reason === 'user_close';
+}
+
+/** Lift the reclaim window; `runKey === undefined` means every run (see `ownerInDisposeScope`). */
+function clearUserReclaim(conversationId, runKey) {
+  for (const key of Array.from(userReclaimedAt.keys())) {
+    if (ownerInDisposeScope(parseOwnerKey(key), conversationId, runKey)) {
+      userReclaimedAt.delete(key);
+    }
+  }
+}
 
 /** >0 while an automation action is executing — its own events are not the user. */
 let aiActionDepth = 0;
@@ -1083,8 +1143,13 @@ async function runBrowserAutomation(action, payload, signal) {
   const owner = resolveOwnerKey(payload);
   const ownerKey = owner.key;
 
+  const reclaimed = userReclaimedAt.has(ownerKey);
+
   if (action === 'get_tabs') {
-    const tabs = await automationTabs(owner, payload.createIfEmpty !== false, signal);
+    // A reclaimed owner never provisions, whatever the caller asked for: the
+    // listing is exactly the tabs that still exist, plus the note explaining
+    // why there may now be none.
+    const tabs = await automationTabs(owner, !reclaimed && payload.createIfEmpty !== false, signal);
     const win = mainWindow();
     const windowId = win && !win.isDestroyed() ? win.webContents.id : 1;
     const currentTabId = activeTabIdByOwner.get(ownerKey) ?? null;
@@ -1097,6 +1162,7 @@ async function runBrowserAutomation(action, payload, signal) {
         currentTabUrl: tabs.find((tab) => tab.tabId === currentTabId)?.url || '',
         currentTabTitle: tabs.find((tab) => tab.tabId === currentTabId)?.title || '',
         detectionStrategy: 'electron-in-app-browser',
+        ...(reclaimed ? { note: USER_RECLAIMED_MESSAGE } : {}),
       },
       windows: [{
         windowId,
@@ -1118,7 +1184,17 @@ async function runBrowserAutomation(action, payload, signal) {
     ? activeTabIdByOwner.get(ownerKey)
     : payload.tabId;
   const match = findViewByTabId(targetTabId, owner);
-  if (!match) throw new Error(`Browser tab not found: ${String(targetTabId)}`);
+  if (!match) {
+    // N7: the user closed this owner's tab and nothing is left to act on. Say
+    // that, rather than "tab not found" — which reads as a transient glitch and
+    // invites the model to open another one, the exact thing being refused.
+    // Read-only actions keep the plain not-found error: they cannot make the
+    // situation worse, and the note on `get_tabs` already told the model why.
+    if (reclaimed && TAKEOVER_GATED_ACTIONS.has(action)) {
+      throw new Error(USER_RECLAIMED_MESSAGE);
+    }
+    throw new Error(`Browser tab not found: ${String(targetTabId)}`);
+  }
   const { view } = match;
 
   if (TAKEOVER_GATED_ACTIONS.has(action)) {
@@ -1393,9 +1469,16 @@ function closeView(id, view) {
   forgetOwnerInteractionIfUnused(ownerKey);
 }
 
-function browserClose({ id }) {
+function browserClose({ id, reason }) {
   const view = getView(id);
-  if (view) closeView(id, view);
+  if (!view) return null;
+  // Read the owner BEFORE the teardown — `closeView` drops `viewMeta`, after
+  // which every view looks legacy.
+  const owner = ownerOf(id);
+  if (isUserCloseReason(reason) && !isLegacyOwner(owner)) {
+    userReclaimedAt.set(owner.key, clock.now());
+  }
+  closeView(id, view);
   return null;
 }
 
@@ -1458,6 +1541,10 @@ function disposeOwnerViews(conversationId, runKey) {
       userInteractionAt.delete(key);
     }
   }
+  // N7: the reclaim window dies with the owner it gated. A run being reaped can
+  // never ask again, and a deleted conversation's window would otherwise outlive
+  // everything it referred to.
+  clearUserReclaim(conversationId, runKey);
   // Emitted last, so the renderer's reaction (dropping the tab record, which
   // fires `browser_close`) can never race the teardown above.
   for (const id of cancelledIds) cancelAutomationAdoption(id);
@@ -1471,6 +1558,21 @@ function browserDisposeOwner({ conversationId, runKey }) {
   // must not silently narrow a full teardown into a no-op.
   const run = sanitizeOwnerPart(runKey) || undefined;
   disposeOwnerViews(conversation, run);
+  return null;
+}
+
+/**
+ * N7 — the user's next message in a conversation lifts its reclaim window.
+ *
+ * Scope is the whole CONVERSATION, every run: the user is addressing the task,
+ * not one of its delegations, and they have no way to tell which subagent run
+ * owned the tab they closed. Refuses the legacy conversation and blank input for
+ * the same reason `browser_dispose_owner` does — those name no owner at all.
+ */
+function browserClearReclaim({ conversationId }) {
+  const conversation = sanitizeOwnerPart(conversationId);
+  if (!conversation || conversation === LEGACY_CONVERSATION) return null;
+  clearUserReclaim(conversation, undefined);
   return null;
 }
 
@@ -1535,6 +1637,8 @@ function browserDispatch(app, cmd, args) {
       return browserNoteUserInteraction(a);
     case 'browser_dispose_owner':
       return browserDisposeOwner(a);
+    case 'browser_clear_reclaim':
+      return browserClearReclaim(a);
     default:
       return BROWSER_MISS;
   }

--- a/electron/browserHost.cjs
+++ b/electron/browserHost.cjs
@@ -54,7 +54,9 @@
  *   `disposeOwnerViews`).
  * - `browser_clear_reclaim {conversationId}` → lift the reclaim window on every
  *   run of that conversation (Electron-only; sent when the user posts their next
- *   message there — see `userReclaimedAt`).
+ *   message there — see `userReclaimedAt`). A lift that actually closed a window
+ *   owes that conversation a one-shot notice on its next model-facing `get_tabs`
+ *   (see `RECLAIM_LIFTED_NOTICE`).
  *
  * ## Navigation event: `browser://nav/{id}`
  * browser.rs's `on_navigation(move |u| { emit(...); true })` fires on every
@@ -410,6 +412,43 @@ const USER_RECLAIMED_MESSAGE =
 const userReclaimedAt = new Map();
 
 /**
+ * ## Lifting the window is itself news (C8)
+ *
+ * `browser_clear_reclaim` lifted the window in total silence: the user's next
+ * message simply made provisioning work again, and the next tool result said
+ * nothing about any of it. The model therefore opened a fresh tab and carried
+ * on as though the user had never closed one — the same "the app ignored me"
+ * the window exists to prevent, one turn later.
+ *
+ * So a lift arms a ONE-SHOT notice and the conversation's next MODEL-FACING
+ * `get_tabs` carries it and clears it. Keyed to the CONVERSATION, like the
+ * window itself: the fact is about the task, not about whichever delegation
+ * happens to look first, and exactly one run is told (there is one fact, and
+ * repeating it every listing would turn it into noise the model learns to skip).
+ *
+ * Three paths deliberately arm or consume nothing:
+ *  - a `browser_clear_reclaim` that lifted no window. The renderer fires it on
+ *    EVERY user message, so arming on the call rather than on a real lift would
+ *    put the notice on every conversation that ever sent one.
+ *  - a dispose. It also clears the window, but there is nobody left to tell:
+ *    the conversation is being deleted or the run reaped. Only a
+ *    CONVERSATION-wide dispose drops a notice already owed — a finished
+ *    subagent (A2) is not the conversation going away.
+ *  - the permission gate's `createIfEmpty:false` probe (`registry.ts`), whose
+ *    listing is resolved internally and thrown away; spending the one-shot
+ *    there would delete it unread.
+ *
+ * While a window is open again, `USER_RECLAIMED_MESSAGE` wins the `note` slot —
+ * the live refusal outranks a past one — and the owed notice simply waits.
+ */
+const RECLAIM_LIFTED_NOTICE =
+  'Note: the user previously closed your browser tab. Confirm they want the browser again '
+  + 'before acting on the page.';
+
+/** conversationIds owed the one-shot notice above. */
+const reclaimNoticePending = new Set();
+
+/**
  * ## What is keyed to the CONVERSATION, and what stays per-RUN
  *
  * Conversation-wide: PROVISIONING, and the bar on touching the user's LEGACY
@@ -471,13 +510,34 @@ function isUserCloseReason(reason) {
   return reason === 'user_close';
 }
 
-/** Lift the reclaim window; `runKey === undefined` means every run (see `ownerInDisposeScope`). */
-function clearUserReclaim(conversationId, runKey) {
+/**
+ * Lift the reclaim window; `runKey === undefined` means every run (see
+ * `ownerInDisposeScope`).
+ *
+ * @param {boolean} [armNotice] true ONLY on the user-message path
+ *   (`browser_clear_reclaim`), and only then does an actual lift owe the
+ *   conversation the one-shot notice (see `RECLAIM_LIFTED_NOTICE`). A dispose
+ *   passes false: it clears the same window, but with nobody left to tell.
+ */
+function clearUserReclaim(conversationId, runKey, armNotice = false) {
+  let lifted = false;
   for (const key of Array.from(userReclaimedAt.keys())) {
     if (ownerInDisposeScope(parseOwnerKey(key), conversationId, runKey)) {
       userReclaimedAt.delete(key);
+      lifted = true;
     }
   }
+  if (armNotice && lifted) reclaimNoticePending.add(conversationId);
+}
+
+/**
+ * Take the one-shot notice owed to `conversationId`, if any. Take-and-clear in
+ * one step (`Set.delete` reports whether it was there) so two runs listing back
+ * to back cannot both be told.
+ */
+function takeReclaimLiftedNotice(conversationId) {
+  if (!conversationId || conversationId === LEGACY_CONVERSATION) return null;
+  return reclaimNoticePending.delete(conversationId) ? RECLAIM_LIFTED_NOTICE : null;
 }
 
 /** >0 while an automation action is executing — its own events are not the user. */
@@ -1231,7 +1291,15 @@ async function runBrowserAutomation(action, payload, signal) {
     // is exactly the tabs that still exist — plus the note explaining why there
     // may now be none, shown to every run of the conversation because none of
     // them will be getting a new tab.
-    const tabs = await automationTabs(owner, payload.createIfEmpty !== false, signal);
+    const modelFacing = payload.createIfEmpty !== false;
+    const tabs = await automationTabs(owner, modelFacing, signal);
+    // One `note` slot, two mutually interesting facts. A window that is open
+    // NOW outranks one the user already lifted, and the owed one-shot is only
+    // spent on a listing a model will actually read (see
+    // `RECLAIM_LIFTED_NOTICE`).
+    const note = conversationIsReclaimed(owner.conversationId)
+      ? USER_RECLAIMED_MESSAGE
+      : (modelFacing ? takeReclaimLiftedNotice(owner.conversationId) : null);
     const win = mainWindow();
     const windowId = win && !win.isDestroyed() ? win.webContents.id : 1;
     const currentTabId = activeTabIdByOwner.get(ownerKey) ?? null;
@@ -1244,7 +1312,7 @@ async function runBrowserAutomation(action, payload, signal) {
         currentTabUrl: tabs.find((tab) => tab.tabId === currentTabId)?.url || '',
         currentTabTitle: tabs.find((tab) => tab.tabId === currentTabId)?.title || '',
         detectionStrategy: 'electron-in-app-browser',
-        ...(conversationIsReclaimed(owner.conversationId) ? { note: USER_RECLAIMED_MESSAGE } : {}),
+        ...(note ? { note } : {}),
       },
       windows: [{
         windowId,
@@ -1288,7 +1356,17 @@ async function runBrowserAutomation(action, payload, signal) {
   if (TAKEOVER_GATED_ACTIONS.has(action) && ((runReclaimed && !match) || targetIsUserTab)) {
     throw new Error(USER_RECLAIMED_MESSAGE);
   }
-  if (!match) throw new Error(`Browser tab not found: ${String(targetTabId)}`);
+  // The one refusal in this file that carried no reason at all — just an id the
+  // model had nothing to say about, which is how "the tab id changed from 2 to
+  // 3" ended up addressed to a user who never asked about tab ids. The id stays
+  // (it is what makes the log readable); the sentence now also says WHY and what
+  // to do next, so the model has something it can repeat in plain language.
+  if (!match) {
+    throw new Error(
+      `Browser tab not found: ${String(targetTabId)}. That tab is no longer open — it was ` +
+        'closed, or the id is not a live tab. Call get_tabs to see the tabs you have now.'
+    );
+  }
   const { view } = match;
 
   if (TAKEOVER_GATED_ACTIONS.has(action)) {
@@ -1644,6 +1722,10 @@ function disposeOwnerViews(conversationId, runKey) {
   // never ask again, and a deleted conversation's window would otherwise outlive
   // everything it referred to.
   clearUserReclaim(conversationId, runKey);
+  // A CONVERSATION-wide dispose is the conversation going away, so a notice it
+  // was still owed dies with it. A run dispose (A2) is a subagent finishing —
+  // the conversation lives on and the news is still owed to whoever is left.
+  if (!runKey) reclaimNoticePending.delete(conversationId);
   // Emitted last, so the renderer's reaction (dropping the tab record, which
   // fires `browser_close`) can never race the teardown above.
   for (const id of cancelledIds) cancelAutomationAdoption(id);
@@ -1671,7 +1753,9 @@ function browserDisposeOwner({ conversationId, runKey }) {
 function browserClearReclaim({ conversationId }) {
   const conversation = sanitizeOwnerPart(conversationId);
   if (!conversation || conversation === LEGACY_CONVERSATION) return null;
-  clearUserReclaim(conversation, undefined);
+  // The one path that arms the one-shot notice: this is the user re-engaging,
+  // so there is somebody to tell (see `RECLAIM_LIFTED_NOTICE`).
+  clearUserReclaim(conversation, undefined, true);
   return null;
 }
 

--- a/electron/browserHost.cjs
+++ b/electron/browserHost.cjs
@@ -419,6 +419,34 @@ const userReclaimedAt = new Map();
  * surviving tabs are untouched by all of this: the user closed one tab, not the
  * task.
  */
+/**
+ * ## The window's two halves are keyed differently, on purpose
+ *
+ * PROVISIONING is blocked for the whole CONVERSATION; the action gate and the
+ * current-tab rules stay per-run.
+ *
+ * Keying provisioning per-run left the promise escapable by delegation, in both
+ * directions: close a subagent's tab and the conversation's own loop opened a
+ * fresh one; close the main loop's tab and the next `run_agent` minted a
+ * brand-new `sar-*` whose window had never been opened, so it provisioned
+ * immediately. The user closed A tab and meant "stop opening tabs" — they
+ * neither know nor care which run owned it, and a promise a delegation can walk
+ * around is not a promise.
+ *
+ * The ACTION gate stays per-run because it answers a different question. A
+ * sibling run holding a tab of its own is mid-task on a page the user never
+ * touched; freezing it would punish work the gesture said nothing about. So:
+ * no new tabs for anyone in this conversation, but whoever still has one keeps
+ * working in it.
+ */
+function conversationIsReclaimed(conversationId) {
+  if (!conversationId || conversationId === LEGACY_CONVERSATION) return false;
+  for (const key of userReclaimedAt.keys()) {
+    if (parseOwnerKey(key).conversationId === conversationId) return true;
+  }
+  return false;
+}
+
 /** May a tab become `owner`'s current tab? Not a legacy one, mid-window. */
 function mayBecomeCurrentTab(owner, tabIsLegacy) {
   return !tabIsLegacy || !userReclaimedAt.has(owner.key);
@@ -988,7 +1016,10 @@ async function automationTabs(owner = LEGACY_OWNER, createIfEmpty = true, signal
       legacy: isLegacyOwner(tabOwner),
     });
   }
-  if (tabs.length === 0 && createIfEmpty) {
+  // The reclaim block lives HERE rather than at the call site so every path
+  // that could mint a view answers to it — including a run whose own window was
+  // never opened, which is exactly how a fresh delegation used to walk around it.
+  if (tabs.length === 0 && createIfEmpty && !conversationIsReclaimed(owner.conversationId)) {
     const view = await createAutomationView(owner, signal);
     tabs.push({
       id: Array.from(views.entries()).find(([, candidate]) => candidate === view)[0],
@@ -1180,13 +1211,16 @@ async function runBrowserAutomation(action, payload, signal) {
   const owner = resolveOwnerKey(payload);
   const ownerKey = owner.key;
 
-  const reclaimed = userReclaimedAt.has(ownerKey);
+  // Per-RUN: gates this caller's actions (see `conversationIsReclaimed` for why
+  // the two halves are keyed differently).
+  const runReclaimed = userReclaimedAt.has(ownerKey);
 
   if (action === 'get_tabs') {
-    // A reclaimed owner never provisions, whatever the caller asked for: the
-    // listing is exactly the tabs that still exist, plus the note explaining
-    // why there may now be none.
-    const tabs = await automationTabs(owner, !reclaimed && payload.createIfEmpty !== false, signal);
+    // Conversation-wide: `automationTabs` refuses to provision, so the listing
+    // is exactly the tabs that still exist — plus the note explaining why there
+    // may now be none, shown to every run of the conversation because none of
+    // them will be getting a new tab.
+    const tabs = await automationTabs(owner, payload.createIfEmpty !== false, signal);
     const win = mainWindow();
     const windowId = win && !win.isDestroyed() ? win.webContents.id : 1;
     const currentTabId = activeTabIdByOwner.get(ownerKey) ?? null;
@@ -1199,7 +1233,7 @@ async function runBrowserAutomation(action, payload, signal) {
         currentTabUrl: tabs.find((tab) => tab.tabId === currentTabId)?.url || '',
         currentTabTitle: tabs.find((tab) => tab.tabId === currentTabId)?.title || '',
         detectionStrategy: 'electron-in-app-browser',
-        ...(reclaimed ? { note: USER_RECLAIMED_MESSAGE } : {}),
+        ...(conversationIsReclaimed(owner.conversationId) ? { note: USER_RECLAIMED_MESSAGE } : {}),
       },
       windows: [{
         windowId,
@@ -1229,7 +1263,7 @@ async function runBrowserAutomation(action, payload, signal) {
   // the very complaint this mechanism answers. Read-only actions are exempt —
   // they cannot make it worse, and the model may still report what the user is
   // looking at. The owner's own surviving tabs are never affected.
-  if (reclaimed && TAKEOVER_GATED_ACTIONS.has(action)
+  if (runReclaimed && TAKEOVER_GATED_ACTIONS.has(action)
     && (!match || isLegacyOwner(ownerOf(match.id)))) {
     throw new Error(USER_RECLAIMED_MESSAGE);
   }

--- a/electron/browserHost.cjs
+++ b/electron/browserHost.cjs
@@ -402,6 +402,29 @@ const USER_RECLAIMED_MESSAGE =
 const userReclaimedAt = new Map();
 
 /**
+ * The window's second half: a reclaimed owner may not TOUCH the legacy pool.
+ *
+ * The legacy pool is listed to every owner on purpose (the user's own pane tabs
+ * are shared). Refusing to provision therefore leaves a reclaimed run seeing
+ * exactly one thing it may still reach — the tab the user is reading — and
+ * without this it would take it: promote it to its current tab, then click,
+ * fill and navigate it. That is a sharper version of the complaint this whole
+ * mechanism answers, arrived at BY the mechanism.
+ *
+ * So a legacy tab is look-but-don't-touch for that owner until the window
+ * lifts: state-changing work on it is refused with the same sentence, read-only
+ * work is not (the model may still report what the user is looking at), and it
+ * may never become that owner's current tab — that record is what steers a
+ * later `get_html` with no tabId onto the user's page. The owner's OWN
+ * surviving tabs are untouched by all of this: the user closed one tab, not the
+ * task.
+ */
+/** May a tab become `owner`'s current tab? Not a legacy one, mid-window. */
+function mayBecomeCurrentTab(owner, tabIsLegacy) {
+  return !tabIsLegacy || !userReclaimedAt.has(owner.key);
+}
+
+/**
  * Unknown/absent values are `lifecycle`: a reason that fails to arrive intact
  * must never be read as a user gesture that gates the run.
  */
@@ -962,6 +985,7 @@ async function automationTabs(owner = LEGACY_OWNER, createIfEmpty = true, signal
       tabId: contents.id,
       url: contents.getURL(),
       title: contents.getTitle(),
+      legacy: isLegacyOwner(tabOwner),
     });
   }
   if (tabs.length === 0 && createIfEmpty) {
@@ -972,10 +996,23 @@ async function automationTabs(owner = LEGACY_OWNER, createIfEmpty = true, signal
       tabId: view.webContents.id,
       url: view.webContents.getURL(),
       title: view.webContents.getTitle(),
+      legacy: isLegacyOwner(owner),
     });
   }
-  if (tabs.length > 0 && !tabs.some((tab) => tab.tabId === activeTabIdByOwner.get(owner.key))) {
-    activeTabIdByOwner.set(owner.key, tabs[0].tabId);
+  if (tabs.length > 0) {
+    const held = tabs.find((tab) => tab.tabId === activeTabIdByOwner.get(owner.key));
+    // Re-point when the record names nothing this owner can see any more — and,
+    // mid-reclaim, when it names a LEGACY tab: the run may have been driving the
+    // user's pane tab perfectly legitimately a moment before the window opened,
+    // so declining to PROMOTE one is not enough on its own. With no eligible
+    // candidate the owner is left with no current tab at all, which is the
+    // honest answer (and what makes a bare `get_html` say "no tab" rather than
+    // reach for the user's page).
+    if (!held || !mayBecomeCurrentTab(owner, held.legacy)) {
+      const candidate = tabs.find((tab) => mayBecomeCurrentTab(owner, tab.legacy));
+      if (candidate) activeTabIdByOwner.set(owner.key, candidate.tabId);
+      else activeTabIdByOwner.delete(owner.key);
+    }
   }
   return tabs;
 }
@@ -1184,17 +1221,19 @@ async function runBrowserAutomation(action, payload, signal) {
     ? activeTabIdByOwner.get(ownerKey)
     : payload.tabId;
   const match = findViewByTabId(targetTabId, owner);
-  if (!match) {
-    // N7: the user closed this owner's tab and nothing is left to act on. Say
-    // that, rather than "tab not found" — which reads as a transient glitch and
-    // invites the model to open another one, the exact thing being refused.
-    // Read-only actions keep the plain not-found error: they cannot make the
-    // situation worse, and the note on `get_tabs` already told the model why.
-    if (reclaimed && TAKEOVER_GATED_ACTIONS.has(action)) {
-      throw new Error(USER_RECLAIMED_MESSAGE);
-    }
-    throw new Error(`Browser tab not found: ${String(targetTabId)}`);
+  // N7 — inside the reclaim window a state-changing action is refused both when
+  // nothing is left to act on AND when the only thing left is a LEGACY tab (the
+  // user's own pane tab, which every owner can see). Same sentence for both:
+  // "tab not found" reads as a transient glitch and invites the model to open
+  // another one, the exact thing being refused, and driving the user's tab is
+  // the very complaint this mechanism answers. Read-only actions are exempt —
+  // they cannot make it worse, and the model may still report what the user is
+  // looking at. The owner's own surviving tabs are never affected.
+  if (reclaimed && TAKEOVER_GATED_ACTIONS.has(action)
+    && (!match || isLegacyOwner(ownerOf(match.id)))) {
+    throw new Error(USER_RECLAIMED_MESSAGE);
   }
+  if (!match) throw new Error(`Browser tab not found: ${String(targetTabId)}`);
   const { view } = match;
 
   if (TAKEOVER_GATED_ACTIONS.has(action)) {
@@ -1236,7 +1275,12 @@ async function runBrowserAutomation(action, payload, signal) {
     }
   }
 
-  activeTabIdByOwner.set(ownerKey, view.webContents.id);
+  // Same rule as the listing's promotion: a read-only look at the user's pane
+  // tab mid-window must not leave that tab as this owner's current one, or the
+  // next tabId-less action drifts onto the user's page anyway.
+  if (mayBecomeCurrentTab(owner, isLegacyOwner(ownerOf(match.id)))) {
+    activeTabIdByOwner.set(ownerKey, view.webContents.id);
+  }
 
   if (action === 'navigate') return navigateAutomationTab(view, payload);
   assertAutomationDocumentAllowed(view);

--- a/electron/browserHost.cjs
+++ b/electron/browserHost.cjs
@@ -381,14 +381,22 @@ const userInteractionAt = new Map();
  * records nothing, as does closing a LEGACY tab (the user closing their own pane
  * tab is just closing a tab).
  *
- * Inside the window, for THAT owner pair (N6 — one subagent's reclaimed tab must
- * not mute its siblings or the conversation's own loop):
+ * While a window is open, the effects are keyed at two DIFFERENT levels (see
+ * `conversationIsReclaimed` for why each is where it is):
+ *
+ * CONVERSATION-wide — every run of it, including runs minted after the close:
  *  - `get_tabs` stops provisioning, and its summary carries `note`;
- *  - a state-changing action or `navigate` left with no tab throws the same
- *    sentence. Deliberately NOT the run-stopped message: the run is alive, and
- *    saying otherwise would have the model report something false to the user.
- *  - anything acting on a tab that IS still open is untouched — the user closed
- *    one tab, not the whole task.
+ *  - no run may state-change the user's LEGACY pane tabs, nor have one promoted
+ *    to its current tab (R1).
+ *
+ * Per-RUN — only the run whose tab was closed:
+ *  - a state-changing action or `navigate` with nothing left to act on throws
+ *    the same sentence. Deliberately NOT the run-stopped message: the run is
+ *    alive, and saying otherwise would have the model report something false to
+ *    the user.
+ *
+ * Untouched either way: read-only work, and anything acting on a tab the RUN
+ * ITSELF still has open — the user closed one tab, not the whole task.
  *
  * The window has no timeout; it is lifted by the user's next message in that
  * conversation (`browser_clear_reclaim`, every run at once — the user is
@@ -402,42 +410,36 @@ const USER_RECLAIMED_MESSAGE =
 const userReclaimedAt = new Map();
 
 /**
- * The window's second half: a reclaimed owner may not TOUCH the legacy pool.
+ * ## What is keyed to the CONVERSATION, and what stays per-RUN
  *
- * The legacy pool is listed to every owner on purpose (the user's own pane tabs
- * are shared). Refusing to provision therefore leaves a reclaimed run seeing
- * exactly one thing it may still reach — the tab the user is reading — and
- * without this it would take it: promote it to its current tab, then click,
- * fill and navigate it. That is a sharper version of the complaint this whole
- * mechanism answers, arrived at BY the mechanism.
+ * Conversation-wide: PROVISIONING, and the bar on touching the user's LEGACY
+ * pane tabs (both the action gate's legacy clause and current-tab promotion).
+ * Per-run: the "nothing left to act on" clause of the action gate.
  *
- * So a legacy tab is look-but-don't-touch for that owner until the window
- * lifts: state-changing work on it is refused with the same sentence, read-only
- * work is not (the model may still report what the user is looking at), and it
- * may never become that owner's current tab — that record is what steers a
- * later `get_html` with no tabId onto the user's page. The owner's OWN
- * surviving tabs are untouched by all of this: the user closed one tab, not the
- * task.
- */
-/**
- * ## The window's two halves are keyed differently, on purpose
+ * Both conversation-wide rules exist because a per-run key let the promise be
+ * walked around by delegation:
  *
- * PROVISIONING is blocked for the whole CONVERSATION; the action gate and the
- * current-tab rules stay per-run.
+ *  - PROVISIONING, both directions: close a subagent's tab and the
+ *    conversation's own loop opened a fresh one; close the main loop's tab and
+ *    the next `run_agent` minted a brand-new `sar-*` whose window had never been
+ *    opened, so it provisioned immediately.
+ *  - THE USER'S TABS (R1): with provisioning blocked, a run holding no window of
+ *    its own sees the user's pane tab as the ONLY tab it can reach — so a
+ *    per-run bar handed that run exactly what the gesture was refusing. The
+ *    legacy pool is listed to every run on purpose (the user's pane tabs are
+ *    shared), which is what makes it reachable in the first place.
  *
- * Keying provisioning per-run left the promise escapable by delegation, in both
- * directions: close a subagent's tab and the conversation's own loop opened a
- * fresh one; close the main loop's tab and the next `run_agent` minted a
- * brand-new `sar-*` whose window had never been opened, so it provisioned
- * immediately. The user closed A tab and meant "stop opening tabs" — they
- * neither know nor care which run owned it, and a promise a delegation can walk
- * around is not a promise.
+ * In both cases the user closed A tab and meant "stop"; they neither know nor
+ * care which run owned it, and a promise a delegation can walk around is not a
+ * promise.
  *
- * The ACTION gate stays per-run because it answers a different question. A
- * sibling run holding a tab of its own is mid-task on a page the user never
- * touched; freezing it would punish work the gesture said nothing about. So:
- * no new tabs for anyone in this conversation, but whoever still has one keeps
- * working in it.
+ * The "nothing left to act on" clause stays per-run because it answers a
+ * different question — it is about THIS run's own closed tab, and a run still
+ * holding tabs is not in that situation at all. Freezing a sibling mid-task on a
+ * page the user never touched would punish work the gesture said nothing about.
+ *
+ * Net: no new tabs for anyone here, nobody touches the user's tabs, and whoever
+ * still has a tab of their own keeps working in it.
  */
 function conversationIsReclaimed(conversationId) {
   if (!conversationId || conversationId === LEGACY_CONVERSATION) return false;
@@ -447,9 +449,18 @@ function conversationIsReclaimed(conversationId) {
   return false;
 }
 
-/** May a tab become `owner`'s current tab? Not a legacy one, mid-window. */
+/**
+ * May a tab become `owner`'s current tab? Not a LEGACY one while any run of
+ * that conversation is reclaimed.
+ *
+ * Keyed on the conversation, not the acting run (R1): the conversation-wide
+ * provisioning block means a run holding no window of its own — a `sar-*`
+ * minted after the user closed the main loop's tab, or the main loop after a
+ * subagent's — sees the user's pane tab as the ONLY tab it can reach. Keying
+ * this per-run handed that run exactly what the gesture was refusing.
+ */
 function mayBecomeCurrentTab(owner, tabIsLegacy) {
-  return !tabIsLegacy || !userReclaimedAt.has(owner.key);
+  return !tabIsLegacy || !conversationIsReclaimed(owner.conversationId);
 }
 
 /**
@@ -1255,16 +1266,26 @@ async function runBrowserAutomation(action, payload, signal) {
     ? activeTabIdByOwner.get(ownerKey)
     : payload.tabId;
   const match = findViewByTabId(targetTabId, owner);
-  // N7 — inside the reclaim window a state-changing action is refused both when
-  // nothing is left to act on AND when the only thing left is a LEGACY tab (the
-  // user's own pane tab, which every owner can see). Same sentence for both:
-  // "tab not found" reads as a transient glitch and invites the model to open
-  // another one, the exact thing being refused, and driving the user's tab is
-  // the very complaint this mechanism answers. Read-only actions are exempt —
-  // they cannot make it worse, and the model may still report what the user is
-  // looking at. The owner's own surviving tabs are never affected.
-  if (runReclaimed && TAKEOVER_GATED_ACTIONS.has(action)
-    && (!match || isLegacyOwner(ownerOf(match.id)))) {
+  // N7 — a state-changing action is refused in two situations, with the same
+  // sentence: "tab not found" reads as a transient glitch and invites the model
+  // to open another one, the exact thing being refused.
+  //
+  // The two halves are keyed differently (R1):
+  //  - NOTHING LEFT TO ACT ON is per-RUN — it is about this run's own closed
+  //    tab, and a run that still has tabs is not in that situation at all.
+  //  - THE TARGET IS A LEGACY TAB is per-CONVERSATION. The user's pane tabs are
+  //    visible to every run, so while any window in the conversation is open,
+  //    NO run of it may drive them — including one holding no window of its own,
+  //    which the conversation-wide provisioning block leaves seeing the user's
+  //    tab as the only thing it can reach.
+  //
+  // Read-only actions are exempt from both: they cannot make it worse, and the
+  // model may still report what the user is looking at. A run's OWN surviving
+  // tabs are never affected — the user closed one tab, not the task.
+  const targetIsUserTab = Boolean(match)
+    && isLegacyOwner(ownerOf(match.id))
+    && conversationIsReclaimed(owner.conversationId);
+  if (TAKEOVER_GATED_ACTIONS.has(action) && ((runReclaimed && !match) || targetIsUserTab)) {
     throw new Error(USER_RECLAIMED_MESSAGE);
   }
   if (!match) throw new Error(`Browser tab not found: ${String(targetTabId)}`);

--- a/electron/browserHost.ownership.test.cjs
+++ b/electron/browserHost.ownership.test.cjs
@@ -988,3 +988,54 @@ test('a pre-aborted signal stops get_tabs before it can provision or open a tab'
     restore();
   }
 });
+
+/**
+ * N3 — the React layer (address bar, back/forward/reload) never touches the
+ * guest webContents, so it produces none of the `before-input-event`/`focus`
+ * signals R4's backoff relies on. `browser_note_user_interaction` is the
+ * bridge: `BrowserTab.tsx` calls it on address-bar focus/input and nav-button
+ * clicks, and it must gate a state-changing action exactly like real
+ * `before-input-event`/`focus` input does (reusing the same `userInteractionAt`
+ * record — see `typeInto`-driven scenarios above).
+ */
+test('browser_note_user_interaction gates a state-changing action like real input does', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    const { clock, state } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+    // `browser_note_user_interaction` takes the view's own string id — same
+    // as `browser_create`/`browser_inspect_set` — NOT the automation `tabId`
+    // (the guest's numeric webContents id) that `navigate`/`get_tabs` use.
+    const viewId = emitted.find((entry) => entry.event === 'browser://automation-open').payload.id;
+
+    host.browserDispatch(null, 'browser_note_user_interaction', { id: viewId });
+    state.t += 2000; // 2s into the 3s quiet window — still "hands on keyboard"
+
+    await navigate(host, OWNER_A, aTab, 'https://example.com/');
+
+    assert.deepEqual(state.sleeps, [500, 500], 'polled twice, then the window went quiet');
+    assert.equal(contentsFor(aTab).url, 'https://example.com/', 'the action ran after the wait');
+  } finally {
+    restore();
+  }
+});
+
+test('browser_note_user_interaction on an unknown id is a silent no-op', async () => {
+  const { host, restore } = loadHost();
+  try {
+    const { clock, state } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+
+    const result = host.browserDispatch(null, 'browser_note_user_interaction', { id: 'no-such-view' });
+    assert.equal(result, null, 'unknown id resolves to null, not an error');
+
+    // Nothing should have been recorded against any owner — the action runs
+    // immediately with no wait.
+    await navigate(host, OWNER_A, aTab, 'https://example.com/');
+    assert.deepEqual(state.sleeps, []);
+  } finally {
+    restore();
+  }
+});

--- a/electron/browserHost.ownership.test.cjs
+++ b/electron/browserHost.ownership.test.cjs
@@ -1179,17 +1179,140 @@ test('a stop during the adoption wait cancels it instead of stranding a hidden v
     // proves the loop exited on the abort rather than on its deadline.
     assert.deepEqual(tabIds(await probeTabs(host, OWNER_A)), []);
 
-    // The pending-owner entry is gone: re-creating that id as a user pane tab
-    // comes back legacy (a stranded entry would hand it to OWNER_A instead).
+    // The invitation is withdrawn, both ways: the renderer is told to drop the
+    // tab record, and a `browser_create` that was already in flight for that id
+    // builds NOTHING. (Letting it through would create a legacy view — the
+    // pending owner is gone — that every other conversation can see and drive,
+    // while the only record able to destroy it carries the stopped run's owner
+    // and is therefore invisible in every strip.)
+    assert.deepEqual(
+      emitted.filter((entry) => entry.event === 'browser://automation-cancel').map((e) => e.payload),
+      [{ id: openEvent.payload.id }]
+    );
+    assert.equal(
+      host.browserDispatch(null, 'browser_create', {
+        id: openEvent.payload.id,
+        url: 'https://example.com/',
+        x: 0,
+        y: 0,
+        width: 800,
+        height: 600,
+      }),
+      null,
+      'a refused adoption resolves quietly — a throw would drive BrowserTab\'s create-retry loop'
+    );
+    assert.deepEqual(tabIds(await probeTabs(host)), [], 'no legacy ghost was created');
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_B)), [], 'and no other owner sees one');
+  } finally {
+    restore();
+  }
+});
+
+/**
+ * I1 (fix round 1) — the cancel/dispose paths drop the pending-owner entry while
+ * `browser://automation-open` is already on its way out, and the renderer
+ * answers it unconditionally with `browser_create`. Both orderings of that race
+ * must end with no view and no record.
+ */
+test('a browser_create landing after a dispose cannot become a legacy ghost', async () => {
+  const { host, emitted, restore } = loadHost({ adopt: false });
+  try {
+    // `browser://automation-open` is emitted before the wait's first await, so
+    // it has already fired by the time this call yields its promise.
+    const pending = host.performBrowserAutomation('get_tabs', { ownerId: OWNER_A });
+    const openId = emitted.find((item) => item.event === 'browser://automation-open').payload.id;
+
+    host.browserDispatch(null, 'browser_dispose_owner', { conversationId: OWNER_A });
+    await assert.rejects(pending, /Browser action cancelled because the run was stopped\./);
+
+    // The renderer's adoption arrives late — exactly the reproduced ghost.
+    assert.equal(
+      host.browserDispatch(null, 'browser_create', {
+        id: openId,
+        url: 'https://ghost.example/',
+        x: 0,
+        y: 0,
+        width: 800,
+        height: 600,
+      }),
+      null
+    );
+
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_B)), [], 'no ghost in another owner\'s tabs');
+    assert.deepEqual(tabIds(await probeTabs(host)), [], 'and none in the legacy pool');
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_A)), []);
+    // Even a repeated create (StrictMode double-mount) stays refused.
     host.browserDispatch(null, 'browser_create', {
-      id: openEvent.payload.id,
-      url: 'https://example.com/',
+      id: openId,
+      url: 'https://ghost.example/',
       x: 0,
       y: 0,
       width: 800,
       height: 600,
     });
-    assert.equal(tabIds(await probeTabs(host)).length, 1);
+    assert.deepEqual(tabIds(await probeTabs(host)), []);
+  } finally {
+    restore();
+  }
+});
+
+test('disposing an already-adopted view tells the renderer to drop its record', async () => {
+  // The other ordering: the renderer adopted BEFORE the dispose landed, so the
+  // tab record exists. Closing the view alone would leave that record behind —
+  // invisible in every strip (it carries the deleted conversation's owner) and
+  // still mounted, syncing bounds for a view that is gone.
+  const { host, emitted, restore } = loadHost();
+  try {
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+    const viewId = emitted.find((entry) => entry.event === 'browser://automation-open').payload.id;
+
+    host.browserDispatch(null, 'browser_dispose_owner', { conversationId: OWNER_A });
+
+    assert.equal(contentsFor(aTab).isDestroyed(), true);
+    assert.deepEqual(
+      emitted.filter((entry) => entry.event === 'browser://automation-cancel').map((e) => e.payload),
+      [{ id: viewId }]
+    );
+    // A create retry that was already in flight for that view is refused too.
+    host.browserDispatch(null, 'browser_create', {
+      id: viewId,
+      url: 'https://retry.example/',
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 600,
+    });
+    assert.deepEqual(tabIds(await probeTabs(host)), []);
+  } finally {
+    restore();
+  }
+});
+
+test('the cancelled-adoption tombstone set stays bounded', async () => {
+  // It only has to outlive an in-flight adoption (milliseconds), so it is capped
+  // and evicts oldest-first rather than growing for the life of the session.
+  const { host, emitted, restore } = loadHost();
+  try {
+    const ids = [];
+    for (let i = 0; i < 70; i += 1) {
+      const owner = `conversation-bulk-${i}`;
+      await getTabs(host, owner);
+      ids.push(emitted[emitted.length - 1].payload.id);
+      host.browserDispatch(null, 'browser_dispose_owner', { conversationId: owner });
+    }
+
+    // The newest cancellations are still refused...
+    host.browserDispatch(null, 'browser_create', {
+      id: ids[69], url: 'https://recent.example/', x: 0, y: 0, width: 800, height: 600,
+    });
+    assert.deepEqual(tabIds(await probeTabs(host)), [], 'a recent cancellation still blocks');
+
+    // ...and the oldest have aged out, which is the bound itself: an adoption
+    // 70 cancellations ago is long dead, so re-using its id is not a ghost path.
+    host.browserDispatch(null, 'browser_create', {
+      id: ids[0], url: 'https://aged-out.example/', x: 0, y: 0, width: 800, height: 600,
+    });
+    assert.equal(tabIds(await probeTabs(host)).length, 1, 'the set did not grow past its cap');
   } finally {
     restore();
   }

--- a/electron/browserHost.ownership.test.cjs
+++ b/electron/browserHost.ownership.test.cjs
@@ -161,9 +161,26 @@ function loadHost({ adopt = true } = {}) {
   delete require.cache[browserHostId];
 
   const emitted = [];
+  // The main window's own webContents can receive input (the chat composer,
+  // the address bar) and be handed focus back after a guest steal (F1), so the
+  // fake carries listeners and a focus-call counter like FakeWebContents does.
+  const mainWindowListeners = new Map();
   const mainWindow = {
     isDestroyed: () => false,
-    webContents: { id: 1 },
+    webContents: {
+      id: 1,
+      focusCalls: 0,
+      on(event, handler) {
+        if (!mainWindowListeners.has(event)) mainWindowListeners.set(event, []);
+        mainWindowListeners.get(event).push(handler);
+        return this;
+      },
+      fire(event, ...args) {
+        for (const handler of mainWindowListeners.get(event) || []) handler(...args);
+      },
+      focus() { this.focusCalls += 1; },
+      isDestroyed: () => false,
+    },
     contentView: { addChildView() {}, removeChildView() {} },
   };
   let host = null;
@@ -223,7 +240,7 @@ function loadHost({ adopt = true } = {}) {
     webRequestListener({ resourceType: 'mainFrame', ...details }, () => {});
   };
 
-  return { host, emitted, restore, fireHeadersReceived };
+  return { host, emitted, restore, fireHeadersReceived, mainWin: mainWindow };
 }
 
 function getTabs(host, ownerId, runId) {
@@ -2610,6 +2627,126 @@ test('a missing tab is refused with a reason and a next step', async () => {
         return true;
       }
     );
+  } finally {
+    restore();
+  }
+});
+
+/**
+ * ## F1 — a navigation-commit focus steal must not blur the user's typing
+ *
+ * Chromium focuses a WebContentsView's frame when a navigation commits, with
+ * no host code involved: real-device acceptance (2026-09-02) showed a page's
+ * own redirect firing a genuine `focusout` on the main window's address bar
+ * at exactly the moment the guest landed. Two harms:
+ *  - the user typing in the MAIN window (composer, address bar) silently
+ *    loses keyboard focus — their next keystrokes go nowhere;
+ *  - the guest `focus` event is misread by R4 as the user being on that tab
+ *    (recording interaction, promoting it to current).
+ *
+ * The steal is distinguished from a real user entering the guest by two
+ * signals: the user typed in the main window UI inside the quiet window, and
+ * NO direct input (pointer/keyboard) landed on the guest just before its
+ * `focus`. In exactly that case the host hands focus straight back and does
+ * not attribute the event to the user.
+ */
+
+function typeInMainUi(mainWin) {
+  mainWin.webContents.fire('before-input-event', {}, { type: 'keyDown', key: 'a' });
+}
+
+test('F1: a focus steal while the user types in the main window bounces back and is not the user', async () => {
+  const { host, restore, mainWin } = loadHost();
+  try {
+    const { clock, state } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+
+    typeInMainUi(mainWin);
+    contentsFor(aTab).fire('focus'); // Chromium's navigation-commit steal
+
+    assert.equal(mainWin.webContents.focusCalls, 1, 'focus handed straight back to the main window');
+
+    // Not the user: a state-changing action runs without any takeover wait.
+    await navigate(host, OWNER_A, aTab, 'https://example.com/');
+    assert.deepEqual(state.sleeps, [], 'no quiet-window wait was triggered by the steal');
+    assert.equal(contentsFor(aTab).url, 'https://example.com/');
+  } finally {
+    restore();
+  }
+});
+
+test('F1: a real user click into the guest neither bounces nor loses its attribution', async () => {
+  const { host, restore, mainWin } = loadHost();
+  try {
+    const { clock, state } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+
+    // Worst case: the user was typing in the composer moments ago, then
+    // deliberately clicks into the page — the pointer landing on the guest is
+    // what separates this from a steal.
+    typeInMainUi(mainWin);
+    contentsFor(aTab).fire('input-event', {}, { type: 'mouseDown' });
+    contentsFor(aTab).fire('focus');
+
+    assert.equal(mainWin.webContents.focusCalls, 0, 'a real entry into the guest keeps focus');
+
+    // Attributed to the user: a state-changing action waits out the window.
+    await navigate(host, OWNER_A, aTab, 'https://example.com/');
+    assert.equal(state.sleeps.length, 6, 'waited out the full 3s quiet window');
+  } finally {
+    restore();
+  }
+});
+
+test('F1: a steal while the user is idle keeps the pre-F1 behavior (recorded, no bounce)', async () => {
+  const { host, restore, mainWin } = loadHost();
+  try {
+    const { clock, state } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+
+    // No main-window typing: nothing distinguishes this from the user
+    // focusing the view, so it stays attributed (a missed bounce is harmless
+    // when nobody is typing).
+    contentsFor(aTab).fire('focus');
+
+    assert.equal(mainWin.webContents.focusCalls, 0);
+    await navigate(host, OWNER_A, aTab, 'https://example.com/');
+    assert.equal(state.sleeps.length, 6, 'the focus stays a user-presence signal');
+  } finally {
+    restore();
+  }
+});
+
+test('F1: a steal does not promote the stolen-onto tab to the owner current tab', async () => {
+  const { host, restore, mainWin } = loadHost();
+  try {
+    const { clock } = fakeClock();
+    host.__testing.setClock(clock);
+
+    // Two user pane (legacy) tabs.
+    host.browserDispatch(null, 'browser_create', {
+      id: 'pane-1', url: 'https://one.example/', x: 0, y: 0, width: 800, height: 600,
+    });
+    host.browserDispatch(null, 'browser_create', {
+      id: 'pane-2', url: 'https://two.example/', x: 0, y: 0, width: 800, height: 600,
+    });
+    const listing = await probeTabs(host);
+    const [tabOne, tabTwo] = tabIds(listing);
+
+    // The user really is on tab one.
+    contentsFor(tabOne).fire('input-event', {}, { type: 'mouseDown' });
+    contentsFor(tabOne).fire('focus');
+    assert.equal((await probeTabs(host)).summary.currentTabId, tabOne);
+
+    // Tab two's page redirects in the background and steals focus while the
+    // user types in the main window: current tab must not move.
+    typeInMainUi(mainWin);
+    contentsFor(tabTwo).fire('focus');
+    assert.equal((await probeTabs(host)).summary.currentTabId, tabOne, 'steal must not move the current tab');
+    assert.equal(mainWin.webContents.focusCalls, 1);
   } finally {
     restore();
   }

--- a/electron/browserHost.ownership.test.cjs
+++ b/electron/browserHost.ownership.test.cjs
@@ -215,14 +215,18 @@ function loadHost({ adopt = true } = {}) {
   return { host, emitted, restore, fireHeadersReceived };
 }
 
-function getTabs(host, ownerId) {
-  return host.performBrowserAutomation('get_tabs', ownerId ? { ownerId } : {});
+function getTabs(host, ownerId, runId) {
+  return host.performBrowserAutomation('get_tabs', {
+    ...(ownerId ? { ownerId } : {}),
+    ...(runId ? { runId } : {}),
+  });
 }
 
 /** A read-only listing: never provisions a view for an owner that has none. */
-function probeTabs(host, ownerId) {
+function probeTabs(host, ownerId, runId) {
   return host.performBrowserAutomation('get_tabs', {
     ...(ownerId ? { ownerId } : {}),
+    ...(runId ? { runId } : {}),
     createIfEmpty: false,
   });
 }
@@ -231,9 +235,10 @@ function tabIds(result) {
   return result.windows[0].tabs.map((tab) => tab.tabId);
 }
 
-function navigate(host, ownerId, tabId, url) {
+function navigate(host, ownerId, tabId, url, runId) {
   return host.performBrowserAutomation('navigate', {
     ...(ownerId ? { ownerId } : {}),
+    ...(runId ? { runId } : {}),
     tabId,
     action: 'goto',
     url,
@@ -1353,6 +1358,290 @@ test('browser_note_user_interaction on an unknown id is a silent no-op', async (
     // immediately with no wait.
     await navigate(host, OWNER_A, aTab, 'https://example.com/');
     assert.deepEqual(state.sleeps, []);
+  } finally {
+    restore();
+  }
+});
+
+/**
+ * ── N6 — ownership refined from "one conversation" to "one subagent run" ──
+ *
+ * A conversation can drive the browser from several places at once: its own
+ * main loop, and any number of delegated subagent runs. With ownership keyed on
+ * the conversation alone all of them shared one pool and one "current tab", so
+ * two sibling subagents researching two different sites saw each other's tabs in
+ * `get_tabs` and silently stole each other's current tab — the exact bug the
+ * per-conversation keying fixed BETWEEN conversations, reproduced inside one.
+ *
+ * The owner is now the pair `{conversationId, runKey}`:
+ *  - `runKey` comes from `payload.runId` (the `sar-*` subagent run id, threaded
+ *    down through `_meta['abu/runKey']`); a caller that sends none — the main
+ *    loop, and every pre-N6 caller — is `main`, so single-run behavior is
+ *    byte-for-byte what it was.
+ *  - `get_tabs` / current-tab / takeover records are all per pair.
+ *  - An EXPLICIT tabId naming a sibling run's tab in the SAME conversation is
+ *    allowed (that is how a parent hands a tab to a child: it puts the id in the
+ *    task description); another CONVERSATION's tab still fails loud, with the
+ *    message unchanged.
+ *  - `browser_dispose_owner` takes an optional `runKey`: with it, exactly that
+ *    run is reaped (a finished subagent releasing its tabs); without it, every
+ *    run of that conversation is (the conversation was deleted) — the pre-N6
+ *    behavior of that command.
+ */
+
+const RUN_1 = 'sar-run-one';
+const RUN_2 = 'sar-run-two';
+
+test('two subagent runs of the same conversation do not see each other tabs', async () => {
+  const { host, restore } = loadHost();
+  try {
+    const run1 = await getTabs(host, OWNER_A, RUN_1);
+    const run2 = await getTabs(host, OWNER_A, RUN_2);
+    const mainLoop = await getTabs(host, OWNER_A);
+
+    assert.equal(tabIds(run1).length, 1);
+    assert.equal(tabIds(run2).length, 1);
+    assert.equal(tabIds(mainLoop).length, 1);
+    const distinct = new Set([tabIds(run1)[0], tabIds(run2)[0], tabIds(mainLoop)[0]]);
+    assert.equal(distinct.size, 3, 'each run provisioned its own tab');
+
+    // Neither sibling leaks into the other listing, and neither leaks into the
+    // conversation main loop's.
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_A, RUN_1)), tabIds(run1));
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_A, RUN_2)), tabIds(run2));
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_A)), tabIds(mainLoop));
+  } finally {
+    restore();
+  }
+});
+
+test('each run keeps its own current tab', async () => {
+  const { host, restore } = loadHost();
+  try {
+    const run1Tab = tabIds(await getTabs(host, OWNER_A, RUN_1))[0];
+    const run2Tab = tabIds(await getTabs(host, OWNER_A, RUN_2))[0];
+    assert.notEqual(run1Tab, run2Tab, 'the two runs really provisioned separate tabs');
+
+    // Run 2 acting on its own tab must not move run 1's current tab.
+    await navigate(host, OWNER_A, run2Tab, 'https://example.com/', RUN_2);
+
+    assert.equal((await probeTabs(host, OWNER_A, RUN_1)).summary.currentTabId, run1Tab);
+    assert.equal((await probeTabs(host, OWNER_A, RUN_2)).summary.currentTabId, run2Tab);
+  } finally {
+    restore();
+  }
+});
+
+test('a run may act on a sibling run tab when the parent hands it the explicit tabId', async () => {
+  const { host, restore } = loadHost();
+  try {
+    const run1Tab = tabIds(await getTabs(host, OWNER_A, RUN_1))[0];
+    await getTabs(host, OWNER_A, RUN_2);
+
+    const logs = [];
+    const realLog = console.log;
+    console.log = (...args) => { logs.push(args.join(' ')); };
+    try {
+      await navigate(host, OWNER_A, run1Tab, 'https://handed-over.example/', RUN_2);
+    } finally {
+      console.log = realLog;
+    }
+
+    assert.equal(contentsFor(run1Tab).getURL(), 'https://handed-over.example/');
+    assert.equal(
+      logs.some((line) => line.includes(RUN_2) && line.includes(RUN_1)),
+      true,
+      'the cross-run access is recorded so it is not invisible'
+    );
+    // Handing a tab over does NOT reassign it: it stays run 1's, and run 2's
+    // own listing is unchanged.
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_A, RUN_1)), [run1Tab]);
+    assert.equal(
+      tabIds(await probeTabs(host, OWNER_A, RUN_2)).includes(run1Tab),
+      false,
+      'an explicit hand-over does not make the tab visible to the borrower'
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('a tab owned by another conversation is still refused, message unchanged', async () => {
+  const { host, restore } = loadHost();
+  try {
+    const foreignTab = tabIds(await getTabs(host, OWNER_B, RUN_1))[0];
+    await getTabs(host, OWNER_A, RUN_2);
+
+    await assert.rejects(
+      navigate(host, OWNER_A, foreignTab, 'https://example.com/', RUN_2),
+      (error) => {
+        assert.equal(
+          error.message,
+          `Browser tab ${foreignTab} belongs to another conversation's task. `
+            + 'Call get_tabs to see your own tabs, or open a new tab with navigate.'
+        );
+        return true;
+      }
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('browser_dispose_owner with a runKey reaps only that run', async () => {
+  const { host, restore } = loadHost();
+  try {
+    const run1Tab = tabIds(await getTabs(host, OWNER_A, RUN_1))[0];
+    const run2Tab = tabIds(await getTabs(host, OWNER_A, RUN_2))[0];
+    const mainTab = tabIds(await getTabs(host, OWNER_A))[0];
+    const otherConversationTab = tabIds(await getTabs(host, OWNER_B, RUN_1))[0];
+
+    host.browserDispatch(null, 'browser_dispose_owner', {
+      conversationId: OWNER_A,
+      runKey: RUN_1,
+    });
+
+    assert.equal(contentsFor(run1Tab).isDestroyed(), true, 'the finished run released its tab');
+    assert.equal(contentsFor(run2Tab).isDestroyed(), false, 'a sibling run is untouched');
+    assert.equal(contentsFor(mainTab).isDestroyed(), false, 'the conversation main loop is untouched');
+    assert.equal(contentsFor(otherConversationTab).isDestroyed(), false);
+
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_A, RUN_1)), []);
+    assert.equal((await probeTabs(host, OWNER_A, RUN_1)).summary.currentTabId, null);
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_A, RUN_2)), [run2Tab]);
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_A)), [mainTab]);
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_B, RUN_1)), [otherConversationTab]);
+  } finally {
+    restore();
+  }
+});
+
+test('browser_dispose_owner without a runKey still reaps every run of the conversation', async () => {
+  const { host, restore } = loadHost();
+  try {
+    const run1Tab = tabIds(await getTabs(host, OWNER_A, RUN_1))[0];
+    const run2Tab = tabIds(await getTabs(host, OWNER_A, RUN_2))[0];
+    const mainTab = tabIds(await getTabs(host, OWNER_A))[0];
+    const otherConversationTab = tabIds(await getTabs(host, OWNER_B, RUN_1))[0];
+
+    host.browserDispatch(null, 'browser_dispose_owner', { conversationId: OWNER_A });
+
+    assert.equal(contentsFor(run1Tab).isDestroyed(), true);
+    assert.equal(contentsFor(run2Tab).isDestroyed(), true);
+    assert.equal(contentsFor(mainTab).isDestroyed(), true);
+    assert.equal(contentsFor(otherConversationTab).isDestroyed(), false);
+
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_A, RUN_1)), []);
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_A, RUN_2)), []);
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_A)), []);
+  } finally {
+    restore();
+  }
+});
+
+test('a per-run dispose clears that run takeover record only', async () => {
+  const { host, restore } = loadHost();
+  try {
+    const { clock, state } = fakeClock();
+    host.__testing.setClock(clock);
+    const run1Tab = tabIds(await getTabs(host, OWNER_A, RUN_1))[0];
+    const run2Tab = tabIds(await getTabs(host, OWNER_A, RUN_2))[0];
+    typeInto(run1Tab);
+    typeInto(run2Tab);
+
+    host.browserDispatch(null, 'browser_dispose_owner', {
+      conversationId: OWNER_A,
+      runKey: RUN_1,
+    });
+
+    // Run 1's record is gone with its views; run 2's is not, so run 2 still
+    // backs off (virtual time never advanced, so its timestamp is still fresh).
+    const freshRun1Tab = tabIds(await getTabs(host, OWNER_A, RUN_1))[0];
+    await navigate(host, OWNER_A, freshRun1Tab, 'https://example.com/', RUN_1);
+    assert.deepEqual(state.sleeps, [], 'no stale takeover record survived the per-run dispose');
+
+    // Run 2's record survived, so run 2 still backs off — proving the sweep was
+    // scoped to one run rather than to the whole conversation.
+    await navigate(host, OWNER_A, run2Tab, 'https://example.com/', RUN_2);
+    assert.ok(state.sleeps.length > 0, 'the sibling run still yields to the user');
+  } finally {
+    restore();
+  }
+});
+
+test('a caller that sends no runId is the same owner as runKey "main"', async () => {
+  // Byte-compat: the single-conversation, no-subagent world is the degenerate
+  // one-dimensional case of the pair, not a second code path.
+  const { host, restore } = loadHost();
+  try {
+    const mainTab = tabIds(await getTabs(host, OWNER_A))[0];
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_A, 'main')), [mainTab]);
+    assert.equal((await probeTabs(host, OWNER_A, 'main')).summary.currentTabId, mainTab);
+  } finally {
+    restore();
+  }
+});
+
+test('legacy pane tabs stay visible to every run of every conversation', async () => {
+  const { host, restore } = loadHost();
+  try {
+    host.browserDispatch(null, 'browser_create', {
+      id: 'pane-tab-1',
+      url: 'https://example.com/',
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 600,
+    });
+    const paneTab = tabIds(await probeTabs(host))[0];
+
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_A, RUN_1)), [paneTab]);
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_B, RUN_2)), [paneTab]);
+
+    // ...and a run may drive it without claiming it.
+    await navigate(host, OWNER_A, paneTab, 'https://still-legacy.example/', RUN_1);
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_B, RUN_2)), [paneTab]);
+  } finally {
+    restore();
+  }
+});
+
+test('a run dispose never reaps the legacy pool, whatever the runKey', async () => {
+  const { host, restore } = loadHost();
+  try {
+    host.browserDispatch(null, 'browser_create', {
+      id: 'pane-tab-1',
+      url: 'https://example.com/',
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 600,
+    });
+    const paneTab = tabIds(await probeTabs(host))[0];
+
+    for (const runKey of [RUN_1, 'main', '', '   ', undefined, 42]) {
+      assert.equal(
+        host.browserDispatch(null, 'browser_dispose_owner', { conversationId: 'legacy', runKey }),
+        null
+      );
+    }
+
+    assert.equal(contentsFor(paneTab).isDestroyed(), false);
+    assert.deepEqual(tabIds(await probeTabs(host)), [paneTab]);
+  } finally {
+    restore();
+  }
+});
+
+test('a runId is never enough on its own to escape the legacy pool', async () => {
+  // An `ownerId`-less caller is legacy no matter what run it claims to be:
+  // otherwise a stray runId would mint a private pool nothing can dispose (the
+  // dispose command refuses the legacy conversation by design).
+  const { host, restore } = loadHost();
+  try {
+    const strayTab = tabIds(await getTabs(host, undefined, RUN_1))[0];
+    assert.deepEqual(tabIds(await probeTabs(host)), [strayTab], 'it landed in the shared pool');
+    assert.deepEqual(tabIds(await probeTabs(host, undefined, RUN_2)), [strayTab]);
   } finally {
     restore();
   }

--- a/electron/browserHost.ownership.test.cjs
+++ b/electron/browserHost.ownership.test.cjs
@@ -1807,12 +1807,14 @@ test('browser_clear_reclaim lifts the window for every run of that conversation'
 
     const run1 = await getTabs(host, OWNER_A, RUN_1);
     assert.equal(tabIds(run1).length, 1, 'the subagent run may open a tab again');
-    // C8: the first listing after the lift is told the window WAS open, once —
-    // silence here is what let the model carry on as if nothing had happened.
+    // C8: listings after the lift are told the window WAS open — silence here
+    // is what let the model carry on as if nothing had happened. The subagent
+    // reads it; the main loop, which can actually ask the user, spends it.
     assert.equal(run1.summary.note, RECLAIM_LIFTED_NOTICE);
     const mainLoop = await getTabs(host, OWNER_A);
     assert.equal(tabIds(mainLoop).length, 1, 'so may the conversation main loop');
-    assert.equal(mainLoop.summary.note, undefined);
+    assert.equal(mainLoop.summary.note, RECLAIM_LIFTED_NOTICE);
+    assert.equal((await getTabs(host, OWNER_A)).summary.note, undefined, 'and only once');
 
     // Another conversation's window is its own and is untouched.
     const other = await getTabs(host, OWNER_B);
@@ -1926,19 +1928,15 @@ test('clearing the window lets every run of the conversation provision again', a
 
     host.browserDispatch(null, 'browser_clear_reclaim', { conversationId: OWNER_A });
 
-    let listings = 0;
     for (const runId of [RUN_1, RUN_2, undefined]) {
       const listing = await getTabs(host, OWNER_A, runId);
       assert.equal(tabIds(listing).length, 1, `run ${runId ?? 'main'} provisions again`);
-      // C8: the lift is announced to the conversation exactly once — the first
-      // run to look — and never gates anyone's provisioning.
-      listings += 1;
-      assert.equal(
-        listing.summary.note,
-        listings === 1 ? RECLAIM_LIFTED_NOTICE : undefined,
-        `run ${runId ?? 'main'} note`
-      );
+      // C8: every run is told the window was lifted, and the notice never gates
+      // anyone's provisioning. The main loop (last here) is the one that spends
+      // it, which the following assertion pins.
+      assert.equal(listing.summary.note, RECLAIM_LIFTED_NOTICE, `run ${runId ?? 'main'} note`);
     }
+    assert.equal((await getTabs(host, OWNER_A)).summary.note, undefined, 'spent by the main loop');
   } finally {
     restore();
   }
@@ -2411,10 +2409,15 @@ test('clearing the window restores the user tab to every run of the conversation
  * carried on as though the user had never closed one — the same "the app
  * ignored me" the reclaim window exists to prevent, one turn later.
  *
- * Lifting now arms a ONE-SHOT notice on the conversation, and the conversation's
- * next MODEL-FACING `get_tabs` carries it and clears it. Exactly one run sees
- * it (whoever looks first), because the fact is about the conversation, not
- * about any one delegation.
+ * Lifting now arms a ONE-SHOT notice on the conversation, which a model-facing
+ * `get_tabs` carries.
+ *
+ * Every run READS it; only the MAIN run SPENDS it. The notice asks the model to
+ * confirm with the user, and a subagent cannot: `ask_user_question` is blocked
+ * for delegations. "Whoever looks first" therefore retired the request on a run
+ * structurally unable to honour it, and told the conversation's own loop — the
+ * only run with a channel to the user — nothing at all. A subagent still sees
+ * the text, so it can decline and hand the question up to its parent.
  *
  * Three things deliberately do NOT arm or consume it: a user message that lifted
  * nothing (there is no news), a dispose (the conversation is being deleted or
@@ -2424,8 +2427,8 @@ test('clearing the window restores the user tab to every run of the conversation
  */
 
 const RECLAIM_LIFTED_NOTICE =
-  'Note: the user previously closed your browser tab. Confirm they want the browser again '
-  + 'before acting on the page.';
+  "Note: the user previously closed the assistant's browser tab. Confirm they want the "
+  + 'browser again before acting on the page.';
 
 function clearReclaim(host, conversationId = OWNER_A) {
   return host.browserDispatch(null, 'browser_clear_reclaim', { conversationId });
@@ -2448,18 +2451,41 @@ test('the first listing after the window is lifted says so, exactly once', async
   }
 });
 
-test('the lifted notice belongs to the conversation, so only one run gets it', async () => {
+test('a subagent listing first reads the notice but does not spend it', async () => {
   const { host, emitted, restore } = loadHost();
   try {
     await getTabs(host, OWNER_A, RUN_1);
     userCloses(host, lastAdoptedViewId(emitted));
     clearReclaim(host);
 
-    // A sibling run that never owned the closed tab is just as entitled to the
-    // news — whoever looks first gets it, and nobody gets it twice.
+    // Subagents first, twice over: they see it (so they can decline and hand
+    // the question up) and it survives them, because neither can ask the user.
+    assert.equal((await getTabs(host, OWNER_A, RUN_1)).summary.note, RECLAIM_LIFTED_NOTICE);
     assert.equal((await getTabs(host, OWNER_A, RUN_2)).summary.note, RECLAIM_LIFTED_NOTICE);
-    assert.equal((await getTabs(host, OWNER_A, RUN_1)).summary.note, undefined);
+
+    // The main loop is the run that can act on it, so it is the run that spends
+    // it — and nobody, itself included, is told twice afterwards.
+    assert.equal((await getTabs(host, OWNER_A)).summary.note, RECLAIM_LIFTED_NOTICE);
     assert.equal((await getTabs(host, OWNER_A)).summary.note, undefined);
+    assert.equal((await getTabs(host, OWNER_A, RUN_1)).summary.note, undefined);
+  } finally {
+    restore();
+  }
+});
+
+test('a subagent-only conversation keeps the notice owed rather than losing it', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A, RUN_1);
+    userCloses(host, lastAdoptedViewId(emitted));
+    clearReclaim(host);
+
+    // Ten subagent listings later the request is still outstanding: nothing
+    // that cannot ask the user may retire it on the user's behalf.
+    for (let i = 0; i < 10; i += 1) {
+      assert.equal((await getTabs(host, OWNER_A, RUN_2)).summary.note, RECLAIM_LIFTED_NOTICE);
+    }
+    assert.equal((await getTabs(host, OWNER_A)).summary.note, RECLAIM_LIFTED_NOTICE);
   } finally {
     restore();
   }

--- a/electron/browserHost.ownership.test.cjs
+++ b/electron/browserHost.ownership.test.cjs
@@ -1911,3 +1911,200 @@ test('browser_clear_reclaim refuses the legacy conversation and blank input', as
     restore();
   }
 });
+
+/**
+ * ## N7 fix round 1 — the window must not funnel the agent onto the user's tab
+ *
+ * `automationTabs` lists the LEGACY pool to every owner (the user's own pane
+ * tabs are shared on purpose). Denying provisioning therefore left a reclaimed
+ * run with exactly one tab it could still see — the tab the user is reading —
+ * which it would promote to its current tab and then click, fill and navigate.
+ * That is a sharper version of the complaint N7 answers, arrived at BY N7.
+ *
+ * So inside the window a legacy tab is look-but-don't-touch for that owner:
+ * state-changing actions on it are refused with the same sentence, read-only
+ * work is not, and the tab may still be LISTED but may never become that
+ * owner's current tab (which is what steers a later `get_html` with no tabId
+ * onto the user's page). The owner's OWN surviving tabs are unaffected.
+ */
+
+function openPaneTab(host, id = 'pane-tab-1', url = 'https://example.com/') {
+  host.browserDispatch(null, 'browser_create', { id, url, x: 0, y: 0, width: 800, height: 600 });
+}
+
+test('a reclaimed run may not drive the user own pane tab', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    // Order matters: the owner provisions its OWN view first — once a legacy
+    // tab exists, `get_tabs` is satisfied by the shared pool and never creates
+    // one, so there would be nothing of the owner's for the user to close.
+    await getTabs(host, OWNER_A);
+    const ownViewId = lastAdoptedViewId(emitted);
+    openPaneTab(host);
+    const paneTab = tabIds(await probeTabs(host))[0];
+    userCloses(host, ownViewId);
+
+    for (const action of ['navigate', 'click', 'fill', 'execute_js', 'keyboard', 'scroll']) {
+      await assert.rejects(
+        host.performBrowserAutomation(action, {
+          ownerId: OWNER_A,
+          tabId: paneTab,
+          action: 'goto',
+          url: 'https://example.com/',
+        }),
+        (error) => {
+          assert.equal(error.message, USER_RECLAIMED_MESSAGE, `wrong message for ${action}`);
+          return true;
+        }
+      );
+    }
+
+    assert.equal(contentsFor(paneTab).getURL(), 'https://example.com/', 'the page never moved');
+  } finally {
+    restore();
+  }
+});
+
+test('a reclaimed run may still LOOK at the user pane tab', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    // Order matters: the owner provisions its OWN view first — once a legacy
+    // tab exists, `get_tabs` is satisfied by the shared pool and never creates
+    // one, so there would be nothing of the owner's for the user to close.
+    await getTabs(host, OWNER_A);
+    const ownViewId = lastAdoptedViewId(emitted);
+    openPaneTab(host);
+    const paneTab = tabIds(await probeTabs(host))[0];
+    userCloses(host, ownViewId);
+
+    // Read-only: it can report what the user is looking at, which is exactly
+    // what "ask them before opening a new one" needs it to be able to do.
+    await host.performBrowserAutomation('screenshot', { ownerId: OWNER_A, tabId: paneTab });
+
+    const listing = await getTabs(host, OWNER_A);
+    assert.deepEqual(tabIds(listing), [paneTab], 'the legacy tab is still listed');
+    assert.equal(listing.summary.note, USER_RECLAIMED_MESSAGE);
+  } finally {
+    restore();
+  }
+});
+
+test('a reclaimed run keeps full use of its own surviving tabs', async () => {
+  const { host, emitted, restore } = loadHost({ adopt: false });
+  try {
+    const [first, second] = await Promise.all([getTabs(host, OWNER_A), getTabs(host, OWNER_A)]);
+    openPaneTab(host);
+    const paneTab = tabIds(await probeTabs(host))[0];
+    const ownTabs = [first, second].map((result) => tabIds(result)[0]);
+    assert.notEqual(ownTabs[0], ownTabs[1], 'the owner really has two of its own views');
+
+    const opens = emitted
+      .filter((entry) => entry.event === 'browser://automation-open')
+      .map((entry) => entry.payload.id);
+    host.browserDispatch(null, 'browser_close', { id: opens[0], reason: 'user_close' });
+    const survivor = ownTabs.find((tab) => !contentsFor(tab).isDestroyed());
+    assert.ok(survivor, 'exactly one of its own views was closed');
+
+    // Its own tab: unrestricted. The user closed one tab, not the task.
+    await navigate(host, OWNER_A, survivor, 'https://still-mine.example/');
+    assert.equal(contentsFor(survivor).getURL(), 'https://still-mine.example/');
+
+    // The user's tab, in the same breath: refused.
+    await assert.rejects(
+      navigate(host, OWNER_A, paneTab, 'https://not-yours.example/'),
+      (error) => {
+        assert.equal(error.message, USER_RECLAIMED_MESSAGE);
+        return true;
+      }
+    );
+
+    // ...and its own tab is what get_tabs points at, not the user's.
+    assert.equal((await getTabs(host, OWNER_A)).summary.currentTabId, survivor);
+  } finally {
+    restore();
+  }
+});
+
+test('a reclaimed run never gets the user pane tab as its current tab', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    // Order matters: the owner provisions its OWN view first — once a legacy
+    // tab exists, `get_tabs` is satisfied by the shared pool and never creates
+    // one, so there would be nothing of the owner's for the user to close.
+    await getTabs(host, OWNER_A);
+    const ownViewId = lastAdoptedViewId(emitted);
+    openPaneTab(host);
+    const paneTab = tabIds(await probeTabs(host))[0];
+    userCloses(host, ownViewId);
+
+    const listing = await getTabs(host, OWNER_A);
+    assert.deepEqual(tabIds(listing), [paneTab], 'listed…');
+    assert.equal(listing.summary.currentTabId, null, '…but never promoted');
+    assert.equal(listing.windows[0].tabs[0].isCurrentTab, false);
+
+    // A bare `get_html` (no tabId) resolves through that record, so an
+    // unpromoted legacy tab is the difference between "no tab" and "the page
+    // the user is reading".
+    await assert.rejects(
+      host.performBrowserAutomation('get_html', { ownerId: OWNER_A }),
+      /Browser tab not found/
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('a current-tab record already pointing at the user pane tab is dropped when the window opens', async () => {
+  // The run drove the user's pane tab legitimately BEFORE the reclaim, so the
+  // record already names it — refusing to promote is not enough on its own.
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A);
+    const ownViewId = lastAdoptedViewId(emitted);
+    openPaneTab(host);
+    const paneTab = tabIds(await probeTabs(host))[0];
+    await navigate(host, OWNER_A, paneTab, 'https://example.com/before/');
+    assert.equal((await getTabs(host, OWNER_A)).summary.currentTabId, paneTab, 'it was current');
+
+    userCloses(host, ownViewId);
+
+    assert.equal((await getTabs(host, OWNER_A)).summary.currentTabId, null);
+  } finally {
+    restore();
+  }
+});
+
+test('clearing the window hands the user pane tab back to the run', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    // Order matters: the owner provisions its OWN view first — once a legacy
+    // tab exists, `get_tabs` is satisfied by the shared pool and never creates
+    // one, so there would be nothing of the owner's for the user to close.
+    await getTabs(host, OWNER_A);
+    const ownViewId = lastAdoptedViewId(emitted);
+    openPaneTab(host);
+    const paneTab = tabIds(await probeTabs(host))[0];
+    userCloses(host, ownViewId);
+
+    host.browserDispatch(null, 'browser_clear_reclaim', { conversationId: OWNER_A });
+
+    await navigate(host, OWNER_A, paneTab, 'https://allowed-again.example/');
+    assert.equal(contentsFor(paneTab).getURL(), 'https://allowed-again.example/');
+  } finally {
+    restore();
+  }
+});
+
+test('an owner with no reclaim window drives legacy tabs exactly as before', async () => {
+  const { host, restore } = loadHost();
+  try {
+    openPaneTab(host);
+    const paneTab = tabIds(await probeTabs(host))[0];
+
+    await navigate(host, OWNER_A, paneTab, 'https://unchanged.example/');
+    assert.equal(contentsFor(paneTab).getURL(), 'https://unchanged.example/');
+    assert.equal((await getTabs(host, OWNER_A)).summary.currentTabId, paneTab);
+  } finally {
+    restore();
+  }
+});

--- a/electron/browserHost.ownership.test.cjs
+++ b/electron/browserHost.ownership.test.cjs
@@ -1807,7 +1807,9 @@ test('browser_clear_reclaim lifts the window for every run of that conversation'
 
     const run1 = await getTabs(host, OWNER_A, RUN_1);
     assert.equal(tabIds(run1).length, 1, 'the subagent run may open a tab again');
-    assert.equal(run1.summary.note, undefined);
+    // C8: the first listing after the lift is told the window WAS open, once —
+    // silence here is what let the model carry on as if nothing had happened.
+    assert.equal(run1.summary.note, RECLAIM_LIFTED_NOTICE);
     const mainLoop = await getTabs(host, OWNER_A);
     assert.equal(tabIds(mainLoop).length, 1, 'so may the conversation main loop');
     assert.equal(mainLoop.summary.note, undefined);
@@ -1924,10 +1926,18 @@ test('clearing the window lets every run of the conversation provision again', a
 
     host.browserDispatch(null, 'browser_clear_reclaim', { conversationId: OWNER_A });
 
+    let listings = 0;
     for (const runId of [RUN_1, RUN_2, undefined]) {
       const listing = await getTabs(host, OWNER_A, runId);
       assert.equal(tabIds(listing).length, 1, `run ${runId ?? 'main'} provisions again`);
-      assert.equal(listing.summary.note, undefined);
+      // C8: the lift is announced to the conversation exactly once — the first
+      // run to look — and never gates anyone's provisioning.
+      listings += 1;
+      assert.equal(
+        listing.summary.note,
+        listings === 1 ? RECLAIM_LIFTED_NOTICE : undefined,
+        `run ${runId ?? 'main'} note`
+      );
     }
   } finally {
     restore();
@@ -2387,6 +2397,193 @@ test('clearing the window restores the user tab to every run of the conversation
     await navigate(host, OWNER_A, paneTab, 'https://allowed-again.example/', freshRun);
     assert.equal(contentsFor(paneTab).getURL(), 'https://allowed-again.example/');
     assert.equal((await getTabs(host, OWNER_A, freshRun)).summary.currentTabId, paneTab);
+  } finally {
+    restore();
+  }
+});
+
+/**
+ * ## C8 — lifting the window is itself news
+ *
+ * `browser_clear_reclaim` used to lift the window in total silence: the user's
+ * next message simply made provisioning work again, and the next tool result
+ * said nothing about any of it. The model therefore opened a fresh tab and
+ * carried on as though the user had never closed one — the same "the app
+ * ignored me" the reclaim window exists to prevent, one turn later.
+ *
+ * Lifting now arms a ONE-SHOT notice on the conversation, and the conversation's
+ * next MODEL-FACING `get_tabs` carries it and clears it. Exactly one run sees
+ * it (whoever looks first), because the fact is about the conversation, not
+ * about any one delegation.
+ *
+ * Three things deliberately do NOT arm or consume it: a user message that lifted
+ * nothing (there is no news), a dispose (the conversation is being deleted or
+ * the run reaped — nobody left to tell), and the permission gate's
+ * `createIfEmpty:false` probe (its result is read by the gate and thrown away,
+ * so consuming the notice there would delete it unread).
+ */
+
+const RECLAIM_LIFTED_NOTICE =
+  'Note: the user previously closed your browser tab. Confirm they want the browser again '
+  + 'before acting on the page.';
+
+function clearReclaim(host, conversationId = OWNER_A) {
+  return host.browserDispatch(null, 'browser_clear_reclaim', { conversationId });
+}
+
+test('the first listing after the window is lifted says so, exactly once', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A);
+    userCloses(host, lastAdoptedViewId(emitted));
+    clearReclaim(host);
+
+    const first = await getTabs(host, OWNER_A);
+    assert.equal(first.summary.note, RECLAIM_LIFTED_NOTICE, 'the first look is told');
+    assert.equal(tabIds(first).length, 1, 'and provisioning works again');
+
+    assert.equal((await getTabs(host, OWNER_A)).summary.note, undefined, 'not a second time');
+  } finally {
+    restore();
+  }
+});
+
+test('the lifted notice belongs to the conversation, so only one run gets it', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A, RUN_1);
+    userCloses(host, lastAdoptedViewId(emitted));
+    clearReclaim(host);
+
+    // A sibling run that never owned the closed tab is just as entitled to the
+    // news — whoever looks first gets it, and nobody gets it twice.
+    assert.equal((await getTabs(host, OWNER_A, RUN_2)).summary.note, RECLAIM_LIFTED_NOTICE);
+    assert.equal((await getTabs(host, OWNER_A, RUN_1)).summary.note, undefined);
+    assert.equal((await getTabs(host, OWNER_A)).summary.note, undefined);
+  } finally {
+    restore();
+  }
+});
+
+test('the permission gate probe neither reads nor eats the lifted notice', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A);
+    userCloses(host, lastAdoptedViewId(emitted));
+    clearReclaim(host);
+
+    // The gate's listing is resolved internally and discarded; carrying the
+    // one-shot there would lose it before any model saw it.
+    assert.equal((await probeTabs(host, OWNER_A)).summary.note, undefined);
+    assert.equal((await getTabs(host, OWNER_A)).summary.note, RECLAIM_LIFTED_NOTICE);
+  } finally {
+    restore();
+  }
+});
+
+test('a user message that lifted nothing arms no notice', async () => {
+  const { host, restore } = loadHost();
+  try {
+    // `clearBrowserReclaim` fires on EVERY user message, so arming on the call
+    // rather than on an actual lift would put the notice on every conversation.
+    await getTabs(host, OWNER_A);
+    clearReclaim(host);
+    assert.equal((await getTabs(host, OWNER_A)).summary.note, undefined);
+  } finally {
+    restore();
+  }
+});
+
+test('a window opened again outranks a notice still owed', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A);
+    userCloses(host, lastAdoptedViewId(emitted));
+    clearReclaim(host);
+
+    // The user closes the replacement too, before anything listed. The live
+    // refusal is the more important of the two facts, and the owed notice is
+    // not spent on a listing that is already being told to ask first.
+    const replacement = await getTabs(host, OWNER_A, RUN_1);
+    assert.equal(replacement.summary.note, RECLAIM_LIFTED_NOTICE);
+    await getTabs(host, OWNER_A);
+    userCloses(host, lastAdoptedViewId(emitted));
+    assert.equal((await getTabs(host, OWNER_A)).summary.note, USER_RECLAIMED_MESSAGE);
+
+    clearReclaim(host);
+    assert.equal((await getTabs(host, OWNER_A)).summary.note, RECLAIM_LIFTED_NOTICE);
+  } finally {
+    restore();
+  }
+});
+
+test('deleting the conversation drops the notice it was owed', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A);
+    userCloses(host, lastAdoptedViewId(emitted));
+    clearReclaim(host);
+
+    host.browserDispatch(null, 'browser_dispose_owner', { conversationId: OWNER_A });
+
+    assert.equal((await getTabs(host, OWNER_A)).summary.note, undefined);
+  } finally {
+    restore();
+  }
+});
+
+test('a finished subagent run does not swallow the conversation notice', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A, RUN_1);
+    userCloses(host, lastAdoptedViewId(emitted));
+    clearReclaim(host);
+
+    // A run being reaped (A2) is not the conversation going away — the news is
+    // still owed to whoever is left.
+    host.browserDispatch(null, 'browser_dispose_owner', { conversationId: OWNER_A, runKey: RUN_1 });
+
+    assert.equal((await getTabs(host, OWNER_A)).summary.note, RECLAIM_LIFTED_NOTICE);
+  } finally {
+    restore();
+  }
+});
+
+test('a conversation that was never reclaimed sees no note at any point', async () => {
+  const { host, restore } = loadHost();
+  try {
+    for (let i = 0; i < 3; i += 1) {
+      assert.equal((await getTabs(host, OWNER_A)).summary.note, undefined);
+      clearReclaim(host);
+    }
+    assert.equal((await probeTabs(host, OWNER_A)).summary.note, undefined);
+  } finally {
+    restore();
+  }
+});
+
+/**
+ * ## C8 — a refusal the model can repeat to the user
+ *
+ * "Browser tab not found: 41" gave the model no reason and one internal
+ * identifier, and the observed failure was the model handing that identifier
+ * straight to the user ("the tab id changed from 2 to 3"). The refusal now
+ * carries a reason phrase and the next step; the id stays in the text for the
+ * log, and the narration rules in the browser guidance keep it out of the
+ * user-facing sentence.
+ */
+test('a missing tab is refused with a reason and a next step', async () => {
+  const { host, restore } = loadHost();
+  try {
+    await assert.rejects(
+      host.performBrowserAutomation('click', { ownerId: OWNER_A, tabId: 999999 }),
+      (error) => {
+        assert.match(error.message, /Browser tab not found: 999999/);
+        assert.match(error.message, /no longer open/, 'says why it is refused');
+        assert.match(error.message, /get_tabs/, 'says what to do next');
+        return true;
+      }
+    );
   } finally {
     restore();
   }

--- a/electron/browserHost.ownership.test.cjs
+++ b/electron/browserHost.ownership.test.cjs
@@ -1021,6 +1021,201 @@ test('browser_note_user_interaction gates a state-changing action like real inpu
   }
 });
 
+/**
+ * N4 — `browser_dispose_owner`.
+ *
+ * A conversation used to be able to disappear (the user deletes it) while its
+ * agent's browser views kept running: no tab strip listed them any more, so
+ * nothing could close them, and main held a live WebContentsView per deleted
+ * conversation for the rest of the session. The renderer's delete cascade now
+ * drops those tab records (which destroys their views) AND sends this command,
+ * which is the only path that can reach main-side state the renderer has no
+ * tab record for — a headless fallback view, or a view adopted after the tab
+ * record was already gone.
+ */
+test('browser_dispose_owner closes every view the deleted conversation owned, and nothing else', async () => {
+  // Two owned views for OWNER_A: with no renderer answering
+  // `browser://automation-open`, two concurrent provisioning calls both see an
+  // empty tab set and both fall through to the headless fallback branch — the
+  // branch whose views the renderer has no record of at all.
+  const { host, restore } = loadHost({ adopt: false });
+  try {
+    const [aFirst, aSecond, bTabs] = await Promise.all([
+      getTabs(host, OWNER_A),
+      getTabs(host, OWNER_A),
+      getTabs(host, OWNER_B),
+    ]);
+    const aTab1 = tabIds(aFirst)[0];
+    const aTab2 = tabIds(aSecond)[0];
+    const bTab = tabIds(bTabs)[0];
+    assert.notEqual(aTab1, aTab2, 'the owner really has two views to dispose');
+
+    // A tab the user opened in the pane — legacy, shared, and never a
+    // conversation's to dispose.
+    host.browserDispatch(null, 'browser_create', {
+      id: 'pane-tab-1',
+      url: 'https://example.com/',
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 600,
+    });
+    const paneTab = tabIds(await probeTabs(host))[0];
+
+    host.browserDispatch(null, 'browser_dispose_owner', { conversationId: OWNER_A });
+
+    assert.equal(contentsFor(aTab1).isDestroyed(), true);
+    assert.equal(contentsFor(aTab2).isDestroyed(), true);
+    assert.equal(contentsFor(bTab).isDestroyed(), false, 'another conversation keeps its tab');
+    assert.equal(contentsFor(paneTab).isDestroyed(), false, 'the user pane tab survives');
+
+    // Neither view is listed any more; the other owner's current tab is intact.
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_A)), [paneTab]);
+    const bAfter = await probeTabs(host, OWNER_B);
+    assert.deepEqual(tabIds(bAfter).sort(), [bTab, paneTab].sort());
+    assert.equal(bAfter.summary.currentTabId, bTab);
+  } finally {
+    restore();
+  }
+});
+
+test('browser_dispose_owner leaves no ownership state behind for the deleted conversation', async () => {
+  const { host, restore } = loadHost();
+  try {
+    const { clock, state } = fakeClock();
+    host.__testing.setClock(clock);
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+    typeInto(aTab); // the user was typing in that tab a moment ago
+
+    host.browserDispatch(null, 'browser_dispose_owner', { conversationId: OWNER_A });
+
+    // The current-tab record is gone: a read-only probe reports no tab at all,
+    // not a destroyed one.
+    const probe = await probeTabs(host, OWNER_A);
+    assert.deepEqual(tabIds(probe), []);
+    assert.equal(probe.summary.currentTabId, null);
+
+    // The interaction record is gone too: virtual time never advanced, so a
+    // surviving timestamp would still be inside the 3s quiet window and hold
+    // this action back for the full 10s wait.
+    const fresh = tabIds(await getTabs(host, OWNER_A))[0];
+    await navigate(host, OWNER_A, fresh, 'https://example.com/');
+    assert.deepEqual(state.sleeps, [], 'no stale takeover record survived the dispose');
+  } finally {
+    restore();
+  }
+});
+
+test('disposing an owner twice, or closing a disposed view, is harmless', async () => {
+  // The renderer removes the tab records (each firing `browser_close`) AND
+  // sends the dispose command; the two race, so every combination must be a
+  // no-op after the first one lands.
+  const { host, emitted, restore } = loadHost();
+  try {
+    const aTab = tabIds(await getTabs(host, OWNER_A))[0];
+    const viewId = emitted.find((entry) => entry.event === 'browser://automation-open').payload.id;
+
+    host.browserDispatch(null, 'browser_dispose_owner', { conversationId: OWNER_A });
+    host.browserDispatch(null, 'browser_dispose_owner', { conversationId: OWNER_A });
+    assert.equal(host.browserDispatch(null, 'browser_close', { id: viewId }), null);
+
+    assert.equal(contentsFor(aTab).isDestroyed(), true);
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_A)), []);
+  } finally {
+    restore();
+  }
+});
+
+test('browser_dispose_owner never reaps the legacy shared pool', async () => {
+  const { host, restore } = loadHost();
+  try {
+    host.browserDispatch(null, 'browser_create', {
+      id: 'pane-tab-1',
+      url: 'https://example.com/',
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 600,
+    });
+    const paneTab = tabIds(await probeTabs(host))[0];
+
+    for (const conversationId of ['legacy', '', '   ', undefined, 42]) {
+      assert.equal(host.browserDispatch(null, 'browser_dispose_owner', { conversationId }), null);
+    }
+
+    assert.equal(contentsFor(paneTab).isDestroyed(), false);
+    assert.deepEqual(tabIds(await probeTabs(host)), [paneTab]);
+  } finally {
+    restore();
+  }
+});
+
+/**
+ * N8 — the adoption wait had no abort check, so a run stopped while main was
+ * waiting for the renderer to adopt still sat out the full 2.5s and then built
+ * a hidden fallback view for a run that no longer existed.
+ */
+test('a stop during the adoption wait cancels it instead of stranding a hidden view', async () => {
+  const { host, emitted, restore } = loadHost({ adopt: false });
+  try {
+    const controller = new AbortController();
+    const pending = host.performBrowserAutomation(
+      'get_tabs',
+      { ownerId: OWNER_A },
+      { signal: controller.signal },
+    );
+    // The call is already inside the adoption wait (the top-of-call abort
+    // check ran before this line), so this is the real "Stop mid-wait" shape.
+    controller.abort();
+
+    await assert.rejects(pending, (error) => {
+      assert.equal(error.message, 'Browser action cancelled because the run was stopped.');
+      return true;
+    });
+
+    const openEvent = emitted.find((entry) => entry.event === 'browser://automation-open');
+    assert.ok(openEvent, 'the wait had really started');
+    // Running the wait out ALWAYS ends in a fallback view, so an empty owner
+    // proves the loop exited on the abort rather than on its deadline.
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_A)), []);
+
+    // The pending-owner entry is gone: re-creating that id as a user pane tab
+    // comes back legacy (a stranded entry would hand it to OWNER_A instead).
+    host.browserDispatch(null, 'browser_create', {
+      id: openEvent.payload.id,
+      url: 'https://example.com/',
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 600,
+    });
+    assert.equal(tabIds(await probeTabs(host)).length, 1);
+  } finally {
+    restore();
+  }
+});
+
+test('disposing an owner mid-adoption does not strand a fallback view for it', async () => {
+  // The delete cascade can land while an automation call is still waiting for
+  // adoption. Without the pending-entry check the wait would run to its
+  // deadline and build a view for a conversation that no longer exists — the
+  // exact orphan the dispose command is meant to prevent.
+  const { host, emitted, restore } = loadHost({ adopt: false });
+  try {
+    const pending = host.performBrowserAutomation('get_tabs', { ownerId: OWNER_A });
+    host.browserDispatch(null, 'browser_dispose_owner', { conversationId: OWNER_A });
+
+    await assert.rejects(pending, (error) => {
+      assert.equal(error.message, 'Browser action cancelled because the run was stopped.');
+      return true;
+    });
+    assert.ok(emitted.some((entry) => entry.event === 'browser://automation-open'));
+    assert.deepEqual(tabIds(await probeTabs(host, OWNER_A)), []);
+  } finally {
+    restore();
+  }
+});
+
 test('browser_note_user_interaction on an unknown id is a silent no-op', async () => {
   const { host, restore } = loadHost();
   try {

--- a/electron/browserHost.ownership.test.cjs
+++ b/electron/browserHost.ownership.test.cjs
@@ -1791,12 +1791,17 @@ test('the reclaim window never blocks work on the tabs that are still open', asy
 test('browser_clear_reclaim lifts the window for every run of that conversation', async () => {
   const { host, emitted, restore } = loadHost();
   try {
+    // Every tab is opened BEFORE any close: the first close blocks provisioning
+    // conversation-wide, so a later run could not get one to close.
     await getTabs(host, OWNER_A, RUN_1);
-    userCloses(host, lastAdoptedViewId(emitted));
+    const run1ViewId = lastAdoptedViewId(emitted);
     await getTabs(host, OWNER_A);
-    userCloses(host, lastAdoptedViewId(emitted));
+    const mainViewId = lastAdoptedViewId(emitted);
     await getTabs(host, OWNER_B);
-    userCloses(host, lastAdoptedViewId(emitted));
+    const otherViewId = lastAdoptedViewId(emitted);
+    userCloses(host, run1ViewId);
+    userCloses(host, mainViewId);
+    userCloses(host, otherViewId);
 
     assert.equal(host.browserDispatch(null, 'browser_clear_reclaim', { conversationId: OWNER_A }), null);
 
@@ -1816,22 +1821,114 @@ test('browser_clear_reclaim lifts the window for every run of that conversation'
   }
 });
 
-test('a reclaim window is scoped to the run whose tab was closed', async () => {
+/**
+ * ## The window's two halves are keyed differently, on purpose
+ *
+ * PROVISIONING is blocked conversation-wide; the ACTION gate and the
+ * current-tab rules stay per-run.
+ *
+ * Keying provisioning per-run made the promise escapable by delegation, in both
+ * directions: close a subagent's tab and the conversation's own loop opened a
+ * fresh one; close the main loop's tab and `run_agent` minted a brand-new
+ * `sar-*` whose window had never been opened, so it provisioned immediately.
+ * The user closed A tab and meant "stop opening tabs" — they neither know nor
+ * care which run owned it.
+ *
+ * The action gate stays per-run because it answers a different question: a
+ * sibling run holding a tab of its own is mid-task on a page the user never
+ * touched, and freezing it would punish work the gesture said nothing about.
+ */
+test('the window blocks provisioning conversation-wide while gating actions per run', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A, RUN_1);
+    const run1ViewId = lastAdoptedViewId(emitted);
+    const siblingTab = tabIds(await getTabs(host, OWNER_A, RUN_2))[0];
+    const mainTab = tabIds(await getTabs(host, OWNER_A))[0];
+
+    userCloses(host, run1ViewId);
+
+    // The closed run: nothing left, and no replacement.
+    const reclaimed = await getTabs(host, OWNER_A, RUN_1);
+    assert.deepEqual(tabIds(reclaimed), []);
+    assert.equal(reclaimed.summary.note, USER_RECLAIMED_MESSAGE);
+
+    // A sibling and the main loop KEEP the tabs they already have, and the note
+    // tells them why they will not be getting any more.
+    const sibling = await getTabs(host, OWNER_A, RUN_2);
+    assert.deepEqual(tabIds(sibling), [siblingTab], 'a sibling keeps its own tab');
+    assert.equal(sibling.summary.note, USER_RECLAIMED_MESSAGE);
+    assert.equal(sibling.summary.currentTabId, siblingTab, 'and it is still its current tab');
+    const mainLoop = await getTabs(host, OWNER_A);
+    assert.deepEqual(tabIds(mainLoop), [mainTab]);
+    assert.equal(mainLoop.summary.note, USER_RECLAIMED_MESSAGE);
+
+    // ...and they may still act on them: the gate is per-run.
+    await navigate(host, OWNER_A, siblingTab, 'https://sibling-still-works.example/', RUN_2);
+    assert.equal(contentsFor(siblingTab).getURL(), 'https://sibling-still-works.example/');
+
+    // A sibling with no window of its own that reaches for a tab it does not
+    // have gets the ordinary error, not the reclaim sentence — it was not the
+    // run the user reclaimed from.
+    await assert.rejects(
+      host.performBrowserAutomation('click', { ownerId: OWNER_A, runId: RUN_2, tabId: 999999 }),
+      /Browser tab not found: 999999/
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('closing a subagent tab stops the conversation own loop from opening one', async () => {
+  // The escape hatch in the other direction: the user closes the tab a
+  // delegation opened, and the conversation's own loop simply opens another.
   const { host, emitted, restore } = loadHost();
   try {
     await getTabs(host, OWNER_A, RUN_1);
     userCloses(host, lastAdoptedViewId(emitted));
 
-    const reclaimed = await getTabs(host, OWNER_A, RUN_1);
-    assert.deepEqual(tabIds(reclaimed), []);
-    assert.equal(reclaimed.summary.note, USER_RECLAIMED_MESSAGE);
-
-    const sibling = await getTabs(host, OWNER_A, RUN_2);
-    assert.equal(tabIds(sibling).length, 1, 'a sibling run is not muted');
-    assert.equal(sibling.summary.note, undefined);
     const mainLoop = await getTabs(host, OWNER_A);
-    assert.equal(tabIds(mainLoop).length, 1, 'nor is the conversation main loop');
-    assert.equal(mainLoop.summary.note, undefined);
+    assert.deepEqual(tabIds(mainLoop), [], 'the main loop provisions nothing either');
+    assert.equal(mainLoop.summary.note, USER_RECLAIMED_MESSAGE);
+
+    // Another conversation is untouched — the block is conversation-wide, not
+    // app-wide.
+    assert.equal(tabIds(await getTabs(host, OWNER_B)).length, 1);
+  } finally {
+    restore();
+  }
+});
+
+test('closing the main loop tab stops a freshly delegated run from opening one', async () => {
+  // The escape hatch by delegation: `run_agent` mints a brand-new `sar-*` whose
+  // window was never opened, so a per-run block would let it provision at once.
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A);
+    userCloses(host, lastAdoptedViewId(emitted));
+
+    const freshRun = await getTabs(host, OWNER_A, 'sar-minted-after-the-close');
+    assert.deepEqual(tabIds(freshRun), [], 'a run that never existed yet still cannot provision');
+    assert.equal(freshRun.summary.note, USER_RECLAIMED_MESSAGE);
+  } finally {
+    restore();
+  }
+});
+
+test('clearing the window lets every run of the conversation provision again', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A, RUN_1);
+    userCloses(host, lastAdoptedViewId(emitted));
+    assert.deepEqual(tabIds(await getTabs(host, OWNER_A)), [], 'blocked before the clear');
+
+    host.browserDispatch(null, 'browser_clear_reclaim', { conversationId: OWNER_A });
+
+    for (const runId of [RUN_1, RUN_2, undefined]) {
+      const listing = await getTabs(host, OWNER_A, runId);
+      assert.equal(tabIds(listing).length, 1, `run ${runId ?? 'main'} provisions again`);
+      assert.equal(listing.summary.note, undefined);
+    }
   } finally {
     restore();
   }
@@ -1887,15 +1984,39 @@ test('disposing an owner clears its reclaim window with the rest of its state', 
 test('a run dispose clears only that run reclaim window', async () => {
   const { host, emitted, restore } = loadHost();
   try {
+    // Both runs get a tab BEFORE either close: once one window is open, the
+    // conversation-wide block means the other run can never provision one.
     await getTabs(host, OWNER_A, RUN_1);
-    userCloses(host, lastAdoptedViewId(emitted));
+    const run1ViewId = lastAdoptedViewId(emitted);
     await getTabs(host, OWNER_A, RUN_2);
-    userCloses(host, lastAdoptedViewId(emitted));
+    const run2ViewId = lastAdoptedViewId(emitted);
+    assert.notEqual(run1ViewId, run2ViewId, 'each run really has its own view');
+    userCloses(host, run1ViewId);
+    userCloses(host, run2ViewId);
 
     host.browserDispatch(null, 'browser_dispose_owner', { conversationId: OWNER_A, runKey: RUN_1 });
 
-    assert.equal((await getTabs(host, OWNER_A, RUN_1)).summary.note, undefined);
-    assert.equal((await getTabs(host, OWNER_A, RUN_2)).summary.note, USER_RECLAIMED_MESSAGE);
+    // The per-run half is what a per-run dispose moves: RUN_1's gate is lifted
+    // (ordinary error), RUN_2 still holds its own window.
+    await assert.rejects(
+      host.performBrowserAutomation('click', { ownerId: OWNER_A, runId: RUN_1 }),
+      /Browser tab not found/
+    );
+    await assert.rejects(
+      host.performBrowserAutomation('click', { ownerId: OWNER_A, runId: RUN_2 }),
+      (error) => {
+        assert.equal(error.message, USER_RECLAIMED_MESSAGE);
+        return true;
+      }
+    );
+
+    // The conversation-wide half does not move until the LAST window is gone:
+    // RUN_2 still holds one, so nobody provisions.
+    assert.deepEqual(tabIds(await getTabs(host, OWNER_A, RUN_1)), []);
+    assert.equal((await getTabs(host, OWNER_A, RUN_1)).summary.note, USER_RECLAIMED_MESSAGE);
+
+    host.browserDispatch(null, 'browser_dispose_owner', { conversationId: OWNER_A, runKey: RUN_2 });
+    assert.equal(tabIds(await getTabs(host, OWNER_A, RUN_1)).length, 1, 'the last window lifted it');
   } finally {
     restore();
   }
@@ -1944,7 +2065,10 @@ test('a reclaimed run may not drive the user own pane tab', async () => {
     const paneTab = tabIds(await probeTabs(host))[0];
     userCloses(host, ownViewId);
 
-    for (const action of ['navigate', 'click', 'fill', 'execute_js', 'keyboard', 'scroll']) {
+    // Every member of TAKEOVER_GATED_ACTIONS — a gap here is a hole in the gate.
+    for (const action of [
+      'navigate', 'click', 'fill', 'select', 'keyboard', 'execute_js', 'scroll', 'start_recording',
+    ]) {
       await assert.rejects(
         host.performBrowserAutomation(action, {
           ownerId: OWNER_A,
@@ -2045,6 +2169,30 @@ test('a reclaimed run never gets the user pane tab as its current tab', async ()
     // A bare `get_html` (no tabId) resolves through that record, so an
     // unpromoted legacy tab is the difference between "no tab" and "the page
     // the user is reading".
+    await assert.rejects(
+      host.performBrowserAutomation('get_html', { ownerId: OWNER_A }),
+      /Browser tab not found/
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('a permitted look at the user pane tab does not make it the run current tab', async () => {
+  // The drift the post-action guard exists for: read-only work on a legacy tab
+  // is allowed, and without the guard that very call would record it as this
+  // owner's current tab — so the NEXT action, issued with no tabId, lands on
+  // the user's page through a door the gate never sees.
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A);
+    const ownViewId = lastAdoptedViewId(emitted);
+    openPaneTab(host);
+    const paneTab = tabIds(await probeTabs(host))[0];
+    userCloses(host, ownViewId);
+
+    await host.performBrowserAutomation('screenshot', { ownerId: OWNER_A, tabId: paneTab });
+
     await assert.rejects(
       host.performBrowserAutomation('get_html', { ownerId: OWNER_A }),
       /Browser tab not found/

--- a/electron/browserHost.ownership.test.cjs
+++ b/electron/browserHost.ownership.test.cjs
@@ -323,6 +323,28 @@ test('get_tabs with createIfEmpty:false lists without provisioning a view', asyn
   }
 });
 
+test('browser://automation-open carries the owner so the renderer can route the tab', async () => {
+  // Without this the renderer has no way to tell whose tab it just adopted, so
+  // a background conversation's view lands in whatever conversation the user is
+  // currently looking at.
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A);
+    const owned = emitted.filter((entry) => entry.event === 'browser://automation-open');
+    assert.equal(owned.length, 1);
+    assert.equal(owned[0].payload.ownerId, OWNER_A);
+
+    // A caller that sends no owner is the legacy shared pool: no ownerId at
+    // all, so every conversation may see the tab (today's behavior).
+    await host.performBrowserAutomation('get_tabs', {});
+    const all = emitted.filter((entry) => entry.event === 'browser://automation-open');
+    assert.equal(all.length, 2);
+    assert.equal('ownerId' in all[1].payload, false);
+  } finally {
+    restore();
+  }
+});
+
 test('get_tabs still provisions a view by default (unchanged for every other caller)', async () => {
   const { host, restore } = loadHost();
   try {

--- a/electron/browserHost.ownership.test.cjs
+++ b/electron/browserHost.ownership.test.cjs
@@ -2256,3 +2256,138 @@ test('an owner with no reclaim window drives legacy tabs exactly as before', asy
     restore();
   }
 });
+
+/**
+ * ## R1 — the legacy bar is the CONVERSATION's, not the reclaimed run's
+ *
+ * Barring a reclaimed RUN from the user's pane tabs left the same harm one step
+ * sideways: the conversation-wide provisioning block means a run that holds no
+ * window of its own — a `sar-*` minted after the user closed the main loop's
+ * tab, or the main loop after a subagent's tab was closed — sees the user's
+ * pane tab as the ONLY tab it can reach, gets it promoted to its current tab,
+ * and drives it. "Sibling runs may act on their own existing tabs" was never a
+ * licence to act on the USER's.
+ *
+ * So the legacy half of both guards keys on the CONVERSATION while any of its
+ * windows is open. The `!match` half stays per-run (it is about the run's own
+ * closed tab), read-only stays allowed, and a run's OWN tabs are untouched.
+ */
+
+test('a non-reclaimed run of a reclaimed conversation still may not drive the user tab', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    // The conversation's own loop opens a tab, the user opens a pane tab, then
+    // the user closes the agent's tab — the reviewer's probe scenario.
+    await getTabs(host, OWNER_A);
+    const mainViewId = lastAdoptedViewId(emitted);
+    openPaneTab(host);
+    const paneTab = tabIds(await probeTabs(host))[0];
+    userCloses(host, mainViewId);
+
+    // A run minted AFTER the close holds no window of its own.
+    const freshRun = 'sar-minted-after-the-close';
+    const listing = await getTabs(host, OWNER_A, freshRun);
+    assert.deepEqual(tabIds(listing), [paneTab], 'the user tab is the only one it can see');
+    assert.equal(listing.summary.currentTabId, null, 'and it is NOT promoted to its current tab');
+    assert.equal(listing.summary.note, USER_RECLAIMED_MESSAGE);
+
+    for (const action of [
+      'navigate', 'click', 'fill', 'select', 'keyboard', 'execute_js', 'scroll', 'start_recording',
+    ]) {
+      await assert.rejects(
+        host.performBrowserAutomation(action, {
+          ownerId: OWNER_A,
+          runId: freshRun,
+          tabId: paneTab,
+          action: 'goto',
+          url: 'https://hijacked.example/',
+        }),
+        (error) => {
+          assert.equal(error.message, USER_RECLAIMED_MESSAGE, `wrong message for ${action}`);
+          return true;
+        }
+      );
+    }
+    assert.equal(contentsFor(paneTab).getURL(), 'https://example.com/', 'the user page never moved');
+
+    // And no tabId-less action can drift onto it either.
+    await assert.rejects(
+      host.performBrowserAutomation('get_html', { ownerId: OWNER_A, runId: freshRun }),
+      /Browser tab not found/
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('the conversation-wide bar leaves read-only work on the user tab alone', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A);
+    const mainViewId = lastAdoptedViewId(emitted);
+    openPaneTab(host);
+    const paneTab = tabIds(await probeTabs(host))[0];
+    userCloses(host, mainViewId);
+
+    // The model may still report what the user is looking at.
+    await host.performBrowserAutomation('screenshot', {
+      ownerId: OWNER_A, runId: 'sar-read-only', tabId: paneTab,
+    });
+    // ...without that look making the user's tab its current one.
+    assert.equal(
+      (await getTabs(host, OWNER_A, 'sar-read-only')).summary.currentTabId,
+      null
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('the conversation-wide bar does not touch a run own tabs', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    // A sibling run with a tab of its own, opened BEFORE any close.
+    const siblingTab = tabIds(await getTabs(host, OWNER_A, RUN_2))[0];
+    await getTabs(host, OWNER_A);
+    const mainViewId = lastAdoptedViewId(emitted);
+    openPaneTab(host);
+    const paneTab = tabIds(await probeTabs(host))[0];
+    userCloses(host, mainViewId);
+
+    // Its own tab: unrestricted, and still its current tab.
+    await navigate(host, OWNER_A, siblingTab, 'https://still-mine.example/', RUN_2);
+    assert.equal(contentsFor(siblingTab).getURL(), 'https://still-mine.example/');
+    assert.equal((await getTabs(host, OWNER_A, RUN_2)).summary.currentTabId, siblingTab);
+
+    // The user's tab, same run, same breath: refused.
+    await assert.rejects(
+      navigate(host, OWNER_A, paneTab, 'https://hijacked.example/', RUN_2),
+      (error) => {
+        assert.equal(error.message, USER_RECLAIMED_MESSAGE);
+        return true;
+      }
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('clearing the window restores the user tab to every run of the conversation', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A);
+    const mainViewId = lastAdoptedViewId(emitted);
+    openPaneTab(host);
+    const paneTab = tabIds(await probeTabs(host))[0];
+    userCloses(host, mainViewId);
+
+    host.browserDispatch(null, 'browser_clear_reclaim', { conversationId: OWNER_A });
+
+    const freshRun = 'sar-after-the-clear';
+    await navigate(host, OWNER_A, paneTab, 'https://allowed-again.example/', freshRun);
+    assert.equal(contentsFor(paneTab).getURL(), 'https://allowed-again.example/');
+    assert.equal((await getTabs(host, OWNER_A, freshRun)).summary.currentTabId, paneTab);
+  } finally {
+    restore();
+  }
+});

--- a/electron/browserHost.ownership.test.cjs
+++ b/electron/browserHost.ownership.test.cjs
@@ -90,7 +90,18 @@ class FakeWebContents {
 
   sendInputEvent() {}
   reload() {}
-  close() { this.destroyed = true; }
+
+  /**
+   * Electron tears the contents down and fires `destroyed`, which is where
+   * browserHost drops the per-view ownership records (`browser_close` itself
+   * only removes the view). A fake that flipped the flag without the event
+   * would leave every test looking at state production never has.
+   */
+  close() {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.fire('destroyed');
+  }
 
   async loadURL(url) {
     this.url = url;
@@ -1642,6 +1653,260 @@ test('a runId is never enough on its own to escape the legacy pool', async () =>
     const strayTab = tabIds(await getTabs(host, undefined, RUN_1))[0];
     assert.deepEqual(tabIds(await probeTabs(host)), [strayTab], 'it landed in the shared pool');
     assert.deepEqual(tabIds(await probeTabs(host, undefined, RUN_2)), [strayTab]);
+  } finally {
+    restore();
+  }
+});
+
+/**
+ * ## N7 — the user closing an agent's tab is a first-class reclaim signal
+ *
+ * Closing a tab used to be pure teardown: the view died, and the agent's very
+ * next `get_tabs` silently provisioned a brand-new one and carried on. From the
+ * user's side that reads as "the app ignored me" — the one gesture that means
+ * "stop using the browser" was the one gesture with no effect on the run.
+ *
+ * A close now carries a REASON. `user_close` (the tab strip's ×, close
+ * others/all — a real gesture) on a view an agent owns opens a RECLAIM WINDOW
+ * for that owner:
+ *  - `get_tabs` stops provisioning (as if `createIfEmpty:false`) and the summary
+ *    carries a note telling the model to ask first;
+ *  - a state-changing action or `navigate` with no tab left throws that same
+ *    sentence — deliberately NOT the run-stopped message, which would tell the
+ *    model something false about the run;
+ *  - read-only work on tabs that are still open is untouched.
+ *
+ * The window is scoped to the owner PAIR (N6), so one subagent's reclaimed tab
+ * does not mute its siblings, and it is lifted by the user's next message in
+ * that conversation (`browser_clear_reclaim`) or by the conversation's dispose.
+ * `lifecycle` closes — the C1 commit path's teardown, the C4 cancel cascade,
+ * conversation delete — record nothing, and neither does closing a LEGACY tab:
+ * the user closing their own pane tab is just closing a tab.
+ */
+
+const USER_RECLAIMED_MESSAGE =
+  'The user closed your browser tab. Ask them before opening a new one.';
+
+/** The view id main last invited the renderer to adopt. */
+function lastAdoptedViewId(emitted) {
+  const opens = emitted.filter((entry) => entry.event === 'browser://automation-open');
+  assert.ok(opens.length > 0, 'no automation view was ever offered for adoption');
+  return opens[opens.length - 1].payload.id;
+}
+
+function userCloses(host, viewId) {
+  return host.browserDispatch(null, 'browser_close', { id: viewId, reason: 'user_close' });
+}
+
+function countOpens(emitted) {
+  return emitted.filter((entry) => entry.event === 'browser://automation-open').length;
+}
+
+test('a user-closed agent tab stops get_tabs from opening another, and says why', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A);
+    const viewId = lastAdoptedViewId(emitted);
+    const opensBefore = countOpens(emitted);
+
+    userCloses(host, viewId);
+
+    const after = await getTabs(host, OWNER_A);
+    assert.deepEqual(tabIds(after), [], 'the run gets no replacement tab');
+    assert.equal(after.summary.totalTabs, 0);
+    assert.equal(after.summary.currentTabId, null);
+    assert.equal(after.summary.note, USER_RECLAIMED_MESSAGE);
+    assert.equal(countOpens(emitted), opensBefore, 'no new adoption was offered');
+  } finally {
+    restore();
+  }
+});
+
+test('a state-changing action with no tab left reports the reclaim, not a missing tab', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A);
+    userCloses(host, lastAdoptedViewId(emitted));
+
+    for (const action of ['navigate', 'click', 'fill', 'execute_js']) {
+      await assert.rejects(
+        host.performBrowserAutomation(action, { ownerId: OWNER_A, action: 'goto', url: 'https://example.com/' }),
+        (error) => {
+          assert.equal(error.message, USER_RECLAIMED_MESSAGE, `wrong message for ${action}`);
+          return true;
+        }
+      );
+    }
+  } finally {
+    restore();
+  }
+});
+
+test('a run with no reclaim window still gets the ordinary tab-not-found error', async () => {
+  const { host, restore } = loadHost();
+  try {
+    await assert.rejects(
+      host.performBrowserAutomation('click', { ownerId: OWNER_A, tabId: 999999 }),
+      /Browser tab not found: 999999/
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('the reclaim window never blocks work on the tabs that are still open', async () => {
+  // Two views for one owner (no renderer adoption ⇒ both fall through to the
+  // headless branch), then the user closes exactly one of them.
+  const { host, emitted, restore } = loadHost({ adopt: false });
+  try {
+    const [first, second] = await Promise.all([getTabs(host, OWNER_A), getTabs(host, OWNER_A)]);
+    const bothTabs = [tabIds(first)[0], tabIds(second)[0]];
+    assert.notEqual(bothTabs[0], bothTabs[1], 'the owner really has two views');
+
+    // A headless fallback view keeps the id main offered for adoption, so the
+    // two offers name the two views; which one backs which tab does not matter
+    // — the survivor is simply the one still alive after the close.
+    const opens = emitted
+      .filter((entry) => entry.event === 'browser://automation-open')
+      .map((entry) => entry.payload.id);
+    assert.equal(opens.length, 2);
+    host.browserDispatch(null, 'browser_close', { id: opens[0], reason: 'user_close' });
+    const survivor = bothTabs.find((tab) => !contentsFor(tab).isDestroyed());
+    assert.ok(survivor, 'exactly one view was closed');
+
+    const stillListed = await probeTabs(host, OWNER_A);
+    assert.deepEqual(tabIds(stillListed), [survivor]);
+    assert.equal(stillListed.summary.note, USER_RECLAIMED_MESSAGE, 'the note is still on');
+
+    // Read-only work on the surviving tab is exactly what a model should keep
+    // doing, and a state-changing action on a tab that IS available is not the
+    // case the window is about ("no tab left" is).
+    await host.performBrowserAutomation('screenshot', { ownerId: OWNER_A, tabId: survivor });
+    await navigate(host, OWNER_A, survivor, 'https://example.com/');
+  } finally {
+    restore();
+  }
+});
+
+test('browser_clear_reclaim lifts the window for every run of that conversation', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A, RUN_1);
+    userCloses(host, lastAdoptedViewId(emitted));
+    await getTabs(host, OWNER_A);
+    userCloses(host, lastAdoptedViewId(emitted));
+    await getTabs(host, OWNER_B);
+    userCloses(host, lastAdoptedViewId(emitted));
+
+    assert.equal(host.browserDispatch(null, 'browser_clear_reclaim', { conversationId: OWNER_A }), null);
+
+    const run1 = await getTabs(host, OWNER_A, RUN_1);
+    assert.equal(tabIds(run1).length, 1, 'the subagent run may open a tab again');
+    assert.equal(run1.summary.note, undefined);
+    const mainLoop = await getTabs(host, OWNER_A);
+    assert.equal(tabIds(mainLoop).length, 1, 'so may the conversation main loop');
+    assert.equal(mainLoop.summary.note, undefined);
+
+    // Another conversation's window is its own and is untouched.
+    const other = await getTabs(host, OWNER_B);
+    assert.deepEqual(tabIds(other), []);
+    assert.equal(other.summary.note, USER_RECLAIMED_MESSAGE);
+  } finally {
+    restore();
+  }
+});
+
+test('a reclaim window is scoped to the run whose tab was closed', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A, RUN_1);
+    userCloses(host, lastAdoptedViewId(emitted));
+
+    const reclaimed = await getTabs(host, OWNER_A, RUN_1);
+    assert.deepEqual(tabIds(reclaimed), []);
+    assert.equal(reclaimed.summary.note, USER_RECLAIMED_MESSAGE);
+
+    const sibling = await getTabs(host, OWNER_A, RUN_2);
+    assert.equal(tabIds(sibling).length, 1, 'a sibling run is not muted');
+    assert.equal(sibling.summary.note, undefined);
+    const mainLoop = await getTabs(host, OWNER_A);
+    assert.equal(tabIds(mainLoop).length, 1, 'nor is the conversation main loop');
+    assert.equal(mainLoop.summary.note, undefined);
+  } finally {
+    restore();
+  }
+});
+
+test('closing a legacy pane tab, or a lifecycle close, records no reclaim', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    // The user's own pane tab: closing it is just closing a tab.
+    host.browserDispatch(null, 'browser_create', {
+      id: 'pane-tab-1',
+      url: 'https://example.com/',
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 600,
+    });
+    host.browserDispatch(null, 'browser_close', { id: 'pane-tab-1', reason: 'user_close' });
+    const legacyAfter = await getTabs(host);
+    assert.equal(tabIds(legacyAfter).length, 1, 'the shared pool still provisions');
+    assert.equal(legacyAfter.summary.note, undefined);
+
+    // A programmatic teardown of an OWNED view records nothing either — and an
+    // unknown reason is treated as one (never as a user gesture).
+    await getTabs(host, OWNER_A);
+    host.browserDispatch(null, 'browser_close', { id: lastAdoptedViewId(emitted) });
+    assert.equal((await getTabs(host, OWNER_A)).summary.note, undefined);
+
+    await getTabs(host, OWNER_B);
+    host.browserDispatch(null, 'browser_close', { id: lastAdoptedViewId(emitted), reason: 'nonsense' });
+    assert.equal((await getTabs(host, OWNER_B)).summary.note, undefined);
+  } finally {
+    restore();
+  }
+});
+
+test('disposing an owner clears its reclaim window with the rest of its state', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A, RUN_1);
+    userCloses(host, lastAdoptedViewId(emitted));
+
+    host.browserDispatch(null, 'browser_dispose_owner', { conversationId: OWNER_A });
+
+    const fresh = await getTabs(host, OWNER_A, RUN_1);
+    assert.equal(tabIds(fresh).length, 1);
+    assert.equal(fresh.summary.note, undefined);
+  } finally {
+    restore();
+  }
+});
+
+test('a run dispose clears only that run reclaim window', async () => {
+  const { host, emitted, restore } = loadHost();
+  try {
+    await getTabs(host, OWNER_A, RUN_1);
+    userCloses(host, lastAdoptedViewId(emitted));
+    await getTabs(host, OWNER_A, RUN_2);
+    userCloses(host, lastAdoptedViewId(emitted));
+
+    host.browserDispatch(null, 'browser_dispose_owner', { conversationId: OWNER_A, runKey: RUN_1 });
+
+    assert.equal((await getTabs(host, OWNER_A, RUN_1)).summary.note, undefined);
+    assert.equal((await getTabs(host, OWNER_A, RUN_2)).summary.note, USER_RECLAIMED_MESSAGE);
+  } finally {
+    restore();
+  }
+});
+
+test('browser_clear_reclaim refuses the legacy conversation and blank input', async () => {
+  const { host, restore } = loadHost();
+  try {
+    for (const conversationId of ['legacy', '', '   ', undefined, 42]) {
+      assert.equal(host.browserDispatch(null, 'browser_clear_reclaim', { conversationId }), null);
+    }
   } finally {
     restore();
   }

--- a/scripts/electron-packaged-smoke.mjs
+++ b/scripts/electron-packaged-smoke.mjs
@@ -3018,12 +3018,18 @@ print(json.dumps({"executable": sys.executable, "files": [str(p) for p in [docx_
       checks.packagedTaskSurvivesChildFrameNavigation = true;
 
       if (process.platform === 'win32') {
-        let rightPanel = window.locator('[data-abu-right-panel]');
-        if (!(await rightPanel.count())) {
+        // This conversation has no workspace, so the panel auto-collapses and
+        // the user opens it from the title-bar toggle. Probe VISIBILITY, never
+        // DOM presence: the panel is kept mounted while closed (its tab bodies
+        // own live native browser views that unmounting would destroy), so
+        // `count()` is 1 whether it is open or closed. Reading presence as
+        // "already open" skips the toggle and then waits out the timeout on a
+        // panel nothing opened.
+        const rightPanel = window.locator('[data-abu-right-panel]');
+        if (!(await rightPanel.isVisible())) {
           const rightPanelToggle = window.locator('[data-window-control="right-panel"]');
           await rightPanelToggle.waitFor({ state: 'visible', timeout: READY_TIMEOUT });
           await rightPanelToggle.click();
-          rightPanel = window.locator('[data-abu-right-panel]');
         }
         await rightPanel.waitFor({ state: 'visible', timeout: READY_TIMEOUT });
         const rightPanelLayout = await window.evaluate(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -353,6 +353,31 @@ function App() {
     };
   }, []);
 
+  // ...and the matching withdrawal. Main cancels an adoption whose run was
+  // stopped, or whose owning conversation was deleted, and can no longer let
+  // this tab exist: the invitation was already sent, so without this the
+  // renderer would keep (or create) a tab record whose owner conversation is
+  // gone — invisible in every strip, closable from none, and still mounted.
+  // Dropping the record is also what destroys any native view already built for
+  // it (previewStore commits every removal through closeBrowserViews).
+  useEffect(() => {
+    if (!isTauriEnv()) return;
+    let unlistenFn: (() => void) | null = null;
+    let cancelled = false;
+    listen<{ id: string }>('browser://automation-cancel', (event) => {
+      const { id } = event.payload ?? {};
+      if (typeof id !== 'string' || !id.startsWith('__abu-browser-automation__')) return;
+      usePreviewStore.getState().closeAdoptedBrowserTab(id);
+    }).then((fn) => {
+      if (cancelled) fn();
+      else unlistenFn = fn;
+    });
+    return () => {
+      cancelled = true;
+      unlistenFn?.();
+    };
+  }, []);
+
   // Pet window sends a message to the currently active conversation
   useEffect(() => {
     let unlistenFn: (() => void) | null = null;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ import { LABS_TODOS_INBOX, LABS_PET } from '@/core/labs/registry';
 import { resolvePetBootAction } from '@/core/pet/petBoot';
 import { setPetVisible, hidePet } from '@/core/pet/petVisibility';
 import RightPanel from '@/components/panel/RightPanel';
-import { usePreviewStore } from '@/stores/previewStore';
+import { isTabVisibleFor, useHasTabs, usePreviewStore } from '@/stores/previewStore';
 import { resolveChatWidth, useViewportWidth } from '@/components/panel/panelWidths';
 import ToastContainer from '@/components/common/ToastContainer';
 import WindowTitleBar from '@/components/window/WindowTitleBar';
@@ -162,8 +162,12 @@ function App() {
   // Preview split (TRAE-style): when the workspace panel has WIDE content
   // (preview/browser/terminal — not the narrow summary tab), the chat column
   // takes a stable, resizable width and the workspace flex-fills the rest.
-  const hasAnyTab = usePreviewStore((s) => s.tabs.length > 0);
-  const hasWideContent = usePreviewStore((s) => s.tabs.some((t) => t.kind !== 'summary'));
+  // `visibleTabs`: a browser tab adopted for another conversation stays alive
+  // in the store but must not size or reveal THIS conversation's panel.
+  const hasAnyTab = useHasTabs();
+  const hasWideContent = usePreviewStore(
+    (s) => s.tabs.some((t) => t.kind !== 'summary' && isTabVisibleFor(t, s.currentConversationId)),
+  );
   const chatWidth = usePreviewStore((s) => s.chatWidth);
   const viewportWidth = useViewportWidth();
   const showTodosInbox = useLabsFlag(LABS_TODOS_INBOX);
@@ -323,14 +327,22 @@ function App() {
   // WebContentsView into the normal workspace. Keeping this in the existing
   // BrowserTab UI gives users a visible address bar, history controls, and a
   // close button while the agent operates the page.
+  //
+  // `ownerId` is the conversation main created the view for. It is what keeps a
+  // background conversation's adoption out of whatever conversation happens to
+  // be on screen; absent (legacy owner) means "any conversation may see it".
   useEffect(() => {
     if (!isTauriEnv()) return;
     let unlistenFn: (() => void) | null = null;
     let cancelled = false;
-    listen<{ id: string; url: string }>('browser://automation-open', (event) => {
-      const { id, url } = event.payload ?? {};
+    listen<{ id: string; url: string; ownerId?: string }>('browser://automation-open', (event) => {
+      const { id, url, ownerId } = event.payload ?? {};
       if (typeof id !== 'string' || !id.startsWith('__abu-browser-automation__')) return;
-      usePreviewStore.getState().openBrowser(typeof url === 'string' ? url : 'about:blank', id);
+      usePreviewStore.getState().openBrowser(
+        typeof url === 'string' ? url : 'about:blank',
+        id,
+        typeof ownerId === 'string' && ownerId ? ownerId : undefined,
+      );
     }).then((fn) => {
       if (cancelled) fn();
       else unlistenFn = fn;

--- a/src/components/panel/RightPanel.lifecycle.test.tsx
+++ b/src/components/panel/RightPanel.lifecycle.test.tsx
@@ -393,6 +393,69 @@ describe('RightPanel browser view lifecycle', () => {
     expect(useSettingsStore.getState().rightPanelCollapsed).toBe(true);
   });
 
+  // Packaged first-run journey: brand-new profile, a conversation with messages
+  // but NO workspace. That conversation legitimately starts with the panel
+  // closed (the no-workspace auto-collapse, unchanged by C1/C2), and the user
+  // opens it from the title-bar toggle.
+  //
+  // Under C1's keep-alive the node is mounted the whole time, so DOM PRESENCE
+  // no longer means "open" — the packaged Windows smoke used `count()` as its
+  // open/closed probe, stopped clicking the toggle, and then waited 45s for a
+  // panel nothing had opened. Pin both halves of that contract.
+  describe('fresh first conversation with no workspace', () => {
+    beforeEach(() => {
+      useChatStore.setState({
+        conversations: { fresh: conversation('fresh', null) },
+        activeConversationId: 'fresh',
+      });
+      // A fresh profile's persisted default (settingsStore: false).
+      useSettingsStore.setState({ rightPanelCollapsed: false });
+    });
+
+    it('stays mounted but hidden until the user opens it', async () => {
+      render(
+        <TooltipProvider>
+          <RightPanel />
+        </TooltipProvider>,
+      );
+
+      // No workspace → the panel auto-collapses, so it is CLOSED...
+      await waitFor(() => {
+        expect(useSettingsStore.getState().rightPanelCollapsed).toBe(true);
+      });
+      // ...but still in the DOM. Presence is not openness under keep-alive:
+      // anything probing `querySelector` to decide whether to open the panel
+      // would wrongly conclude it is already open.
+      expect(panelEl()).toBeInTheDocument();
+      expect(panelEl()).not.toBeVisible();
+    });
+
+    it('becomes visible and opens the summary when the title-bar toggle expands it', async () => {
+      render(
+        <TooltipProvider>
+          <RightPanel />
+        </TooltipProvider>,
+      );
+      await waitFor(() => {
+        expect(useSettingsStore.getState().rightPanelCollapsed).toBe(true);
+      });
+
+      // The title-bar toggle — the only affordance that opens a workspace-less
+      // conversation's panel.
+      await act(async () => {
+        useSettingsStore.getState().setRightPanelCollapsed(false);
+      });
+
+      await waitFor(() => {
+        expect(panelEl()).toBeVisible();
+      });
+      expect(panelEl()).not.toHaveAttribute('hidden');
+      // The summary effect re-runs on the `collapsed` edge and seeds the
+      // default tab, so the opened panel has content rather than an empty shell.
+      expect(getVisibleTabs().map((tab) => tab.kind)).toEqual(['summary']);
+    });
+  });
+
   it('still destroys the native view when the user closes the tab explicitly', async () => {
     await renderPanel();
     await seedBrowserTab();

--- a/src/components/panel/RightPanel.lifecycle.test.tsx
+++ b/src/components/panel/RightPanel.lifecycle.test.tsx
@@ -401,7 +401,11 @@ describe('RightPanel browser view lifecycle', () => {
       usePreviewStore.getState().closeTab(BROWSER_TAB_ID);
     });
 
-    expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: BROWSER_TAB_ID });
+    expect(invokeMock).toHaveBeenCalledWith('browser_close', {
+      id: BROWSER_TAB_ID,
+      // Closing the tab is a gesture, and the host treats it as one (N7).
+      reason: 'user_close',
+    });
     expect(usePreviewStore.getState().tabs.map((tab) => tab.id)).not.toContain(BROWSER_TAB_ID);
   });
 });

--- a/src/components/panel/RightPanel.lifecycle.test.tsx
+++ b/src/components/panel/RightPanel.lifecycle.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment happy-dom
+/// <reference types="@testing-library/jest-dom" />
+import { act, render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import RightPanel from './RightPanel';
+import { initLanguage } from '@/i18n';
+import { useChatStore } from '@/stores/chatStore';
+import { usePreviewStore } from '@/stores/previewStore';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import type { Conversation } from '@/types';
+
+// Only BrowserTab stays real — this suite is about the native browser view's
+// lifetime, and the other tab bodies pull in editors/xterm we don't need.
+vi.mock('./PreviewPanel', () => ({
+  default: () => <div>Preview</div>,
+}));
+vi.mock('./workspace/TerminalTab', () => ({
+  default: () => <div>Terminal</div>,
+}));
+vi.mock('./workspace/SummaryBody', () => ({
+  default: () => <div>Summary body</div>,
+}));
+
+const invokeMock = vi.mocked(invoke);
+
+const BROWSER_TAB_ID = 'browser-lifecycle-view';
+
+function conversation(id: string): Conversation {
+  return {
+    id,
+    title: id,
+    messages: [{ id: `${id}-m1`, role: 'user', content: 'hi', timestamp: 1 }],
+    createdAt: 1,
+    updatedAt: 1,
+    status: 'idle',
+    workspacePath: '/tmp/workspace',
+  };
+}
+
+function panelEl(): HTMLElement | null {
+  return document.querySelector('[data-abu-right-panel]');
+}
+
+function browserTabMounted(): boolean {
+  return document.querySelector('input[placeholder]') !== null;
+}
+
+async function renderPanel() {
+  const result = render(
+    <TooltipProvider>
+      <RightPanel />
+    </TooltipProvider>,
+  );
+  // Auto-expand fires once per conversation on mount (workspace + messages).
+  await waitFor(() => {
+    expect(useSettingsStore.getState().rightPanelCollapsed).toBe(false);
+  });
+  return result;
+}
+
+/** Seed one agent browser tab plus a conversation-scoped summary tab. */
+async function seedBrowserTab() {
+  act(() => {
+    usePreviewStore.setState({
+      tabs: [
+        { id: 'summary-tab', kind: 'summary' },
+        { id: BROWSER_TAB_ID, kind: 'browser', url: 'https://example.com' },
+      ],
+      activeTabId: BROWSER_TAB_ID,
+    });
+  });
+  await waitFor(() => {
+    expect(invokeMock).toHaveBeenCalledWith(
+      'browser_create',
+      expect.objectContaining({ id: BROWSER_TAB_ID }),
+    );
+  });
+  invokeMock.mockClear();
+}
+
+describe('RightPanel browser view lifecycle', () => {
+  beforeEach(() => {
+    const runtime = globalThis as typeof globalThis & { __TAURI_INTERNALS__?: unknown };
+    runtime.__TAURI_INTERNALS__ = {};
+    initLanguage('en-US');
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
+
+    useChatStore.setState({
+      conversations: { a: conversation('a'), b: conversation('b') },
+      activeConversationId: 'a',
+    });
+    useSettingsStore.setState({
+      // Start collapsed so RightPanel's once-per-conversation auto-expand fires
+      // on mount and is spent — otherwise it would fight the manual collapse
+      // this suite performs (pre-existing behaviour, unrelated to view
+      // lifetime).
+      rightPanelCollapsed: true,
+      viewMode: 'chat',
+      systemSettingsOpen: false,
+      sidebarCollapsed: true,
+    });
+    usePreviewStore.setState({
+      tabs: [],
+      activeTabId: null,
+      focusTabId: null,
+      menuOpen: false,
+      appModalOpen: false,
+      previewFilePath: null,
+      chatWidth: null,
+      reloadNonce: 0,
+      fileTreeMode: false,
+    });
+
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      bottom: 500,
+      height: 400,
+      left: 100,
+      right: 700,
+      top: 100,
+      width: 600,
+      x: 100,
+      y: 100,
+      toJSON: () => ({}),
+    });
+    Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+      configurable: true,
+      get: () => document.body,
+    });
+  });
+
+  it('keeps the browser tab and its native view when the conversation changes', async () => {
+    await renderPanel();
+    await seedBrowserTab();
+
+    await act(async () => {
+      useChatStore.setState({ activeConversationId: 'b' });
+    });
+
+    // Conversation-scoped tabs still reset; the agent's browser tab survives.
+    expect(usePreviewStore.getState().tabs.map((tab) => tab.kind)).toEqual(['browser']);
+    expect(invokeMock).not.toHaveBeenCalledWith('browser_close', expect.anything());
+    expect(browserTabMounted()).toBe(true);
+  });
+
+  it('keeps the panel mounted (hidden) when collapsed, so the native view survives', async () => {
+    await renderPanel();
+    await seedBrowserTab();
+
+    await act(async () => {
+      useSettingsStore.setState({ rightPanelCollapsed: true });
+    });
+
+    expect(panelEl()).toBeInTheDocument();
+    expect(panelEl()).toHaveAttribute('hidden');
+    expect(browserTabMounted()).toBe(true);
+    expect(invokeMock).not.toHaveBeenCalledWith('browser_close', expect.anything());
+  });
+
+  it('keeps the panel mounted (hidden) when the view mode leaves chat', async () => {
+    await renderPanel();
+    await seedBrowserTab();
+
+    await act(async () => {
+      useSettingsStore.setState({ viewMode: 'automation' });
+    });
+
+    expect(panelEl()).toHaveAttribute('hidden');
+    expect(browserTabMounted()).toBe(true);
+    expect(invokeMock).not.toHaveBeenCalledWith('browser_close', expect.anything());
+  });
+
+  it('still destroys the native view when the user closes the tab explicitly', async () => {
+    await renderPanel();
+    await seedBrowserTab();
+
+    await act(async () => {
+      usePreviewStore.getState().closeTab(BROWSER_TAB_ID);
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: BROWSER_TAB_ID });
+    expect(usePreviewStore.getState().tabs.map((tab) => tab.id)).not.toContain(BROWSER_TAB_ID);
+  });
+});

--- a/src/components/panel/RightPanel.lifecycle.test.tsx
+++ b/src/components/panel/RightPanel.lifecycle.test.tsx
@@ -39,6 +39,46 @@ function conversation(id: string): Conversation {
   };
 }
 
+const LAID_OUT_RECT = {
+  bottom: 500,
+  height: 400,
+  left: 100,
+  right: 700,
+  top: 100,
+  width: 600,
+  x: 100,
+  y: 100,
+  toJSON: () => ({}),
+} as DOMRect;
+
+const ZERO_RECT = {
+  bottom: 0,
+  height: 0,
+  left: 0,
+  right: 0,
+  top: 0,
+  width: 0,
+  x: 0,
+  y: 0,
+  toJSON: () => ({}),
+} as DOMRect;
+
+/**
+ * happy-dom has no layout engine, so model the ONE geometric fact this suite
+ * depends on: an element under a `display:none` / `[hidden]` ancestor has a
+ * zero rect and a null `offsetParent`. Driving the stubs off the real DOM keeps
+ * BrowserTab's actual visibility branch under test — a constant "laid out"
+ * stub would hide the very code path that keeps a collapsed panel from leaving
+ * a native page painted over the app.
+ */
+function underHiddenAncestor(el: Element | null): boolean {
+  for (let node: Element | null = el; node; node = node.parentElement) {
+    if (!(node instanceof HTMLElement)) continue;
+    if (node.hasAttribute('hidden') || node.style.display === 'none') return true;
+  }
+  return false;
+}
+
 function panelEl(): HTMLElement | null {
   return document.querySelector('[data-abu-right-panel]');
 }
@@ -114,20 +154,16 @@ describe('RightPanel browser view lifecycle', () => {
       fileTreeMode: false,
     });
 
-    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
-      bottom: 500,
-      height: 400,
-      left: 100,
-      right: 700,
-      top: 100,
-      width: 600,
-      x: 100,
-      y: 100,
-      toJSON: () => ({}),
-    });
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
+      function (this: HTMLElement) {
+        return underHiddenAncestor(this) ? ZERO_RECT : LAID_OUT_RECT;
+      },
+    );
     Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
       configurable: true,
-      get: () => document.body,
+      get(this: HTMLElement) {
+        return underHiddenAncestor(this) ? null : document.body;
+      },
     });
   });
 
@@ -170,6 +206,47 @@ describe('RightPanel browser view lifecycle', () => {
     expect(panelEl()).toHaveAttribute('hidden');
     expect(browserTabMounted()).toBe(true);
     expect(invokeMock).not.toHaveBeenCalledWith('browser_close', expect.anything());
+  });
+
+  // The keep-alive above is only safe because the native layer — which paints
+  // OVER React and ignores CSS — actually goes away with the panel. That rests
+  // entirely on BrowserTab reading a zero rect / null offsetParent, so exercise
+  // it for real rather than stubbing the geometry to "always laid out".
+  it('hides the native layer while the panel is collapsed and shows the same view on re-expand', async () => {
+    await renderPanel();
+    await seedBrowserTab();
+
+    await act(async () => {
+      useSettingsStore.setState({ rightPanelCollapsed: true });
+    });
+
+    // The tab is still mounted, so this hide can only have come from syncBounds
+    // seeing the collapsed panel's zero rect — not from an unmount cleanup.
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith('browser_hide', { id: BROWSER_TAB_ID });
+    });
+    expect(browserTabMounted()).toBe(true);
+
+    // Let a few more syncBounds ticks run: a hidden pane must not resume
+    // painting the native layer over whatever replaced it.
+    const hideIndex = invokeMock.mock.calls.findIndex(([command]) => command === 'browser_hide');
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 600));
+    });
+    const afterHide = invokeMock.mock.calls.slice(hideIndex + 1).map(([command]) => command);
+    expect(afterHide).not.toContain('browser_set_bounds');
+    expect(afterHide).not.toContain('browser_show');
+
+    await act(async () => {
+      useSettingsStore.setState({ rightPanelCollapsed: false });
+    });
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith('browser_show', { id: BROWSER_TAB_ID });
+    });
+    // Shown, never re-created: same WebContentsView, so the same tab id the
+    // agent is already holding.
+    expect(invokeMock).not.toHaveBeenCalledWith('browser_create', expect.anything());
   });
 
   it('still destroys the native view when the user closes the tab explicitly', async () => {

--- a/src/components/panel/RightPanel.lifecycle.test.tsx
+++ b/src/components/panel/RightPanel.lifecycle.test.tsx
@@ -6,7 +6,7 @@ import { invoke } from '@tauri-apps/api/core';
 import RightPanel from './RightPanel';
 import { initLanguage } from '@/i18n';
 import { useChatStore } from '@/stores/chatStore';
-import { usePreviewStore } from '@/stores/previewStore';
+import { getVisibleTabs, usePreviewStore, workspaceTabButtonId } from '@/stores/previewStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import type { Conversation } from '@/types';
@@ -26,6 +26,7 @@ vi.mock('./workspace/SummaryBody', () => ({
 const invokeMock = vi.mocked(invoke);
 
 const BROWSER_TAB_ID = 'browser-lifecycle-view';
+const OWNED_TAB_ID = 'browser-owned-view';
 
 function conversation(id: string): Conversation {
   return {
@@ -103,18 +104,32 @@ async function renderPanel() {
 /** Seed one agent browser tab plus a conversation-scoped summary tab. */
 async function seedBrowserTab() {
   act(() => {
-    usePreviewStore.setState({
-      tabs: [
-        { id: 'summary-tab', kind: 'summary' },
-        { id: BROWSER_TAB_ID, kind: 'browser', url: 'https://example.com' },
-      ],
-      activeTabId: BROWSER_TAB_ID,
-    });
+    usePreviewStore.getState().openSummary();
+    // No owner id — the legacy/user-opened shape, visible in any conversation.
+    usePreviewStore.getState().openBrowser('https://example.com', BROWSER_TAB_ID);
   });
   await waitFor(() => {
     expect(invokeMock).toHaveBeenCalledWith(
       'browser_create',
       expect.objectContaining({ id: BROWSER_TAB_ID }),
+    );
+  });
+  invokeMock.mockClear();
+}
+
+/**
+ * Seed an agent browser tab ADOPTED FOR `conversationId` — the production path
+ * (`browser://automation-open` → `openBrowser(url, id, ownerId)`), so the tab
+ * carries its owner rather than being a legacy any-conversation tab.
+ */
+async function seedOwnedBrowserTab(conversationId: string) {
+  act(() => {
+    usePreviewStore.getState().openBrowser('https://example.com', OWNED_TAB_ID, conversationId);
+  });
+  await waitFor(() => {
+    expect(invokeMock).toHaveBeenCalledWith(
+      'browser_create',
+      expect.objectContaining({ id: OWNED_TAB_ID }),
     );
   });
   invokeMock.mockClear();
@@ -152,6 +167,8 @@ describe('RightPanel browser view lifecycle', () => {
       chatWidth: null,
       reloadNonce: 0,
       fileTreeMode: false,
+      currentConversationId: null,
+      lastActiveTabByConversation: {},
     });
 
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
@@ -246,6 +263,62 @@ describe('RightPanel browser view lifecycle', () => {
     });
     // Shown, never re-created: same WebContentsView, so the same tab id the
     // agent is already holding.
+    expect(invokeMock).not.toHaveBeenCalledWith('browser_create', expect.anything());
+  });
+
+  // C1 left the surviving browser tab active for whatever conversation the user
+  // switched to, so B's panel opened on A's live page and B never got its own
+  // summary. An adopted tab belongs to its owner conversation only.
+  it('hides conversation A’s agent tab from B, which opens its own summary instead', async () => {
+    await renderPanel();
+    await seedOwnedBrowserTab('a');
+
+    await act(async () => {
+      useChatStore.setState({ activeConversationId: 'b' });
+    });
+
+    const s = usePreviewStore.getState();
+    // The view is alive — just not B's business.
+    expect(s.tabs.map((tab) => tab.id)).toContain(OWNED_TAB_ID);
+    expect(invokeMock).not.toHaveBeenCalledWith('browser_close', expect.anything());
+    expect(browserTabMounted()).toBe(true);
+    // B sees only its own freshly opened summary.
+    expect(getVisibleTabs().map((tab) => tab.kind)).toEqual(['summary']);
+    expect(s.activeTabId).toBe(getVisibleTabs()[0].id);
+    // ...and the tab strip does not offer A's tab.
+    expect(document.getElementById(workspaceTabButtonId(OWNED_TAB_ID))).toBeNull();
+
+    // The native layer paints over React, so an invisible tab MUST be hidden.
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith('browser_hide', { id: OWNED_TAB_ID });
+    });
+  });
+
+  it('restores conversation A’s agent tab when the user switches back', async () => {
+    await renderPanel();
+    await seedOwnedBrowserTab('a');
+
+    await act(async () => {
+      useChatStore.setState({ activeConversationId: 'b' });
+    });
+    // Let the native layer actually go down in B before coming back, so the
+    // re-show below is a real state transition rather than a no-op.
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith('browser_hide', { id: OWNED_TAB_ID });
+    });
+    invokeMock.mockClear();
+    await act(async () => {
+      useChatStore.setState({ activeConversationId: 'a' });
+    });
+
+    const s = usePreviewStore.getState();
+    expect(getVisibleTabs().map((tab) => tab.id)).toEqual([OWNED_TAB_ID]);
+    expect(s.activeTabId).toBe(OWNED_TAB_ID);
+    expect(document.getElementById(workspaceTabButtonId(OWNED_TAB_ID))).not.toBeNull();
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith('browser_show', { id: OWNED_TAB_ID });
+    });
+    // Same WebContentsView the agent is still driving.
     expect(invokeMock).not.toHaveBeenCalledWith('browser_create', expect.anything());
   });
 

--- a/src/components/panel/RightPanel.lifecycle.test.tsx
+++ b/src/components/panel/RightPanel.lifecycle.test.tsx
@@ -28,7 +28,7 @@ const invokeMock = vi.mocked(invoke);
 const BROWSER_TAB_ID = 'browser-lifecycle-view';
 const OWNED_TAB_ID = 'browser-owned-view';
 
-function conversation(id: string): Conversation {
+function conversation(id: string, workspacePath: string | null = '/tmp/workspace'): Conversation {
   return {
     id,
     title: id,
@@ -36,7 +36,7 @@ function conversation(id: string): Conversation {
     createdAt: 1,
     updatedAt: 1,
     status: 'idle',
-    workspacePath: '/tmp/workspace',
+    ...(workspacePath ? { workspacePath } : {}),
   };
 }
 
@@ -320,6 +320,77 @@ describe('RightPanel browser view lifecycle', () => {
     });
     // Same WebContentsView the agent is still driving.
     expect(invokeMock).not.toHaveBeenCalledWith('browser_create', expect.anything());
+  });
+
+  // The wide-content effect auto-expands the panel and collapses the sidebar.
+  // Once C2 scoped tabs per conversation, `hasWideContent` started flipping on
+  // every switch, so returning to a conversation with an agent browser tab
+  // replayed that "content just opened" reaction — overriding whatever the user
+  // had arranged. Only a flip WITHIN one conversation may trigger it.
+  it('auto-expands and collapses the sidebar the first time wide content appears', async () => {
+    await renderPanel();
+    await act(async () => {
+      useSettingsStore.setState({ rightPanelCollapsed: true, sidebarCollapsed: false });
+    });
+
+    await seedOwnedBrowserTab('a');
+
+    expect(useSettingsStore.getState().rightPanelCollapsed).toBe(false);
+    expect(useSettingsStore.getState().sidebarCollapsed).toBe(true);
+  });
+
+  it('does not replay the auto-expand reaction on an A → B → A round trip', async () => {
+    await renderPanel();
+    await seedOwnedBrowserTab('a');
+    // The user's arrangement: sidebar deliberately open next to the browser tab.
+    await act(async () => {
+      useSettingsStore.setState({ sidebarCollapsed: false });
+    });
+
+    await act(async () => {
+      useChatStore.setState({ activeConversationId: 'b' });
+    });
+    await act(async () => {
+      useChatStore.setState({ activeConversationId: 'a' });
+    });
+
+    // A's tab is visible again (a false→true flip of hasWideContent), but it is
+    // the same content coming back, not new content — the sidebar stays as the
+    // user left it.
+    expect(getVisibleTabs().map((tab) => tab.id)).toEqual([OWNED_TAB_ID]);
+    expect(useSettingsStore.getState().sidebarCollapsed).toBe(false);
+  });
+
+  it('leaves a manually collapsed panel collapsed across a round trip', async () => {
+    // Workspace-less conversations on purpose: the panel's OTHER auto-expand
+    // (once per conversation, gated on `hasWorkspace`) would otherwise re-expand
+    // on return for its own long-standing reasons, masking what this pins.
+    useChatStore.setState({
+      conversations: { a: conversation('a', null), b: conversation('b', null) },
+      activeConversationId: 'a',
+    });
+    render(
+      <TooltipProvider>
+        <RightPanel />
+      </TooltipProvider>,
+    );
+    await act(async () => {
+      useSettingsStore.setState({ rightPanelCollapsed: false, sidebarCollapsed: true });
+    });
+    await seedOwnedBrowserTab('a');
+    // The user collapses the panel while the agent keeps browsing.
+    await act(async () => {
+      useSettingsStore.setState({ rightPanelCollapsed: true });
+    });
+
+    await act(async () => {
+      useChatStore.setState({ activeConversationId: 'b' });
+    });
+    await act(async () => {
+      useChatStore.setState({ activeConversationId: 'a' });
+    });
+
+    expect(useSettingsStore.getState().rightPanelCollapsed).toBe(true);
   });
 
   it('still destroys the native view when the user closes the tab explicitly', async () => {

--- a/src/components/panel/RightPanel.tsx
+++ b/src/components/panel/RightPanel.tsx
@@ -127,11 +127,16 @@ export default function RightPanel() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversationId]);
 
-  // Close all workspace tabs when switching conversations (tabs are
-  // conversation-scoped). Defined BEFORE the summary-open effect so that runs
-  // against a cleared tab list.
+  // Close the conversation-scoped workspace tabs when switching conversations
+  // (summary / preview / terminal / subagent). Defined BEFORE the summary-open
+  // effect so that runs against a cleared tab list.
+  //
+  // Browser tabs are exempt: their native view is a page an agent may still be
+  // driving in the background, and closing the tab destroyed it mid-task
+  // (losing the page, its login state and any typed form data) — the panel's
+  // per-conversation reset must not reach into the agent's runtime.
   useEffect(() => {
-    usePreviewStore.getState().closeAllTabs();
+    usePreviewStore.getState().closeTabsForConversationSwitch();
   }, [conversationId]);
 
   // Default the panel to the "task summary" tab: once per conversation, when the
@@ -184,15 +189,15 @@ export default function RightPanel() {
   // flex-fills and the chat owns the width).
   const currentWidth = dragWidth ?? PANEL_WIDTH;
 
-  // Hide panel when not in chat view or no conversation has started yet
-  if (viewMode !== 'chat' || (!hasMessages && !hasAnyTab)) {
-    return null;
-  }
-
-  // When collapsed, render nothing (toggle button is in the title bar)
-  if (collapsed) {
-    return null;
-  }
+  // Hide the panel when collapsed (the toggle lives in the title bar), when the
+  // app is not on the chat view, or before a conversation has anything to show.
+  //
+  // HIDE, never unmount: unmounting tears down every tab body, and a browser
+  // tab body owns a live native webview an agent may be driving. Same
+  // keep-alive contract WorkspacePanel already applies to its inactive tabs —
+  // the hidden placeholder yields a zero rect, which is exactly the signal
+  // BrowserTab uses to hide its native layer.
+  const panelHidden = viewMode !== 'chat' || (!hasMessages && !hasAnyTab) || collapsed;
 
   // When expanded, render the tabbed workspace.
   // Wide content: flex-fill the space the chat column leaves (chat owns width).
@@ -201,6 +206,7 @@ export default function RightPanel() {
     <div
       data-abu-right-panel
       data-electron-no-drag
+      hidden={panelHidden}
       className={cn(
         // Raised content card floating on the canvas (matches dev's panel redesign):
         // margins on 3 sides + rounded/border/shadow. No h-full — flex fills height
@@ -210,9 +216,14 @@ export default function RightPanel() {
         hasWideContent ? 'flex-1 min-w-0' : 'shrink-0',
       )}
       style={
-        hasWideContent
-          ? { minWidth: PREVIEW_MIN_WIDTH }
-          : { width: currentWidth, minWidth: currentWidth, maxWidth: currentWidth, transition: isDragging ? 'none' : 'width 200ms, min-width 200ms, max-width 200ms' }
+        // Inline `display: none` (not just the `hidden` attribute): the layout
+        // classes above set `display: flex`, which would otherwise win over the
+        // UA stylesheet's `[hidden] { display: none }`.
+        panelHidden
+          ? { display: 'none' }
+          : hasWideContent
+            ? { minWidth: PREVIEW_MIN_WIDTH }
+            : { width: currentWidth, minWidth: currentWidth, maxWidth: currentWidth, transition: isDragging ? 'none' : 'width 200ms, min-width 200ms, max-width 200ms' }
       }
     >
       {/* Full-screen overlay during drag — blocks iframe/webview from stealing mouse events */}

--- a/src/components/panel/RightPanel.tsx
+++ b/src/components/panel/RightPanel.tsx
@@ -30,6 +30,13 @@ export default function RightPanel() {
   const hasWideContent = usePreviewStore(
     (s) => s.tabs.some((t) => t.kind !== 'summary' && isTabVisibleFor(t, s.currentConversationId)),
   );
+  // The conversation the tab set is currently scoped to. Read from the STORE
+  // (not `conversationId` below, which is the chat's active conversation and
+  // changes one commit earlier): this and `hasWideContent` come from the same
+  // store snapshot, so they always move together in a single commit. The
+  // wide-content effect relies on that to tell "content appeared" apart from
+  // "a different conversation's tabs came into view".
+  const scopedConversationId = usePreviewStore((s) => s.currentConversationId);
   const conversation = useActiveConversation();
   const prevHasMessagesRef = useRef(false);
   // Track whether auto-expand already fired for this conversation
@@ -177,22 +184,35 @@ export default function RightPanel() {
 
   // Auto-expand right panel + collapse left sidebar when WIDE content opens
   // (preview/browser/terminal — not the summary tab, which is the default and
-  // shouldn't fight the sidebar).
+  // shouldn't fight the sidebar), and reset the drag width whenever the panel
+  // crosses between the narrow and wide layouts.
+  //
+  // Both react to the SAME edge, so they share one guard: only a narrow↔wide
+  // flip WITHIN one conversation counts. A conversation switch swaps the whole
+  // visible tab set at once, and the resulting flip is not the user opening or
+  // closing anything — it is a conversation's own layout leaving and coming
+  // back. Treating that as an open would re-expand the panel and re-collapse
+  // the sidebar on every return to a conversation with an agent browser tab,
+  // overriding a collapse the user had just made.
   const sidebarCollapsed = useSettingsStore((s) => s.sidebarCollapsed);
   const toggleSidebar = useSettingsStore((s) => s.toggleSidebar);
+  const wideEdgeRef = useRef<{ conversationId: string | null; wide: boolean } | null>(null);
   useEffect(() => {
+    const previous = wideEdgeRef.current;
+    // Re-seed first: after a switch, whatever this conversation already had
+    // open becomes the new baseline rather than an edge.
+    wideEdgeRef.current = { conversationId: scopedConversationId, wide: hasWideContent };
+    if (!previous || previous.conversationId !== scopedConversationId) return;
+    if (previous.wide === hasWideContent) return;
+
+    setDragWidth(null);
     if (!hasWideContent) return;
     if (collapsed) setRightPanelCollapsed(false);
     // In file-tree mode the sidebar hosts the tree the user is browsing, so
     // collapsing it on file-open would hide the tree — keep it open then.
     if (!sidebarCollapsed && !usePreviewStore.getState().fileTreeMode) toggleSidebar();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasWideContent]);
-
-  // Reset drag width when switching between narrow/wide layout
-  useEffect(() => {
-    setDragWidth(null);
-  }, [hasWideContent]);
+  }, [hasWideContent, scopedConversationId]);
 
   // Narrow-panel width (only meaningful when NOT wide — in wide mode the panel
   // flex-fills and the chat owns the width).

--- a/src/components/panel/RightPanel.tsx
+++ b/src/components/panel/RightPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettingsStore } from '@/stores/settingsStore';
-import { usePreviewStore } from '@/stores/previewStore';
+import { getVisibleTabs, isTabVisibleFor, useHasTabs, usePreviewStore } from '@/stores/previewStore';
 import { useActiveConversation } from '@/stores/chatStore';
 import { cn } from '@/lib/utils';
 import WorkspacePanel from './workspace/WorkspacePanel';
@@ -21,10 +21,15 @@ export default function RightPanel() {
   const collapsed = useSettingsStore((s) => s.rightPanelCollapsed);
   const setRightPanelCollapsed = useSettingsStore((s) => s.setRightPanelCollapsed);
   const viewMode = useSettingsStore((s) => s.viewMode);
-  const hasAnyTab = usePreviewStore((s) => s.tabs.length > 0);
+  // `visibleTabs`, not `tabs`: a browser tab adopted for ANOTHER conversation
+  // stays in the store (its native view is alive) but is not this
+  // conversation's content and must not size or open this conversation's panel.
+  const hasAnyTab = useHasTabs();
   // "Wide" content (preview/browser/terminal) flex-fills; the summary tab and
   // the empty state stay at the narrow fixed width.
-  const hasWideContent = usePreviewStore((s) => s.tabs.some((t) => t.kind !== 'summary'));
+  const hasWideContent = usePreviewStore(
+    (s) => s.tabs.some((t) => t.kind !== 'summary' && isTabVisibleFor(t, s.currentConversationId)),
+  );
   const conversation = useActiveConversation();
   const prevHasMessagesRef = useRef(false);
   // Track whether auto-expand already fired for this conversation
@@ -65,7 +70,7 @@ export default function RightPanel() {
     const startX = e.clientX;
     // Wide content flex-fills, so the divider resizes the chat; otherwise it
     // resizes the narrow panel itself.
-    const isWide = usePreviewStore.getState().tabs.some((t) => t.kind !== 'summary');
+    const isWide = getVisibleTabs().some((t) => t.kind !== 'summary');
     const sidebarOpen = !useSettingsStore.getState().sidebarCollapsed;
 
     setIsDragging(true);
@@ -134,9 +139,11 @@ export default function RightPanel() {
   // Browser tabs are exempt: their native view is a page an agent may still be
   // driving in the background, and closing the tab destroyed it mid-task
   // (losing the page, its login state and any typed form data) — the panel's
-  // per-conversation reset must not reach into the agent's runtime.
+  // per-conversation reset must not reach into the agent's runtime. Passing the
+  // conversation id re-scopes visibility instead: an agent tab adopted for
+  // another conversation goes hidden here and comes back when the user does.
   useEffect(() => {
-    usePreviewStore.getState().closeTabsForConversationSwitch();
+    usePreviewStore.getState().closeTabsForConversationSwitch(conversationId);
   }, [conversationId]);
 
   // Default the panel to the "task summary" tab: once per conversation, when the
@@ -144,7 +151,9 @@ export default function RightPanel() {
   // the summary tab afterwards leaves the "从这里开始" empty state (not reopened).
   useEffect(() => {
     if (collapsed || !hasMessages || summaryInitedRef.current) return;
-    if (usePreviewStore.getState().tabs.length === 0) {
+    // "No tab" means no tab THIS conversation can see: another conversation's
+    // surviving agent browser tab must not suppress this one's summary.
+    if (getVisibleTabs().length === 0) {
       summaryInitedRef.current = true;
       usePreviewStore.getState().openSummary();
     }

--- a/src/components/panel/workspace/BrowserTab.test.tsx
+++ b/src/components/panel/workspace/BrowserTab.test.tsx
@@ -614,4 +614,26 @@ describe('BrowserTab native overlay visibility', () => {
     // The beforeEach rect: 600×400 at (100, 100).
     expect(createArgs).toMatchObject({ x: 100, y: 100, width: 600, height: 400 });
   });
+
+  it('hides the native view on unmount instead of destroying it', async () => {
+    const { unmount } = render(
+      <TooltipProvider>
+        <BrowserTab tabId="browser-unmount-keepalive" url="https://example.com" />
+      </TooltipProvider>,
+    );
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('browser_create', expect.objectContaining({
+        id: 'browser-unmount-keepalive',
+      }));
+    });
+    invoke.mockClear();
+
+    unmount();
+
+    // The view outlives this component — only the tab record (previewStore)
+    // may destroy it.
+    expect(invoke).toHaveBeenCalledWith('browser_hide', { id: 'browser-unmount-keepalive' });
+    expect(invoke).not.toHaveBeenCalledWith('browser_close', expect.anything());
+  });
 });

--- a/src/components/panel/workspace/BrowserTab.test.tsx
+++ b/src/components/panel/workspace/BrowserTab.test.tsx
@@ -636,4 +636,92 @@ describe('BrowserTab native overlay visibility', () => {
     expect(invoke).toHaveBeenCalledWith('browser_hide', { id: 'browser-unmount-keepalive' });
     expect(invoke).not.toHaveBeenCalledWith('browser_close', expect.anything());
   });
+
+  // N3: address-bar focus/typing and back/forward/reload clicks all live in
+  // this MAIN-window React layer, never touching the guest webContents that
+  // the takeover backoff (R4, electron/browserHost.cjs) listens on — so using
+  // them was invisible to the backoff. `browser_note_user_interaction`
+  // bridges that gap; these tests pin the renderer side of the wiring.
+  describe('N3 — React-layer takeover signal (browser_note_user_interaction)', () => {
+    async function renderReadyTab(tabId: string) {
+      const view = render(
+        <TooltipProvider>
+          <BrowserTab tabId={tabId} url="https://example.com" />
+        </TooltipProvider>,
+      );
+      await waitFor(() => {
+        expect(invoke).toHaveBeenCalledWith('browser_create', expect.objectContaining({ id: tabId }));
+      });
+      invoke.mockClear();
+      return view;
+    }
+
+    it('notes user interaction when the address bar receives focus', async () => {
+      const { getByPlaceholderText } = await renderReadyTab('browser-n3-focus');
+
+      fireEvent.focus(getByPlaceholderText('Enter a URL or search'));
+
+      expect(invoke).toHaveBeenCalledWith('browser_note_user_interaction', { id: 'browser-n3-focus' });
+    });
+
+    it('notes user interaction on address-bar input, throttled to one call per window', async () => {
+      const { getByPlaceholderText } = await renderReadyTab('browser-n3-typing');
+      const input = getByPlaceholderText('Enter a URL or search');
+
+      // A typing storm: many changes fired back-to-back, well inside the
+      // 500ms throttle window.
+      for (const ch of ['h', 'ht', 'htt', 'http', 'https']) {
+        fireEvent.change(input, { target: { value: ch } });
+      }
+
+      const noteCalls = invoke.mock.calls.filter(([command]) => command === 'browser_note_user_interaction');
+      expect(noteCalls).toHaveLength(1);
+      expect(noteCalls[0][1]).toEqual({ id: 'browser-n3-typing' });
+    });
+
+    it('notes user interaction on back/forward/reload button clicks', async () => {
+      // waitFor's internal polling needs real timers, so render (and its
+      // waitFor above) happens first; fake time is only frozen afterwards,
+      // for the throttle-window assertions below.
+      const { container } = await renderReadyTab('browser-n3-navbuttons');
+      vi.useFakeTimers();
+      try {
+        const fixedNow = new Date('2026-01-01T00:00:00.000Z');
+        vi.setSystemTime(fixedNow);
+        const [backButton, forwardButton, reloadButton] = container.querySelectorAll('button');
+
+        fireEvent.click(backButton);
+        expect(invoke).toHaveBeenCalledWith('browser_note_user_interaction', { id: 'browser-n3-navbuttons' });
+        expect(invoke).toHaveBeenCalledWith('browser_back', { id: 'browser-n3-navbuttons' });
+
+        // Past the throttle window so forward/reload each independently note it.
+        invoke.mockClear();
+        vi.setSystemTime(new Date(fixedNow.getTime() + 1000));
+        fireEvent.click(forwardButton);
+        expect(invoke).toHaveBeenCalledWith('browser_note_user_interaction', { id: 'browser-n3-navbuttons' });
+
+        invoke.mockClear();
+        vi.setSystemTime(new Date(fixedNow.getTime() + 2000));
+        fireEvent.click(reloadButton);
+        expect(invoke).toHaveBeenCalledWith('browser_note_user_interaction', { id: 'browser-n3-navbuttons' });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not gate browser_navigate itself — the renderer path stays un-gated for the user', async () => {
+      const { getByPlaceholderText } = await renderReadyTab('browser-n3-navigate-ungated');
+      const input = getByPlaceholderText('Enter a URL or search');
+
+      fireEvent.change(input, { target: { value: 'https://new.example.com' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(invoke).toHaveBeenCalledWith('browser_navigate', expect.objectContaining({
+          id: 'browser-n3-navigate-ungated',
+          url: 'https://new.example.com',
+        }));
+      });
+    });
+  });
 });

--- a/src/components/panel/workspace/BrowserTab.test.tsx
+++ b/src/components/panel/workspace/BrowserTab.test.tsx
@@ -665,18 +665,42 @@ describe('BrowserTab native overlay visibility', () => {
     });
 
     it('notes user interaction on address-bar input, throttled to one call per window', async () => {
+      // waitFor's internal polling needs real timers, so render (and its
+      // waitFor inside renderReadyTab) happens first; fake time is only
+      // frozen afterwards, for the throttle-window assertions below. Mirrors
+      // the nav-buttons test above — real timers here let a slow/loaded CI
+      // box spend real wall-clock time on the typing storm and blow past the
+      // 500ms window, which is exactly the flake this pins down.
       const { getByPlaceholderText } = await renderReadyTab('browser-n3-typing');
       const input = getByPlaceholderText('Enter a URL or search');
 
-      // A typing storm: many changes fired back-to-back, well inside the
-      // 500ms throttle window.
-      for (const ch of ['h', 'ht', 'htt', 'http', 'https']) {
-        fireEvent.change(input, { target: { value: ch } });
-      }
+      vi.useFakeTimers();
+      try {
+        const fixedNow = new Date('2026-01-01T00:00:00.000Z');
+        vi.setSystemTime(fixedNow);
 
-      const noteCalls = invoke.mock.calls.filter(([command]) => command === 'browser_note_user_interaction');
-      expect(noteCalls).toHaveLength(1);
-      expect(noteCalls[0][1]).toEqual({ id: 'browser-n3-typing' });
+        // A typing storm: many changes fired back-to-back, well inside the
+        // 500ms throttle window (frozen, so this can never flake).
+        for (const ch of ['h', 'ht', 'htt', 'http', 'https']) {
+          fireEvent.change(input, { target: { value: ch } });
+        }
+
+        let noteCalls = invoke.mock.calls.filter(([command]) => command === 'browser_note_user_interaction');
+        expect(noteCalls).toHaveLength(1);
+        expect(noteCalls[0][1]).toEqual({ id: 'browser-n3-typing' });
+
+        // Past the throttle window: the next change is allowed through,
+        // pinning window-expiry behavior alongside suppression.
+        invoke.mockClear();
+        vi.setSystemTime(new Date(fixedNow.getTime() + 501));
+        fireEvent.change(input, { target: { value: 'https://' } });
+
+        noteCalls = invoke.mock.calls.filter(([command]) => command === 'browser_note_user_interaction');
+        expect(noteCalls).toHaveLength(1);
+        expect(noteCalls[0][1]).toEqual({ id: 'browser-n3-typing' });
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('notes user interaction on back/forward/reload button clicks', async () => {

--- a/src/components/panel/workspace/BrowserTab.test.tsx
+++ b/src/components/panel/workspace/BrowserTab.test.tsx
@@ -748,4 +748,135 @@ describe('BrowserTab native overlay visibility', () => {
       });
     });
   });
+
+  // Real-device acceptance (2026-09-01, G6/G7): the user typed into the address
+  // bar without pressing Enter; the agent's resumed programmatic navigation
+  // fired a `browser://nav/*` event, which unconditionally rewrote the bound
+  // input value and silently wiped the draft. The address bar must not follow
+  // programmatic URL updates while the user is editing it.
+  describe('address bar draft protection', () => {
+    const navHandlers = new Map<string, (event: { payload: string }) => void>();
+
+    async function renderTabWithNav(tabId: string) {
+      navHandlers.clear();
+      listen.mockImplementation((event: string, handler: (e: { payload: string }) => void) => {
+        navHandlers.set(event, handler);
+        return Promise.resolve(() => {});
+      });
+      const view = render(
+        <TooltipProvider>
+          <BrowserTab tabId={tabId} url="https://example.com" />
+        </TooltipProvider>,
+      );
+      await waitFor(() => {
+        expect(invoke).toHaveBeenCalledWith('browser_create', expect.objectContaining({ id: tabId }));
+      });
+      await waitFor(() => {
+        expect(navHandlers.has(`browser://nav/${tabId}`)).toBe(true);
+      });
+      const fireNav = (url: string) => {
+        act(() => {
+          navHandlers.get(`browser://nav/${tabId}`)!({ payload: url });
+        });
+      };
+      const input = view.getByPlaceholderText('Enter a URL or search') as HTMLInputElement;
+      return { view, input, fireNav };
+    }
+
+    it('follows programmatic navigation while the address bar is untouched', async () => {
+      const { input, fireNav } = await renderTabWithNav('browser-draft-follow');
+
+      fireNav('https://agent-went-here.example.com/page');
+
+      expect(input.value).toBe('https://agent-went-here.example.com/page');
+    });
+
+    it('keeps a focused draft when a programmatic navigation updates the tab URL', async () => {
+      const { input, fireNav } = await renderTabWithNav('browser-draft-focused');
+
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: 'weather tomor' } });
+      fireNav('https://agent-went-here.example.com/page');
+
+      expect(input.value).toBe('weather tomor');
+    });
+
+    it('keeps a blurred draft that was never committed', async () => {
+      const { input, fireNav } = await renderTabWithNav('browser-draft-blurred');
+
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: 'half-typed query' } });
+      fireEvent.blur(input);
+      fireNav('https://agent-went-here.example.com/page');
+
+      expect(input.value).toBe('half-typed query');
+    });
+
+    it('protects a clean focused input, then resyncs to the latest URL on blur', async () => {
+      const { input, fireNav } = await renderTabWithNav('browser-draft-clean-focus');
+
+      fireEvent.focus(input);
+      fireNav('https://agent-went-here.example.com/page');
+      // Still showing what the user was looking at while focused…
+      expect(input.value).toBe('https://example.com');
+
+      fireEvent.blur(input);
+      // …and following again once they leave without edits.
+      expect(input.value).toBe('https://agent-went-here.example.com/page');
+    });
+
+    it('resyncs an emptied draft to the current URL on blur', async () => {
+      const { input, fireNav } = await renderTabWithNav('browser-draft-emptied');
+
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '' } });
+      fireNav('https://agent-went-here.example.com/page');
+      fireEvent.blur(input);
+
+      expect(input.value).toBe('https://agent-went-here.example.com/page');
+      fireNav('https://agent-next.example.com/');
+      expect(input.value).toBe('https://agent-next.example.com/');
+    });
+
+    it('reverts the draft to the current page URL on Escape and resumes following', async () => {
+      const { input, fireNav } = await renderTabWithNav('browser-draft-escape');
+
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: 'abandoned draft' } });
+      fireNav('https://agent-went-here.example.com/page');
+      fireEvent.keyDown(input, { key: 'Escape' });
+
+      expect(input.value).toBe('https://agent-went-here.example.com/page');
+
+      fireEvent.blur(input);
+      fireNav('https://agent-next.example.com/');
+      expect(input.value).toBe('https://agent-next.example.com/');
+    });
+
+    it('committing a draft with Enter clears protection so navigation follows again', async () => {
+      const { input, fireNav } = await renderTabWithNav('browser-draft-commit');
+
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: 'https://typed.example.com' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      fireEvent.blur(input);
+
+      fireNav('https://redirected.example.com/landing');
+      expect(input.value).toBe('https://redirected.example.com/landing');
+    });
+
+    it('still records the programmatic navigation as the committed URL while a draft is held', async () => {
+      const { input, fireNav } = await renderTabWithNav('browser-draft-committed-url');
+
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: 'draft in progress' } });
+      fireNav('https://agent-went-here.example.com/page');
+      expect(input.value).toBe('draft in progress');
+
+      // Escape reveals the committed URL the tab actually tracked underneath.
+      fireEvent.keyDown(input, { key: 'Escape' });
+      expect(input.value).toBe('https://agent-went-here.example.com/page');
+    });
+  });
+
 });

--- a/src/components/panel/workspace/BrowserTab.tsx
+++ b/src/components/panel/workspace/BrowserTab.tsx
@@ -169,6 +169,14 @@ export default function BrowserTab({ tabId, url }: { tabId: string; url: string 
   // one IPC call per 500ms so a typing storm in the address bar does not spam
   // `browser_note_user_interaction`.
   const lastNoteUserInteractionAtRef = useRef(0);
+  // Address-bar draft protection: while the input is focused, or holds an
+  // uncommitted edit, a programmatic navigation (`browser://nav/*`) must not
+  // rewrite the bound value — real-device acceptance (2026-09-01, G6/G7)
+  // showed the agent's resumed navigation silently wiping a half-typed draft.
+  // `committedUrl` still tracks the real page underneath; the input resyncs on
+  // blur once it is clean (untouched, emptied, or reverted).
+  const addressFocusedRef = useRef(false);
+  const addressDirtyRef = useRef(false);
 
   // Freeze-frame shown while the native view is hidden for an overlay. The
   // native view paints above React, so hiding it for a modal/menu would flash
@@ -401,7 +409,9 @@ export default function BrowserTab({ tabId, url }: { tabId: string; url: string 
       const unlisten = await listen<string>(`browser://nav/${tabId}`, (e) => {
         const u = e.payload;
         if (u && u !== 'about:blank') {
-          setAddressInput(u);
+          if (!addressFocusedRef.current && !addressDirtyRef.current) {
+            setAddressInput(u);
+          }
           setCommittedUrl(u);
           updateBrowserUrl(tabId, u);
         }
@@ -537,6 +547,7 @@ export default function BrowserTab({ tabId, url }: { tabId: string; url: string 
   const commit = (raw: string) => {
     const trimmed = raw.trim();
     if (!trimmed) return;
+    addressDirtyRef.current = false;
     const normalized = normalizeBrowserUrl(trimmed);
     setAddressInput(normalized);
     setCommittedUrl(normalized);
@@ -578,10 +589,33 @@ export default function BrowserTab({ tabId, url }: { tabId: string; url: string 
           ref={addressInputRef}
           value={addressInput}
           placeholder={t.workspace.browser.addressPlaceholder}
-          onFocus={() => noteUserInteraction()}
-          onChange={(e) => { noteUserInteraction(); setAddressInput(e.target.value); }}
+          onFocus={() => { addressFocusedRef.current = true; noteUserInteraction(); }}
+          onBlur={() => {
+            addressFocusedRef.current = false;
+            // A clean, emptied, or reverted input resumes following the page;
+            // a real uncommitted draft survives blur (acceptance G6/G7).
+            if (
+              !addressDirtyRef.current
+              || !addressInput.trim()
+              || addressInput === committedUrl
+            ) {
+              addressDirtyRef.current = false;
+              setAddressInput(committedUrl);
+            }
+          }}
+          onChange={(e) => {
+            addressDirtyRef.current = true;
+            noteUserInteraction();
+            setAddressInput(e.target.value);
+          }}
           onKeyDown={(e) => {
             if (e.key === 'Enter') commit(addressInput);
+            if (e.key === 'Escape') {
+              // Standard browser behavior — and the only way out of a held
+              // draft without committing it: show the page's real URL again.
+              addressDirtyRef.current = false;
+              setAddressInput(committedUrl);
+            }
           }}
           className="flex-1 h-7 text-minor"
         />

--- a/src/components/panel/workspace/BrowserTab.tsx
+++ b/src/components/panel/workspace/BrowserTab.tsx
@@ -164,6 +164,11 @@ export default function BrowserTab({ tabId, url }: { tabId: string; url: string 
   // Holds the initial URL for the mount effect (read once); never reassigned
   // during render (that would trip react-hooks/refs).
   const committedUrlRef = useRef(committedUrl);
+  // N3: last time this tab told the main process "the user is here" via the
+  // React-layer toolbar (address bar / back / forward / reload). Throttled to
+  // one IPC call per 500ms so a typing storm in the address bar does not spam
+  // `browser_note_user_interaction`.
+  const lastNoteUserInteractionAtRef = useRef(0);
 
   // Freeze-frame shown while the native view is hidden for an overlay. The
   // native view paints above React, so hiding it for a modal/menu would flash
@@ -502,6 +507,20 @@ export default function BrowserTab({ tabId, url }: { tabId: string; url: string 
     void invoke('browser_inspect_set', { id: tabId, enabled: false, labels: inspectLabelsRef.current }).catch(() => {});
   }, [blockingApprovalOpen, inspecting, lightboxOpen, menuOpen, systemSettingsOpen, tabId]);
 
+  // N3: the guest webContents only tells the main process the user is here
+  // via `before-input-event`/`focus` — the toolbar's own React controls
+  // (address bar, back/forward/reload) live in the MAIN window and never
+  // touch it, so using them was invisible to the takeover backoff (R4) and
+  // automation could act mid-navigation. Fire-and-forget, catch-swallow: this
+  // is a best-effort presence ping, never something the UI should surface an
+  // error for. Throttled to at most one call per 500ms per tab.
+  const noteUserInteraction = useCallback(() => {
+    const now = Date.now();
+    if (now - lastNoteUserInteractionAtRef.current < 500) return;
+    lastNoteUserInteractionAtRef.current = now;
+    void invoke('browser_note_user_interaction', { id: tabId }).catch(() => {});
+  }, [tabId]);
+
   const toggleInspect = useCallback(async () => {
     const next = !inspecting;
     setInspecting(next);
@@ -540,17 +559,17 @@ export default function BrowserTab({ tabId, url }: { tabId: string; url: string 
     <div className="flex flex-col h-full">
       <div className="flex items-center gap-1.5 shrink-0 px-2 py-1.5 border-b border-[var(--abu-bg-pressed)] bg-[var(--abu-bg-subtle)]">
         <ToolbarTooltip content={t.workspace.browser.back}>
-          <Button variant="ghost" size="icon-xs" disabled={!committedUrl} onClick={() => void invoke('browser_back', { id: tabId }).catch(() => {})} className="text-[var(--abu-text-tertiary)]">
+          <Button variant="ghost" size="icon-xs" disabled={!committedUrl} onClick={() => { noteUserInteraction(); void invoke('browser_back', { id: tabId }).catch(() => {}); }} className="text-[var(--abu-text-tertiary)]">
             <ArrowLeft className="w-3.5 h-3.5" strokeWidth={1.5} />
           </Button>
         </ToolbarTooltip>
         <ToolbarTooltip content={t.workspace.browser.forward}>
-          <Button variant="ghost" size="icon-xs" disabled={!committedUrl} onClick={() => void invoke('browser_forward', { id: tabId }).catch(() => {})} className="text-[var(--abu-text-tertiary)]">
+          <Button variant="ghost" size="icon-xs" disabled={!committedUrl} onClick={() => { noteUserInteraction(); void invoke('browser_forward', { id: tabId }).catch(() => {}); }} className="text-[var(--abu-text-tertiary)]">
             <ArrowRight className="w-3.5 h-3.5" strokeWidth={1.5} />
           </Button>
         </ToolbarTooltip>
         <ToolbarTooltip content={t.workspace.browser.reload}>
-          <Button variant="ghost" size="icon-xs" disabled={!committedUrl} onClick={() => void invoke('browser_reload', { id: tabId }).catch(() => {})} className="text-[var(--abu-text-tertiary)]">
+          <Button variant="ghost" size="icon-xs" disabled={!committedUrl} onClick={() => { noteUserInteraction(); void invoke('browser_reload', { id: tabId }).catch(() => {}); }} className="text-[var(--abu-text-tertiary)]">
             <RotateCw className="w-3.5 h-3.5" strokeWidth={1.5} />
           </Button>
         </ToolbarTooltip>
@@ -559,7 +578,8 @@ export default function BrowserTab({ tabId, url }: { tabId: string; url: string 
           ref={addressInputRef}
           value={addressInput}
           placeholder={t.workspace.browser.addressPlaceholder}
-          onChange={(e) => setAddressInput(e.target.value)}
+          onFocus={() => noteUserInteraction()}
+          onChange={(e) => { noteUserInteraction(); setAddressInput(e.target.value); }}
           onKeyDown={(e) => {
             if (e.key === 'Enter') commit(addressInput);
           }}

--- a/src/components/panel/workspace/BrowserTab.tsx
+++ b/src/components/panel/workspace/BrowserTab.tsx
@@ -432,7 +432,12 @@ export default function BrowserTab({ tabId, url }: { tabId: string; url: string 
       disposed = true;
       navUnlisten?.();
       elementUnlisten?.();
-      void invoke('browser_close', { id: tabId }).catch(() => {});
+      // Unmount is NOT a close. The native view's lifetime belongs to the tab
+      // record in previewStore (which destroys it when the tab is really
+      // closed); this component can unmount while the tab stays open, and an
+      // agent's page / login state / half-filled form must survive that.
+      // Hide instead, and let the remount reconcile visibility.
+      void invoke('browser_hide', { id: tabId }).catch(() => {});
       createdRef.current = false;
       shownRef.current = false;
       desiredVisibleRef.current = false;

--- a/src/components/panel/workspace/TabStrip.tsx
+++ b/src/components/panel/workspace/TabStrip.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { FileText, AppWindow, SquareTerminal, ListChecks, X, Plus, PanelRight, Bot } from 'lucide-react';
 import {
   usePreviewStore,
+  useVisibleTabs,
   workspaceTabButtonId,
   workspaceTabPanelId,
   type WorkspaceTab,
@@ -59,7 +60,10 @@ function tabTitle(tab: WorkspaceTab, t: ReturnType<typeof useI18n>['t']): string
 export default function TabStrip() {
   const { t } = useI18n();
   const windowsWorkspaceHeader = isWindows() && hasElectronCommandHost();
-  const tabs = usePreviewStore((s) => s.tabs);
+  // The strip lists only what this conversation owns or shares: a browser tab
+  // adopted for another conversation keeps running (hidden) but is not listed,
+  // not activatable, and not closable from here.
+  const tabs = useVisibleTabs();
   const activeTabId = usePreviewStore((s) => s.activeTabId);
   const activateTab = usePreviewStore((s) => s.activateTab);
   const closeTab = usePreviewStore((s) => s.closeTab);

--- a/src/components/panel/workspace/WorkspacePanel.tsx
+++ b/src/components/panel/workspace/WorkspacePanel.tsx
@@ -1,5 +1,5 @@
 import { ListChecks, AppWindow, SquareTerminal } from 'lucide-react';
-import { usePreviewStore, workspaceTabButtonId, workspaceTabPanelId } from '@/stores/previewStore';
+import { usePreviewStore, useVisibleTabs, workspaceTabButtonId, workspaceTabPanelId } from '@/stores/previewStore';
 import { useI18n } from '@/i18n';
 import TabStrip from './TabStrip';
 import SummaryBody from './SummaryBody';
@@ -51,16 +51,29 @@ function WorkspaceEmptyState() {
  * launcher. See docs/2026-07-17-workspace-tabs-design.md.
  */
 export default function WorkspacePanel() {
+  // Bodies are mounted for EVERY tab (keep-alive), including browser tabs
+  // adopted for another conversation — their native view must survive. What
+  // this conversation may *see* is `visibleTabs`; a foreign tab is therefore
+  // never the active one, so its panel stays `hidden` and BrowserTab reads the
+  // zero rect that hides its native layer.
   const tabs = usePreviewStore((s) => s.tabs);
+  const visibleTabs = useVisibleTabs();
   const activeTabId = usePreviewStore((s) => s.activeTabId);
+  const empty = visibleTabs.length === 0;
 
   return (
     <div className="flex flex-col h-full">
       <TabStrip />
-      {tabs.length === 0 ? (
-        <WorkspaceEmptyState />
-      ) : (
-        <div className="flex-1 min-h-0 relative">
+      {empty && <WorkspaceEmptyState />}
+      {tabs.length > 0 && (
+        <div
+          className="flex-1 min-h-0 relative"
+          hidden={empty}
+          // Inline display (not just `hidden`): a hidden body area must be
+          // laid out at zero size, which is the only signal that takes the
+          // native browser layer down with it.
+          style={empty ? { display: 'none' } : undefined}
+        >
           {tabs.map((tab) => (
             <div
               key={tab.id}

--- a/src/core/agent/agentLoopRunner.test.ts
+++ b/src/core/agent/agentLoopRunner.test.ts
@@ -1444,6 +1444,38 @@ describe('agentLoopRunner', () => {
       );
     });
 
+    // N6: run identity decides WHOSE browser tabs a call may list, drive and
+    // reclaim, so it is authority-bearing exactly like the ceiling, the scope
+    // and the IM target above — and must be answered by the shell, never by the
+    // sidecar's copy of the context.
+    //
+    // The shell's answer for a MAIN-LOOP session is "there is no subagent run
+    // here", i.e. the host's `main` pool. That closes two things at once:
+    // a sidecar cannot pick a sibling run's tabs by naming its id, and a
+    // subagent nested INSIDE the sidecar's own loop (the `@agent`
+    // direct-delegation path, which stamps its own `sar-*` and reaches the
+    // shell on the main loop's runId) folds into the conversation's `main`
+    // pool — reaped by the conversation delete cascade and visible to the
+    // parent, instead of owning a pool that no dispose path ever reaps.
+    it('tool.invoke neutralizes a sidecar-supplied agentRunId — the main loop owns no subagent run', async () => {
+      const { ensureHandlersRegistered, registerRunSession } = await importFresh();
+      ensureHandlersRegistered();
+      registerRunSession('run-1', makeSession());
+      const handler = handlerFor(onSidecarRequest, 'tool.invoke') as (p: unknown) => Promise<unknown>;
+
+      await handler({
+        runId: 'run-1',
+        toolName: 'read_file',
+        input: { path: '/tmp/x' },
+        context: { agentRunId: 'sar-forged' },
+      });
+
+      expect(executeAnyToolMock.mock.calls.at(-1)?.[4]).toEqual(expect.objectContaining({
+        conversationId: 'conv-1',
+        agentRunId: undefined,
+      }));
+    });
+
     it('tool.invoke overwrites a forged IM reply target with the shell session target', async () => {
       const { ensureHandlersRegistered, registerRunSession } = await importFresh();
       ensureHandlersRegistered();

--- a/src/core/agent/agentLoopRunner.ts
+++ b/src/core/agent/agentLoopRunner.ts
@@ -1214,6 +1214,23 @@ function contextForSession(
     imReplyTarget: session.options.imReplyTarget
       ? { ...session.options.imReplyTarget }
       : undefined,
+    // Security boundary: run identity decides WHOSE browser tabs a call may
+    // list, drive and reclaim (N6 keys tab ownership on
+    // {conversationId, runKey}), so it is shell-owned like everything above.
+    // This session IS the conversation's own loop, so the shell's answer is
+    // "no subagent run" — the host reads that as the `main` pool.
+    //
+    // It also has to be stated rather than left to `...incoming`, because a
+    // subagent nested inside the SIDECAR's loop (the `@agent` direct-delegation
+    // path: agentLoop.ts → shims/subagentRunnerRun.ts → scopeSubagentLoopProgress
+    // stamps its own `sar-*` → subagentLoop's tool context → toWireToolContext,
+    // a denylist that passes it through) reaches the shell on THIS main-loop
+    // runId. Letting that id survive would mint a pool owned by a run the shell
+    // has no session for: `runSubagent`'s per-run release never runs on that
+    // path, so nothing would free those tabs at run end. Folding them into
+    // `main` puts them back where the conversation delete cascade reaps them
+    // and the parent can see them.
+    agentRunId: undefined,
     ...(Object.prototype.hasOwnProperty.call(session.options, 'workspacePathSnapshot')
       ? { workspacePath: session.options.workspacePathSnapshot ?? null }
       : {}),

--- a/src/core/agent/browserNarrationRules.test.ts
+++ b/src/core/agent/browserNarrationRules.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BROWSER_NARRATION_RULES,
+  browserNarrationSection,
+  rosterHasBrowserTool,
+} from './browserNarrationRules';
+
+/**
+ * C8 — how the model may TALK about browser work.
+ *
+ * The rules live here rather than inline in either prompt builder because they
+ * have two injection sites that must not drift: `orchestrator.ts`'s
+ * `browser-guide` section (main loop) and `subagentLoop.ts`'s own prompt build
+ * (delegations, which own browser tabs per run and were getting none of this).
+ */
+describe('rosterHasBrowserTool', () => {
+  it('recognises the built-in browser and the Chrome bridge', () => {
+    expect(rosterHasBrowserTool(['read_file', 'abu-browser__get_tabs'])).toBe(true);
+    // The bridge prefix is NOT a superstring of the built-in one
+    // (`abu-browser-bridge__` vs `abu-browser__`), so it needs its own check.
+    expect(rosterHasBrowserTool(['abu-browser-bridge__snapshot'])).toBe(true);
+  });
+
+  it('does not fire on a roster with no browser tool', () => {
+    expect(rosterHasBrowserTool(['read_file', 'run_command', 'web_search'])).toBe(false);
+    expect(rosterHasBrowserTool([])).toBe(false);
+  });
+
+  it('does not fire on a lookalike name that is not a browser tool', () => {
+    expect(rosterHasBrowserTool(['abu-browserish__click', 'browser_notes'])).toBe(false);
+  });
+});
+
+describe('browserNarrationSection', () => {
+  it('is empty when the run cannot touch a browser at all', () => {
+    // A subagent with no browser tools must not pay tokens for rules about a
+    // capability it does not have.
+    expect(browserNarrationSection(['read_file'])).toBe('');
+  });
+
+  it('carries all three rules under a heading when a browser tool is offered', () => {
+    const section = browserNarrationSection(['abu-browser__get_tabs']);
+    expect(section).toContain('## Browser Operations');
+    expect(section).toContain(BROWSER_NARRATION_RULES);
+  });
+});
+
+describe('BROWSER_NARRATION_RULES', () => {
+  it('bans internal identifiers and names what to say instead', () => {
+    expect(BROWSER_NARRATION_RULES).toContain('Never repeat internal identifiers to the user');
+    expect(BROWSER_NARRATION_RULES).toContain('by its visible title or site');
+  });
+
+  it('covers any reasoned refusal, not an enumerated few', () => {
+    // The earlier wording listed three reasons (closed tab / user interacting /
+    // rate-limited) and so said nothing about the blocked-site denial or the
+    // run-stopped cancellation — the D4 case it was written to answer.
+    expect(BROWSER_NARRATION_RULES).toContain('explains why an action was refused or cancelled');
+    expect(BROWSER_NARRATION_RULES).toContain("do not retry without the user's go-ahead");
+    expect(BROWSER_NARRATION_RULES).not.toContain('rate-limiting');
+  });
+
+  it('forbids narrating troubleshooting', () => {
+    expect(BROWSER_NARRATION_RULES).toContain('Do not narrate your troubleshooting');
+  });
+});

--- a/src/core/agent/browserNarrationRules.ts
+++ b/src/core/agent/browserNarrationRules.ts
@@ -1,0 +1,54 @@
+/**
+ * C8 — narration discipline for browser work.
+ *
+ * Three observed breaks, one each:
+ *  - the model relayed an internal identifier to the user ("the tab id changed
+ *    from 2 to 3") because the refusal it read had nothing else in it;
+ *  - it reported a refusal with no reason at all ("the action was cancelled"),
+ *    though the tool result carried one;
+ *  - it narrated its own retries instead of reporting the outcome.
+ *
+ * The text lives in this module, not inline in a prompt builder, because it has
+ * TWO injection sites that must not drift: `orchestrator.ts`'s `browser-guide`
+ * section (the main loop) and `subagentLoop.ts`'s own prompt build. Subagent
+ * browser work is first-class — tabs are owned per RUN — so a delegation
+ * driving a page needs the same discipline as the loop that spawned it.
+ *
+ * Rule ② is deliberately phrased over ANY reasoned refusal rather than an
+ * enumerated list: the browser domain refuses for at least six reasons (reclaim
+ * window, takeover backoff, HTTP 429, run stopped, blocked site, cross-
+ * conversation tab), and an enumeration silently excuses the model from the
+ * ones it forgot to mention.
+ */
+export const BROWSER_NARRATION_RULES = `- Never repeat internal identifiers to the user — tab or view ids, tool and runtime names, raw error text. Refer to a page by its visible title or site
+- When a browser tool result explains why an action was refused or cancelled, relay that reason plainly and do not retry without the user's go-ahead
+- Do not narrate your troubleshooting; report what happened and the one question or next step that follows from it`;
+
+/** Both browser runtimes, by tool-name prefix (see `toolPrefetch.ts`). */
+const BROWSER_TOOL_PREFIXES = ['abu-browser__', 'abu-browser-bridge__'];
+
+/**
+ * Does this run's tool roster contain a browser tool at all? Prefix-matched
+ * rather than enumerated, so a tool added to either runtime does not silently
+ * stop counting as browser work.
+ */
+export function rosterHasBrowserTool(toolNames: Iterable<string>): boolean {
+  for (const name of toolNames) {
+    if (BROWSER_TOOL_PREFIXES.some((prefix) => name.startsWith(prefix))) return true;
+  }
+  return false;
+}
+
+/**
+ * The rules as a standalone prompt section, or `''` when the run holds no
+ * browser tool — a roster that cannot reach a page must not pay tokens for
+ * rules about pages.
+ *
+ * The main loop does NOT use this: its `browser-guide` section already exists
+ * and appends `BROWSER_NARRATION_RULES` into it, so the guidance stays one
+ * heading rather than two.
+ */
+export function browserNarrationSection(toolNames: Iterable<string>): string {
+  if (!rosterHasBrowserTool(toolNames)) return '';
+  return `\n\n## Browser Operations\n${BROWSER_NARRATION_RULES}`;
+}

--- a/src/core/agent/orchestrator.test.ts
+++ b/src/core/agent/orchestrator.test.ts
@@ -238,6 +238,26 @@ describe('buildSystemPrompt - structure', () => {
     expect(prompt).toContain('Do not substitute the `computer` tool or launch a system browser');
   });
 
+  // C8 — the three narration rules ride the same browser-guide section as the
+  // routing rules above, and apply to every browser path (built-in, Chrome
+  // bridge, legacy host): what the model may say about a browser result is not
+  // a property of which runtime produced it.
+  it('forbids surfacing internal identifiers and blind retries after a refusal', async () => {
+    const prompt = await buildSystemPrompt(generalRoute, basePrompt, 'test-conv');
+    expect(prompt).toContain('Never repeat internal identifiers to the user');
+    expect(prompt).toContain('by its visible title or site');
+    expect(prompt).toContain('state that reason plainly and do not try again until the user says to');
+    expect(prompt).toContain('Do not narrate your troubleshooting');
+  });
+
+  it('keeps the narration rules when only the Chrome bridge is available', async () => {
+    browserMocks.hasElectronCommandHost.mockReturnValue(false);
+    browserMocks.isConnected.mockReturnValue(false);
+    const prompt = await buildSystemPrompt(generalRoute, basePrompt, 'test-conv');
+    expect(prompt).toContain('Never repeat internal identifiers to the user');
+    expect(prompt).toContain('Do not narrate your troubleshooting');
+  });
+
   it('does not silently fall back when the Electron browser runtime is unavailable', async () => {
     browserMocks.isConnected.mockReturnValue(false);
     const prompt = await buildSystemPrompt(generalRoute, basePrompt, 'test-conv');

--- a/src/core/agent/orchestrator.test.ts
+++ b/src/core/agent/orchestrator.test.ts
@@ -246,7 +246,8 @@ describe('buildSystemPrompt - structure', () => {
     const prompt = await buildSystemPrompt(generalRoute, basePrompt, 'test-conv');
     expect(prompt).toContain('Never repeat internal identifiers to the user');
     expect(prompt).toContain('by its visible title or site');
-    expect(prompt).toContain('state that reason plainly and do not try again until the user says to');
+    expect(prompt).toContain('explains why an action was refused or cancelled');
+    expect(prompt).toContain("do not retry without the user's go-ahead");
     expect(prompt).toContain('Do not narrate your troubleshooting');
   });
 

--- a/src/core/agent/orchestrator.ts
+++ b/src/core/agent/orchestrator.ts
@@ -15,6 +15,7 @@ import { mcpManager } from '../mcp/client';
 import { substituteVariables, executeInlineCommands } from '../skill/preprocessor';
 import { getSkillsGuidance } from './prompts/skillsGuidance';
 import { buildResponseLanguageSection } from './prompts/responseLanguage';
+import { BROWSER_NARRATION_RULES } from './browserNarrationRules';
 import type { PromptSection } from '../llm/promptSections';
 import { sectionsToString, orderSectionsForCaching } from '../llm/promptSections';
 
@@ -691,12 +692,9 @@ ${isWindows()
     // How to TALK about browser work, as opposed to which tool to reach for.
     // Unconditional: these hold for every browser path above, because what may
     // be said about a result is not a property of the runtime that produced it.
-    // Each line answers an observed break — the model relaying "tab id 2 became
-    // 3", reporting a refusal with no reason, and narrating its own retries.
-    browserNote += `
-- Never repeat internal identifiers to the user — tab or view ids, tool and runtime names, raw error text. Refer to a page by its visible title or site
-- When a browser result says the user closed the tab, is interacting with the page, or the site is rate-limiting, state that reason plainly and do not try again until the user says to
-- Do not narrate your troubleshooting; report what happened and the one question or next step that follows from it`;
+    // Shared with `subagentLoop.ts`'s prompt build — delegations own browser
+    // tabs per run, and the two copies must not drift.
+    browserNote += `\n${BROWSER_NARRATION_RULES}`;
 
     if (playwrightConnected) {
       browserNote += `

--- a/src/core/agent/orchestrator.ts
+++ b/src/core/agent/orchestrator.ts
@@ -688,6 +688,16 @@ ${isWindows()
 - Only when the user explicitly asks to use their existing Chrome tabs, cookies, extensions, or signed-in state, call use_skill("Abu-Chrome-Bridge") and use the \`abu-browser-bridge__\` tools${chromeBridgeConnected ? ' (the Chrome bridge is connected)' : ''}
 - Do not substitute the \`computer\` tool or launch a system browser for web-page screenshots and interaction unless the user explicitly asks for whole-desktop Computer Use or an external browser`;
 
+    // How to TALK about browser work, as opposed to which tool to reach for.
+    // Unconditional: these hold for every browser path above, because what may
+    // be said about a result is not a property of the runtime that produced it.
+    // Each line answers an observed break — the model relaying "tab id 2 became
+    // 3", reporting a refusal with no reason, and narrating its own retries.
+    browserNote += `
+- Never repeat internal identifiers to the user — tab or view ids, tool and runtime names, raw error text. Refer to a page by its visible title or site
+- When a browser result says the user closed the tab, is interacting with the page, or the site is rate-limiting, state that reason plainly and do not try again until the user says to
+- Do not narrate your troubleshooting; report what happened and the one question or next step that follows from it`;
+
     if (playwrightConnected) {
       browserNote += `
 - The playwright tool launches a **brand-new blank browser** — not the user's existing browser. Do not use it to view pages the user already has open`;

--- a/src/core/agent/subagentLoop.ts
+++ b/src/core/agent/subagentLoop.ts
@@ -430,6 +430,14 @@ export interface SubagentLoopOptions {
   agent: SubagentDefinition;
   task: string;
   context?: string;
+  /**
+   * App-owned identity for THIS run (`sar-*`), stamped by
+   * `scopeSubagentLoopProgress` — the same value that namespaces the run's
+   * progress ids. It reaches tools as `ToolExecutionContext.agentRunId` so
+   * per-run resources (browser tab ownership) can tell sibling delegations
+   * apart; a run without one is treated as the conversation's own loop.
+   */
+  agentRunId?: string;
   /** Summary of parent conversation context for better task understanding */
   parentConversationSummary?: string;
   /** Shell-materialized source user turn for multimodal delegation. */
@@ -1073,6 +1081,10 @@ export async function runSubagentLoop(options: SubagentLoopOptions): Promise<Sub
           const subagentToolContext: ToolExecutionContext = {
             workspacePath,
             conversationId: options.parentConversationId,
+            // Per-run resources (browser tabs) are owned by the pair
+            // {conversation, run}: without this, sibling delegations of one
+            // conversation share one pool and steal each other's tabs.
+            agentRunId: options.agentRunId,
             loopId: options.parentLoopId,
             interactionMode: resolveSubagentInteractionMode(options),
             authorizationScopeId: options.authorizationScopeId,

--- a/src/core/agent/subagentLoop.ts
+++ b/src/core/agent/subagentLoop.ts
@@ -52,6 +52,7 @@ import { matchesToolName, matchesToolPattern } from '../skill/toolFilter';
 import { createLogger } from '../logging/logger';
 import { deriveRunInteractionMode } from './runInteractionMode';
 import { resolveSubagentToolRoster } from './subagentToolRoster';
+import { browserNarrationSection } from './browserNarrationRules';
 import {
   ActiveToolResultAdmission,
   type ActiveToolResultToken,
@@ -695,6 +696,14 @@ export async function runSubagentLoop(options: SubagentLoopOptions): Promise<Sub
     // a toolCallId injected by the main harness that sub-agents never receive —
     // leaving it visible causes a confusing "内部错误" response, so strip it here.
     const offeredToolNames = new Set(tools.map((tool) => tool.name));
+
+    // C8 — narration discipline, conditional on the roster this run actually
+    // got. It has to live HERE rather than with the other prompt blocks above
+    // because the roster is only known now, and it is worth the placement: a
+    // subagent owns its browser tabs per RUN (N6), so it hits the same
+    // refusals the main loop does, while `buildSystemPromptSections` — where
+    // the main loop gets these rules — never runs for a delegation.
+    systemPrompt += browserNarrationSection(offeredToolNames);
 
     // 4. Create LLM adapter
     // Enterprise mode always uses OpenAI-compatible adapter (LiteLLM exposes that interface).

--- a/src/core/agent/subagentProgressIdentity.test.ts
+++ b/src/core/agent/subagentProgressIdentity.test.ts
@@ -105,4 +105,29 @@ describe('subagent progress identity', () => {
     expect(onProgress.mock.calls[0][0].id).toBe('subagent-v1:nested%2Fa:call_1');
     expect(onProgress.mock.calls[1][0]).toBe(turn);
   });
+
+  // N6: the same scope id is the run's identity for per-run RESOURCES too
+  // (browser tab ownership), which the in-process loop reads off the options
+  // and puts in every ToolExecutionContext.
+  it('stamps the scope id onto the options as the run identity', () => {
+    const options = scopeSubagentLoopProgress(makeOptions(vi.fn()), 'sar-explicit');
+
+    expect(options.agentRunId).toBe('sar-explicit');
+  });
+
+  it('stamps it even for a run with no progress sink — the two consumers are independent', () => {
+    const withoutProgress = { ...makeOptions(vi.fn()), onProgress: undefined };
+
+    const options = scopeSubagentLoopProgress(withoutProgress, 'sar-silent');
+
+    expect(options.agentRunId).toBe('sar-silent');
+  });
+
+  it('mints a distinct identity per run when none is given', () => {
+    const first = scopeSubagentLoopProgress(makeOptions(vi.fn()));
+    const second = scopeSubagentLoopProgress(makeOptions(vi.fn()));
+
+    expect(first.agentRunId).toMatch(/^sar-/);
+    expect(first.agentRunId).not.toBe(second.agentRunId);
+  });
 });

--- a/src/core/agent/subagentProgressIdentity.ts
+++ b/src/core/agent/subagentProgressIdentity.ts
@@ -50,17 +50,24 @@ export function scopeSubagentProgressEvent(
 }
 
 /**
- * Wrap one loop's progress callback in an app-owned namespace. Keeping this in
- * a runtime-neutral production module lets both the shell selector and the
- * in-sidecar nested-run shim apply exactly the same identity boundary.
+ * Stamp one loop with its app-owned run identity: it namespaces the loop's
+ * progress ids, and rides `options.agentRunId` into every tool call the loop
+ * makes so per-run resources (browser tab ownership) can tell one delegation
+ * from its siblings. Keeping this in a runtime-neutral production module lets
+ * both the shell selector and the in-sidecar nested-run shim apply exactly the
+ * same identity boundary.
+ *
+ * `agentRunId` is stamped even when the caller passed no `onProgress`: the two
+ * consumers are independent, and a run with no progress sink still owns tabs.
  */
 export function scopeSubagentLoopProgress(
   options: SubagentLoopOptions,
   scopeId: string = createSubagentProgressScopeId(),
 ): SubagentLoopOptions {
-  if (!options.onProgress) return options;
+  if (!options.onProgress) return { ...options, agentRunId: scopeId };
   return {
     ...options,
+    agentRunId: scopeId,
     onProgress: (event) => options.onProgress?.(scopeSubagentProgressEvent(scopeId, event)),
   };
 }

--- a/src/core/agent/subagentRecovery.integration.test.ts
+++ b/src/core/agent/subagentRecovery.integration.test.ts
@@ -172,6 +172,50 @@ describe('subagent max_tokens recovery (integration)', () => {
     expect(chatOptions.systemPrompt).not.toContain('/global/workspace');
   });
 
+  /**
+   * C8 — the narration rules reach delegations too.
+   *
+   * `buildSystemPromptSections` (where the main loop gets them) never runs for
+   * a subagent: this loop builds its own prompt. But subagents own browser tabs
+   * per RUN, so they hit the same refusals — and were getting none of the
+   * guidance on how to report them.
+   */
+  it('gives a subagent holding browser tools the narration rules', async () => {
+    mockGetAllTools.mockReturnValue(
+      ['read_file', 'abu-browser__get_tabs'].map((name) => ({
+        name,
+        description: name,
+        inputSchema: { type: 'object', properties: {} },
+        execute: vi.fn(),
+      })),
+    );
+    mockClaudeChat.mockImplementationOnce(emits([
+      { type: 'text', text: 'ok' } as StreamEvent,
+      { type: 'done', stopReason: 'end_turn' } as StreamEvent,
+    ]));
+
+    await runSubagentLoop({ agent, task: 'read the page' });
+
+    const { systemPrompt } = mockClaudeChat.mock.calls[0][1] as { systemPrompt?: string };
+    expect(systemPrompt).toContain('Never repeat internal identifiers to the user');
+    expect(systemPrompt).toContain('explains why an action was refused or cancelled');
+    expect(systemPrompt).toContain('Do not narrate your troubleshooting');
+  });
+
+  it('omits the browser narration rules from a roster that has no browser tool', async () => {
+    // The default roster (read_file/computer/...) holds no browser tool — a run
+    // that cannot reach a page must not pay tokens for rules about pages.
+    mockClaudeChat.mockImplementationOnce(emits([
+      { type: 'text', text: 'ok' } as StreamEvent,
+      { type: 'done', stopReason: 'end_turn' } as StreamEvent,
+    ]));
+
+    await runSubagentLoop({ agent, task: 'do the thing' });
+
+    const { systemPrompt } = mockClaudeChat.mock.calls[0][1] as { systemPrompt?: string };
+    expect(systemPrompt).not.toContain('Never repeat internal identifiers to the user');
+  });
+
   it('starts a delegated multimodal turn with source blocks in order and task text last', async () => {
     const imageBytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 1, 2, 3, 4]);
     mockReadDelegatedMedia.mockResolvedValue(imageBytes);

--- a/src/core/agent/subagentRunner.test.ts
+++ b/src/core/agent/subagentRunner.test.ts
@@ -190,6 +190,13 @@ vi.mock('../enterprise/llm-resolver', () => ({
   resolveEffectiveLlmCreds: (...a: unknown[]) => resolveEffectiveLlmCredsMock(...a),
 }));
 
+const disposeRunBrowserViewsMock = vi.fn();
+vi.mock('../browser/browserViewLifecycle', () => ({
+  disposeRunBrowserViews: (...a: unknown[]) => disposeRunBrowserViewsMock(...a),
+  disposeOwnedBrowserViews: vi.fn(),
+  closeBrowserViews: vi.fn(),
+}));
+
 const emitHookMock = vi.fn((event: unknown) => event);
 vi.mock('./lifecycleHooks', () => ({
   emitHook: (...a: unknown[]) => emitHookMock(...a),
@@ -285,6 +292,7 @@ describe('subagentRunner', () => {
     resolveEffectiveLlmCredsMock.mockReset();
     resolveEffectiveLlmCredsMock.mockReturnValue({ apiKey: 'sk-test', baseUrl: undefined, forceOpenAiCompatible: false });
     emitHookMock.mockClear();
+    disposeRunBrowserViewsMock.mockReset();
   });
 
   describe('wire projection contract', () => {
@@ -357,6 +365,9 @@ describe('subagentRunner', () => {
         'capsPort',
         'workspaceReader',
         'skillCommandApprovalFactory',
+        // N6: run identity is shell-stamped into the trusted tool context, so
+        // sending it would create a second, forgeable source of the same fact.
+        'agentRunId',
       ]);
     });
 
@@ -529,6 +540,9 @@ describe('subagentRunner', () => {
         agent,
         task: 'do the thing',
         skillCommandApprovalFactory: expect.any(Function),
+        // The in-process loop reads its run identity straight off the options
+        // (there is no shell/sidecar boundary to stamp it at).
+        agentRunId: expect.stringMatching(/^sar-/),
       });
       expect(sidecarRequestMock).not.toHaveBeenCalled();
       expect(result.text).toBe('in-process result');
@@ -1369,6 +1383,85 @@ describe('subagentRunner', () => {
       const toolInvokeHandler = onSidecarRequest.mock.calls.find((c) => c[0] === 'tool.invoke')![1] as (p: unknown) => Promise<unknown>;
 
       await expect(toolInvokeHandler({ runId, toolName: 'read_file', input: {} })).rejects.toThrow(/unknown runId/);
+    });
+
+    // N6: browser tab ownership is the pair {conversationId, runKey}, so every
+    // tool call has to carry the run that issued it. Like workspacePath and the
+    // abort signal, it is stamped from the SHELL's session — never taken from
+    // the sidecar's `context`, which decides nothing about which run's tabs a
+    // call may see and reclaim.
+    it('stamps the shell-owned run id into the trusted tool context, overriding any sidecar-supplied value', async () => {
+      getSidecarStatus.mockReturnValue('running');
+      const d = deferred<unknown>();
+      sidecarRequestMock.mockReturnValue(d.promise);
+      const { runSubagent } = await importFresh();
+
+      const runPromise = runSubagent({ agent, task: 'browse', parentConversationId: 'conv-1' });
+      const toolInvokeHandler = onSidecarRequest.mock.calls.find((c) => c[0] === 'tool.invoke')![1] as (p: unknown) => Promise<unknown>;
+      const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
+
+      await toolInvokeHandler({
+        runId,
+        toolName: 'read_file',
+        input: {},
+        context: { agentRunId: 'sar-forged-by-sidecar' },
+      });
+
+      expect(runId).toMatch(/^sar-/);
+      expect(executeAnyToolMock).toHaveBeenCalledWith(
+        'read_file',
+        {},
+        undefined,
+        undefined,
+        expect.objectContaining({ conversationId: 'conv-1', agentRunId: runId }),
+      );
+
+      d.resolve({ text: 'done', toolCallCount: 1, turnCount: 1, tokenUsage: { input: 0, output: 0 }, duration: 1 });
+      await runPromise;
+    });
+  });
+
+  // A2 — a finished run's browser tabs are visible to nobody else, so nothing
+  // but the run's own settlement can ever release them. The seal is the point
+  // after which the run can no longer start another tool.
+  describe('per-run browser view release', () => {
+    it('releases exactly this run of this conversation when the sidecar run settles', async () => {
+      getSidecarStatus.mockReturnValue('running');
+      sidecarRequestMock.mockResolvedValue({ text: 'done', toolCallCount: 0, turnCount: 1, tokenUsage: { input: 0, output: 0 }, duration: 1, stopReason: 'completed' });
+      const { runSubagent } = await importFresh();
+
+      await runSubagent({ agent, task: 'browse', parentConversationId: 'conv-1' });
+      const runId = (sidecarRequestMock.mock.calls[0][1] as { runId: string }).runId;
+
+      expect(disposeRunBrowserViewsMock).toHaveBeenCalledWith('conv-1', runId);
+    });
+
+    it('releases the run even when it fails', async () => {
+      getSidecarStatus.mockReturnValue('running');
+      sidecarRequestMock.mockRejectedValue(new Error('transport died'));
+      const { runSubagent } = await importFresh();
+
+      await runSubagent({ agent, task: 'browse', parentConversationId: 'conv-1' });
+
+      expect(disposeRunBrowserViewsMock).toHaveBeenCalled();
+      for (const call of disposeRunBrowserViewsMock.mock.calls) {
+        expect(call[0]).toBe('conv-1');
+        expect(call[1]).toMatch(/^sar-/);
+      }
+    });
+
+    it('releases an in-process run too — it owns tabs the same way', async () => {
+      getSidecarStatus.mockReturnValue('stopped');
+      const { runSubagent } = await importFresh();
+
+      await runSubagent({ agent, task: 'browse', parentConversationId: 'conv-1' });
+
+      expect(disposeRunBrowserViewsMock).toHaveBeenCalledTimes(1);
+      const [conversationId, runKey] = disposeRunBrowserViewsMock.mock.calls[0];
+      expect(conversationId).toBe('conv-1');
+      // The same id the in-process loop stamped into its tool contexts.
+      expect(runKey).toBe((runSubagentLoopMock.mock.calls[0][0] as { agentRunId?: string }).agentRunId);
+      expect(runKey).toMatch(/^sar-/);
     });
   });
 

--- a/src/core/agent/subagentRunner.ts
+++ b/src/core/agent/subagentRunner.ts
@@ -147,6 +147,7 @@ import {
   scopeSubagentLoopProgress,
   scopeSubagentProgressEvent,
 } from './subagentProgressIdentity';
+import { disposeRunBrowserViews } from '../browser/browserViewLifecycle';
 import {
   materializeSidecarMediaRefsForShell,
   prepareToolResultForSidecarWire,
@@ -244,6 +245,13 @@ export const SUBAGENT_LOOP_OPTIONS_INTENTIONALLY_LOCAL_FIELDS = [
   'capsPort',
   'workspaceReader',
   'skillCommandApprovalFactory',
+  // Deliberately NOT on the wire: run identity is what decides whose browser
+  // tabs a tool call may see and reclaim, so the shell stamps it into the
+  // trusted tool context from its OWN session (`RunSession.runId`) rather than
+  // accepting the sidecar's copy. Sending it would create a second, forgeable
+  // source of the same fact. The in-process engine reads it from these options
+  // directly, which is why the field exists at all.
+  'agentRunId',
 ] as const satisfies readonly (keyof SubagentLoopOptions)[];
 
 export type SubagentLoopOptionsWireExhaustive = AssertNever<
@@ -311,6 +319,15 @@ function isSerializableSubagentResult(v: unknown): v is SerializableSubagentResu
 // only the runId crosses the wire. See module doc's "Reverse channel".
 
 interface RunSession {
+  /**
+   * The app-owned `sar-*` id this session is registered under. Held on the
+   * session so `buildTrustedSubagentToolContext` can stamp it into every tool
+   * context WITHOUT trusting the sidecar's copy — the sidecar sends a `context`
+   * with each `tool.invoke`, and run identity is exactly the kind of field a
+   * compromised or buggy sidecar must not be able to choose (it decides which
+   * run's browser tabs the call may see and reclaim).
+   */
+  runId: string;
   options: SubagentLoopOptions;
   /** Shell-owned outbound identity for IM tools; never accepted from sidecar context. */
   imReplyTarget?: { platform: string; chatId: string };
@@ -340,6 +357,7 @@ function buildTrustedSubagentToolContext(
     runPermissionCeiling: session.options.runPermissionCeiling,
     loopId: session.options.parentLoopId,
     conversationId: session.options.parentConversationId,
+    agentRunId: session.runId,
     imReplyTarget: session.imReplyTarget ? { ...session.imReplyTarget } : undefined,
     interactionMode: resolveSubagentInteractionMode(session.options),
     abortSignal: session.options.signal,
@@ -741,6 +759,21 @@ export async function runSubagent(options: SubagentLoopOptions): Promise<Subagen
   }
 }
 
+/**
+ * The in-process engine plus the same per-run resource release the sidecar path
+ * gets at its settlement seal (A2). There is no `RunResourceSettlement` on this
+ * path — nothing crosses a transport, so there is nothing to wait to settle —
+ * but the run still owns browser tabs that only it can see, and the moment it
+ * returns is the moment nothing can reach them again.
+ */
+async function runLocalSubagentLoop(options: SubagentLoopOptions): Promise<SubagentResult> {
+  try {
+    return await runSubagentLoop(options);
+  } finally {
+    disposeRunBrowserViews(options.parentConversationId, options.agentRunId);
+  }
+}
+
 async function runSubagentForSignal(options: SubagentLoopOptions): Promise<SubagentResult> {
   if (options.signal?.aborted) {
     return cancelledSubagentResult();
@@ -762,7 +795,7 @@ async function runSubagentForSignal(options: SubagentLoopOptions): Promise<Subag
 
   if (getSidecarStatus() !== 'running') {
     logger.debug('subagent path selected', { path: 'local', runId, sidecarStatus: getSidecarStatus() });
-    return runSubagentLoop(localOptions);
+    return runLocalSubagentLoop(localOptions);
   }
 
   ensureHandlersRegistered();
@@ -780,7 +813,7 @@ async function runSubagentForSignal(options: SubagentLoopOptions): Promise<Subag
       runId,
       error: err instanceof Error ? err.message : String(err),
     });
-    return runSubagentLoop(localOptions);
+    return runLocalSubagentLoop(localOptions);
   }
 
   const sessionOptions: SubagentLoopOptions = {
@@ -788,6 +821,7 @@ async function runSubagentForSignal(options: SubagentLoopOptions): Promise<Subag
     workspaceReader: { getCurrentPath: () => params.workspacePathSnapshot },
   };
   const session: RunSession = {
+    runId,
     options: sessionOptions,
     imReplyTarget: options.imContext?.replyChatId
       ? { platform: options.imContext.platform, chatId: options.imContext.replyChatId }
@@ -859,7 +893,10 @@ async function runSubagentForSignal(options: SubagentLoopOptions): Promise<Subag
         runId,
         error: err instanceof Error ? err.message : String(err),
       });
-      return runSubagentLoop(scopeSubagentLoopProgress(options));
+      // A fresh scope id on purpose (the sidecar attempt may already have
+      // emitted progress under `runId`); the rerun therefore owns — and
+      // releases — its own browser tabs.
+      return runLocalSubagentLoop(scopeSubagentLoopProgress(options));
     }
     logger.warn('subagent transport failed after tool execution — surfacing error, no rerun', {
       runId,
@@ -883,6 +920,11 @@ async function runSubagentForSignal(options: SubagentLoopOptions): Promise<Subag
   } finally {
     await session.progressApplyTail;
     session.resourceSettlement.seal();
+    // A2 — the seal is the point after which this run can no longer start
+    // another tool, so it is the point at which its per-run resources are
+    // nobody's any more. Its browser tabs are invisible to every other run, so
+    // nothing else could ever list or close them.
+    disposeRunBrowserViews(options.parentConversationId, runId);
     if (options.authorizationScopeId !== undefined) {
       await session.resourceSettlement.settlement;
     }

--- a/src/core/browser/browserViewLifecycle.test.ts
+++ b/src/core/browser/browserViewLifecycle.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+// N6/A2 — the run-scoped half of browser view teardown.
+//
+// A subagent run's tabs are owned by the pair {conversationId, runKey} and are
+// listed to nobody else, so when the run ends there is no other path that could
+// ever close them: they would sit in main until the whole conversation is
+// deleted. This is the command that releases them, and its two guards matter as
+// much as the call — a missing runKey here would silently widen a per-run
+// release into "reap the conversation", killing the user's own pane work and
+// every sibling delegation.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { disposeOwnedBrowserViews, disposeRunBrowserViews } from './browserViewLifecycle';
+
+const invokeMock = vi.mocked(invoke);
+const runtimeWindow = (globalThis as unknown as { window: Record<string, unknown> }).window;
+
+describe('disposeRunBrowserViews', () => {
+  let previousInternals: unknown;
+
+  beforeEach(() => {
+    // Every host command is guarded by `isTauriEnv()`; the desktop shell is the
+    // only place these views exist (same seam chatStore.test.ts uses).
+    previousInternals = runtimeWindow.__TAURI_INTERNALS__;
+    runtimeWindow.__TAURI_INTERNALS__ = {};
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    runtimeWindow.__TAURI_INTERNALS__ = previousInternals;
+    invokeMock.mockReset();
+  });
+
+  it('stays silent outside the desktop shell', () => {
+    runtimeWindow.__TAURI_INTERNALS__ = undefined;
+
+    disposeRunBrowserViews('conv-1', 'sar-abc');
+
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('asks the host to reap exactly one run of one conversation', () => {
+    disposeRunBrowserViews('conv-1', 'sar-abc');
+
+    expect(invokeMock).toHaveBeenCalledWith('browser_dispose_owner', {
+      conversationId: 'conv-1',
+      runKey: 'sar-abc',
+    });
+  });
+
+  it('does nothing without a run key, rather than widening into a conversation-wide reap', () => {
+    disposeRunBrowserViews('conv-1', undefined);
+    disposeRunBrowserViews('conv-1', '');
+
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing without a conversation id', () => {
+    disposeRunBrowserViews(undefined, 'sar-abc');
+
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('never rejects when the host command fails — cleanup must not fail a run', async () => {
+    invokeMock.mockRejectedValue(new Error('host is gone'));
+
+    expect(() => disposeRunBrowserViews('conv-1', 'sar-abc')).not.toThrow();
+    await Promise.resolve();
+  });
+
+  it('leaves the conversation-wide command untouched (no runKey on the delete cascade)', () => {
+    disposeOwnedBrowserViews('conv-1');
+
+    expect(invokeMock).toHaveBeenCalledWith('browser_dispose_owner', {
+      conversationId: 'conv-1',
+    });
+  });
+});

--- a/src/core/browser/browserViewLifecycle.test.ts
+++ b/src/core/browser/browserViewLifecycle.test.ts
@@ -10,7 +10,12 @@
 // every sibling delegation.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { invoke } from '@tauri-apps/api/core';
-import { disposeOwnedBrowserViews, disposeRunBrowserViews } from './browserViewLifecycle';
+import {
+  clearBrowserReclaim,
+  closeBrowserViews,
+  disposeOwnedBrowserViews,
+  disposeRunBrowserViews,
+} from './browserViewLifecycle';
 
 const invokeMock = vi.mocked(invoke);
 const runtimeWindow = (globalThis as unknown as { window: Record<string, unknown> }).window;
@@ -75,5 +80,73 @@ describe('disposeRunBrowserViews', () => {
     expect(invokeMock).toHaveBeenCalledWith('browser_dispose_owner', {
       conversationId: 'conv-1',
     });
+  });
+});
+
+// N7 — a close now says WHY, because the host treats a user gesture as a signal
+// to stop opening tabs and treats everything else as ordinary teardown.
+describe('closeBrowserViews reason', () => {
+  let previousInternals: unknown;
+
+  beforeEach(() => {
+    previousInternals = runtimeWindow.__TAURI_INTERNALS__;
+    runtimeWindow.__TAURI_INTERNALS__ = {};
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    runtimeWindow.__TAURI_INTERNALS__ = previousInternals;
+    invokeMock.mockReset();
+  });
+
+  it('defaults to lifecycle, so only a caller that KNOWS it is a gesture can claim one', () => {
+    closeBrowserViews(['tab-1']);
+
+    expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: 'tab-1', reason: 'lifecycle' });
+  });
+
+  it('stamps every id in a user-gesture close', () => {
+    closeBrowserViews(['tab-1', 'tab-2'], 'user_close');
+
+    expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: 'tab-1', reason: 'user_close' });
+    expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: 'tab-2', reason: 'user_close' });
+  });
+});
+
+describe('clearBrowserReclaim', () => {
+  let previousInternals: unknown;
+
+  beforeEach(() => {
+    previousInternals = runtimeWindow.__TAURI_INTERNALS__;
+    runtimeWindow.__TAURI_INTERNALS__ = {};
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    runtimeWindow.__TAURI_INTERNALS__ = previousInternals;
+    invokeMock.mockReset();
+  });
+
+  it('lifts the window for the whole conversation', () => {
+    clearBrowserReclaim('conv-1');
+
+    expect(invokeMock).toHaveBeenCalledWith('browser_clear_reclaim', { conversationId: 'conv-1' });
+  });
+
+  it('does nothing without a conversation id, or outside the desktop shell', () => {
+    clearBrowserReclaim('');
+    runtimeWindow.__TAURI_INTERNALS__ = undefined;
+    clearBrowserReclaim('conv-1');
+
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('never rejects when the host command fails — a send must not fail on cleanup', async () => {
+    invokeMock.mockRejectedValue(new Error('host is gone'));
+
+    expect(() => clearBrowserReclaim('conv-1')).not.toThrow();
+    await Promise.resolve();
   });
 });

--- a/src/core/browser/browserViewLifecycle.ts
+++ b/src/core/browser/browserViewLifecycle.ts
@@ -1,0 +1,26 @@
+import { invoke } from '@tauri-apps/api/core';
+import { isTauriEnv } from '@/utils/tauriEnv';
+
+/**
+ * Destroy the native webviews behind the given workspace browser tab ids.
+ *
+ * A browser tab's native view (an Electron `WebContentsView` painted over the
+ * React UI) is owned by the TAB RECORD in `previewStore`, not by the
+ * `<BrowserTab>` component that renders it. The panel legitimately unmounts
+ * around a live view — collapsed panel, non-chat view mode — and an agent's
+ * page, login state and half-filled form must survive that, so unmounting only
+ * hides the view. Destroying it happens exactly where the tab record is
+ * removed (`closeTab` / `closeOtherTabs` / `closeAllTabs`), which is the one
+ * place that means "the user closed this tab".
+ *
+ * Best-effort and non-blocking: `browser_close` is idempotent in the host and a
+ * tab whose view was never created (empty "start" tab) is a no-op there.
+ */
+export function closeBrowserViews(tabIds: readonly string[]): void {
+  if (tabIds.length === 0 || !isTauriEnv()) return;
+  for (const id of tabIds) {
+    // `Promise.resolve` so a host stub that returns a non-promise can't throw
+    // inside a store action.
+    void Promise.resolve(invoke('browser_close', { id })).catch(() => {});
+  }
+}

--- a/src/core/browser/browserViewLifecycle.ts
+++ b/src/core/browser/browserViewLifecycle.ts
@@ -2,6 +2,22 @@ import { invoke } from '@tauri-apps/api/core';
 import { isTauriEnv } from '@/utils/tauriEnv';
 
 /**
+ * Why a browser view is being destroyed.
+ *
+ * `user_close` means a HUMAN closed the tab (the tab strip's ×, close others,
+ * close all) — the host reads that as "stop using the browser" and refuses to
+ * open another tab for that owner until the user speaks again (N7). Everything
+ * else is `lifecycle`: the app tidying up after itself (a withdrawn adoption, a
+ * conversation delete), which must never be mistaken for a gesture.
+ *
+ * The distinction can only be made at the ACTION that removes the record — by
+ * the time the ids reach the host they all look identical — so it is threaded
+ * from `previewStore`'s user-facing close actions and defaults to `lifecycle`
+ * for every other path.
+ */
+export type BrowserCloseReason = 'user_close' | 'lifecycle';
+
+/**
  * Destroy the native webviews behind the given workspace browser tab ids.
  *
  * A browser tab's native view (an Electron `WebContentsView` painted over the
@@ -16,12 +32,15 @@ import { isTauriEnv } from '@/utils/tauriEnv';
  * Best-effort and non-blocking: `browser_close` is idempotent in the host and a
  * tab whose view was never created (empty "start" tab) is a no-op there.
  */
-export function closeBrowserViews(tabIds: readonly string[]): void {
+export function closeBrowserViews(
+  tabIds: readonly string[],
+  reason: BrowserCloseReason = 'lifecycle',
+): void {
   if (tabIds.length === 0 || !isTauriEnv()) return;
   for (const id of tabIds) {
     // `Promise.resolve` so a host stub that returns a non-promise can't throw
     // inside a store action.
-    void Promise.resolve(invoke('browser_close', { id })).catch(() => {});
+    void Promise.resolve(invoke('browser_close', { id, reason })).catch(() => {});
   }
 }
 
@@ -62,4 +81,22 @@ export function disposeRunBrowserViews(conversationId?: string, runKey?: string)
   void Promise.resolve(
     invoke('browser_dispose_owner', { conversationId, runKey })
   ).catch(() => {});
+}
+
+/**
+ * Lift the reclaim window a `user_close` opened for `conversationId` (N7).
+ *
+ * The user closing an agent's tab tells the host to stop opening new ones; the
+ * user then WRITING to that conversation is them re-engaging with the task, and
+ * is the signal that lifts it. Scope is the whole conversation — every subagent
+ * run — because the user is addressing the task, not one of its delegations, and
+ * has no way to know which run owned the tab they closed.
+ *
+ * Fire-and-forget: sending a message must never be blocked, delayed or failed by
+ * browser bookkeeping. A lost call costs the run one more "ask the user first",
+ * which the next message clears.
+ */
+export function clearBrowserReclaim(conversationId: string): void {
+  if (!conversationId || !isTauriEnv()) return;
+  void Promise.resolve(invoke('browser_clear_reclaim', { conversationId })).catch(() => {});
 }

--- a/src/core/browser/browserViewLifecycle.ts
+++ b/src/core/browser/browserViewLifecycle.ts
@@ -24,3 +24,21 @@ export function closeBrowserViews(tabIds: readonly string[]): void {
     void Promise.resolve(invoke('browser_close', { id })).catch(() => {});
   }
 }
+
+/**
+ * Tear down every browser view the host still holds for `conversationId`.
+ *
+ * Removing the tab records (above) already destroys the views this renderer
+ * knows about; this is the belt-and-braces half for main-side state no tab
+ * record covers — a headless fallback view nothing ever adopted, or an
+ * adoption still in flight when the conversation was deleted. Ordering against
+ * the per-tab `browser_close` calls does not matter: both are idempotent in the
+ * host, and whichever lands second finds nothing left to close.
+ *
+ * Fire-and-forget like its sibling: a delete cascade must never be blocked (or
+ * failed) by browser cleanup.
+ */
+export function disposeOwnedBrowserViews(conversationId: string): void {
+  if (!conversationId || !isTauriEnv()) return;
+  void Promise.resolve(invoke('browser_dispose_owner', { conversationId })).catch(() => {});
+}

--- a/src/core/browser/browserViewLifecycle.ts
+++ b/src/core/browser/browserViewLifecycle.ts
@@ -42,3 +42,24 @@ export function disposeOwnedBrowserViews(conversationId: string): void {
   if (!conversationId || !isTauriEnv()) return;
   void Promise.resolve(invoke('browser_dispose_owner', { conversationId })).catch(() => {});
 }
+
+/**
+ * Tear down the browser views ONE subagent run owns, leaving the conversation's
+ * own loop and every sibling run untouched (N6/A2).
+ *
+ * A subagent's tabs are owned by the pair `{conversationId, runKey}` and are
+ * invisible to every other run, so when the run ends nothing else can ever list
+ * or close them: without this they would sit in main until the whole
+ * conversation is deleted — one live `WebContentsView` per finished delegation,
+ * for the rest of the session. Called at the run's settlement seal, the point
+ * after which the run can no longer start another tool.
+ *
+ * Fire-and-forget and best-effort, like its siblings: a run must never fail, or
+ * be held open by, its own resource cleanup.
+ */
+export function disposeRunBrowserViews(conversationId?: string, runKey?: string): void {
+  if (!conversationId || !runKey || !isTauriEnv()) return;
+  void Promise.resolve(
+    invoke('browser_dispose_owner', { conversationId, runKey })
+  ).catch(() => {});
+}

--- a/src/core/mcp/client.ts
+++ b/src/core/mcp/client.ts
@@ -32,6 +32,17 @@ const ABU_CONVERSATION_META_KEY = 'abu/conversationId';
 const ABU_CREATE_IF_EMPTY_META_KEY = 'abu/createIfEmpty';
 
 /**
+ * MCP request `_meta` key carrying the SUBAGENT RUN that issued the call. The
+ * browser host owns tabs by the pair `{conversationId, runKey}` (N6), so the
+ * conversation id above is only half the owner: without this, a conversation's
+ * own loop and each of its delegated subagent runs share one tab pool and one
+ * "current tab" and steal each other's pages. Absent ⇒ the conversation's own
+ * loop (the host reads that as `main`). Mirrors `ABU_RUN_META_KEY` in
+ * `abu-browser-bridge/src/tools.ts` (same duplication rationale as above).
+ */
+const ABU_RUN_META_KEY = 'abu/runKey';
+
+/**
  * Map a tool's runtime ToolExecutionContext to callTool() opts. Factored out
  * of the execute() closure built during tool discovery so the mapping is
  * directly unit-testable — the discovery flow itself depends on the MCP SDK,
@@ -39,9 +50,10 @@ const ABU_CREATE_IF_EMPTY_META_KEY = 'abu/createIfEmpty';
  */
 export function toCallToolOpts(
   context?: ToolExecutionContext
-): { conversationId?: string; signal?: AbortSignal } {
+): { conversationId?: string; agentRunId?: string; signal?: AbortSignal } {
   return {
     conversationId: context?.conversationId,
+    agentRunId: context?.agentRunId,
     signal: context?.abortSignal,
   };
 }
@@ -769,6 +781,12 @@ export class MCPClientManager {
     args: Record<string, unknown>,
     opts?: {
       conversationId?: string;
+      /**
+       * The `sar-*` subagent run that issued the call, or omitted for the
+       * conversation's own loop. Second half of the browser host's tab-owner
+       * pair — see `ABU_RUN_META_KEY`.
+       */
+      agentRunId?: string;
       signal?: AbortSignal;
       /**
        * Only meaningful for the browser server's `get_tabs`: pass `false` for a
@@ -822,6 +840,11 @@ export class MCPClientManager {
       const meta: Record<string, unknown> = {};
       if (opts?.conversationId) {
         meta[ABU_CONVERSATION_META_KEY] = opts.conversationId;
+      }
+      // Only when there IS one: a main-loop call keeps its exact pre-N6 `_meta`
+      // shape, and the host owns the "absent ⇒ main" default.
+      if (opts?.agentRunId) {
+        meta[ABU_RUN_META_KEY] = opts.agentRunId;
       }
       if (opts?.createBrowserTabIfEmpty === false) {
         meta[ABU_CREATE_IF_EMPTY_META_KEY] = false;

--- a/src/core/tools/registry.browserGateOwnership.test.ts
+++ b/src/core/tools/registry.browserGateOwnership.test.ts
@@ -128,6 +128,44 @@ describe('browser permission gate ↔ per-conversation tab ownership', () => {
     });
   });
 
+  // N6 extends the same argument one level down: ownership is the pair
+  // {conversationId, runKey}, so a probe that sent only the conversation would
+  // be the CONVERSATION MAIN LOOP asking, see none of the subagent's tabs, and
+  // resolve null for every action a subagent takes — the identical fail-open
+  // this suite exists to prevent, moved from "between conversations" to
+  // "between a conversation and its own delegations".
+  it('sends the subagent run key too, so a delegated run can see its own tab', async () => {
+    const RUN = 'sar-delegated';
+    mockCallTool.mockImplementation((params: { _meta?: Record<string, unknown> }) =>
+      Promise.resolve(
+        params._meta?.['abu/conversationId'] === OWNER
+          && params._meta?.['abu/runKey'] === RUN
+          ? tabsPayload([{ tabId: OWNED_TAB_ID, url: 'https://example.com/dashboard' }])
+          : tabsPayload([]),
+      ),
+    );
+    const asked: ConfirmInfo[] = [];
+    const confirm = async (info: ConfirmInfo) => { asked.push(info); return true; };
+
+    const decision = await checkToolApproval(
+      'abu-browser__click',
+      { tabId: OWNED_TAB_ID, locator: '{"ref":"e1"}' },
+      { conversationId: OWNER, agentRunId: RUN } as never,
+      confirm as never,
+    );
+
+    expect(decision.decision).toBe('allow');
+    expect(mockCallTool.mock.calls[0][0]).toMatchObject({
+      name: 'get_tabs',
+      _meta: {
+        'abu/conversationId': OWNER,
+        'abu/runKey': RUN,
+        'abu/createIfEmpty': false,
+      },
+    });
+    expect(asked[0].browserOrigin).toBe('https://example.com');
+  });
+
   it('still DENIES a user-blocked site reached through an owned tab (no fail-open)', async () => {
     mockCallTool.mockImplementation((params: { _meta?: Record<string, unknown> }) =>
       Promise.resolve(

--- a/src/core/tools/registry.mcpConversationId.test.ts
+++ b/src/core/tools/registry.mcpConversationId.test.ts
@@ -64,6 +64,35 @@ describe('executeAnyTool → mcpManager.callTool → _meta (MCP tool dispatch)',
     });
   });
 
+  // N6: browser tab ownership is the pair {conversationId, runKey}, so a
+  // subagent run's id has to reach the server the same way its conversation id
+  // does — through `_meta`, never through the tool's input schema (the model
+  // must not see, or be able to forge, either half).
+  it('forwards the subagent run id from ToolExecutionContext into the MCP request _meta', async () => {
+    await executeAnyTool('test-server__test_tool', { a: 1 }, undefined, undefined, {
+      conversationId: 'c1',
+      agentRunId: 'sar-xyz',
+    });
+
+    expect(mockCallTool).toHaveBeenCalledTimes(1);
+    expect(mockCallTool.mock.calls[0][0]).toMatchObject({
+      name: 'test_tool',
+      arguments: { a: 1 },
+      _meta: { 'abu/conversationId': 'c1', 'abu/runKey': 'sar-xyz' },
+    });
+  });
+
+  // Degenerate-case compat: the main loop sends no run id, and its request must
+  // stay byte-identical to what it was before N6 — the host owns the
+  // "absent ⇒ main" default.
+  it('omits the run key entirely for a main-loop call', async () => {
+    await executeAnyTool('test-server__test_tool', { a: 1 }, undefined, undefined, {
+      conversationId: 'c1',
+    });
+
+    expect(mockCallTool.mock.calls[0][0]._meta).toEqual({ 'abu/conversationId': 'c1' });
+  });
+
   it('omits _meta when the run has no conversationId in context', async () => {
     await executeAnyTool('test-server__test_tool', { a: 1 }, undefined, undefined, undefined);
 

--- a/src/core/tools/registry.mcpConversationId.test.ts
+++ b/src/core/tools/registry.mcpConversationId.test.ts
@@ -93,6 +93,21 @@ describe('executeAnyTool → mcpManager.callTool → _meta (MCP tool dispatch)',
     expect(mockCallTool.mock.calls[0][0]._meta).toEqual({ 'abu/conversationId': 'c1' });
   });
 
+  // The other half of the main-loop neutralization (agentLoopRunner's
+  // `contextForSession` sets `agentRunId: undefined` to overwrite a
+  // sidecar-supplied one). That leaves the property PRESENT with an undefined
+  // value, so this pins the last hop: a neutralized run id must produce no
+  // `abu/runKey` at all — an `abu/runKey: undefined` on the wire would reach
+  // the host as a malformed owner half rather than as "the main loop".
+  it('emits no run key when the context carries an explicitly neutralized agentRunId', async () => {
+    await executeAnyTool('test-server__test_tool', { a: 1 }, undefined, undefined, {
+      conversationId: 'c1',
+      agentRunId: undefined,
+    });
+
+    expect(mockCallTool.mock.calls[0][0]._meta).toEqual({ 'abu/conversationId': 'c1' });
+  });
+
   it('omits _meta when the run has no conversationId in context', async () => {
     await executeAnyTool('test-server__test_tool', { a: 1 }, undefined, undefined, undefined);
 

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -348,6 +348,7 @@ async function resolveBrowserActionOrigin(
   namespacedName: string,
   input: Record<string, unknown>,
   conversationId?: string,
+  agentRunId?: string,
 ): Promise<string | null> {
   const separator = namespacedName.indexOf('__');
   const serverName = namespacedName.slice(0, separator);
@@ -385,6 +386,13 @@ async function resolveBrowserActionOrigin(
     const result = await Promise.race([
       mcpManager.callTool(serverName, 'get_tabs', {}, {
         conversationId,
+        // The run id is as REQUIRED as the conversation id, and for the same
+        // reason: the host owns tabs by the pair, so a probe that sent only the
+        // conversation would list the MAIN loop's tabs and resolve null for
+        // every tab a subagent opened — silently re-opening the exact fail-open
+        // (blocked sites stop being denied, unattended runs deny everything)
+        // that threading the conversation id closed.
+        agentRunId,
         createBrowserTabIfEmpty: false,
       }),
       new Promise<null>((resolve) => setTimeout(() => resolve(null), 3000)),
@@ -730,6 +738,7 @@ export async function checkToolApproval(
         name,
         input,
         toolContext?.conversationId,
+        toolContext?.agentRunId,
       );
       const siteVerdict = getSiteVerdict(
         origin,
@@ -933,6 +942,7 @@ export async function executeAnyTool(
     if (mcpManager.isConnected(serverName)) {
       const result = await mcpManager.callTool(serverName, toolName, executionInput, {
         conversationId: toolContext?.conversationId,
+        agentRunId: toolContext?.agentRunId,
         signal: toolContext?.abortSignal,
       });
       // Only truncate string results; rich content (images) passes through

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -269,9 +269,19 @@ describe('chatStore', () => {
           'agent-survivor',
           paneTab,
         ]);
-        expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: 'agent-deleted' });
-        expect(invokeMock).not.toHaveBeenCalledWith('browser_close', { id: 'agent-survivor' });
-        expect(invokeMock).not.toHaveBeenCalledWith('browser_close', { id: paneTab });
+        expect(invokeMock).toHaveBeenCalledWith('browser_close', {
+          id: 'agent-deleted',
+          // A delete cascade is the app tidying up, never a user gesture (N7).
+          reason: 'lifecycle',
+        });
+        expect(invokeMock).not.toHaveBeenCalledWith(
+          'browser_close',
+          expect.objectContaining({ id: 'agent-survivor' }),
+        );
+        expect(invokeMock).not.toHaveBeenCalledWith(
+          'browser_close',
+          expect.objectContaining({ id: paneTab }),
+        );
         expect(invokeMock).toHaveBeenCalledWith('browser_dispose_owner', {
           conversationId: deletedId,
         });
@@ -612,6 +622,59 @@ describe('chatStore', () => {
       const reindexIdx = calls.findIndex((c) => c[0] === 'catalog_reindex_conversation');
       expect(indexWriteIdx).toBeGreaterThanOrEqual(0);
       expect(indexWriteIdx).toBeLessThan(reindexIdx);
+    });
+  });
+
+  // N7 — the user closing an agent's browser tab tells the host to stop opening
+  // new ones. Writing to that conversation again is them re-engaging with the
+  // task, and is what lifts the window. `addMessage` is the single point every
+  // send path (sidecar dispatch and the in-process fallbacks alike) commits a
+  // user message through, so the signal is taken there rather than in each.
+  describe('browser reclaim window', () => {
+    const runtime = globalThis as unknown as Record<string, unknown>;
+    const invokeMock = vi.mocked(invoke);
+    let previousInternals: unknown;
+
+    beforeEach(() => {
+      previousInternals = (runtime.window as Record<string, unknown>).__TAURI_INTERNALS__;
+      (runtime.window as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+      invokeMock.mockReset();
+      invokeMock.mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      (runtime.window as Record<string, unknown>).__TAURI_INTERNALS__ = previousInternals;
+      invokeMock.mockReset();
+    });
+
+    it('lifts on the user’s next message in that conversation', () => {
+      const id = useChatStore.getState().createConversation();
+
+      useChatStore.getState().addMessage(id, {
+        id: 'user-1', role: 'user', content: 'go on', timestamp: FIXED_TIMESTAMP,
+      });
+
+      expect(invokeMock).toHaveBeenCalledWith('browser_clear_reclaim', { conversationId: id });
+    });
+
+    it('does not lift on anything the user did not write', () => {
+      const id = useChatStore.getState().createConversation();
+
+      useChatStore.getState().addMessage(id, {
+        id: 'assistant-1', role: 'assistant', content: 'working', timestamp: FIXED_TIMESTAMP,
+      });
+      // A system-injected wake-up rides the `user` role (agentLoop drains the
+      // system queue as user turns) — it is the app talking to itself, and must
+      // not hand the browser back on the user's behalf.
+      useChatStore.getState().addMessage(id, {
+        id: 'wakeup-1',
+        role: 'user',
+        content: 'continue',
+        timestamp: FIXED_TIMESTAMP,
+        isSystem: true,
+      });
+
+      expect(invokeMock).not.toHaveBeenCalledWith('browser_clear_reclaim', expect.anything());
     });
   });
 

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -230,6 +230,67 @@ describe('chatStore', () => {
       expect(useBatchProgressStore.getState().batches[makeBatchKey(survivorBatch)]).toBeDefined();
     });
 
+    // C2-I1 / C1-I2 — a deleted conversation's browser tab is invisible in
+    // every conversation's strip (nothing can click it closed) and its native
+    // WebContentsView keeps running for the rest of the session. The cascade
+    // must both drop the records (which destroys the views it knows about) and
+    // tell main to dispose whatever it holds for that owner.
+    describe('browser view cascade', () => {
+      const runtime = globalThis as unknown as Record<string, unknown>;
+      const invokeMock = vi.mocked(invoke);
+      let previousInternals: unknown;
+
+      beforeEach(() => {
+        previousInternals = (runtime.window as Record<string, unknown>).__TAURI_INTERNALS__;
+        (runtime.window as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+        invokeMock.mockReset();
+        invokeMock.mockResolvedValue(undefined);
+      });
+
+      afterEach(() => {
+        (runtime.window as Record<string, unknown>).__TAURI_INTERNALS__ = previousInternals;
+        invokeMock.mockReset();
+        // closeAllTabs only reaches the tabs the CURRENT conversation can see,
+        // so foreign-owned leftovers would survive the outer reset.
+        usePreviewStore.setState({ tabs: [], activeTabId: null, currentConversationId: null });
+      });
+
+      it('closes the deleted conversation’s browser tabs and disposes its main-side views', () => {
+        const deletedId = useChatStore.getState().createConversation();
+        const survivorId = useChatStore.getState().createConversation();
+        usePreviewStore.getState().closeTabsForConversationSwitch(deletedId);
+        usePreviewStore.getState().openBrowser('https://agent.example', 'agent-deleted', deletedId);
+        usePreviewStore.getState().openBrowser('https://other.example', 'agent-survivor', survivorId);
+        const paneTab = usePreviewStore.getState().openBrowser('https://user-opened.example');
+
+        useChatStore.getState().deleteConversation(deletedId);
+
+        expect(usePreviewStore.getState().tabs.map((tab) => tab.id)).toEqual([
+          'agent-survivor',
+          paneTab,
+        ]);
+        expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: 'agent-deleted' });
+        expect(invokeMock).not.toHaveBeenCalledWith('browser_close', { id: 'agent-survivor' });
+        expect(invokeMock).not.toHaveBeenCalledWith('browser_close', { id: paneTab });
+        expect(invokeMock).toHaveBeenCalledWith('browser_dispose_owner', {
+          conversationId: deletedId,
+        });
+      });
+
+      it('still disposes main-side state when the renderer holds no tab for the conversation', () => {
+        // Headless fallback views and adoptions that landed after the tab
+        // record was dropped exist only in main — the dispose command is the
+        // only thing that can reach them.
+        const deletedId = useChatStore.getState().createConversation();
+
+        useChatStore.getState().deleteConversation(deletedId);
+
+        expect(invokeMock).toHaveBeenCalledWith('browser_dispose_owner', {
+          conversationId: deletedId,
+        });
+      });
+    });
+
     it('does not resurrect deleted batch state when in-flight progress settles late', async () => {
       const conversationId = useChatStore.getState().createConversation();
       const identity = {

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -32,6 +32,7 @@ import { useEnterpriseStore } from './enterpriseStore';
 import { useWorkProcessFoldStore } from './workProcessFoldStore';
 import { useBatchProgressStore } from './batchProgressStore';
 import { usePreviewStore } from './previewStore';
+import { disposeOwnedBrowserViews } from '../core/browser/browserViewLifecycle';
 import { appendBoundedSubagentToolCall } from '../core/session/durableToolResultContent';
 import { normalizeUpstreamErrorDetails, sanitizeUntrustedLlmErrorText } from '../core/llm/adapter';
 
@@ -1012,6 +1013,16 @@ export const useChatStore = create<ChatStore>()(
         // clearing their ephemeral batches so the active view lease is
         // released synchronously and no clickable dead tab survives deletion.
         usePreviewStore.getState().closeSubagentTabsForConversation(id);
+        // Browser tabs an agent adopted for this conversation are owned by the
+        // tab RECORD, so dropping it here is what destroys the native view.
+        // Without this the view keeps running with no strip anywhere able to
+        // show or close it: the tab is invisible in every other conversation,
+        // and this one is about to stop existing.
+        usePreviewStore.getState().closeOwnedTabsForConversation(id);
+        // ...and the same for main-side views this renderer holds no record of
+        // (a headless fallback view, an adoption still in flight). Fire-and-
+        // forget, failure-swallowed, like the disk cleanups below.
+        disposeOwnedBrowserViews(id);
         useBatchProgressStore.getState().clearConversation(id);
         clearConversationComposerDraft(
           id,

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -32,7 +32,7 @@ import { useEnterpriseStore } from './enterpriseStore';
 import { useWorkProcessFoldStore } from './workProcessFoldStore';
 import { useBatchProgressStore } from './batchProgressStore';
 import { usePreviewStore } from './previewStore';
-import { disposeOwnedBrowserViews } from '../core/browser/browserViewLifecycle';
+import { clearBrowserReclaim, disposeOwnedBrowserViews } from '../core/browser/browserViewLifecycle';
 import { appendBoundedSubagentToolCall } from '../core/session/durableToolResultContent';
 import { normalizeUpstreamErrorDetails, sanitizeUntrustedLlmErrorText } from '../core/llm/adapter';
 
@@ -1202,6 +1202,18 @@ export const useChatStore = create<ChatStore>()(
             if (meta) await updateIndexEntry(meta);
           }),
         );
+        // N7 — the user closing an agent's browser tab makes the host refuse to
+        // open another one until they speak again; writing to the conversation
+        // is them speaking. This is the one place every send path commits a user
+        // message (the sidecar dispatch in agentLoopRunner and agentLoop's
+        // in-process fallbacks all land here), so the signal is taken here
+        // rather than duplicated per path. `isSystem` messages ride the `user`
+        // role but are the app waking itself up — they must not hand the browser
+        // back on the user's behalf. Fire-and-forget: a send never waits on, or
+        // fails because of, browser bookkeeping.
+        if (message.role === 'user' && !message.isSystem) {
+          clearBrowserReclaim(convId);
+        }
         // Snapshot any user-uploaded files (currently only images with filePath).
         // Fire-and-forget — must never block the UI flow.
         // ★ Architecture contract: when adding new content types with stripForDisk

--- a/src/stores/previewStore.test.ts
+++ b/src/stores/previewStore.test.ts
@@ -604,6 +604,49 @@ describe('previewStore', () => {
       expect(invokeMock).not.toHaveBeenCalledWith('browser_close', { id: 'agent-a-8' });
     });
 
+    // C2-I1 / N4 — a deleted conversation's browser tab is invisible in every
+    // conversation's strip, so nothing in the UI can ever close it. The delete
+    // cascade must remove the RECORD (the one thing that destroys the view).
+    it('closeOwnedTabsForConversation destroys only the deleted conversation’s views', () => {
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-b');
+      usePreviewStore.getState().openBrowser('https://a-one.example', 'agent-a-del-1', 'conv-a');
+      usePreviewStore.getState().openBrowser('https://a-two.example', 'agent-a-del-2', 'conv-a');
+      usePreviewStore.getState().openBrowser('https://b.example', 'agent-b-keep', 'conv-b');
+      const paneTab = usePreviewStore.getState().openBrowser('https://user-opened.example');
+
+      usePreviewStore.getState().closeOwnedTabsForConversation('conv-a');
+
+      expect(ids(usePreviewStore.getState().tabs)).toEqual(['agent-b-keep', paneTab]);
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: 'agent-a-del-1' });
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: 'agent-a-del-2' });
+      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', { id: 'agent-b-keep' });
+      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', { id: paneTab });
+    });
+
+    it('closeOwnedTabsForConversation lands the active tab on a visible survivor', () => {
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-a');
+      usePreviewStore.getState().openSummary();
+      const summaryId = usePreviewStore.getState().activeTabId!;
+      usePreviewStore.getState().openBrowser('https://a.example', 'agent-a-active', 'conv-a');
+      usePreviewStore.getState().activateTab('agent-a-active');
+
+      usePreviewStore.getState().closeOwnedTabsForConversation('conv-a');
+
+      const s = usePreviewStore.getState();
+      expect(ids(s.tabs)).toEqual([summaryId]);
+      expect(s.activeTabId).toBe(summaryId);
+    });
+
+    it('closeOwnedTabsForConversation is a no-op when that conversation owns nothing', () => {
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-a');
+      usePreviewStore.getState().openBrowser('https://a.example', 'agent-a-only', 'conv-a');
+
+      usePreviewStore.getState().closeOwnedTabsForConversation('conv-untouched');
+
+      expect(ids(usePreviewStore.getState().tabs)).toEqual(['agent-a-only']);
+      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', expect.anything());
+    });
+
     it('a foreign-owned tab never keeps the panel wide or the chat width pinned', () => {
       usePreviewStore.getState().closeTabsForConversationSwitch('conv-a');
       usePreviewStore.getState().openBrowser('https://one.example', 'agent-a-9', 'conv-a');

--- a/src/stores/previewStore.test.ts
+++ b/src/stores/previewStore.test.ts
@@ -647,6 +647,49 @@ describe('previewStore', () => {
       expect(invokeMock).not.toHaveBeenCalledWith('browser_close', expect.anything());
     });
 
+    // I1 — main withdraws an adoption (`browser://automation-cancel`) when the
+    // run was stopped or the owning conversation was deleted. The record must go
+    // even though it is invisible here: nothing else could ever remove it, and
+    // it is what keeps the native view (and a mounted BrowserTab) alive.
+    it('closeAdoptedBrowserTab drops a withdrawn tab from another conversation', () => {
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-b');
+      usePreviewStore.getState().openBrowser('about:blank', 'agent-a-cancel', 'conv-a');
+      usePreviewStore.getState().openBrowser('https://b.example', 'agent-b-keep', 'conv-b');
+
+      usePreviewStore.getState().closeAdoptedBrowserTab('agent-a-cancel');
+
+      expect(ids(usePreviewStore.getState().tabs)).toEqual(['agent-b-keep']);
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: 'agent-a-cancel' });
+      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', { id: 'agent-b-keep' });
+    });
+
+    it('closeAdoptedBrowserTab re-activates a survivor when the withdrawn tab was active', () => {
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-a');
+      usePreviewStore.getState().openSummary();
+      const summaryId = usePreviewStore.getState().activeTabId!;
+      usePreviewStore.getState().openBrowser('about:blank', 'agent-a-visible', 'conv-a');
+      usePreviewStore.getState().activateTab('agent-a-visible');
+
+      usePreviewStore.getState().closeAdoptedBrowserTab('agent-a-visible');
+
+      const s = usePreviewStore.getState();
+      expect(ids(s.tabs)).toEqual([summaryId]);
+      expect(s.activeTabId).toBe(summaryId);
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: 'agent-a-visible' });
+    });
+
+    it('closeAdoptedBrowserTab ignores an unknown id and never touches a non-browser tab', () => {
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-a');
+      usePreviewStore.getState().openSummary();
+      const summaryId = usePreviewStore.getState().activeTabId!;
+
+      usePreviewStore.getState().closeAdoptedBrowserTab('no-such-tab');
+      usePreviewStore.getState().closeAdoptedBrowserTab(summaryId);
+
+      expect(ids(usePreviewStore.getState().tabs)).toEqual([summaryId]);
+      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', expect.anything());
+    });
+
     it('a foreign-owned tab never keeps the panel wide or the chat width pinned', () => {
       usePreviewStore.getState().closeTabsForConversationSwitch('conv-a');
       usePreviewStore.getState().openBrowser('https://one.example', 'agent-a-9', 'conv-a');

--- a/src/stores/previewStore.test.ts
+++ b/src/stores/previewStore.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
 import { makeBatchKey, type BatchIdentity } from '@/types';
 import {
   BATCH_PROGRESS_GLOBAL_RICH_CONTENT_BYTES,
@@ -392,6 +393,80 @@ describe('previewStore', () => {
       expect(s.tabs).toHaveLength(0);
       expect(s.activeTabId).toBeNull();
       expect(s.previewFilePath).toBeNull();
+    });
+  });
+
+  // A browser tab's native WebContentsView is owned by the tab RECORD here, not
+  // by the React component that renders it: removing the record destroys the
+  // view, and nothing else may.
+  describe('native browser view ownership', () => {
+    // This suite runs in the `node` environment, so stub the desktop host
+    // marker `isTauriEnv()` looks for on `window`.
+    const runtime = globalThis as unknown as Record<string, unknown>;
+    const invokeMock = vi.mocked(invoke);
+
+    beforeEach(() => {
+      runtime.window = { __TAURI_INTERNALS__: {} };
+      invokeMock.mockReset();
+      invokeMock.mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      delete runtime.window;
+      invokeMock.mockReset();
+    });
+
+    it('closeTab destroys the native view behind a browser tab', () => {
+      const id = usePreviewStore.getState().openBrowser('https://example.com');
+      usePreviewStore.getState().closeTab(id);
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id });
+    });
+
+    it('closeTab of a non-browser tab touches no native view', () => {
+      usePreviewStore.getState().openPreview('/a/1.md');
+      const id = usePreviewStore.getState().tabs[0].id;
+      usePreviewStore.getState().closeTab(id);
+      expect(invokeMock).not.toHaveBeenCalled();
+    });
+
+    it('closeOtherTabs and closeAllTabs destroy every browser view they remove', () => {
+      const kept = usePreviewStore.getState().openBrowser('https://kept.example');
+      const dropped = usePreviewStore.getState().openBrowser('https://dropped.example');
+
+      usePreviewStore.getState().closeOtherTabs(kept);
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: dropped });
+      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', { id: kept });
+
+      invokeMock.mockClear();
+      usePreviewStore.getState().closeAllTabs();
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: kept });
+    });
+
+    it('closeTabsForConversationSwitch keeps browser tabs and their views alive', () => {
+      const browserId = usePreviewStore.getState().openBrowser('https://example.com');
+      usePreviewStore.getState().openPreview('/a/1.md');
+      usePreviewStore.getState().openSummary();
+      usePreviewStore.getState().openTerminal();
+
+      usePreviewStore.getState().closeTabsForConversationSwitch();
+
+      const s = usePreviewStore.getState();
+      expect(s.tabs.map((t) => t.id)).toEqual([browserId]);
+      expect(s.activeTabId).toBe(browserId);
+      expect(s.previewFilePath).toBeNull();
+      expect(invokeMock).not.toHaveBeenCalled();
+    });
+
+    it('closeTabsForConversationSwitch clears everything when no browser tab is open', () => {
+      usePreviewStore.getState().openPreview('/a/1.md');
+      usePreviewStore.setState({ chatWidth: 400 });
+
+      usePreviewStore.getState().closeTabsForConversationSwitch();
+
+      const s = usePreviewStore.getState();
+      expect(s.tabs).toHaveLength(0);
+      expect(s.activeTabId).toBeNull();
+      expect(s.chatWidth).toBeNull();
     });
   });
 

--- a/src/stores/previewStore.test.ts
+++ b/src/stores/previewStore.test.ts
@@ -5,7 +5,7 @@ import {
   BATCH_PROGRESS_GLOBAL_RICH_CONTENT_BYTES,
   useBatchProgressStore,
 } from './batchProgressStore';
-import { subagentTabId, usePreviewStore, type WorkspaceTab } from './previewStore';
+import { getVisibleTabs, subagentTabId, usePreviewStore, type WorkspaceTab } from './previewStore';
 
 function reset() {
   usePreviewStore.setState({
@@ -18,6 +18,8 @@ function reset() {
     chatWidth: null,
     reloadNonce: 0,
     fileTreeMode: false,
+    currentConversationId: null,
+    lastActiveTabByConversation: {},
   });
   useBatchProgressStore.setState({
     batches: {},
@@ -467,6 +469,149 @@ describe('previewStore', () => {
       expect(s.tabs).toHaveLength(0);
       expect(s.activeTabId).toBeNull();
       expect(s.chatWidth).toBeNull();
+    });
+  });
+
+  // An adopted agent browser tab belongs to the conversation that asked for it.
+  // Its native view must stay alive across conversation switches (C1), but it
+  // must only be listed/activatable in its owner's panel — otherwise switching
+  // to another conversation shows that conversation someone else's live page.
+  describe('conversation-scoped browser tabs', () => {
+    const runtime = globalThis as unknown as Record<string, unknown>;
+    const invokeMock = vi.mocked(invoke);
+
+    beforeEach(() => {
+      runtime.window = { __TAURI_INTERNALS__: {} };
+      invokeMock.mockReset();
+      invokeMock.mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      delete runtime.window;
+      invokeMock.mockReset();
+    });
+
+    function ids(tabs: WorkspaceTab[]): string[] {
+      return tabs.map((tab) => tab.id);
+    }
+
+    it('records the owner on an adopted tab and keeps it visible in its own conversation', () => {
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-a');
+      const id = usePreviewStore.getState().openBrowser('about:blank', 'agent-a-1', 'conv-a');
+
+      const s = usePreviewStore.getState();
+      expect(s.tabs).toEqual([
+        { id: 'agent-a-1', kind: 'browser', url: 'about:blank', ownerConversationId: 'conv-a' },
+      ]);
+      expect(ids(getVisibleTabs())).toEqual([id]);
+      expect(s.activeTabId).toBe(id);
+    });
+
+    it('adoption for the CURRENT conversation still respects the no-steal rule', () => {
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-a');
+      const watched = usePreviewStore.getState().openBrowser('https://user-is-watching.example');
+
+      usePreviewStore.getState().openBrowser('about:blank', 'agent-a-2', 'conv-a');
+
+      const s = usePreviewStore.getState();
+      expect(ids(getVisibleTabs())).toEqual([watched, 'agent-a-2']);
+      expect(s.activeTabId).toBe(watched);
+    });
+
+    it('adoption for a BACKGROUND conversation never enters this conversation view', () => {
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-b');
+      usePreviewStore.getState().openSummary();
+      const summaryId = usePreviewStore.getState().activeTabId;
+
+      usePreviewStore.getState().openBrowser('https://baidu.com', 'agent-a-3', 'conv-a');
+
+      const s = usePreviewStore.getState();
+      // Present in the store (its native view is alive) but invisible here.
+      expect(ids(s.tabs)).toContain('agent-a-3');
+      expect(ids(getVisibleTabs())).toEqual([summaryId!]);
+      expect(s.activeTabId).toBe(summaryId);
+      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', expect.anything());
+    });
+
+    it('adoption for a BACKGROUND conversation leaves an empty panel empty', () => {
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-b');
+
+      usePreviewStore.getState().openBrowser('https://baidu.com', 'agent-a-4', 'conv-a');
+
+      const s = usePreviewStore.getState();
+      expect(getVisibleTabs()).toEqual([]);
+      expect(s.activeTabId).toBeNull();
+      expect(ids(s.tabs)).toEqual(['agent-a-4']);
+    });
+
+    it('an adopted tab with no owner (legacy) stays visible in every conversation', () => {
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-a');
+      usePreviewStore.getState().openBrowser('about:blank', 'legacy-view');
+
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-b');
+
+      expect(ids(getVisibleTabs())).toEqual(['legacy-view']);
+    });
+
+    it('A → B → A hides then restores A’s tabs, keeping every native view alive', () => {
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-a');
+      usePreviewStore.getState().openBrowser('https://one.example', 'agent-a-5', 'conv-a');
+      usePreviewStore.getState().openBrowser('https://two.example', 'agent-a-6', 'conv-a');
+      usePreviewStore.getState().activateTab('agent-a-6');
+
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-b');
+      const inB = usePreviewStore.getState();
+      expect(getVisibleTabs()).toEqual([]);
+      expect(inB.activeTabId).toBeNull();
+      expect(ids(inB.tabs)).toEqual(['agent-a-5', 'agent-a-6']);
+
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-a');
+      const backInA = usePreviewStore.getState();
+      expect(ids(getVisibleTabs())).toEqual(['agent-a-5', 'agent-a-6']);
+      // A's last active tab comes back, not just the first one.
+      expect(backInA.activeTabId).toBe('agent-a-6');
+      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', expect.anything());
+    });
+
+    it('activateTab cannot activate another conversation’s browser tab', () => {
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-a');
+      usePreviewStore.getState().openBrowser('https://one.example', 'agent-a-7', 'conv-a');
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-b');
+      usePreviewStore.getState().openSummary();
+      const summaryId = usePreviewStore.getState().activeTabId;
+
+      usePreviewStore.getState().activateTab('agent-a-7');
+
+      expect(usePreviewStore.getState().activeTabId).toBe(summaryId);
+    });
+
+    it('closeAllTabs / closeOtherTabs only reach the tabs this conversation can see', () => {
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-a');
+      usePreviewStore.getState().openBrowser('https://one.example', 'agent-a-8', 'conv-a');
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-b');
+      usePreviewStore.getState().openSummary();
+      usePreviewStore.getState().openBrowser('https://b.example', 'agent-b-1', 'conv-b');
+
+      usePreviewStore.getState().closeOtherTabs('agent-b-1');
+      expect(ids(usePreviewStore.getState().tabs)).toEqual(['agent-a-8', 'agent-b-1']);
+      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', { id: 'agent-a-8' });
+
+      usePreviewStore.getState().closeAllTabs();
+      const s = usePreviewStore.getState();
+      expect(ids(s.tabs)).toEqual(['agent-a-8']);
+      expect(getVisibleTabs()).toEqual([]);
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: 'agent-b-1' });
+      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', { id: 'agent-a-8' });
+    });
+
+    it('a foreign-owned tab never keeps the panel wide or the chat width pinned', () => {
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-a');
+      usePreviewStore.getState().openBrowser('https://one.example', 'agent-a-9', 'conv-a');
+      usePreviewStore.setState({ chatWidth: 400 });
+
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-b');
+
+      expect(usePreviewStore.getState().chatWidth).toBeNull();
     });
   });
 

--- a/src/stores/previewStore.test.ts
+++ b/src/stores/previewStore.test.ts
@@ -421,7 +421,49 @@ describe('previewStore', () => {
     it('closeTab destroys the native view behind a browser tab', () => {
       const id = usePreviewStore.getState().openBrowser('https://example.com');
       usePreviewStore.getState().closeTab(id);
-      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id });
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id, reason: 'user_close' });
+    });
+
+    // N7 — the host reads `reason` as "did a human do this?", and answers a
+    // human by refusing to open another tab until they say so. Attribution
+    // therefore belongs to the ACTION: `closeTab`/`closeOtherTabs`/
+    // `closeAllTabs` exist only behind a tab-strip gesture, and every other
+    // removal path (conversation switch, delete cascade, a withdrawn adoption)
+    // is the app tidying up after itself.
+    it('user-gesture close actions stamp user_close', () => {
+      const kept = usePreviewStore.getState().openBrowser('https://kept.example');
+      const dropped = usePreviewStore.getState().openBrowser('https://dropped.example');
+
+      usePreviewStore.getState().closeOtherTabs(kept);
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: dropped, reason: 'user_close' });
+
+      invokeMock.mockClear();
+      usePreviewStore.getState().closeAllTabs();
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: kept, reason: 'user_close' });
+    });
+
+    it('programmatic teardown stamps lifecycle, never a gesture', () => {
+      usePreviewStore.getState().closeTabsForConversationSwitch('conv-a');
+      usePreviewStore.getState().openBrowser('https://a.example', 'agent-a-reason', 'conv-a');
+      usePreviewStore.getState().openBrowser('https://b.example', 'agent-b-reason', 'conv-b');
+
+      // A withdrawn adoption (C4's `browser://automation-cancel`)…
+      usePreviewStore.getState().closeAdoptedBrowserTab('agent-b-reason');
+      // …and the conversation delete cascade.
+      usePreviewStore.getState().closeOwnedTabsForConversation('conv-a');
+
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', {
+        id: 'agent-b-reason',
+        reason: 'lifecycle',
+      });
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', {
+        id: 'agent-a-reason',
+        reason: 'lifecycle',
+      });
+      expect(invokeMock).not.toHaveBeenCalledWith(
+        'browser_close',
+        expect.objectContaining({ reason: 'user_close' }),
+      );
     });
 
     it('closeTab of a non-browser tab touches no native view', () => {
@@ -436,12 +478,12 @@ describe('previewStore', () => {
       const dropped = usePreviewStore.getState().openBrowser('https://dropped.example');
 
       usePreviewStore.getState().closeOtherTabs(kept);
-      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: dropped });
-      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', { id: kept });
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', expect.objectContaining({ id: dropped }));
+      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', expect.objectContaining({ id: kept }));
 
       invokeMock.mockClear();
       usePreviewStore.getState().closeAllTabs();
-      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: kept });
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', expect.objectContaining({ id: kept }));
     });
 
     it('closeTabsForConversationSwitch keeps browser tabs and their views alive', () => {
@@ -594,14 +636,14 @@ describe('previewStore', () => {
 
       usePreviewStore.getState().closeOtherTabs('agent-b-1');
       expect(ids(usePreviewStore.getState().tabs)).toEqual(['agent-a-8', 'agent-b-1']);
-      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', { id: 'agent-a-8' });
+      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', expect.objectContaining({ id: 'agent-a-8' }));
 
       usePreviewStore.getState().closeAllTabs();
       const s = usePreviewStore.getState();
       expect(ids(s.tabs)).toEqual(['agent-a-8']);
       expect(getVisibleTabs()).toEqual([]);
-      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: 'agent-b-1' });
-      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', { id: 'agent-a-8' });
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', expect.objectContaining({ id: 'agent-b-1' }));
+      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', expect.objectContaining({ id: 'agent-a-8' }));
     });
 
     // C2-I1 / N4 — a deleted conversation's browser tab is invisible in every
@@ -617,10 +659,10 @@ describe('previewStore', () => {
       usePreviewStore.getState().closeOwnedTabsForConversation('conv-a');
 
       expect(ids(usePreviewStore.getState().tabs)).toEqual(['agent-b-keep', paneTab]);
-      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: 'agent-a-del-1' });
-      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: 'agent-a-del-2' });
-      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', { id: 'agent-b-keep' });
-      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', { id: paneTab });
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', expect.objectContaining({ id: 'agent-a-del-1' }));
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', expect.objectContaining({ id: 'agent-a-del-2' }));
+      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', expect.objectContaining({ id: 'agent-b-keep' }));
+      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', expect.objectContaining({ id: paneTab }));
     });
 
     it('closeOwnedTabsForConversation lands the active tab on a visible survivor', () => {
@@ -659,8 +701,8 @@ describe('previewStore', () => {
       usePreviewStore.getState().closeAdoptedBrowserTab('agent-a-cancel');
 
       expect(ids(usePreviewStore.getState().tabs)).toEqual(['agent-b-keep']);
-      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: 'agent-a-cancel' });
-      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', { id: 'agent-b-keep' });
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', expect.objectContaining({ id: 'agent-a-cancel' }));
+      expect(invokeMock).not.toHaveBeenCalledWith('browser_close', expect.objectContaining({ id: 'agent-b-keep' }));
     });
 
     it('closeAdoptedBrowserTab re-activates a survivor when the withdrawn tab was active', () => {
@@ -675,7 +717,7 @@ describe('previewStore', () => {
       const s = usePreviewStore.getState();
       expect(ids(s.tabs)).toEqual([summaryId]);
       expect(s.activeTabId).toBe(summaryId);
-      expect(invokeMock).toHaveBeenCalledWith('browser_close', { id: 'agent-a-visible' });
+      expect(invokeMock).toHaveBeenCalledWith('browser_close', expect.objectContaining({ id: 'agent-a-visible' }));
     });
 
     it('closeAdoptedBrowserTab ignores an unknown id and never touches a non-browser tab', () => {

--- a/src/stores/previewStore.ts
+++ b/src/stores/previewStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { useSettingsStore } from './settingsStore';
 import { useBatchProgressStore } from './batchProgressStore';
+import { closeBrowserViews } from '@/core/browser/browserViewLifecycle';
 import { makeBatchKey, type BatchIdentity } from '@/types';
 
 /**
@@ -51,6 +52,17 @@ function genId(): string {
 function computePreviewFilePath(tabs: WorkspaceTab[], activeTabId: string | null): string | null {
   const active = tabs.find((t) => t.id === activeTabId);
   return active && active.kind === 'preview' ? active.filePath : null;
+}
+
+/**
+ * Ids of the browser tabs that exist in `oldTabs` but not in `nextTabs` — the
+ * tabs whose native views this transition must destroy.
+ */
+function removedBrowserTabIds(oldTabs: WorkspaceTab[], nextTabs: WorkspaceTab[]): string[] {
+  const surviving = new Set(nextTabs.map((tab) => tab.id));
+  return oldTabs
+    .filter((tab) => tab.kind === 'browser' && !surviving.has(tab.id))
+    .map((tab) => tab.id);
 }
 
 function activeSubagentIdentity(tabs: WorkspaceTab[], activeTabId: string | null): BatchIdentity | undefined {
@@ -131,6 +143,10 @@ interface PreviewState {
   closeOtherTabs: (id: string) => void;
   // Close every tab.
   closeAllTabs: () => void;
+  // Reset the panel for a conversation switch: closes every conversation-scoped
+  // tab (summary / preview / terminal / subagent) but KEEPS browser tabs, whose
+  // native views belong to a running agent rather than to the panel.
+  closeTabsForConversationSwitch: () => void;
   // Close subagent tabs owned by one conversation. Other workspace tabs stay
   // open; used by chatStore's synchronous delete cascade.
   closeSubagentTabsForConversation: (conversationId: string) => void;
@@ -171,6 +187,11 @@ export const usePreviewStore = create<PreviewState>((set, get) => {
   ): void => {
     const prev = get();
     reconcileSubagentLeases(prev.tabs, prev.activeTabId, nextTabs, nextActiveId);
+    // Dropping a browser tab record is the ONLY thing that destroys its native
+    // view — see closeBrowserViews. Doing it here (rather than per action)
+    // makes it an invariant of the store: no removal path can leak a view, and
+    // no UI unmount can kill one.
+    closeBrowserViews(removedBrowserTabIds(prev.tabs, nextTabs));
     const previewFilePath = computePreviewFilePath(nextTabs, nextActiveId);
     set({
       tabs: nextTabs,
@@ -319,6 +340,20 @@ export const usePreviewStore = create<PreviewState>((set, get) => {
 
   closeAllTabs: () => {
     commitTabs([], null);
+  },
+
+  closeTabsForConversationSwitch: () => {
+    const { tabs, activeTabId } = get();
+    // Everything except a browser tab is scoped to the conversation that
+    // opened it. A browser tab is a live native view an agent may still be
+    // driving — closing it here used to kill the page mid-task (and, on the
+    // agent's next action, hand back a brand-new tab id).
+    const nextTabs = tabs.filter((tab) => tab.kind === 'browser');
+    if (nextTabs.length === tabs.length) return;
+    const nextActiveId = activeTabId && nextTabs.some((tab) => tab.id === activeTabId)
+      ? activeTabId
+      : nextTabs[0]?.id ?? null;
+    commitTabs(nextTabs, nextActiveId);
   },
 
   closeSubagentTabsForConversation: (conversationId) => {

--- a/src/stores/previewStore.ts
+++ b/src/stores/previewStore.ts
@@ -185,6 +185,12 @@ interface PreviewState {
   // Close subagent tabs owned by one conversation. Other workspace tabs stay
   // open; used by chatStore's synchronous delete cascade.
   closeSubagentTabsForConversation: (conversationId: string) => void;
+  // Close the browser tabs an agent adopted for one conversation, wherever they
+  // sit in the strip — including while another conversation is on screen (they
+  // are invisible there, so no UI path could ever close them). Removing the
+  // record is what destroys the native view, so this is the renderer's half of
+  // the delete cascade's browser cleanup. Legacy/user-opened tabs are untouched.
+  closeOwnedTabsForConversation: (conversationId: string) => void;
   // Drag-reorder: move the tab with id `fromId` to `toId`'s position.
   reorderTabs: (fromId: string, toId: string) => void;
   // Commit a new URL for a browser tab (address-bar navigation).
@@ -252,6 +258,29 @@ export const usePreviewStore = create<PreviewState>((set, get) => {
         : {}),
     });
     useBatchProgressStore.getState().setActiveVisibleBatch(activeSubagentIdentity(nextTabs, nextActiveId));
+  };
+
+  /**
+   * Remove every tab `matches` selects, keeping the active tab on the nearest
+   * VISIBLE survivor (forward from the old slot, then backward). Shared by the
+   * two delete-cascade removals — subagent tabs and owned browser tabs — which
+   * differ only in what they select: both take out a set of tabs a deleted
+   * conversation owned, from anywhere in the strip.
+   */
+  const removeTabsWhere = (matches: (tab: WorkspaceTab) => boolean): void => {
+    const { tabs, activeTabId, currentConversationId } = get();
+    if (!tabs.some(matches)) return;
+    const nextTabs = tabs.filter((tab) => !matches(tab));
+    let nextActiveId = activeTabId;
+    if (activeTabId && !nextTabs.some((tab) => tab.id === activeTabId)) {
+      const oldIdx = tabs.findIndex((tab) => tab.id === activeTabId);
+      const survives = (tab: WorkspaceTab): boolean =>
+        nextTabs.some((next) => next.id === tab.id) && isTabVisibleFor(tab, currentConversationId);
+      const after = tabs.slice(oldIdx + 1).find(survives);
+      const before = tabs.slice(0, oldIdx).reverse().find(survives);
+      nextActiveId = (after ?? before)?.id ?? null;
+    }
+    commitTabs(nextTabs, nextActiveId);
   };
 
   /** Tabs the panel currently shows, recomputed from `tabs` (never stale). */
@@ -436,21 +465,11 @@ export const usePreviewStore = create<PreviewState>((set, get) => {
   },
 
   closeSubagentTabsForConversation: (conversationId) => {
-    const { tabs, activeTabId, currentConversationId } = get();
-    const matches = (tab: WorkspaceTab): boolean =>
-      tab.kind === 'subagent' && tab.identity.conversationId === conversationId;
-    if (!tabs.some(matches)) return;
-    const nextTabs = tabs.filter((tab) => !matches(tab));
-    let nextActiveId = activeTabId;
-    if (activeTabId && !nextTabs.some((tab) => tab.id === activeTabId)) {
-      const oldIdx = tabs.findIndex((tab) => tab.id === activeTabId);
-      const survives = (tab: WorkspaceTab): boolean =>
-        nextTabs.some((next) => next.id === tab.id) && isTabVisibleFor(tab, currentConversationId);
-      const after = tabs.slice(oldIdx + 1).find(survives);
-      const before = tabs.slice(0, oldIdx).reverse().find(survives);
-      nextActiveId = (after ?? before)?.id ?? null;
-    }
-    commitTabs(nextTabs, nextActiveId);
+    removeTabsWhere((tab) => tab.kind === 'subagent' && tab.identity.conversationId === conversationId);
+  },
+
+  closeOwnedTabsForConversation: (conversationId) => {
+    removeTabsWhere((tab) => tab.kind === 'browser' && tab.ownerConversationId === conversationId);
   },
 
   reorderTabs: (fromId, toId) => {

--- a/src/stores/previewStore.ts
+++ b/src/stores/previewStore.ts
@@ -191,6 +191,13 @@ interface PreviewState {
   // record is what destroys the native view, so this is the renderer's half of
   // the delete cascade's browser cleanup. Legacy/user-opened tabs are untouched.
   closeOwnedTabsForConversation: (conversationId: string) => void;
+  // Drop one adopted browser tab because MAIN withdrew it
+  // (`browser://automation-cancel`: the run was stopped, or the conversation
+  // that owned the view was deleted). Reaches the tab wherever it sits — a
+  // withdrawn tab is typically invisible in the current conversation, so no
+  // user-facing close path could ever remove it — and destroys any native view
+  // that was already created for it.
+  closeAdoptedBrowserTab: (id: string) => void;
   // Drag-reorder: move the tab with id `fromId` to `toId`'s position.
   reorderTabs: (fromId: string, toId: string) => void;
   // Commit a new URL for a browser tab (address-bar navigation).
@@ -470,6 +477,10 @@ export const usePreviewStore = create<PreviewState>((set, get) => {
 
   closeOwnedTabsForConversation: (conversationId) => {
     removeTabsWhere((tab) => tab.kind === 'browser' && tab.ownerConversationId === conversationId);
+  },
+
+  closeAdoptedBrowserTab: (id) => {
+    removeTabsWhere((tab) => tab.kind === 'browser' && tab.id === id);
   },
 
   reorderTabs: (fromId, toId) => {

--- a/src/stores/previewStore.ts
+++ b/src/stores/previewStore.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { create } from 'zustand';
 import { useSettingsStore } from './settingsStore';
 import { useBatchProgressStore } from './batchProgressStore';
-import { closeBrowserViews } from '@/core/browser/browserViewLifecycle';
+import { closeBrowserViews, type BrowserCloseReason } from '@/core/browser/browserViewLifecycle';
 import { makeBatchKey, type BatchIdentity } from '@/types';
 
 /**
@@ -231,7 +231,15 @@ export const usePreviewStore = create<PreviewState>((set, get) => {
   const commitTabs = (
     nextTabs: WorkspaceTab[],
     requestedActiveId: string | null,
-    options: { focusTabId?: string | null; conversationId?: string | null } = {},
+    options: {
+      focusTabId?: string | null;
+      conversationId?: string | null;
+      // Why any browser views this commit removes are being destroyed (N7).
+      // Defaults to 'lifecycle': only a caller that KNOWS it is running behind
+      // a user gesture may claim one, so a new removal path can never
+      // accidentally look like the user reclaiming the browser.
+      closeReason?: BrowserCloseReason;
+    } = {},
   ): void => {
     const prev = get();
     const conversationId = options.conversationId !== undefined
@@ -249,7 +257,7 @@ export const usePreviewStore = create<PreviewState>((set, get) => {
     // view — see closeBrowserViews. Doing it here (rather than per action)
     // makes it an invariant of the store: no removal path can leak a view, and
     // no UI unmount can kill one.
-    closeBrowserViews(removedBrowserTabIds(prev.tabs, nextTabs));
+    closeBrowserViews(removedBrowserTabIds(prev.tabs, nextTabs), options.closeReason);
     const previewFilePath = computePreviewFilePath(nextTabs, nextActiveId);
     set({
       tabs: nextTabs,
@@ -436,7 +444,10 @@ export const usePreviewStore = create<PreviewState>((set, get) => {
     const focusTabId = options?.focusAfterClose && nextActiveId && nextTabs.some((tab) => tab.id === nextActiveId)
       ? nextActiveId
       : null;
-    commitTabs(nextTabs, nextActiveId, { focusTabId });
+    // The three actions below exist only behind a tab-strip gesture (×, middle
+    // click, the context menu) — closing an agent's tab there is the user
+    // reclaiming the browser, which the host must hear (N7).
+    commitTabs(nextTabs, nextActiveId, { focusTabId, closeReason: 'user_close' });
   },
 
   // "Close other / close all" are tab-strip commands, so they reach exactly
@@ -446,12 +457,16 @@ export const usePreviewStore = create<PreviewState>((set, get) => {
     const { tabs, currentConversationId } = get();
     if (!tabs.some((t) => t.id === id)) return;
     const nextTabs = tabs.filter((t) => t.id === id || !isTabVisibleFor(t, currentConversationId));
-    commitTabs(nextTabs, id);
+    commitTabs(nextTabs, id, { closeReason: 'user_close' });
   },
 
   closeAllTabs: () => {
     const { tabs, currentConversationId } = get();
-    commitTabs(tabs.filter((t) => !isTabVisibleFor(t, currentConversationId)), null);
+    commitTabs(
+      tabs.filter((t) => !isTabVisibleFor(t, currentConversationId)),
+      null,
+      { closeReason: 'user_close' },
+    );
   },
 
   closeTabsForConversationSwitch: (conversationId = null) => {

--- a/src/stores/previewStore.ts
+++ b/src/stores/previewStore.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { create } from 'zustand';
 import { useSettingsStore } from './settingsStore';
 import { useBatchProgressStore } from './batchProgressStore';
@@ -24,9 +25,29 @@ function expandRightPanel(): void {
 export type WorkspaceTab =
   | { id: string; kind: 'summary' }
   | { id: string; kind: 'preview'; filePath: string }
-  | { id: string; kind: 'browser'; url: string }
+  // `ownerConversationId` is the conversation an agent adopted this view for
+  // (main's `ownerKey`, threaded through `browser://automation-open`). Absent =
+  // user-opened / legacy, which every conversation may see.
+  | { id: string; kind: 'browser'; url: string; ownerConversationId?: string }
   | { id: string; kind: 'terminal' }
   | { id: string; kind: 'subagent'; identity: BatchIdentity; taskIndex: number; title: string };
+
+/**
+ * Whether `conversationId`'s panel may list/activate `tab`.
+ *
+ * Only an OWNED browser tab is scoped: its native view keeps running for its
+ * owner conversation (C1 keep-alive), but showing it to another conversation
+ * would open that conversation's panel on someone else's live page — and,
+ * because the native layer paints over React, leave it painted there.
+ */
+export function isTabVisibleFor(tab: WorkspaceTab, conversationId: string | null): boolean {
+  if (tab.kind !== 'browser' || !tab.ownerConversationId) return true;
+  return tab.ownerConversationId === conversationId;
+}
+
+export function visibleTabsFor(tabs: WorkspaceTab[], conversationId: string | null): WorkspaceTab[] {
+  return tabs.filter((tab) => isTabVisibleFor(tab, conversationId));
+}
 
 export function subagentTabId(identity: BatchIdentity, taskIndex: number): string {
   return `subagent:${makeBatchKey(identity)}:${taskIndex}`;
@@ -86,8 +107,19 @@ function reconcileSubagentLeases(
 
 interface PreviewState {
   // All open workspace tabs (preview/browser/terminal), in display order.
+  // Includes browser tabs owned by OTHER conversations — their native views
+  // stay alive and mounted (hidden), they are just not this conversation's to
+  // show. UI must render the tab strip / empty state off `useVisibleTabs()`;
+  // only the keep-alive tab bodies iterate this full list.
   tabs: WorkspaceTab[];
-  // Currently active tab id, or null when there are no tabs.
+  // The conversation whose panel is on screen. Set by the conversation-switch
+  // reset; null before the first switch (and when no conversation is active).
+  currentConversationId: string | null;
+  // conversation id -> the tab it was last looking at, so switching back
+  // restores that tab rather than always the leftmost survivor. Ephemeral.
+  lastActiveTabByConversation: Record<string, string>;
+  // Currently active tab id, or null when there are no tabs. ALWAYS a tab this
+  // conversation can see (or null) — commitTabs enforces it.
   activeTabId: string | null;
   focusTabId: string | null;
   // True while a workspace popover (tab-strip `+` / context menu) is open. The
@@ -127,8 +159,9 @@ interface PreviewState {
   // (~11 across the app) are unchanged from the pre-tabs single-preview API.
   openPreview: (filePath: string) => void;
   // Open (or activate an existing) browser tab for `url` (default ''). Main
-  // may supply an id when adopting an agent-created Electron browser view.
-  openBrowser: (url?: string, requestedId?: string) => string;
+  // may supply an id when adopting an agent-created Electron browser view, plus
+  // the conversation that view belongs to (omitted for the legacy shared pool).
+  openBrowser: (url?: string, requestedId?: string, ownerConversationId?: string) => string;
   // Open a new terminal tab (terminals are never deduped — each is its own session).
   openTerminal: () => void;
   openSubagent: (identity: BatchIdentity, taskIndex: number, title: string) => string;
@@ -143,10 +176,12 @@ interface PreviewState {
   closeOtherTabs: (id: string) => void;
   // Close every tab.
   closeAllTabs: () => void;
-  // Reset the panel for a conversation switch: closes every conversation-scoped
-  // tab (summary / preview / terminal / subagent) but KEEPS browser tabs, whose
-  // native views belong to a running agent rather than to the panel.
-  closeTabsForConversationSwitch: () => void;
+  // Reset the panel for a switch to `conversationId`: closes every
+  // conversation-scoped tab (summary / preview / terminal / subagent) but KEEPS
+  // browser tabs, whose native views belong to a running agent rather than to
+  // the panel. Browser tabs owned by another conversation become invisible
+  // here; the new conversation's own tabs (if any) come back visible.
+  closeTabsForConversationSwitch: (conversationId?: string | null) => void;
   // Close subagent tabs owned by one conversation. Other workspace tabs stay
   // open; used by chatStore's synchronous delete cascade.
   closeSubagentTabsForConversation: (conversationId: string) => void;
@@ -182,10 +217,20 @@ interface PreviewState {
 export const usePreviewStore = create<PreviewState>((set, get) => {
   const commitTabs = (
     nextTabs: WorkspaceTab[],
-    nextActiveId: string | null,
-    options: { focusTabId?: string | null } = {},
+    requestedActiveId: string | null,
+    options: { focusTabId?: string | null; conversationId?: string | null } = {},
   ): void => {
     const prev = get();
+    const conversationId = options.conversationId !== undefined
+      ? options.conversationId
+      : prev.currentConversationId;
+    const nextVisible = visibleTabsFor(nextTabs, conversationId);
+    // Invariant: the active tab is always one this conversation can see. A
+    // foreign-owned browser view would otherwise be rendered (and painted, by
+    // the native layer) over the current conversation's panel.
+    const nextActiveId = requestedActiveId && nextVisible.some((tab) => tab.id === requestedActiveId)
+      ? requestedActiveId
+      : null;
     reconcileSubagentLeases(prev.tabs, prev.activeTabId, nextTabs, nextActiveId);
     // Dropping a browser tab record is the ONLY thing that destroys its native
     // view — see closeBrowserViews. Doing it here (rather than per action)
@@ -195,16 +240,30 @@ export const usePreviewStore = create<PreviewState>((set, get) => {
     const previewFilePath = computePreviewFilePath(nextTabs, nextActiveId);
     set({
       tabs: nextTabs,
+      currentConversationId: conversationId,
       activeTabId: nextActiveId,
       previewFilePath,
       focusTabId: options.focusTabId ?? null,
-      ...(nextTabs.length === 0 ? { chatWidth: null } : {}),
+      // Panel width is a per-conversation concern: an invisible foreign tab
+      // must not keep this conversation's chat column pinned.
+      ...(nextVisible.length === 0 ? { chatWidth: null } : {}),
+      ...(conversationId && nextActiveId
+        ? { lastActiveTabByConversation: { ...prev.lastActiveTabByConversation, [conversationId]: nextActiveId } }
+        : {}),
     });
     useBatchProgressStore.getState().setActiveVisibleBatch(activeSubagentIdentity(nextTabs, nextActiveId));
   };
 
+  /** Tabs the panel currently shows, recomputed from `tabs` (never stale). */
+  const visibleNow = (): WorkspaceTab[] => {
+    const { tabs, currentConversationId } = get();
+    return visibleTabsFor(tabs, currentConversationId);
+  };
+
   return ({
   tabs: [],
+  currentConversationId: null,
+  lastActiveTabByConversation: {},
   activeTabId: null,
   focusTabId: null,
   menuOpen: false,
@@ -241,31 +300,40 @@ export const usePreviewStore = create<PreviewState>((set, get) => {
     expandRightPanel();
   },
 
-  openBrowser: (url = '', requestedId) => {
-    const { tabs, activeTabId } = get();
+  openBrowser: (url = '', requestedId, ownerConversationId) => {
+    const { tabs, activeTabId, currentConversationId } = get();
     if (requestedId) {
       const requested = tabs.find((t) => t.id === requestedId);
       if (requested) {
         // Re-entry for an already-adopted id (main's adoption poll re-finding
         // the same view) is a deliberate re-open, not a new-tab event — keep
-        // today's re-activate behavior.
-        commitTabs(tabs, requested.id);
+        // today's re-activate behavior, unless the tab belongs to a background
+        // conversation, in which case re-entry must not touch this view.
+        const visibleHere = isTabVisibleFor(requested, currentConversationId);
+        commitTabs(tabs, visibleHere ? requested.id : activeTabId);
         return requested.id;
       }
-      const nextTabs: WorkspaceTab[] = [...tabs, {
+      const adopted: WorkspaceTab = {
         id: requestedId,
         kind: 'browser',
         url,
-      }];
+        ...(ownerConversationId ? { ownerConversationId } : {}),
+      };
+      const nextTabs: WorkspaceTab[] = [...tabs, adopted];
       // Adopting a brand-new agent-created tab must not steal focus from a
       // user who is actively watching a browser tab — add it in the
       // background. If the user isn't on a browser tab (or has no tabs at
       // all), activating it preserves today's single-task first-tab UX.
+      // An adoption for a BACKGROUND conversation never activates at all: the
+      // user is looking at a different conversation and must keep seeing it.
       const currentActiveIsBrowser = tabs.find((t) => t.id === activeTabId)?.kind === 'browser';
-      commitTabs(nextTabs, currentActiveIsBrowser ? activeTabId : requestedId);
+      const steals = !isTabVisibleFor(adopted, currentConversationId) || currentActiveIsBrowser;
+      commitTabs(nextTabs, steals ? activeTabId : requestedId);
       return requestedId;
     }
-    const existing = tabs.find((t) => t.kind === 'browser' && t.url === url);
+    // Dedupe only against tabs this conversation can see — matching a hidden
+    // foreign tab would "activate" something the panel refuses to show.
+    const existing = visibleNow().find((t) => t.kind === 'browser' && t.url === url);
     if (existing) {
       commitTabs(tabs, existing.id);
       expandRightPanel();
@@ -304,8 +372,10 @@ export const usePreviewStore = create<PreviewState>((set, get) => {
   },
 
   activateTab: (id) => {
-    const { tabs } = get();
-    if (!tabs.some((t) => t.id === id)) return;
+    const { tabs, currentConversationId } = get();
+    const tab = tabs.find((t) => t.id === id);
+    // A browser tab owned by another conversation is not this panel's to show.
+    if (!tab || !isTabVisibleFor(tab, currentConversationId)) return;
     commitTabs(tabs, id);
   },
 
@@ -315,14 +385,16 @@ export const usePreviewStore = create<PreviewState>((set, get) => {
 
   closeTab: (id, options) => {
     const { tabs, activeTabId } = get();
-    const idx = tabs.findIndex((t) => t.id === id);
-    if (idx === -1) return;
+    if (!tabs.some((t) => t.id === id)) return;
     const nextTabs = tabs.filter((t) => t.id !== id);
     let nextActiveId = activeTabId;
     if (activeTabId === id) {
-      // Prefer the tab that was next (now shifted into `idx`'s slot), else
-      // the one before it, else there's nothing left.
-      const neighbor = tabs[idx + 1] ?? tabs[idx - 1] ?? null;
+      // Prefer the tab that was next, else the one before it, else there's
+      // nothing left. Neighbors are picked among the tabs the user can
+      // actually see — a hidden foreign tab is not a landing spot.
+      const visible = visibleNow();
+      const idx = visible.findIndex((t) => t.id === id);
+      const neighbor = visible[idx + 1] ?? visible[idx - 1] ?? null;
       nextActiveId = neighbor ? neighbor.id : null;
     }
     const focusTabId = options?.focusAfterClose && nextActiveId && nextTabs.some((tab) => tab.id === nextActiveId)
@@ -331,33 +403,40 @@ export const usePreviewStore = create<PreviewState>((set, get) => {
     commitTabs(nextTabs, nextActiveId, { focusTabId });
   },
 
+  // "Close other / close all" are tab-strip commands, so they reach exactly
+  // what the strip lists: another conversation's browser view is neither shown
+  // here nor closable from here.
   closeOtherTabs: (id) => {
-    const { tabs } = get();
+    const { tabs, currentConversationId } = get();
     if (!tabs.some((t) => t.id === id)) return;
-    const nextTabs = tabs.filter((t) => t.id === id);
+    const nextTabs = tabs.filter((t) => t.id === id || !isTabVisibleFor(t, currentConversationId));
     commitTabs(nextTabs, id);
   },
 
   closeAllTabs: () => {
-    commitTabs([], null);
+    const { tabs, currentConversationId } = get();
+    commitTabs(tabs.filter((t) => !isTabVisibleFor(t, currentConversationId)), null);
   },
 
-  closeTabsForConversationSwitch: () => {
-    const { tabs, activeTabId } = get();
+  closeTabsForConversationSwitch: (conversationId = null) => {
+    const { tabs, lastActiveTabByConversation } = get();
     // Everything except a browser tab is scoped to the conversation that
     // opened it. A browser tab is a live native view an agent may still be
     // driving — closing it here used to kill the page mid-task (and, on the
     // agent's next action, hand back a brand-new tab id).
     const nextTabs = tabs.filter((tab) => tab.kind === 'browser');
-    if (nextTabs.length === tabs.length) return;
-    const nextActiveId = activeTabId && nextTabs.some((tab) => tab.id === activeTabId)
-      ? activeTabId
-      : nextTabs[0]?.id ?? null;
-    commitTabs(nextTabs, nextActiveId);
+    // Land on what this conversation was last looking at; otherwise its
+    // leftmost visible tab; otherwise nothing (the summary effect takes over).
+    const visible = visibleTabsFor(nextTabs, conversationId);
+    const remembered = conversationId ? lastActiveTabByConversation[conversationId] : undefined;
+    const nextActiveId = (remembered && visible.some((tab) => tab.id === remembered)
+      ? remembered
+      : visible[0]?.id) ?? null;
+    commitTabs(nextTabs, nextActiveId, { conversationId });
   },
 
   closeSubagentTabsForConversation: (conversationId) => {
-    const { tabs, activeTabId } = get();
+    const { tabs, activeTabId, currentConversationId } = get();
     const matches = (tab: WorkspaceTab): boolean =>
       tab.kind === 'subagent' && tab.identity.conversationId === conversationId;
     if (!tabs.some(matches)) return;
@@ -365,7 +444,8 @@ export const usePreviewStore = create<PreviewState>((set, get) => {
     let nextActiveId = activeTabId;
     if (activeTabId && !nextTabs.some((tab) => tab.id === activeTabId)) {
       const oldIdx = tabs.findIndex((tab) => tab.id === activeTabId);
-      const survives = (tab: WorkspaceTab): boolean => nextTabs.some((next) => next.id === tab.id);
+      const survives = (tab: WorkspaceTab): boolean =>
+        nextTabs.some((next) => next.id === tab.id) && isTabVisibleFor(tab, currentConversationId);
       const after = tabs.slice(oldIdx + 1).find(survives);
       const before = tabs.slice(0, oldIdx).reverse().find(survives);
       nextActiveId = (after ?? before)?.id ?? null;
@@ -391,7 +471,7 @@ export const usePreviewStore = create<PreviewState>((set, get) => {
   },
 
   closePreviewTabsForPath: (path) => {
-    const { tabs, activeTabId } = get();
+    const { tabs, activeTabId, currentConversationId } = get();
     const matches = (t: WorkspaceTab): boolean =>
       t.kind === 'preview' && (t.filePath === path || t.filePath.startsWith(path + '/'));
     if (!tabs.some(matches)) return;
@@ -401,7 +481,8 @@ export const usePreviewStore = create<PreviewState>((set, get) => {
       // The active tab was among those closed — activate the nearest survivor
       // (search forward from its old slot, then backward).
       const oldIdx = tabs.findIndex((t) => t.id === activeTabId);
-      const survives = (t: WorkspaceTab) => nextTabs.some((n) => n.id === t.id);
+      const survives = (t: WorkspaceTab) =>
+        nextTabs.some((n) => n.id === t.id) && isTabVisibleFor(t, currentConversationId);
       const after = tabs.slice(oldIdx + 1).find(survives);
       const before = tabs.slice(0, oldIdx).reverse().find(survives);
       nextActiveId = (after ?? before)?.id ?? null;
@@ -454,7 +535,26 @@ export const usePreviewStore = create<PreviewState>((set, get) => {
   });
 });
 
-/** True while the workspace has at least one open tab. */
+/**
+ * The tabs the current conversation's panel may list — every tab except a
+ * browser tab another conversation's agent owns. Derived at read time (rather
+ * than mirrored into state) so it can never go stale behind `tabs`; the two
+ * selector reads are reference-stable, and the memo keeps the filtered array
+ * stable across renders.
+ */
+export function useVisibleTabs(): WorkspaceTab[] {
+  const tabs = usePreviewStore((s) => s.tabs);
+  const currentConversationId = usePreviewStore((s) => s.currentConversationId);
+  return useMemo(() => visibleTabsFor(tabs, currentConversationId), [tabs, currentConversationId]);
+}
+
+/** Imperative counterpart of `useVisibleTabs` for non-React call sites. */
+export function getVisibleTabs(): WorkspaceTab[] {
+  const { tabs, currentConversationId } = usePreviewStore.getState();
+  return visibleTabsFor(tabs, currentConversationId);
+}
+
+/** True while the workspace has at least one tab THIS conversation can see. */
 export function useHasTabs(): boolean {
-  return usePreviewStore((s) => s.tabs.length > 0);
+  return usePreviewStore((s) => s.tabs.some((tab) => isTabVisibleFor(tab, s.currentConversationId)));
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -568,6 +568,21 @@ export interface ToolExecutionContext {
   loopId?: string;
   /** Conversation ID — tools should prefer this over activeConversationId */
   conversationId?: string;
+  /**
+   * The app-owned subagent run (`sar-*`) this tool call belongs to, or absent
+   * for the conversation's own agent loop.
+   *
+   * Set by the TRUSTED runtime only (`subagentRunner`'s shell-side session for
+   * a sidecar-hosted run, `subagentLoop` for an in-process one) — never taken
+   * from model input, and never from the sidecar's copy of the context.
+   *
+   * Consumed by resources that must be owned per RUN rather than per
+   * conversation, because one conversation can drive them from its own loop and
+   * from several delegated subagents at the same time: today that is browser tab
+   * ownership (it rides `_meta['abu/runKey']` to the browser host, which keys
+   * every tab, "current tab" and takeover record on `{conversationId, runKey}`).
+   */
+  agentRunId?: string;
   /** Tool call ID — injected by toolExecutor; lets a tool locate itself and key per-call state (e.g. run_agent_batch progress) */
   toolCallId?: string;
   /** Assistant message ID owning this tool call; injected by toolExecutor for trusted metadata checkpoints. */

--- a/tests/e2e/browser-view-lifecycle.spec.ts
+++ b/tests/e2e/browser-view-lifecycle.spec.ts
@@ -1,0 +1,685 @@
+/**
+ * Real Electron + real native browser view coverage for the two journeys PR-C
+ * (feat/browser-runtime-correctness-c) exists to fix:
+ *
+ *   1. Run a browser task in conversation A, switch to conversation B, then
+ *      switch back to A — the native view must survive (same tab id, same
+ *      page), stay invisible to B the whole time, and its URL must not
+ *      regress to `about:blank`.
+ *   2. Collapse the right panel while a browser task is live, then expand it
+ *      again — same survival contract, no conversation switch involved.
+ *
+ * Both are blind spots today: on unpatched `dev` the adopted tab either gets
+ * reassigned to whichever conversation is on screen, or its native view is
+ * torn down and rebuilt as a blank tab. These specs fail on `dev` and pass on
+ * this branch.
+ *
+ * Mirrors tests/e2e/tool-approval.spec.ts's conventions: a loopback-only
+ * OpenAI-compatible SSE mock (no real credential/network endpoint), the real
+ * `electron/main.cjs` entry point via Playwright's `_electron`, and
+ * `nativeBrowserViewStates()` as ground truth for the actual native
+ * WebContentsView (not just the React tab strip).
+ *
+ * The one addition over tool-approval.spec.ts: `abu-browser__navigate` needs
+ * a `tabId` obtained from the PRECEDING `abu-browser__get_tabs` tool result,
+ * and that id (a live Electron `webContents.id`) is not known until runtime.
+ * `MockReplyPlanEntry` therefore allows a reply to be a function of the
+ * request body actually received, so the second tool call can read the first
+ * one's result out of the conversation history the mock server already has.
+ */
+import { expect, test } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { createServer, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { ElectronApplication, Page } from 'playwright';
+import {
+  closeAbuElectron,
+  configureLocalMockProvider,
+  createElectronDataRoot,
+  launchAbuElectron,
+  removeElectronDataRoot,
+  type ElectronDataRoot,
+} from './electronHelpers';
+
+const READY_TIMEOUT = 45_000;
+const CHAT_PLACEHOLDER = '想让阿布帮你做点什么？';
+const TEST_API_KEY = 'abu-e2e-browser-lifecycle-not-a-real-secret';
+const TEST_MODEL_ID = 'abu-e2e-browser-lifecycle-model';
+const PROVIDER_ID = 'abu-e2e-browser-lifecycle-provider';
+const LOCAL_MOCK_PROVIDER_OPTIONS = {
+  apiKey: TEST_API_KEY,
+  modelId: TEST_MODEL_ID,
+  modelLabel: 'Abu E2E deterministic browser-lifecycle model',
+  permissionMode: 'standard',
+  providerId: PROVIDER_ID,
+  providerName: 'Abu E2E loopback browser-lifecycle provider',
+  supportsReasoning: null,
+  supportsTools: true,
+} as const;
+
+interface MockRequest {
+  authorization: string | undefined;
+  body: unknown;
+  pathname: string;
+  purpose: 'compression' | 'memory' | 'task';
+}
+
+type MockReplyPlan =
+  | {
+      kind: 'tool-call';
+      arguments: Record<string, unknown>;
+      toolCallId: string;
+      toolName: string;
+    }
+  | { kind: 'complete'; responseText: string };
+
+/**
+ * A reply may be computed from the request body the mock just received —
+ * needed for the `navigate` call, whose `tabId` argument only exists once the
+ * `get_tabs` result (already appended to this request's message history) is
+ * on the wire.
+ */
+type MockReplyPlanEntry = MockReplyPlan | ((body: unknown) => MockReplyPlan);
+
+interface OpenAiMock {
+  baseUrl: string;
+  close: () => Promise<void>;
+  requests: MockRequest[];
+}
+
+interface OpenAiRequestMessage {
+  role?: unknown;
+  content?: unknown;
+}
+
+function sseChunk(delta: Record<string, unknown>, finishReason: string | null): string {
+  return `data: ${JSON.stringify({
+    id: 'chatcmpl-abu-e2e-browser-lifecycle',
+    object: 'chat.completion.chunk',
+    created: 0,
+    model: TEST_MODEL_ID,
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  })}\n\n`;
+}
+
+function toolCallSse(plan: Extract<MockReplyPlan, { kind: 'tool-call' }>): string {
+  return sseChunk({
+    tool_calls: [{
+      index: 0,
+      id: plan.toolCallId,
+      type: 'function',
+      function: { name: plan.toolName, arguments: JSON.stringify(plan.arguments) },
+    }],
+  }, null) + sseChunk({}, 'tool_calls') + 'data: [DONE]\n\n';
+}
+
+function completeSse(responseText: string): string {
+  return sseChunk({ content: responseText }, null) + sseChunk({}, 'stop') + 'data: [DONE]\n\n';
+}
+
+/**
+ * Background requests the agent loop fires on its own — memory extraction
+ * after a turn, and context compression once a conversation grows — that are
+ * unrelated to the scripted tool-call/complete sequence below. Classified the
+ * same way tests/e2e/task-lifecycle.spec.ts does, by sniffing the system/user
+ * prompt content each one sends, so they get an innocuous canned reply
+ * instead of silently consuming a slot in `replyPlans` and desyncing every
+ * request after them.
+ */
+function isMemoryExtractionRequest(body: unknown): boolean {
+  if (!body || typeof body !== 'object' || !('messages' in body)) return false;
+  const messages = (body as { messages?: unknown }).messages;
+  return Array.isArray(messages) && messages.some((message) => {
+    if (!message || typeof message !== 'object') return false;
+    const candidate = message as { content?: unknown; role?: unknown };
+    return candidate.role === 'system'
+      && typeof candidate.content === 'string'
+      && candidate.content.includes('你是一个记忆提取助手');
+  });
+}
+
+function isCompressionRequest(body: unknown): boolean {
+  if (!body || typeof body !== 'object' || !('messages' in body)) return false;
+  const messages = (body as { messages?: unknown }).messages;
+  return Array.isArray(messages) && messages.some((message) => {
+    if (!message || typeof message !== 'object') return false;
+    const content = (message as { content?: unknown }).content;
+    return typeof content === 'string' && content.includes('请将以下对话内容压缩为一段简洁的摘要');
+  });
+}
+
+async function startOpenAiMock(replyPlans: readonly MockReplyPlanEntry[]): Promise<OpenAiMock> {
+  const requests: MockRequest[] = [];
+  let taskRequestCount = 0;
+  const activeResponses = new Set<ServerResponse>();
+  const server = createServer(async (req, res) => {
+    activeResponses.add(res);
+    res.once('close', () => activeResponses.delete(res));
+
+    const requestUrl = new URL(req.url ?? '/', 'http://127.0.0.1');
+    let rawBody = '';
+    for await (const chunk of req) rawBody += String(chunk);
+
+    let body: unknown = rawBody;
+    try {
+      body = JSON.parse(rawBody);
+    } catch {
+      // Preserve malformed input for diagnostics without accepting it as valid.
+    }
+
+    if (req.method !== 'POST' || requestUrl.pathname !== '/v1/chat/completions') {
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'unexpected local E2E mock route' }));
+      return;
+    }
+
+    const purpose = isMemoryExtractionRequest(body)
+      ? 'memory'
+      : isCompressionRequest(body)
+        ? 'compression'
+        : 'task';
+    requests.push({
+      authorization: req.headers.authorization,
+      body,
+      pathname: requestUrl.pathname,
+      purpose,
+    });
+
+    if (purpose === 'memory') {
+      res.writeHead(200, {
+        'cache-control': 'no-cache',
+        connection: 'keep-alive',
+        'content-type': 'text/event-stream; charset=utf-8',
+      });
+      res.end(completeSse('[]'));
+      return;
+    }
+    if (purpose === 'compression') {
+      res.writeHead(200, {
+        'cache-control': 'no-cache',
+        connection: 'keep-alive',
+        'content-type': 'text/event-stream; charset=utf-8',
+      });
+      res.end(completeSse('Abu E2E compacted conversation summary.'));
+      return;
+    }
+
+    const rawPlan = replyPlans[taskRequestCount++];
+    if (!rawPlan) {
+      res.writeHead(500, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'unexpected extra local E2E mock request' }));
+      return;
+    }
+    const replyPlan = typeof rawPlan === 'function' ? rawPlan(body) : rawPlan;
+
+    res.writeHead(200, {
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+      'content-type': 'text/event-stream; charset=utf-8',
+    });
+    res.end(replyPlan.kind === 'tool-call' ? toolCallSse(replyPlan) : completeSse(replyPlan.responseText));
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    // Loopback only: the mock must never listen on an externally reachable interface.
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await closeServer(server, activeResponses);
+    throw new Error('The local OpenAI-compatible mock did not receive a TCP port');
+  }
+
+  return {
+    // Numeric IPv4 spelling of 127.0.0.1, matching tool-approval.spec.ts: it
+    // avoids the adapter's literal-loopback => Ollama heuristic so the real
+    // SSE/tools path is used.
+    baseUrl: `http://2130706433:${address.port}/v1`,
+    close: () => closeServer(server, activeResponses),
+    requests,
+  };
+}
+
+/** The scripted tool-call/complete sequence only, excluding background memory/compression noise. */
+function taskRequests(mock: OpenAiMock): MockRequest[] {
+  return mock.requests.filter((request) => request.purpose === 'task');
+}
+
+function closeServer(server: Server, activeResponses: ReadonlySet<ServerResponse>): Promise<void> {
+  for (const response of activeResponses) response.destroy();
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      server.closeAllConnections?.();
+      reject(new Error('Timed out closing local OpenAI E2E mock'));
+    }, 5_000);
+    server.close((error) => {
+      clearTimeout(timeout);
+      if (error) reject(error);
+      else resolve();
+    });
+    server.closeAllConnections?.();
+  });
+}
+
+/**
+ * Pull the `currentTabId` a preceding `abu-browser__get_tabs` tool result put
+ * into this request's message history, so a subsequent `navigate` call can
+ * target the same live tab. The tool result is JSON (`JSON.stringify(data,
+ * null, 2)`, see electron/browser-runtime's `formatResult`), so a small regex
+ * avoids depending on the adapter's exact message-content shape.
+ */
+function extractCurrentTabId(body: unknown): number {
+  const messages = (body as { messages?: OpenAiRequestMessage[] } | null)?.messages ?? [];
+  const toolMessage = messages.find((message) =>
+    message.role === 'tool'
+    && typeof message.content === 'string'
+    && message.content.includes('"currentTabId"')
+  );
+  if (!toolMessage) {
+    throw new Error('Expected an abu-browser__get_tabs tool result in the request body');
+  }
+  const match = /"currentTabId":\s*(\d+)/.exec(String(toolMessage.content));
+  if (!match) {
+    throw new Error('Could not find currentTabId in the get_tabs tool result');
+  }
+  return Number(match[1]);
+}
+
+/** A tiny loopback HTTP fixture the agent can navigate the real browser view to. */
+interface FixturePage {
+  url: string;
+  host: string;
+  close: () => Promise<void>;
+}
+
+async function startFixturePage(marker: string): Promise<FixturePage> {
+  const server = createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    res.end(`<!doctype html><html><head><title>${marker}</title></head><body><h1>${marker}</h1></body></html>`);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo | null;
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('The local fixture page did not receive a TCP port');
+  }
+  const url = `http://127.0.0.1:${address.port}/`;
+  return {
+    url,
+    host: new URL(url).host,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+async function waitForApp(page: Page): Promise<void> {
+  await page.waitForLoadState('domcontentloaded');
+  await expect(page.getByPlaceholder(CHAT_PLACEHOLDER)).toBeVisible({ timeout: READY_TIMEOUT });
+}
+
+/** Ground truth for the real native WebContentsView the React tab strip merely reflects. */
+async function nativeBrowserViewStates(
+  electronApp: ElectronApplication,
+): Promise<Array<{ url: string; visible: boolean }>> {
+  return electronApp.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    if (!window || window.isDestroyed()) return [];
+    return window.contentView.children.flatMap((child) => {
+      const candidate = child as unknown as {
+        getVisible?: () => boolean;
+        webContents?: {
+          getURL: () => string;
+          isDestroyed: () => boolean;
+        };
+      };
+      if (
+        typeof candidate.getVisible !== 'function'
+        || !candidate.webContents
+        || candidate.webContents.isDestroyed()
+      ) {
+        return [];
+      }
+      return [{
+        url: candidate.webContents.getURL(),
+        visible: candidate.getVisible(),
+      }];
+    });
+  });
+}
+
+/** Find our fixture's native view state, or null while it hasn't been created (yet). */
+async function ourNativeViewState(
+  electronApp: ElectronApplication,
+  fixtureUrl: string,
+): Promise<{ url: string; visible: boolean } | null> {
+  const states = await nativeBrowserViewStates(electronApp);
+  return states.find((state) => state.url === fixtureUrl) ?? null;
+}
+
+function browserConfirmHeading(page: Page) {
+  return page.getByRole('heading', { name: /^(浏览器操作确认|Confirm browser action)$/ });
+}
+
+function browserAllowOnceButton(page: Page) {
+  return page.getByRole('button', { name: /^(仅本次对话|This conversation only)$/ });
+}
+
+function showPanelToggle(page: Page) {
+  return page.getByRole('button', { name: /^(显示面板|Show panel)$/i });
+}
+
+function hidePanelButton(page: Page) {
+  return page.getByRole('button', { name: /^(隐藏面板|Hide panel)$/i });
+}
+
+/**
+ * Whether a locator is genuinely clickable right now — actionable per
+ * Playwright's own checks (visible, stable, receives pointer events at its
+ * center — not just occluded by another element), without performing the
+ * click. Needed because the sidebar's zero-width auto-collapsed container
+ * only clips PAINT (`overflow: hidden`): the "New Task" button inside it
+ * still reports a real, non-zero `getBoundingClientRect()` (Chromium doesn't
+ * reflow a fixed-width child to fit a shrunk flex ancestor), so neither
+ * `isVisible()` nor `boundingBox()` can tell the collapsed state apart from
+ * the expanded one — only an actionability probe (which also checks hit
+ * targeting at that point) catches it, the same way the click itself would.
+ */
+async function isReallyClickable(locator: ReturnType<Page['locator']>, timeout = 300): Promise<boolean> {
+  try {
+    await locator.click({ timeout, trial: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * A browser tab appearing for the first time in a conversation auto-collapses
+ * the LEFT sidebar to make room (RightPanel.tsx's wide-content auto-expand
+ * effect) — the sidebar's own "New Task" button and conversation list then
+ * sit behind a zero-width, `overflow: hidden` container that clips them out
+ * of the paint (see `isReallyClickable`). Re-expand via the always-present
+ * title-bar toggle before any test step needs the sidebar (e.g. clicking a
+ * past conversation); a no-op when it is already expanded (the toggle's
+ * aria-label flips to "hide sidebar"). Polls briefly since the auto-collapse
+ * effect can still be in flight a moment after the tab strip first shows the
+ * fixture page.
+ */
+async function ensureSidebarExpanded(page: Page): Promise<void> {
+  const showSidebar = page.getByRole('button', { name: /^(显示侧栏|Show sidebar)$/ });
+  const sidebarNewTask = page.locator('[data-sidebar-action="new-task"]');
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (await isReallyClickable(sidebarNewTask)) return;
+    if (await showSidebar.isVisible().catch(() => false)) {
+      await showSidebar.click();
+    }
+    await page.waitForTimeout(150);
+  }
+}
+
+/**
+ * Click whichever "New Task" control is actually on screen right now: the
+ * sidebar's own button, or — while a wide browser tab has auto-collapsed the
+ * sidebar — the title bar's icon-only copy of the same action (rendered only
+ * while `sidebarCollapsed`, see WindowTitleBar.tsx `showNewTask`). Avoids a
+ * race against exactly when the auto-collapse effect fires.
+ */
+async function clickNewTask(page: Page): Promise<void> {
+  const sidebarButton = page.locator('[data-sidebar-action="new-task"]');
+  if (await isReallyClickable(sidebarButton)) {
+    await sidebarButton.click();
+    return;
+  }
+  const titleBarButton = page
+    .locator('button[aria-label="新建任务"], button[aria-label="New Task"]')
+    .first();
+  await titleBarButton.click();
+}
+
+/** The workspace tab-strip row for the tab currently titled with this fixture's host. */
+function browserTabRow(page: Page, host: string) {
+  return page.locator('[data-abu-workspace-tabs] [data-tab-id]', { hasText: host });
+}
+
+/**
+ * `runAgentLoopDispatched` (src/core/agent/agentLoopRunner.ts) is the promise
+ * `ChatInput` awaits before releasing its per-draft-key "send in flight"
+ * lock, and it does not resolve until the WHOLE turn (every tool call, the
+ * final answer, post-turn bookkeeping) is done — not just once the final
+ * answer is visible on screen, which can render slightly earlier via the
+ * streaming store update. Every "new task" send in these specs reuses the
+ * SAME lock key (there is no conversation id yet), so pressing Enter right
+ * after the previous turn's answer appears can still race that lock and get
+ * rejected with a "still pending" toast.
+ *
+ * Ground truth for "did this send actually go out" is the mock server
+ * receiving a new task-classified request — NOT the toast's visibility,
+ * which can still read `true` for a moment after a *later* retry has already
+ * succeeded (the earlier toast is merely still fading out) and would
+ * otherwise cause a spurious extra retry that dispatches the message twice.
+ */
+async function sendComposerMessage(page: Page, mock: OpenAiMock, text: string): Promise<void> {
+  const input = page.getByPlaceholder(CHAT_PLACEHOLDER);
+  const before = taskRequests(mock).length;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await input.fill(text);
+    await input.press('Enter');
+    const attemptDeadline = Date.now() + 1_000;
+    while (taskRequests(mock).length <= before && Date.now() < attemptDeadline) {
+      await page.waitForTimeout(50);
+    }
+    if (taskRequests(mock).length > before) return;
+    await page.waitForTimeout(250);
+  }
+  throw new Error(`Composer refused to send "${text}" after repeated retries (still pending)`);
+}
+
+let app: ElectronApplication | undefined;
+let dataRoot: ElectronDataRoot | undefined;
+let mock: OpenAiMock | undefined;
+let fixture: FixturePage | undefined;
+
+test.describe.serial('Electron browser view lifecycle E2E', () => {
+  test.afterEach(async () => {
+    if (app) {
+      await closeAbuElectron(app);
+      app = undefined;
+    }
+    if (mock) {
+      await mock.close();
+      mock = undefined;
+    }
+    if (fixture) {
+      await fixture.close();
+      fixture = undefined;
+    }
+    if (dataRoot) {
+      removeElectronDataRoot(dataRoot);
+      dataRoot = undefined;
+    }
+  });
+
+  test('keeps the same browser tab and page alive across a conversation switch and back', async () => {
+    const responseA = `abu-e2e-lifecycle-a-complete-${randomUUID()}`;
+    const responseB = `abu-e2e-lifecycle-b-complete-${randomUUID()}`;
+    const getTabsCallId = `call-get-tabs-${randomUUID()}`;
+    const navigateCallId = `call-navigate-${randomUUID()}`;
+    fixture = await startFixturePage(`abu-e2e-lifecycle-switch-${randomUUID()}`);
+    dataRoot = createElectronDataRoot();
+
+    mock = await startOpenAiMock([
+      {
+        kind: 'tool-call',
+        arguments: {},
+        toolCallId: getTabsCallId,
+        toolName: 'abu-browser__get_tabs',
+      },
+      (body) => ({
+        kind: 'tool-call',
+        arguments: { tabId: extractCurrentTabId(body), url: fixture!.url },
+        toolCallId: navigateCallId,
+        toolName: 'abu-browser__navigate',
+      }),
+      { kind: 'complete', responseText: responseA },
+      { kind: 'complete', responseText: responseB },
+    ]);
+
+    const launched = await launchAbuElectron(dataRoot);
+    app = launched.app;
+    const page = await app.firstWindow({ timeout: READY_TIMEOUT });
+    await waitForApp(page);
+    await configureLocalMockProvider(page, mock.baseUrl, LOCAL_MOCK_PROVIDER_OPTIONS);
+
+    // --- Conversation A: run a browser task that lands on the fixture page ---
+    const promptA = `abu-e2e-lc-a-${randomUUID().slice(0, 8)}`;
+    await sendComposerMessage(page, mock, promptA);
+
+    await expect.poll(() => taskRequests(mock!).length, { timeout: READY_TIMEOUT }).toBe(2);
+    await expect(browserConfirmHeading(page)).toBeVisible({ timeout: READY_TIMEOUT });
+    await browserAllowOnceButton(page).click();
+
+    await expect.poll(() => taskRequests(mock!).length, { timeout: READY_TIMEOUT }).toBe(3);
+    await expect(page.getByText(responseA, { exact: true })).toBeVisible({ timeout: READY_TIMEOUT });
+
+    // The tab strip shows the real page (never regressed to about:blank / the
+    // "new tab" placeholder), and the native view actually loaded it.
+    const tabInA = browserTabRow(page, fixture.host);
+    await expect(tabInA).toHaveCount(1, { timeout: READY_TIMEOUT });
+    const tabId = await tabInA.getAttribute('data-tab-id');
+    expect(tabId).toBeTruthy();
+    await expect.poll(
+      async () => (await ourNativeViewState(app!, fixture!.url))?.visible ?? null,
+      { timeout: READY_TIMEOUT },
+    ).toBe(true);
+
+    // --- Switch to a brand-new conversation B ---
+    await clickNewTask(page);
+    const promptB = `abu-e2e-lc-b-${randomUUID().slice(0, 8)}`;
+    await sendComposerMessage(page, mock, promptB);
+
+    await expect.poll(() => taskRequests(mock!).length, { timeout: READY_TIMEOUT }).toBe(4);
+    await expect(page.getByText(responseB, { exact: true })).toBeVisible({ timeout: READY_TIMEOUT });
+
+    // B must never see A's tab...
+    await expect(browserTabRow(page, fixture.host)).toHaveCount(0);
+    await expect(page.locator(`[data-abu-workspace-tabs] [data-tab-id="${tabId}"]`)).toHaveCount(0);
+    // ...but the native view is still alive (hidden, not destroyed/reset) — a
+    // surviving background task, not a killed one.
+    await expect.poll(
+      async () => (await ourNativeViewState(app!, fixture!.url))?.visible ?? null,
+      { timeout: READY_TIMEOUT },
+    ).toBe(false);
+
+    // --- Switch back to A ---
+    await ensureSidebarExpanded(page);
+    await page.getByText(promptA, { exact: true }).click();
+
+    const tabInAAgain = page.locator(`[data-abu-workspace-tabs] [data-tab-id="${tabId}"]`);
+    await expect(tabInAAgain).toHaveCount(1, { timeout: READY_TIMEOUT });
+    // Same tab id, and its title is still the fixture host — not "about:blank"
+    // and not the generic "new tab" placeholder a rebuilt tab would show.
+    await expect(tabInAAgain).toContainText(fixture.host);
+
+    // The right panel may have auto-collapsed on the switch away (this
+    // conversation has no workspace); reveal it if so, then confirm the SAME
+    // native view resumes showing the SAME page.
+    if (await showPanelToggle(page).isVisible().catch(() => false)) {
+      await showPanelToggle(page).click();
+    }
+    await expect.poll(
+      async () => (await ourNativeViewState(app!, fixture!.url))?.visible ?? null,
+      { timeout: READY_TIMEOUT },
+    ).toBe(true);
+    // Exactly one native view ever loaded the fixture URL — the agent was
+    // never handed a rebuilt tab that had to reload it.
+    const finalStates = await nativeBrowserViewStates(app!);
+    expect(finalStates.filter((state) => state.url === fixture!.url)).toHaveLength(1);
+  });
+
+  test('keeps the same browser tab and page alive across collapsing and expanding the right panel', async () => {
+    const responseA = `abu-e2e-lifecycle-collapse-complete-${randomUUID()}`;
+    const getTabsCallId = `call-get-tabs-${randomUUID()}`;
+    const navigateCallId = `call-navigate-${randomUUID()}`;
+    fixture = await startFixturePage(`abu-e2e-lifecycle-collapse-${randomUUID()}`);
+    dataRoot = createElectronDataRoot();
+
+    mock = await startOpenAiMock([
+      {
+        kind: 'tool-call',
+        arguments: {},
+        toolCallId: getTabsCallId,
+        toolName: 'abu-browser__get_tabs',
+      },
+      (body) => ({
+        kind: 'tool-call',
+        arguments: { tabId: extractCurrentTabId(body), url: fixture!.url },
+        toolCallId: navigateCallId,
+        toolName: 'abu-browser__navigate',
+      }),
+      { kind: 'complete', responseText: responseA },
+    ]);
+
+    const launched = await launchAbuElectron(dataRoot);
+    app = launched.app;
+    const page = await app.firstWindow({ timeout: READY_TIMEOUT });
+    await waitForApp(page);
+    await configureLocalMockProvider(page, mock.baseUrl, LOCAL_MOCK_PROVIDER_OPTIONS);
+
+    const prompt = `abu-e2e-lc-c-${randomUUID().slice(0, 8)}`;
+    await sendComposerMessage(page, mock, prompt);
+
+    await expect.poll(() => taskRequests(mock!).length, { timeout: READY_TIMEOUT }).toBe(2);
+    await expect(browserConfirmHeading(page)).toBeVisible({ timeout: READY_TIMEOUT });
+    await browserAllowOnceButton(page).click();
+
+    await expect.poll(() => taskRequests(mock!).length, { timeout: READY_TIMEOUT }).toBe(3);
+    await expect(page.getByText(responseA, { exact: true })).toBeVisible({ timeout: READY_TIMEOUT });
+
+    const tab = browserTabRow(page, fixture.host);
+    await expect(tab).toHaveCount(1, { timeout: READY_TIMEOUT });
+    const tabId = await tab.getAttribute('data-tab-id');
+    expect(tabId).toBeTruthy();
+    // Same-conversation "wide content appeared" auto-expands the panel, so
+    // the view should already be on screen at this point.
+    await expect.poll(
+      async () => (await ourNativeViewState(app!, fixture!.url))?.visible ?? null,
+      { timeout: READY_TIMEOUT },
+    ).toBe(true);
+
+    // --- Collapse the right panel ---
+    await hidePanelButton(page).click();
+    await expect(page.locator('[data-abu-right-panel]')).toBeHidden({ timeout: READY_TIMEOUT });
+    await expect.poll(
+      async () => (await ourNativeViewState(app!, fixture!.url))?.visible ?? null,
+      { timeout: READY_TIMEOUT },
+    ).toBe(false);
+    // The tab itself is untouched while collapsed — hidden, not destroyed.
+    const tabWhileCollapsed = page.locator(`[data-abu-workspace-tabs] [data-tab-id="${tabId}"]`);
+    await expect(tabWhileCollapsed).toHaveCount(1);
+    await expect(tabWhileCollapsed).toContainText(fixture.host);
+
+    // --- Expand the right panel again ---
+    await showPanelToggle(page).click();
+    await expect(page.locator('[data-abu-right-panel]')).toBeVisible({ timeout: READY_TIMEOUT });
+
+    const tabAfterExpand = page.locator(`[data-abu-workspace-tabs] [data-tab-id="${tabId}"]`);
+    await expect(tabAfterExpand).toHaveCount(1, { timeout: READY_TIMEOUT });
+    await expect(tabAfterExpand).toContainText(fixture.host);
+    await expect.poll(
+      async () => (await ourNativeViewState(app!, fixture!.url))?.visible ?? null,
+      { timeout: READY_TIMEOUT },
+    ).toBe(true);
+    const finalStates = await nativeBrowserViewStates(app!);
+    expect(finalStates.filter((state) => state.url === fixture!.url)).toHaveLength(1);
+  });
+});

--- a/tests/e2e/browser-view-lifecycle.spec.ts
+++ b/tests/e2e/browser-view-lifecycle.spec.ts
@@ -357,6 +357,67 @@ async function nativeBrowserViewStates(
   });
 }
 
+/**
+ * Stamp a variable into the LIVE DOCUMENT behind the fixture's native view.
+ *
+ * A surviving URL is not proof of a surviving page: a view that was torn down
+ * and rebuilt, or silently reloaded, comes back showing the same URL with a
+ * fresh document — and everything an agent actually cares about (scroll
+ * position, a half-filled form, a logged-in session's in-page state) is gone.
+ * An in-page variable is destroyed by both, so this is the assertion that tells
+ * "the same document is still here" apart from "something is showing that URL".
+ */
+async function stampLivePageMarker(
+  electronApp: ElectronApplication,
+  fixtureUrl: string,
+  marker: string,
+): Promise<void> {
+  const stamped = await electronApp.evaluate(async ({ BrowserWindow }, payload) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    if (!window || window.isDestroyed()) return false;
+    for (const child of window.contentView.children) {
+      const contents = (child as unknown as {
+        webContents?: {
+          getURL: () => string;
+          isDestroyed: () => boolean;
+          executeJavaScript: (code: string) => Promise<unknown>;
+        };
+      }).webContents;
+      if (!contents || contents.isDestroyed() || contents.getURL() !== payload.fixtureUrl) continue;
+      await contents.executeJavaScript(
+        `window.__abuE2eLivePageMarker = ${JSON.stringify(payload.marker)}; true`,
+      );
+      return true;
+    }
+    return false;
+  }, { fixtureUrl, marker });
+  if (!stamped) throw new Error('No native view was showing the fixture page to stamp');
+}
+
+/** Read that variable back; null when the document (or the view) is gone. */
+async function readLivePageMarker(
+  electronApp: ElectronApplication,
+  fixtureUrl: string,
+): Promise<string | null> {
+  return electronApp.evaluate(async ({ BrowserWindow }, url) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    if (!window || window.isDestroyed()) return null;
+    for (const child of window.contentView.children) {
+      const contents = (child as unknown as {
+        webContents?: {
+          getURL: () => string;
+          isDestroyed: () => boolean;
+          executeJavaScript: (code: string) => Promise<unknown>;
+        };
+      }).webContents;
+      if (!contents || contents.isDestroyed() || contents.getURL() !== url) continue;
+      const value = await contents.executeJavaScript('window.__abuE2eLivePageMarker ?? null');
+      return typeof value === 'string' ? value : null;
+    }
+    return null;
+  }, fixtureUrl);
+}
+
 /** Find our fixture's native view state, or null while it hasn't been created (yet). */
 async function ourNativeViewState(
   electronApp: ElectronApplication,
@@ -562,6 +623,12 @@ test.describe.serial('Electron browser view lifecycle E2E', () => {
       { timeout: READY_TIMEOUT },
     ).toBe(true);
 
+    // Stamp the live document, so the round trip below has to prove the PAGE
+    // survived, not just that something is showing the same URL.
+    const liveMarker = `abu-e2e-live-page-${randomUUID()}`;
+    await stampLivePageMarker(app, fixture.url, liveMarker);
+    expect(await readLivePageMarker(app, fixture.url)).toBe(liveMarker);
+
     // --- Switch to a brand-new conversation B ---
     await clickNewTask(page);
     const promptB = `abu-e2e-lc-b-${randomUUID().slice(0, 8)}`;
@@ -604,6 +671,8 @@ test.describe.serial('Electron browser view lifecycle E2E', () => {
     // never handed a rebuilt tab that had to reload it.
     const finalStates = await nativeBrowserViewStates(app!);
     expect(finalStates.filter((state) => state.url === fixture!.url)).toHaveLength(1);
+    // ...and it is the SAME DOCUMENT: a silent reload would have wiped this.
+    expect(await readLivePageMarker(app!, fixture.url)).toBe(liveMarker);
   });
 
   test('keeps the same browser tab and page alive across collapsing and expanding the right panel', async () => {


### PR DESCRIPTION
叠在 PR-B 上。修真机验收暴露的 dev 既有「切对话杀 view」缺陷族，并落地两项已批产品决策（N6/N7）+ 体验收尾。

## 内容（C1-C8）
- C1 view 生命周期与面板/对话 UI 解耦（keep-alive+hidden；显式关闭才销毁）
- C2 采纳按属主挂 tab、可见性按会话（切对话不再串台/丢页面）+ auto-expand 防反复触发
- C3 地址栏/前进后退/刷新记入接管检测（新特权命令 browser_note_user_interaction，安全核验：guest 无 preload 双层阻断）
- C4 删对话清扫 disposeOwnerViews + 采纳等待 abort + 取消采纳墓碑（防 legacy 幽灵 view）
- C5 e2e：切对话/折叠面板后 view 存活+页内状态存活（dev 上红、本分支绿）
- C6 归属细化到子代理 run（{conversationId,runKey}，shell-stamp 信任边界，run 结束回收；父子默认不可见、显式 tabId 交接）
- C7 用户关 tab=一等收回信号（会话级禁开新 tab、AI 先征求同意、下条消息解除；三轮加固封 legacy 漏斗/委派绕过/全 run 禁碰用户 tab）
- C8 体验收尾（Codex 基准）：两段式收回提示（主循环消费/子代理可读）、拦截文案带因、主/子代理叙事纪律三条

## 证据
- verify=0（480 文件/7345 测试）、electron:test=0、e2e 仅剩既定本机 flake；ownership 套件 86 项
- 8 任务逐个复审（6 个经修复循环）+ 整分支终审 + 三轮终审后加固（含实测探针复核）
- 修复的真问题：权限门 run 级 fail-open、@agent-under-sidecar 铸不可回收池+归属可伪造、dispose 竞态幽灵 view、收回窗口三种绕过
- 账本：worktree `.superpowers/sdd/2026-09-01-browser-lifecycle-pr-c/progress.md`

## 跟进（已开任务卡/记档）
主循环 view 闲置回收、地址栏草稿保护、委派密集会话 notice 重复、约 30 条 minors 清单在账本。

🤖 Generated with [Claude Code](https://claude.com/claude-code)