### PR TITLE
fix(hooks): harden pre-commit against high-load interrupts

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,13 @@
-npx lint-staged
+# Make the hook safe against an abrupt kill (e.g. an outer timeout under heavy
+# multi-worktree load SIGKILLing the hook mid-run). lint-staged loses uncommitted
+# work in two ways, and BOTH flags are needed (verified on lint-staged 17):
+#   --no-hide-partially-staged: don't remove the unstaged hunks of a partially
+#     staged file during the run. This is the one that prevents the "工作树变干净"
+#     data loss — otherwise a mid-run kill skips the restore and those hunks are
+#     gone from the working tree, surviving only in a dropped backup stash.
+#   --no-stash: don't create the backup stash at all, so a kill can't leave an
+#     orphan "lint-staged automatic backup" stash behind.
+# No task below mutates files (eslint has no --fix), so neither mechanism buys us
+# anything. Trade-off: a partially staged file is checked in full, not just its
+# staged hunks — acceptable, and far cheaper than losing work.
+npx lint-staged --no-stash --no-hide-partially-staged

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
   "lint-staged": {
     "src/**/*.{ts,tsx}": [
       "eslint --max-warnings 0",
-      "vitest related --run"
+      "vitest related --run --maxWorkers=2"
     ]
   },
   "overrides": {


### PR DESCRIPTION
## Problem

Two independent problems in the `husky` + `lint-staged` pre-commit hook, both surfacing under heavy multi-worktree load (load avg 20–47):

1. **Slow → outer timeout.** `vitest related` sizes its worker pool to CPU count. With several worktrees busy at once this oversubscribes and thrashes, so the hook can outlive an outer timeout and get killed.
2. **Killed hook eats uncommitted work.** When the hook is killed mid-run, `lint-staged` *hides* the unstaged hunks of a partially staged file for the duration of the run. A `SIGKILL` skips the restore, so those hunks vanish from the working tree and survive only in a dropped backup stash — the tree looks clean and it reads as lost work. Hit twice in one day.

## Fix

| Change | Why |
|---|---|
| `vitest related --run --maxWorkers=2` | Caps concurrency so the hook stays bounded under load |
| `lint-staged --no-stash --no-hide-partially-staged` | Makes the hook safe against an abrupt kill |

### Both flags are required

`--no-stash` **alone does not** prevent the data loss on lint-staged 17 — the backup stash and the hide mechanism are decoupled:

- `--no-hide-partially-staged` keeps the unstaged hunks in the working tree (this is what actually saves the work).
- `--no-stash` additionally avoids leaving an orphan `lint-staged automatic backup` stash behind on every kill.

## Verification

Reproduced the exact `SIGKILL`-mid-run scenario on a **partially staged** file in an isolated throwaway repo:

| Flags | Unstaged hunk survives? | Stash left behind? |
|---|---|---|
| *(default, current)* | ❌ lost | ⚠️ orphan backup stash |
| `--no-stash` only | ❌ still lost | none |
| `--no-hide-partially-staged` only | ✅ survives | ⚠️ orphan backup stash |
| **both (this PR)** | ✅ survives | ✅ none |

Also ran the real hook against staged throwaway `src/**` fixtures: `eslint` ✔ and `vitest related --run --maxWorkers=2` ✔, exit `0`; debug output confirms the flag reaches vitest as `args: [ 'related', '--run', '--maxWorkers=2' ]`. Fixtures removed afterwards.

## Deliberately not done

- **No `testTimeout`.** `vitest.config.ts` leaves it at the 5s default *by design* ("hung tests fail fast rather than masking hangs"). The slowness here is worker oversubscription, not slow test bodies, so `maxWorkers` is the correct lever.
- **Tests stay in pre-commit.** Moving them to pre-push/CI would weaken the gate. Checking strength is unchanged — this only addresses concurrency, timeout and recovery robustness.

## Trade-off

A partially staged file is now checked in full rather than only its staged hunks. No task mutates files (`eslint` has no `--fix`), so neither stashing nor hiding was buying us anything — and this is far cheaper than losing work.

> Note: being tooling files, this only takes effect for commits made after it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)