### PR TITLE
chore(release): gate package-lock.json version in release preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,12 +51,13 @@ Inspired by Claude Code's Cowork mode. Features multi-agent architecture with ex
 
 1. 确保 `dev` 分支 CI 全绿（build + lint + test）。
 2. **版本号在 `dev` 上 bump，三处同步**：`package.json`、`src-tauri/tauri.conf.json`、`src-tauri/Cargo.toml`（顺带 `src-tauri/Cargo.lock` 里 `name = "abu"` 那条）。（版本号跟着 dev 流到 main，不再出现 dev/main 版本错位。）
+   - 📦 **`package-lock.json` 的两个 `version` 字段也要跟着 bump**：bump 完 `package.json` 后跑 `npm install --package-lock-only`，应该只出 2 行 diff、没有依赖变化。忘了它不会当场报错，但之后任何人一跑 `npm install` 都会被 npm 顺手改回来，把这 2 行无关 churn 漏进别人的 PR。`release:check` 现在会拦这个。
    - 🌐 **更新日志双语双维护（语言分流）** —— 每次发版在 `dev` 上把该版条目**两份都写好**，语言不混：
      - **`CHANGELOG.md`（英文 canonical）** → 驱动 **GitHub Release**（CI「Create GitHub Release」步抽该版段）+ latest.json 的 `notes`（英文默认，给 Tauri updater 和国际用户）。
      - **`CHANGELOG.zh-CN.md`（中文）** → 驱动 latest.json 的 `notes_i18n["zh-CN"]`。
      - CI publish job 把两份各抽该版段写进 `latest.json.notes_i18n`；**客户端 `checker.ts` 按 UI locale（`getLocale()`）选对应语言**推给更新弹窗，官网按页面语言取。
      - ⚠️ 两份同版号、结构对应，但**语言不混**：CHANGELOG.md 全英文、CHANGELOG.zh-CN.md 全中文。v0.31.0 之前的历史仅英文版有，不用回填。
-   - ✅ **发版前跑 `npm run release:check`**（`scripts/release-preflight.mjs`）：校验四处版本号一致 + 两份 CHANGELOG 该版段都在且语言正确（英文版无 CJK、中文版有中文）。CI 也把它挂成 `release.yml` 的 `preflight` job（tag 一推先跑，**任一项不对就整个发版红、包都不出**）；本地先跑省一次 CI 往返。
+   - ✅ **发版前跑 `npm run release:check`**（`scripts/release-preflight.mjs`）：校验五个文件的版本号一致（`package.json`、`package-lock.json` 的两个字段、`tauri.conf.json`、`Cargo.toml`、`Cargo.lock`）+ 两份 CHANGELOG 该版段都在且语言正确（英文版无 CJK、中文版有中文）。CI 也把它挂成 `release.yml` 的 `preflight` job（tag 一推先跑，**任一项不对就整个发版红、包都不出**）；本地先跑省一次 CI 往返。
 3. 在 `dev` 的候选提交上打一个最终 RC tag；等三平台原生构建、签名/公证、安装态冒烟和发布预检全部通过。
 4. `git checkout main && git pull --ff-only origin main && git merge --ff-only dev` — `main` 只 fast-forward 到这个已经在 `dev` 验证过的**同一 SHA**，不使用 GitHub squash/rebase/cherry-pick 生成孪生提交。
 5. `git push origin main`，然后 `git tag vX.Y.Z && git push origin vX.Y.Z`。主分支保护要求该 SHA 先在 `dev` 上获得 `promotion-ready`，任意 feature/main 直推都会被拒绝。⚠️ **别用 `git push origin main --tags`**。

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -16,8 +16,10 @@ convention in [`RELEASING.md`](./RELEASING.md). This page is the actionable sour
 
 ## 1. Prepare (on `dev`)
 
-- [ ] Bump the version in **all four** files to `X.Y.Z`:
+- [ ] Bump the version in **all five** files to `X.Y.Z`:
   - `package.json`
+  - `package-lock.json` (both version fields — run `npm install --package-lock-only`
+    after bumping `package.json`; expect a 2-line diff and no dependency changes)
   - `src-tauri/tauri.conf.json`
   - `src-tauri/Cargo.toml`
   - `src-tauri/Cargo.lock` (the `name = "abu"` entry)
@@ -29,7 +31,7 @@ convention in [`RELEASING.md`](./RELEASING.md). This page is the actionable sour
 ## 2. Verify — fail here, not after tagging
 
 ```bash
-npm run release:check      # version match across 4 files + both changelog sections in the right language
+npm run release:check      # version match across 5 files + both changelog sections in the right language
 npm run build              # gen:models:check + tsc + vite build
 npm run lint
 npm test

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -7,9 +7,9 @@
  * `npm run release:check`.
  *
  * Checks:
- *   1. Version agrees across package.json, src-tauri/tauri.conf.json,
- *      src-tauri/Cargo.toml, src-tauri/Cargo.lock — and, when --tag is passed,
- *      matches the tag.
+ *   1. Version agrees across package.json, package-lock.json (both of its
+ *      version fields), src-tauri/tauri.conf.json, src-tauri/Cargo.toml,
+ *      src-tauri/Cargo.lock — and, when --tag is passed, matches the tag.
  *   2. CHANGELOG.md has this version's section, English only (no CJK).
  *   3. CHANGELOG.zh-CN.md has this version's section, containing Chinese (CJK).
  *
@@ -36,12 +36,18 @@ const readOr = (p) => {
 
 // ── 1. Version consistency ──
 const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+const pkgLock = JSON.parse(readFileSync('package-lock.json', 'utf8'));
 const tauri = JSON.parse(readFileSync('src-tauri/tauri.conf.json', 'utf8'));
 const cargoToml = readFileSync('src-tauri/Cargo.toml', 'utf8');
 const cargoLock = readFileSync('src-tauri/Cargo.lock', 'utf8');
 
 const versions = {
   'package.json': pkg.version,
+  // npm mirrors package.json's version in two places in the lockfile. A bump
+  // that forgets them leaves every later `npm install` rewriting these lines,
+  // leaking unrelated churn into whatever PR is open at the time.
+  'package-lock.json (root)': pkgLock.version,
+  'package-lock.json (packages[""])': pkgLock.packages?.['']?.version,
   'src-tauri/tauri.conf.json': tauri.version,
   'src-tauri/Cargo.toml': (cargoToml.match(/^version = "([^"]+)"/m) || [])[1],
   'src-tauri/Cargo.lock': (cargoLock.match(/name = "abu"\nversion = "([^"]+)"/) || [])[1],
@@ -99,7 +105,8 @@ if (errors.length) {
   console.error(
     '\nFix before tagging. Convention (RELEASING.md): CHANGELOG.md is English, ' +
       'CHANGELOG.zh-CN.md is Chinese, and the version must match across package.json, ' +
-      'tauri.conf.json, Cargo.toml, and Cargo.lock.\n',
+      'package-lock.json, tauri.conf.json, Cargo.toml, and Cargo.lock. ' +
+      'Re-sync the lockfile with `npm install --package-lock-only`.\n',
   );
   process.exit(1);
 }


### PR DESCRIPTION
## Why

`package.json` was bumped to 0.42.0 while `package-lock.json`'s two `version` fields stayed at 0.41.0 — and `npm run release:check` passed anyway. Preflight only compared `package.json`, `tauri.conf.json`, `Cargo.toml` and `Cargo.lock`, so the lockfile was invisible to the gate.

That drift is not cosmetic: npm rewrites those two lines on the next plain `npm install`, so it surfaces weeks later as unrelated churn inside whatever PR a contributor happens to have open. It has now happened at least twice — fixed reactively at 0.40.0 (`51cae63f`) and again at 0.42.0 (`1b9747eb`).

Note: `dev` itself is already in sync; this PR closes the gap that let it drift, it does not re-sync anything. (`main` still shows 0.41.0 in the lockfile because it is 121 commits behind `dev`; the next fast-forward promotion carries `1b9747eb` across.)

## What changed

- `scripts/release-preflight.mjs` now includes both lockfile version fields — `.version` and `.packages[""].version` — in the version-consistency check, labelled separately so the error says which one drifted. The failure footer points at `npm install --package-lock-only`.
- `RELEASE-CHECKLIST.md`: prepare step bumps **five** files, with the lockfile's regeneration command and the expected 2-line/no-dependency-change diff spelled out.
- `AGENTS.md`: release process step 2 documents the lockfile bump and what `release:check` now covers, so the gate and the instructions can't disagree.

## Verification

`npm run release:check` on this branch:

- clean tree → `✓ Release preflight passed for v0.42.0.`
- root `.version` forced to 0.41.0 → fails with `version mismatch: package-lock.json (root) = 0.41.0, expected 0.42.0`
- `.packages[""].version` forced to 0.41.0 → fails with `version mismatch: package-lock.json (packages[""]) = 0.41.0, expected 0.42.0`
- lockfile restored afterwards; `git diff --stat package-lock.json` is empty.

Each field was drifted independently to confirm neither is masked by the other. The diff touches one `.mjs` script and two Markdown files — ESLint's config only matches `**/*.{ts,tsx}`, so `lint`/`typecheck` scope is unaffected.

## Not done

No test file. `scripts/release-preflight.mjs` has no existing test, and the sibling `scripts/*.test.mjs` suites all run through `node --test` in per-area npm scripts that `verify:full` doesn't invoke — adding one would mean a new script plus CI wiring for a four-line check. Flagging it rather than smuggling it in; happy to add if you'd rather have it gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)