### PR TITLE
fix(chat): 回收 active-turn spacer 未消费的底部滚动范围

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -64,6 +64,7 @@ import {
   getAnchorScrollCorrection,
   isAtBottomFromGeometry,
   isChapterRailAtBottom,
+  reclaimTurnSpacerSurplus,
   reconcileTurnScrollAnchor,
   selectLatestUserAnchor,
   shouldFollowOutput,
@@ -341,6 +342,10 @@ export default function ChatView({
   const pendingTurnAnchorRef = useRef<PendingTurnAnchor | null>(null);
   const turnSpacerElementRef = useRef<HTMLDivElement | null>(null);
   const turnSpacerHeightRef = useRef(0);
+  /** scrollHeight the last spacer-surplus reclaim expects once Virtuoso
+   *  applies the shrink — further reclaims wait for this catch-up because the
+   *  measured gap is stale until then (see reclaimTurnSpacerSurplus). */
+  const reclaimSettleScrollHeightRef = useRef<number | null>(null);
   const armAnchorRafRef = useRef(0);
   const runningConversationRef = useRef<string | null>(null);
   const dismissedTurnAnchorRef = useRef<{ conversationId: string; messageId: string } | null>(null);
@@ -426,23 +431,66 @@ export default function ChatView({
 
     const currentTop = anchorElement.getBoundingClientRect().top - el.getBoundingClientRect().top;
     const correction = getAnchorScrollCorrection(anchor.targetTop, currentTop);
-    if (correction === 0) return;
-    const previousScrollTop = el.scrollTop;
-    emitChatScrollTrace('turn-anchor', 'scheduled', el, {
-      totalListHeight,
-      anchorTop: currentTop,
-      spacerHeight: reconciled.spacerHeight,
-      contentHeight: reconciled.contentHeight,
-      baselineContentHeight: anchor.baselineContentHeight,
-    });
-    el.scrollTop += correction;
+    if (correction !== 0) {
+      const previousScrollTop = el.scrollTop;
+      emitChatScrollTrace('turn-anchor', 'scheduled', el, {
+        totalListHeight,
+        anchorTop: currentTop,
+        spacerHeight: reconciled.spacerHeight,
+        contentHeight: reconciled.contentHeight,
+        baselineContentHeight: anchor.baselineContentHeight,
+      });
+      el.scrollTop += correction;
+      emitChatScrollTrace('turn-anchor', 'applied', el, {
+        totalListHeight,
+        scrollDelta: el.scrollTop - previousScrollTop,
+        anchorTop: anchorElement.getBoundingClientRect().top - el.getBoundingClientRect().top,
+        spacerHeight: readTurnSpacerHeight(),
+        contentHeight: measureActiveTailHeight(anchorElement) ?? undefined,
+        baselineContentHeight: anchor.baselineContentHeight,
+      });
+    }
+
+    // With the anchor pinned at targetTop, any scroll range still left below
+    // is spacer ledger that never corresponded to missing range (the arm's
+    // settlement spreads over frames — see reclaimTurnSpacerSurplus). Return
+    // it by shrinking the spacer; the viewport does not move.
+    const settled = turnAnchorRef.current;
+    if (settled?.phase !== 'armed') return;
+    if (reclaimSettleScrollHeightRef.current != null) {
+      // The previous reclaim's shrink reaches scrollHeight only on Virtuoso's
+      // next height pass; until then the measured gap still carries the
+      // reclaimed pixels and re-reclaiming would drain the spacer.
+      if (el.scrollHeight > reclaimSettleScrollHeightRef.current) return;
+      reclaimSettleScrollHeightRef.current = null;
+    }
+    const distanceToBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    const reclaim = reclaimTurnSpacerSurplus(settled, distanceToBottom);
+    if (reclaim.reclaimed === 0) return;
+    reclaimSettleScrollHeightRef.current = el.scrollHeight - reclaim.reclaimed;
+    turnAnchorRef.current = reclaim.anchor;
+    if (reclaim.anchor.phase === 'exhausted') {
+      const previousScrollTop = el.scrollTop;
+      writeTurnSpacerWithCompensation(el, 0, 'sync-bottom');
+      emitChatScrollTrace('turn-anchor', 'applied', el, {
+        totalListHeight,
+        scrollDelta: el.scrollTop - previousScrollTop,
+        spacerHeight: 0,
+        contentHeight: reconciled.contentHeight,
+        baselineContentHeight: anchor.baselineContentHeight,
+      });
+      updatePinned(true);
+      setIsAtBottom(true);
+      return;
+    }
+    writeTurnSpacerHeight(reclaim.spacerHeight);
     emitChatScrollTrace('turn-anchor', 'applied', el, {
       totalListHeight,
-      scrollDelta: el.scrollTop - previousScrollTop,
+      scrollDelta: 0,
       anchorTop: anchorElement.getBoundingClientRect().top - el.getBoundingClientRect().top,
       spacerHeight: readTurnSpacerHeight(),
       contentHeight: measureActiveTailHeight(anchorElement) ?? undefined,
-      baselineContentHeight: anchor.baselineContentHeight,
+      baselineContentHeight: reclaim.anchor.baselineContentHeight,
     });
   }, [
     measureActiveTailHeight,
@@ -469,6 +517,7 @@ export default function ChatView({
     const exit = exitTurnScrollAnchor(turnAnchorRef.current, reason);
     turnAnchorRef.current = exit.anchor;
     pendingTurnAnchorRef.current = null;
+    reclaimSettleScrollHeightRef.current = null;
     if (exit.spacerHeight === 0) {
       writeTurnSpacerWithCompensation(
         scrollParentEl,
@@ -928,6 +977,7 @@ export default function ChatView({
         contentHeight,
       });
       turnAnchorRef.current = anchor;
+      reclaimSettleScrollHeightRef.current = null;
       const previousScrollTop = scrollParentEl.scrollTop;
       emitChatScrollTrace('turn-anchor', 'scheduled', scrollParentEl, {
         anchorTop,

--- a/src/components/chat/ChatView.turnScrollAnchor.test.tsx
+++ b/src/components/chat/ChatView.turnScrollAnchor.test.tsx
@@ -98,6 +98,10 @@ const geometry = {
   anchorHeight: 40,
   baselineContentHeight: 100,
   contentHeight: 100,
+  /** Scroll range below the spacer that the arm's ledger never allocated —
+   *  models the cold-start settlement surplus (late Virtuoso list-height
+   *  materialization + native scroll anchoring adjustments). */
+  extraScrollRange: 0,
   scroller: null as HTMLElement | null,
 };
 
@@ -139,6 +143,7 @@ function installGeometry(scroller: HTMLElement): { getScrollTop: () => number } 
     300
     + Math.max(0, geometry.contentHeight - geometry.baselineContentHeight)
     + spacerHeight()
+    + geometry.extraScrollRange
   );
   Object.defineProperties(scroller, {
     clientHeight: { configurable: true, value: 300 },
@@ -180,6 +185,7 @@ describe('ChatView active-turn scroll state machine', () => {
     harness.scrollToIndex.mockReset();
     geometry.anchorHeight = 40;
     geometry.contentHeight = geometry.baselineContentHeight;
+    geometry.extraScrollRange = 0;
     geometry.scroller = null;
     useChatStore.setState(useChatStore.getInitialState(), true);
     useSettingsStore.setState(useSettingsStore.getInitialState(), true);
@@ -226,6 +232,61 @@ describe('ChatView active-turn scroll state machine', () => {
     expect(spacer.dataset.spacerHeight).toBe('0');
     expect(getScrollTop()).toBe(220);
     expect(harness.props?.followOutput?.(false)).toBe('auto');
+  });
+
+  it('reclaims a cold-start settlement surplus into the spacer without moving the viewport', async () => {
+    const conversationId = setupConversation();
+    render(<ChatView />);
+    const scroller = document.querySelector<HTMLElement>('.overlay-scroll')!;
+    const { getScrollTop } = installGeometry(scroller);
+    const spacer = await armNewTurn(conversationId);
+    expect(getScrollTop()).toBe(200);
+
+    // The arm's multi-frame settlement (late Virtuoso list-height + native
+    // scroll anchoring) leaves 26px of scroll range below the pinned anchor.
+    geometry.extraScrollRange = 26;
+    act(() => harness.props?.totalListHeightChanged?.(326));
+
+    // The surplus is returned by shrinking the spacer; the viewport (and the
+    // pinned anchor) do not move, and the bottom gap closes to zero.
+    expect(spacer.dataset.spacerHeight).toBe('174');
+    expect(getScrollTop()).toBe(200);
+    expect(scroller.scrollHeight - getScrollTop() - 300).toBe(0);
+
+    // Later growth reconciles against the reduced ledger — the reclaimed
+    // pixels stay gone and the gap stays closed.
+    geometry.contentHeight = 180;
+    act(() => harness.props?.totalListHeightChanged?.(406));
+    expect(spacer.dataset.spacerHeight).toBe('94');
+    expect(scroller.scrollHeight - getScrollTop() - 300).toBe(0);
+  });
+
+  it('does not re-reclaim while Virtuoso has not yet applied the previous shrink', async () => {
+    const conversationId = setupConversation();
+    render(<ChatView />);
+    const scroller = document.querySelector<HTMLElement>('.overlay-scroll')!;
+    const { getScrollTop } = installGeometry(scroller);
+    const spacer = await armNewTurn(conversationId);
+    expect(getScrollTop()).toBe(200);
+
+    geometry.extraScrollRange = 26;
+    act(() => harness.props?.totalListHeightChanged?.(326));
+    expect(spacer.dataset.spacerHeight).toBe('174');
+
+    // In the real renderer the spacer's style shrink reaches scrollHeight only
+    // on Virtuoso's next height pass. Model that lag: scrollHeight still
+    // carries the 26 reclaimed pixels, so the measured gap is stale — a second
+    // reconcile must NOT shave the spacer again.
+    geometry.extraScrollRange = 52;
+    act(() => harness.props?.totalListHeightChanged?.(326));
+    expect(spacer.dataset.spacerHeight).toBe('174');
+
+    // Virtuoso catches up (the stale pixels leave scrollHeight): the gap is
+    // truly closed and reconciliation stays quiet.
+    geometry.extraScrollRange = 26;
+    act(() => harness.props?.totalListHeightChanged?.(326));
+    expect(spacer.dataset.spacerHeight).toBe('174');
+    expect(scroller.scrollHeight - getScrollTop() - 300).toBe(0);
   });
 
   it('self-clears a pending gate whose dispatch never persisted a message', async () => {

--- a/src/components/chat/turnScrollAnchor.test.ts
+++ b/src/components/chat/turnScrollAnchor.test.ts
@@ -10,6 +10,7 @@ import {
   getAnchorScrollCorrection,
   isAtBottomFromGeometry,
   isChapterRailAtBottom,
+  reclaimTurnSpacerSurplus,
   reconcileTurnScrollAnchor,
   selectLatestUserAnchor,
   shouldFollowOutput,
@@ -90,6 +91,53 @@ describe('turn scroll anchor invariants', () => {
     expect(result.anchor).toMatchObject({ phase: 'exhausted', spacerHeight: 0 });
     expect(result.handoff).toBe('sync-bottom');
     expect(shouldFollowOutput(result.anchor)).toBe('auto');
+  });
+
+  it('risk G — reclaims a bottom surplus into the spacer without moving the viewport', () => {
+    // Cold-start arm settlement: the spacer's scroll range materializes
+    // asynchronously (react-virtuoso applies its list height on its own
+    // cycle), and native scroll anchoring can leave surplus range below the
+    // pinned anchor. Every surplus pixel is a spacer pixel that corresponds to
+    // no missing range — reconciliation must return it.
+    const initial = arm();
+    const reclaim = reclaimTurnSpacerSurplus(initial, 26);
+
+    expect(reclaim.reclaimed).toBe(26);
+    expect(reclaim.spacerHeight).toBe(374);
+    expect(reclaim.anchor).toMatchObject({
+      phase: 'armed',
+      spacerHeight: 374,
+      initialSpacerHeight: 374,
+    });
+
+    // The reduction is durable: later tail growth reconciles against the
+    // reduced ledger instead of reinstating the reclaimed pixels.
+    const afterGrowth = reconcileTurnScrollAnchor(reclaim.anchor, {
+      contentHeight: 1_100,
+      anchorPresent: true,
+    });
+    expect(afterGrowth.spacerHeight).toBe(274);
+  });
+
+  it('risk G — ignores sub-tolerance surplus and never reclaims below zero', () => {
+    const initial = arm();
+    expect(reclaimTurnSpacerSurplus(initial, ANCHOR_TOLERANCE_PX).reclaimed).toBe(0);
+    expect(reclaimTurnSpacerSurplus(initial, ANCHOR_TOLERANCE_PX).anchor).toBe(initial);
+
+    const capped = reclaimTurnSpacerSurplus(initial, 500);
+    expect(capped.reclaimed).toBe(400);
+    expect(capped.spacerHeight).toBe(0);
+    expect(capped.anchor.phase).toBe('exhausted');
+  });
+
+  it('risk G — an exhausted anchor has no spacer to reclaim', () => {
+    const exhausted = reconcileTurnScrollAnchor(arm(), {
+      contentHeight: 1_400,
+      anchorPresent: true,
+    }).anchor;
+    const reclaim = reclaimTurnSpacerSurplus(exhausted, 26);
+    expect(reclaim.reclaimed).toBe(0);
+    expect(reclaim.anchor).toBe(exhausted);
   });
 
   it('risk C — an unmounted anchor also requests a synchronous handoff', () => {

--- a/src/components/chat/turnScrollAnchor.ts
+++ b/src/components/chat/turnScrollAnchor.ts
@@ -107,6 +107,44 @@ export function reconcileTurnScrollAnchor(
   };
 }
 
+/**
+ * Return surplus bottom scroll range to the spacer ledger.
+ *
+ * The arm computes its ledger (initialScrollDelta / initialSpacerHeight) in a
+ * single layout pass, but the spacer's scroll range materializes
+ * asynchronously: react-virtuoso applies its list height on its own
+ * measurement cycle, so the arm's scroll clamps and settlement spreads across
+ * frames. While that settlement races streamed content, the browser's native
+ * scroll anchoring can land the viewport pinned at targetTop with scroll
+ * range left over below. Every surplus pixel is a spacer pixel that no longer
+ * corresponds to missing range — the same physical-blind-spot defect as the
+ * former +96px measurement reserve — so reconciliation shrinks the spacer by
+ * the measured surplus. Bottom-only geometry: the anchored viewport does not
+ * move. The reduction is written to initialSpacerHeight so later reconciles
+ * do not reinstate the reclaimed pixels.
+ */
+export function reclaimTurnSpacerSurplus(
+  anchor: TurnScrollAnchor,
+  distanceToBottom: number,
+): { anchor: TurnScrollAnchor; spacerHeight: number; reclaimed: number } {
+  if (anchor.phase !== 'armed' || distanceToBottom <= ANCHOR_TOLERANCE_PX) {
+    return { anchor, spacerHeight: anchor.spacerHeight, reclaimed: 0 };
+  }
+  const reclaimed = Math.min(anchor.spacerHeight, distanceToBottom);
+  if (reclaimed <= 0) return { anchor, spacerHeight: anchor.spacerHeight, reclaimed: 0 };
+  const spacerHeight = anchor.spacerHeight - reclaimed;
+  return {
+    anchor: {
+      ...anchor,
+      phase: spacerHeight > 0 ? 'armed' : 'exhausted',
+      initialSpacerHeight: anchor.initialSpacerHeight - reclaimed,
+      spacerHeight,
+    },
+    spacerHeight,
+    reclaimed,
+  };
+}
+
 export function canArmTurnScrollAnchor(input: {
   anchorHeight: number;
   viewportHeight: number;


### PR DESCRIPTION
## 问题

`tests/e2e/thinking-scroll-anchor.spec.ts` 有一种独立于已知亚像素 flake 的失败模式：**全新 worktree 冷启动首跑**时 `maxArmedBottomGap` 挂在 26，且**从第一个 armed 帧起** `distanceToBottom` 就恒定钉在 25——不是抖动，是永久偏移。anchorTop 稳定、spacer 正常收缩、scrollTop 一动不动，最终 settle 却完美（0.5）。这不是测试容差问题：streaming 全程视口真的浮在离底 25px 处，底部有一条用户看不到的盲带。

本仓库 e2e-electron job 正在推成 required check，这个 flake 一旦在 CI 触发就会卡住合并。

## 根因

逐帧几何探针（scroller / 列 / wrapper 各子元素高度 + spacer/row rect）拿到的证据链：

1. **arm 的 spacer 写入从来不会在同一 layout pass 里增大 scrollHeight** —— 热跑也一样。spacer 位于 react-virtuoso 的定高容器内，容器高度由 Virtuoso 在自己的测量周期异步应用，wrapper 的 `overflow-hidden` 把溢出裁掉。失败 run 的 arm trace：想滚 497.5px，scrollHeight 写前写后都是 1492，实际只滚了 80.5（clamp 在旧 max），anchor 停在 437 而非 20。
2. 正常情况下这不是问题：后续每次 reconcile 的 correction 往下追，每步都 clamp 在底部（d=−0.5），逐步收敛到「anchor=20 且 d=0」。
3. **冷帧下容器高度 +448 一次性到账**，期间 Chrome 的**原生 scroll anchoring** 自己补滚了 +383.5。落点让 anchor 距 target 只差 34、但底部多出 64 富余；correction 只钉 anchorTop（+34），剩下的 ~30（后因 typing footer 的 `-mt-1` 变 26）**没有任何机制回收**——armed 阶段所有 stick-to-bottom 路径都被设计性压制，而 spacer 账本自身是自洽的。于是 26px 从 arm 起钉死到 spacer 耗尽。

## 修复

`reclaimTurnSpacerSurplus`（`turnScrollAnchor.ts`）：anchor 已钉在 targetTop 时，底部剩余的滚动范围就是**不对应任何缺失范围的 spacer 死像素**——与当年 `+96px` 测量保留区是同一类缺陷（该保留区的注释至今还写在 `armTurnScrollAnchor` 里）。按测得富余收缩 spacer，并把减量写进 `initialSpacerHeight`，使后续 reconcile 不会把它加回来。纯底部几何，视口一像素不动。

`ChatView` 的 `reconcileActiveTurnGeometry` 在 correction 之后执行回收（correction 为 0 的帧也执行——失败 run 里正是这种帧）；回收导致 exhausted 时走既有的 sync-bottom handoff。

**二阶坑**：回收写入同样要等 Virtuoso 的下一个高度周期才反映到 scrollHeight，期间 gap 读数是陈旧的。没有守卫会连续回收、掏空 spacer 并提前跳底。`reclaimSettleScrollHeightRef` 挡住这一点，并有专门的集成测试钉住。

## 验证

- 新增 3 个纯函数单测 + 2 个集成回归（含防重复回收），均先红后绿
- `npm run verify` 全绿
- 真实 Electron e2e：热跑通过；**4× CPU 节流下 armed gap 从 26 降到 0.5**
- 冷启动首跑（本 PR 前必挂）现已通过

## 说明

- 摘自 `claude/jovial-cerf-34edc7` 的 dpr 容差 commit 已**丢弃**：dev 上的 b3b4c394（直接放宽到 4px）覆盖面更宽，本 PR 不再动 spec。
- 另有一种**未在本 PR 处理**的失败签名：spacer 耗尽后的 settle 阶段停在离底若干像素不动（CI 上见过 9px，本地 4× 节流见过 2.5px），8 个采样全等、`spacerHeight:0`。那是 post-exhaustion 的 stick-to-bottom 路径问题，与本 PR 修的 armed 阶段是两回事，目前被 dev 的 4px 容差盖住。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
