### PR TITLE
fix(chat): fix the last-mile stick-to-bottom race after a turn settles

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -56,6 +56,7 @@ import {
   subscribeChatTurnScrollIntent,
 } from './chatTurnScrollIntent';
 import {
+  ANCHOR_TOLERANCE_PX,
   VIRTUOSO_AT_BOTTOM_THRESHOLD_PX,
   armTurnScrollAnchor,
   canArmTurnScrollAnchor,
@@ -1055,6 +1056,44 @@ export default function ChatView({
     reconcileActiveTurnGeometry,
     scrollParentEl,
   ]);
+  // The bottom lock's last mile. `totalListHeightChanged` reports Virtuoso's
+  // own height model and its correction is deferred a frame, so content that
+  // reaches the scroller after that write — Virtuoso's final measurement
+  // settling once tokens stop — produces no further event and leaves a pinned
+  // reader parked a few pixels above the bottom for the rest of the turn.
+  // Observing the scrolled content closes that race at its source: the
+  // scroller's own geometry is the authority, and ResizeObserver runs after
+  // layout and before paint, so the correction is invisible rather than the
+  // one-frame jump a deferred re-scroll would show.
+  useLayoutEffect(() => {
+    if (!scrollParentEl || typeof ResizeObserver === 'undefined') return;
+    const content = scrollParentEl.querySelector<HTMLElement>('[data-chat-scroll-content]');
+    if (!content) return;
+
+    const observer = new ResizeObserver(() => {
+      if (!pinnedRef.current) return;
+      // A turn whose anchor has been announced but not yet armed is holding the
+      // bottom-pin off on purpose (see shouldSuppressLegacyFollow, whose
+      // callers "must agree" so one path cannot re-enable what another holds
+      // off). Reading the ref rather than calling that helper keeps this
+      // observer out of its suppression budget, which belongs to the callbacks.
+      if (pendingTurnAnchorRef.current) return;
+      // An armed anchor owns its own geometry: its spacer ledger deliberately
+      // holds the viewport away from the bottom, so a bottom sync here would
+      // fight the anchor instead of completing it.
+      if (turnAnchorRef.current?.phase === 'armed') return;
+      const distanceToBottom =
+        scrollParentEl.scrollHeight - scrollParentEl.scrollTop - scrollParentEl.clientHeight;
+      // Same dead zone the other writers use, so a settled scroller stays put
+      // instead of trading sub-pixel corrections with them every resize.
+      if (distanceToBottom <= ANCHOR_TOLERANCE_PX) return;
+      emitChatScrollTrace('content-resize', 'scheduled', scrollParentEl, {});
+      const scrollDelta = syncElementToBottom(scrollParentEl);
+      emitChatScrollTrace('content-resize', 'applied', scrollParentEl, { scrollDelta });
+    });
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [scrollParentEl]);
   useLayoutEffect(() => {
     if (scrollParentEl) reconcileActiveTurnGeometry(scrollParentEl);
   });
@@ -1400,7 +1439,10 @@ export default function ChatView({
         {chapterNavVisible && railFits && (
           <ChapterRail chapters={chapters} currentIndex={currentChapter} onJump={jumpToChapter} />
         )}
-        <div className="w-full max-w-4xl mx-auto px-6 md:px-10 pt-5 pb-16 overflow-hidden">
+        <div
+          data-chat-scroll-content
+          className="w-full max-w-4xl mx-auto px-6 md:px-10 pt-5 pb-16 overflow-hidden"
+        >
           <Virtuoso
             // Remount per conversation so `initialTopMostItemIndex` re-applies
             // on every switch — the view lands at the newest message without a

--- a/src/components/chat/ChatView.turnScrollAnchor.test.tsx
+++ b/src/components/chat/ChatView.turnScrollAnchor.test.tsx
@@ -93,6 +93,41 @@ vi.mock('./ChapterMenu', async () => {
   };
 });
 
+// happy-dom's ResizeObserver never fires without real layout, so record every
+// observer and let a test drive the exact one it means to (determinism rule).
+interface RecordedObserver {
+  callback: () => void;
+  targets: Element[];
+}
+const resizeObservers: RecordedObserver[] = [];
+
+class RecordingResizeObserver {
+  private readonly record: RecordedObserver;
+  constructor(callback: () => void) {
+    this.record = { callback, targets: [] };
+    resizeObservers.push(this.record);
+  }
+  observe(target: Element) {
+    this.record.targets.push(target);
+  }
+  disconnect() {
+    this.record.targets.length = 0;
+  }
+}
+
+/** Fire the observer watching `target`, mirroring a post-layout resize. */
+function fireResizeFor(target: Element | null): boolean {
+  if (!target) return false;
+  let fired = false;
+  for (const observer of resizeObservers) {
+    if (observer.targets.includes(target)) {
+      observer.callback();
+      fired = true;
+    }
+  }
+  return fired;
+}
+
 const geometry = {
   anchorDocumentTop: 220,
   anchorHeight: 40,
@@ -187,6 +222,8 @@ describe('ChatView active-turn scroll state machine', () => {
     geometry.contentHeight = geometry.baselineContentHeight;
     geometry.extraScrollRange = 0;
     geometry.scroller = null;
+    resizeObservers.length = 0;
+    vi.stubGlobal('ResizeObserver', RecordingResizeObserver);
     useChatStore.setState(useChatStore.getInitialState(), true);
     useSettingsStore.setState(useSettingsStore.getInitialState(), true);
     useEnterpriseStore.setState({ mode: { kind: 'personal' }, initialized: true });
@@ -211,6 +248,7 @@ describe('ChatView active-turn scroll state machine', () => {
 
   afterEach(() => {
     rectSpy.mockRestore();
+    vi.unstubAllGlobals();
     cleanup();
   });
 
@@ -287,6 +325,68 @@ describe('ChatView active-turn scroll state machine', () => {
     act(() => harness.props?.totalListHeightChanged?.(326));
     expect(spacer.dataset.spacerHeight).toBe('174');
     expect(scroller.scrollHeight - getScrollTop() - 300).toBe(0);
+  });
+
+  it('re-sticks when content grows after the last list-height event', async () => {
+    const conversationId = setupConversation();
+    render(<ChatView />);
+    const scroller = document.querySelector<HTMLElement>('.overlay-scroll')!;
+    const { getScrollTop } = installGeometry(scroller);
+    await armNewTurn(conversationId);
+
+    // Exhaust the spacer: the anchor hands off and the view sits at the bottom.
+    geometry.contentHeight = 320;
+    act(() => harness.props?.totalListHeightChanged?.(520));
+    expect(scroller.scrollHeight - getScrollTop() - 300).toBe(0);
+
+    // The real race: the last growth reaches the scroller AFTER the final
+    // `totalListHeightChanged`, so no further event ever arrives to correct it
+    // and the view freezes a few pixels above the bottom.
+    geometry.contentHeight = 329;
+    expect(scroller.scrollHeight - getScrollTop() - 300).toBe(9);
+
+    // A resize of the scrolled content is the authoritative signal that the
+    // geometry changed. It runs after layout and before paint, so correcting
+    // here is invisible rather than a visible one-frame jump.
+    const content = scroller.querySelector<HTMLElement>('[data-chat-scroll-content]');
+    expect(fireResizeFor(content), 'the scrolled content is not observed').toBe(true);
+    act(() => {});
+    expect(scroller.scrollHeight - getScrollTop() - 300).toBe(0);
+  });
+
+  it('holds the bottom-pin off while a turn anchor is announced but not armed', async () => {
+    const conversationId = setupConversation();
+    render(<ChatView />);
+    const scroller = document.querySelector<HTMLElement>('.overlay-scroll')!;
+    const { getScrollTop } = installGeometry(scroller);
+    scroller.scrollTop = 0;
+
+    // Announced, not yet armed: the arm is about to measure this very geometry,
+    // and every follow path must agree to hold off until it has (otherwise one
+    // writer re-enables the bottom-pin another is deliberately holding off).
+    announceChatTurnScrollIntent({ conversationId, source: 'composer' });
+    geometry.contentHeight = 400;
+    fireResizeFor(scroller.querySelector<HTMLElement>('[data-chat-scroll-content]'));
+    act(() => {});
+
+    expect(getScrollTop()).toBe(0);
+  });
+
+  it('leaves an unpinned reader alone when late content resizes', async () => {
+    const conversationId = setupConversation();
+    render(<ChatView />);
+    const scroller = document.querySelector<HTMLElement>('.overlay-scroll')!;
+    const { getScrollTop } = installGeometry(scroller);
+    await armNewTurn(conversationId);
+    // An explicit upward gesture unpins and freezes the spacer.
+    act(() => { scroller.dispatchEvent(new WheelEvent('wheel', { deltaY: -12 })); });
+    scroller.scrollTop = 120;
+
+    geometry.contentHeight = 329;
+    fireResizeFor(scroller.querySelector<HTMLElement>('[data-chat-scroll-content]'));
+    act(() => {});
+
+    expect(getScrollTop()).toBe(120);
   });
 
   it('self-clears a pending gate whose dispatch never persisted a message', async () => {

--- a/src/components/chat/chatScrollTrace.ts
+++ b/src/components/chat/chatScrollTrace.ts
@@ -5,6 +5,10 @@ export type ChatScrollFollowSource =
   | 'conversation-switch'
   | 'turn-anchor'
   | 'total-list-height'
+  // Content the scroller measured itself, rather than a height Virtuoso
+  // reported. Distinguishing the two is the point: a correction attributed
+  // here is one no list-height callback would have delivered.
+  | 'content-resize'
   | 'virtuoso-follow-output';
 
 export type ChatScrollTracePhase = 'decision' | 'scheduled' | 'applied';


### PR DESCRIPTION
## Problem

After a long streaming reply finishes, the viewport sometimes **stays permanently a few pixels above the bottom**: 9px seen on CI (PR #336), 2.5px seen locally under 4× CPU throttling. The signature is very clean — sampled frames all identical, `spacerHeight:0`, `scrollTop` unmoved; the scroller simply stops and never moves again.

This is not sub-pixel quantization. Commit b3b4c394 on dev widened the `finalBottomGap` tolerance to 4px (the comment assumes at most 3px on hosted runners with integer dpr), and the 9px measured on CI is more than double that assumption — widening the tolerance is just a bet, and when the bet loses the run goes red.

## Root cause

Post-exhaustion stick-to-bottom correction is driven **only** by `totalListHeightChanged`, while `stickToBottom` defers its `scrollTop` write by one frame (rAF). That creates a race between the content's final growth (Virtuoso's own measurement converging after tokens stop) and that rAF write:

| | `scrollHeight` at the last stick write | after | result |
|---|---|---|---|
| passing run | 4774 (growth already accounted) | — | gap 0.5 ✓ |
| failing run | 4771 (growth **not yet** accounted) | sH→4774, **no further events** | gap 2.5 ✗ |

Same diff, same machine; the only difference is whether those 3px land before or after the rAF. If they land after, no second `totalListHeightChanged` ever arrives to correct it — Virtuoso only emits when its own height model changes, and it does not report that final convergence. CI's 9px is the same mechanism, larger, on a slower machine.

Frame-by-frame trace evidence (failing run): the last `total-list-height applied` records `scrollHeight=4771, distanceToBottom=-0.5` (genuinely at the bottom), the very next geometry frame shows `scrollHeight=4774` with `scrollTop` unchanged → gap 2.5, and the following 9 frames are all identical with zero trace entries.

### One hypothesis disproved along the way

`leaveTurnAnchor('run-terminal')`'s `'sync-bottom'` gets silently swallowed by `writeTurnSpacerWithCompensation`'s `previousHeight === 0` guard (the ref is already 0 once the spacer is exhausted). That defect is real and untested. But the trace shows the **run terminal fires 20 events from the end**, with 10 normal stick rounds after it — so it is irrelevant to this symptom, and this PR leaves it alone.

## Fix

Watch the scroll content with a ResizeObserver (new `data-chat-scroll-content` marker) and, while **pinned and not armed**, synchronously stick to the bottom whenever the gap exceeds the existing `ANCHOR_TOLERANCE_PX` (2px) dead zone.

- **Why a ResizeObserver rather than "retry for a few more frames"**: the scroller's own geometry is the authority, and RO fires exactly when content height changes, so there is no retry window to guess at. This matches existing practice in the codebase — the armed path also uses an RO, with a comment saying it is "event-driven, replacing the guesswork of 'scroll again after N ms'".
- **Why it will not reintroduce the old jitter**: RO runs after layout and before paint, so the correction is invisible; it reuses the same 2px dead zone as the other writers, so a scroller that has already settled is not repeatedly nudged. During the armed phase it yields outright (the spacer ledger owns the viewport then).
- Adds a `content-resize` trace source so that "corrections the scroller measured itself" are distinguishable from list-height callbacks — and those corrections are precisely the ones no list-height callback would ever deliver.

## Verification

- 2 new **deterministic** tests: one reproducing CI's 9px freeze signature (red before, green after), one guarding "do not steal the viewport when the user has scrolled up"
- `npm run build` / `npm run lint` green
- Real Electron e2e passing

## One unattributed observation (reviewers please note)

The **first run** with the fix produced one e2e failure with an `anchorDrift` signature: the anchor stopped at 61.25 instead of converging to targetTop 20, then drifted 6px. That signature did not appear anywhere else in this investigation; it belongs to the "arm never converged" family (a sibling of the "converges but leaves slack" case #337 fixed).

Comparison data (same machine, same spec):

| code | result |
|---|---|
| clean dev (incl. #337) | 3/3 pass |
| this PR | 4/4 pass (plus the failure above = 1 in 5) |

The trace from the failing run shows `content-resize` **never fired** during the entire armed window, and the geometry at arm time matched the passing baseline field for field — i.e. this PR's observer was not the thing moving the viewport. But 5 samples are not enough to assert non-involvement, so **no claim of exclusion is made**; the raw logs are kept in the session. If the signature reappears on CI, it points at the arm-convergence path, not at this PR.

## Note

**Spec tolerances were not tightened** (dev's 4px is left as-is). The new deterministic unit tests are the more reliable regression guard; tightening the e2e tolerance would trade a reliable guard for one that still gambles on timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
