### PR TITLE
fix(stores): scan for the first non-ASCII char instead of testing a prefix

### DIFF
--- a/src/stores/batchProgressStore.ts
+++ b/src/stores/batchProgressStore.ts
@@ -130,7 +130,7 @@ const IMAGE_BLOCK_JSON_ENVELOPE_BYTES = textEncoder.encode(JSON.stringify({
   source: { type: 'base64', media_type: '', data: '' },
 })).byteLength;
 const RESULT_CONTENT_ARRAY_ENVELOPE_BYTES = 2;
-const JSON_SAFE_ASCII = /^[\x20-\x21\x23-\x5b\x5d-\x7e]*$/;
+const JSON_UNSAFE_ASCII = /[^\x20-\x21\x23-\x5b\x5d-\x7e]/;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -153,18 +153,20 @@ function isImageMediaType(value: string): boolean {
  * second attacker-sized JSON copy. This accounts for JSON escapes and treats a
  * surrogate pair atomically so retained text never ends on half an emoji. */
 function jsonStringContentBytes(text: string, maxBytes = Number.POSITIVE_INFINITY): { bytes: number; end: number } {
-  const safeAsciiLimit = Number.isFinite(maxBytes)
-    ? Math.max(0, Math.min(text.length, Math.floor(maxBytes)))
-    : text.length;
-  const safeAsciiCandidate = safeAsciiLimit === text.length
-    ? text
-    : text.slice(0, safeAsciiLimit);
-  if (JSON_SAFE_ASCII.test(safeAsciiCandidate)) {
-    return { bytes: safeAsciiLimit, end: safeAsciiLimit };
+  // Locate the first character JSON does not encode as its own single byte, so
+  // everything before it can be accounted for by arithmetic. Scanning for that
+  // character (instead of testing whether a sliced candidate is entirely safe)
+  // keeps the "megabytes of ASCII with one emoji in them" case off the
+  // per-code-unit walk below, which v8 coverage instrumentation slows ~12x.
+  const firstUnsafe = text.search(JSON_UNSAFE_ASCII);
+  const safeAsciiEnd = firstUnsafe === -1 ? text.length : firstUnsafe;
+  if (safeAsciiEnd >= maxBytes) {
+    const limit = Math.max(0, Math.floor(maxBytes));
+    return { bytes: limit, end: limit };
   }
 
-  let bytes = 0;
-  let index = 0;
+  let bytes = safeAsciiEnd;
+  let index = safeAsciiEnd;
   while (index < text.length) {
     const code = text.charCodeAt(index);
     let codeUnits = 1;


### PR DESCRIPTION
## 问题

`batchProgressStore.test.ts:327`（`truncates large near-boundary UTF-8 text…`）在 `npm run verify` / `npm run test:coverage` 的**全量 + coverage** 下稳定超时，但：

- `npm test`（无 coverage）全量通过
- 单文件带 coverage 通过（38/38）

这个组合很容易被当成 flake 或 timeout 设太紧。它不是。

## 根因

`jsonStringContentBytes` 的 ASCII 快路径是**全有或全无**的：切出一段候选前缀，判断「这一整段是不是全是 JSON-safe ASCII」。只要**任意位置**出现一个非 ASCII 字符，判断就失败，于是把原生扫描已得到的信息全部丢弃，从 index 0 开始用 `charCodeAt` 逐码元重走一遍——外加一次与输入等长的 slice 分配。

测试的输入正好是最坏形状：16 MB 的 `a` + 末尾一个 `😀`。一个字符让 1670 万次逐码元循环全部白跑。v8 block coverage 只惩罚 JS 循环、不惩罚原生正则，把这段拖慢约 12×，全量并行负载再一叠加就冲破 5 s。

**这条慢路径在生产里同样可达**，不只是测试构造：几 MB 日志文本里夹一个 emoji 就会走满。

## 改法

改成先定位「第一个 JSON 不会原样编码成单字节的字符」，它之前的部分用算术记账，逐码元循环从那里开始而不是从 0 开始。

语义完全等价——对照过 `maxBytes` 为无穷 / 小数 / 负数，以及非安全字符正好落在预算上、落在预算之后这几种边界——做的功严格更少，且不再产生超大 slice。

## 实测（3 次取值）

| 输入 | 无 coverage | 有 coverage |
|---|---|---|
| 纯 ASCII（快路径命中） | 50–59 ms | 20–31 ms |
| ASCII + 末尾 emoji，**改前** | 96–142 ms | **1260–1367 ms** |
| ASCII + 末尾 emoji，**改后** | — | **33–55 ms** |

距 5 s 超时约 100× 余量。CJK 最坏情况（从第 0 个字符就非 ASCII，扫描帮不上忙）走法与原来一致：20 万字符在 coverage 下 26–34 ms。

**没有改任何 timeout**，全局和单测都没动。

## 验证

- 基线复现：全量 + coverage → `1 failed`，正是该测试，`Test timed out in 5000ms`
- 修复后 `npm run test:coverage`：**483 文件 / 7506 通过，exit 0**，覆盖率阈值全过
- 在旧基点上跑过两次全绿，其中一次在与基线相当的负载下（487 s vs 631 s），排除「机器闲所以过了」的混淆
- `npm run build`、`npm run lint` 干净

## 与其他分支的关系

本地 `codex/feat/batch-task-cancellation`（未合入 dev、未推远端）**重写了同一条测试**，走的是另一条路：把 fixture 缩到 32 字符 + `vi.spyOn(TextEncoder.prototype, 'encode')` 断言不调用编码器。

两者互补，不冲突：

- 本 PR 只动实现（`.ts` 第 133、156–168 行），**一行测试文件都没动**；那条分支在 `.ts` 里改的是第 19、99、403+ 行，零重叠，也没碰 `jsonStringContentBytes`
- 我把它那条测试原样搬过来跑在本 PR 的实现上，**通过**
- 只落它的测试改动的话，超时会消失但生产性能 bug 仍在；两者都落是最优解

改名 `JSON_SAFE_ASCII` → `JSON_UNSAFE_ASCII` 是这类改动典型的「文本能合、类型编不过」语义陷阱，已确认全部本地 + 远端分支中除本文件外无任何引用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)