### PR TITLE
test(e2e): follow the capabilities rebuild — portalled selects and renamed copy

### DIFF
--- a/tests/e2e/tool-approval.spec.ts
+++ b/tests/e2e/tool-approval.spec.ts
@@ -20,6 +20,16 @@ import {
 
 const READY_TIMEOUT = 45_000;
 const CHAT_PLACEHOLDER = '想让阿布帮你做点什么？';
+/**
+ * The task-local capability dialog keeps the "start setup" wording as its
+ * own accessible name (`settings.capabilityChromeSetupTitle`), but since the
+ * Capabilities rebuild the page it hosts is the ordinary Chrome capability
+ * detail page, headed by the capability itself
+ * (`settings.capabilityMyChrome`) rather than by the setup phrase. Assert
+ * both, so the test still proves it is the Chrome setup that opened.
+ */
+const CAPABILITY_SETUP_DIALOG = /^(连接我的 Chrome|Connect My Chrome)$/;
+const MY_CHROME_HEADING = /^(我的 Chrome|My Chrome)$/;
 const TEST_API_KEY = 'abu-e2e-tool-approval-not-a-real-secret';
 const TEST_MODEL_ID = 'abu-e2e-tool-approval-model';
 const PROVIDER_ID = 'abu-e2e-tool-approval-provider';
@@ -476,8 +486,9 @@ test.describe.serial('Electron run_command approval E2E', () => {
     await expect.poll(() => mock!.requests.length, { timeout: READY_TIMEOUT }).toBe(1);
     const setupDialog = page.getByRole('dialog');
     await expect(setupDialog).toBeVisible({ timeout: READY_TIMEOUT });
+    await expect(setupDialog).toHaveAttribute('aria-label', CAPABILITY_SETUP_DIALOG);
     await expect(
-      setupDialog.getByText(/^(连接我的 Chrome|Connect My Chrome)$/),
+      setupDialog.getByRole('heading', { name: MY_CHROME_HEADING }),
     ).toBeVisible();
 
     await setupDialog.getByRole('button', {

--- a/tests/e2e/trigger-capability.spec.ts
+++ b/tests/e2e/trigger-capability.spec.ts
@@ -8,7 +8,7 @@
 import { expect, test } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
-import type { ElectronApplication, Page } from 'playwright';
+import type { ElectronApplication, Locator, Page } from 'playwright';
 import {
   closeAbuElectron,
   launchAbuElectron,
@@ -31,6 +31,14 @@ const EDIT = /^(编辑|Edit)$/;
 const SAVE = /^(保存|Save)$/;
 const AUTONOMY = /^(自主程度|Autonomy Level)$/;
 const FULL = /^(完全放开|Fully open)$/;
+/**
+ * The Select trigger's accessible name is `<field label>: <current value>`
+ * (`ui/select.tsx`), so it names both the control and what it currently
+ * shows. Left unanchored because the zh option label carries a `（默认）`
+ * suffix the assertion has no reason to restate.
+ */
+const AUTONOMY_READ_ONLY = /自主程度: 只看不动|Autonomy Level: Read only/;
+const AUTONOMY_FULL = /自主程度: 完全放开|Autonomy Level: Fully open/;
 
 async function waitForApp(page: Page): Promise<void> {
   await page.waitForLoadState('domcontentloaded');
@@ -54,6 +62,25 @@ function triggerEditor(page: Page) {
 
 function autonomyField(editor: ReturnType<typeof triggerEditor>) {
   return editor.getByText(AUTONOMY, { exact: true }).locator('..');
+}
+
+/**
+ * The menu a `Select` trigger has just opened.
+ *
+ * Since the Capabilities rebuild the menu is portalled into `document.body`
+ * (`src/components/ui/select.tsx`) so that no card below it can paint over it.
+ * An option is therefore no longer a descendant of the field that owns the
+ * control, and reaching one *through* that field finds nothing at all. Resolve
+ * options at page scope instead — but pin them to the menu THIS trigger
+ * controls (`aria-controls`), so the assertion still says which control was
+ * opened rather than clicking whatever option-shaped button the page happens
+ * to have. Same idiom as `capabilities.spec.ts`.
+ */
+async function openedMenu(page: Page, trigger: Locator): Promise<Locator> {
+  await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  const menuId = await trigger.getAttribute('aria-controls');
+  expect(menuId).toBeTruthy();
+  return page.locator(`#${menuId}`);
 }
 
 async function persistedCapability(page: Page, triggerName: string): Promise<string | undefined> {
@@ -100,9 +127,12 @@ test.describe.serial('Trigger autonomy — real Electron', () => {
     let editor = triggerEditor(page);
     await expect(editor).toBeVisible();
     const field = autonomyField(editor);
-    await expect(field.getByRole('button', { name: /自主程度: 只看不动|Autonomy Level: Read only/ })).toBeVisible();
-    await field.getByRole('button', { name: /自主程度: 只看不动|Autonomy Level: Read only/ }).click();
-    await field.getByRole('button', { name: FULL }).click();
+    const autonomyTrigger = field.getByRole('button', { name: AUTONOMY_READ_ONLY });
+    await expect(autonomyTrigger).toBeVisible();
+    await autonomyTrigger.click();
+    const autonomyMenu = await openedMenu(page, autonomyTrigger);
+    await autonomyMenu.getByRole('button', { name: FULL }).click();
+    await expect(autonomyMenu).toBeHidden();
     await expect(editor.getByText(/完全放开只适合可信输入源|trusted event sources only/)).toBeVisible();
 
     const triggerName = 'Electron capability E2E';
@@ -123,7 +153,7 @@ test.describe.serial('Trigger autonomy — real Electron', () => {
     await page.getByRole('button', { name: EDIT }).click();
     editor = triggerEditor(page);
     await expect(editor).toBeVisible();
-    await expect(autonomyField(editor).getByRole('button', { name: /自主程度: 完全放开|Autonomy Level: Fully open/ })).toBeVisible();
+    await expect(autonomyField(editor).getByRole('button', { name: AUTONOMY_FULL })).toBeVisible();
     await editor.getByRole('button', { name: SAVE }).click();
     await expect(editor).toBeHidden();
 


### PR DESCRIPTION
Fixes #378.

## What

Two spec files, test-only. No product code touched.

**`tests/e2e/trigger-capability.spec.ts`** — the autonomy dropdown's options are
now resolved at page scope instead of through the field container. The *trigger*
stays scoped to its field, and the menu is pinned to the one that trigger owns
(`aria-controls`), so the assertion still says which control was opened rather
than clicking whatever option-shaped button the page happens to have. Adds a
`toBeHidden()` on the menu after the pick, and names the two trigger
accessible-name regexes that were repeated inline.

**`tests/e2e/tool-approval.spec.ts`** — the capability-setup assertion now checks
the dialog's accessible name (`settings.capabilityChromeSetupTitle`, unchanged)
*and* the heading of the page it hosts (`settings.capabilityMyChrome`), both
taken from the current i18n entries.

## Why

`e2e-electron` has been red on `dev` since #370. Neither failure is a product
defect — both specs still describe the page as it was before the Capabilities
rebuild:

1. The `Select` menu is now portalled into `document.body`
   (`src/components/ui/select.tsx`) so it cannot be clipped by the card below
   it. An option is therefore no longer a descendant of the field that owns the
   control, and reaching one *through* that field finds nothing. This is the
   idiom `capabilities.spec.ts` already uses, reused here rather than reinvented.
2. The task-local capability dialog hosts the ordinary Chrome capability detail
   page, which the rebuild headed with the capability itself rather than with
   the setup phrase. The setup wording survives only as the dialog's
   `aria-label`, which `getByText` cannot see.

I also swept every spec under `tests/e2e/**` and `e2e/**` for the same two
mistakes — container-scoped option lookups, and CJK literals that no longer
appear anywhere in `src/` or `electron/`. `trigger-capability.spec.ts` was the
only file reaching into a field for an option; every other unmatched literal is
either fixture data or a deliberate `toHaveCount(0)` on copy that was removed.

## Evidence

Local, this branch, `npm run setup:electron-dev` first:

| gate | result |
|---|---|
| `npm run test:e2e:electron` (**full**, 45 tests) | **exit 0** — 44 passed, 1 skipped (`windows-titlebar-drag`, Windows-only), 2.5m |
| `npm run verify` | **exit 0** — 505 files, 8736 passed / 1 skipped, coverage gate met |
| `npm run electron:test` | **exit 0** — `ACCEPTANCE PASS` |

The full e2e suite was green on the **first** run — no reruns needed. The known
flakes (`browser-unattended` journeys ②/③b, `thinking-scroll-anchor` #339) all
passed first time.

Per #378 the full suite is the point: running only the two specs nearest the
change is exactly how this reached `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
