### PR TITLE
refactor(browser): type-constrain site-verdict writes, order settings pushes, unfreeze subagent settings

### DIFF
--- a/sidecar/src/agentLoopHost.test.ts
+++ b/sidecar/src/agentLoopHost.test.ts
@@ -788,6 +788,14 @@ describe('agentLoopHost', () => {
       expect(() => handleStateSettings(null)).not.toThrow();
       expect(() => handleStateSettings({})).not.toThrow();
     });
+
+    // A push with no revision cannot be ordered against the mirror, and
+    // applying an unorderable snapshot is how a stale one restores a
+    // permission the user just removed. Dropped, not applied.
+    it('ignores a push carrying no revision', () => {
+      expect(() => handleStateSettings({ settings: { agentMaxTurns: 5 } })).not.toThrow();
+      expect(() => handleStateSettings({ settings: { agentMaxTurns: 5 }, revision: 'one' })).not.toThrow();
+    });
   });
 
   describe('handleStatePlanMode', () => {

--- a/sidecar/src/agentLoopHost.ts
+++ b/sidecar/src/agentLoopHost.ts
@@ -1210,10 +1210,19 @@ export function handleStateExecPatch(rawParams: unknown): void {
   run.applyExecPatch(run.conversationId, rawParams.plannedSteps as PlannedStep[]);
 }
 
-/** `{ settings }` — sidecar-GLOBAL settings mirror push, see `settingsMirror.ts`. Not per-run, so not routed through `activeRuns`. */
+/**
+ * `{ settings, revision }` — sidecar-GLOBAL settings mirror push, see
+ * `settingsMirror.ts`. Not per-run, so not routed through `activeRuns`.
+ *
+ * `revision` is the shell's monotonic push counter and is REQUIRED: a push that
+ * cannot be ordered against the mirror's current contents is dropped rather
+ * than applied, because applying one is how a stale snapshot restores a
+ * permission the user just removed (see `settingsMirror.ts`'s doc).
+ */
 export function handleStateSettings(rawParams: unknown): void {
   if (!isRecord(rawParams) || !isRecord(rawParams.settings)) return;
-  applySettingsSnapshot(rawParams.settings as unknown as SettingsState);
+  if (typeof rawParams.revision !== 'number') return;
+  applySettingsSnapshot(rawParams.settings as unknown as SettingsState, rawParams.revision);
 }
 
 /** `{ conversationId, mode }` — mirror-apply (no re-notify — `planMode.ts`'s `applyPlanModeState` doesn't fire `onPlanModeChange`, per P1-3b-2's design). */

--- a/sidecar/src/main.ts
+++ b/sidecar/src/main.ts
@@ -68,8 +68,12 @@
  *     applies `report_plan`'s planned-steps write (which bypasses
  *     ExecutionPort shell-side) to that run's execution mirror. Unknown
  *     runId silent drop.
- *   - `state.settings` → P1-3B-3A: `{settings}` — sidecar-GLOBAL settings
- *     mirror push (see settingsMirror.ts), NOT per-run/routed by runId.
+ *   - `state.settings` → P1-3B-3A: `{settings, revision}` — sidecar-GLOBAL
+ *     settings mirror push (see settingsMirror.ts), NOT per-run/routed by
+ *     runId. `revision` is the shell's monotonic push counter and is
+ *     REQUIRED: a push that is not strictly newer than the last applied one
+ *     is dropped, so an out-of-order notification cannot restore a
+ *     permission the user just removed.
  *   - `state.planMode` → P1-3B-3A: `{conversationId, mode}` — mirror-apply
  *     via planMode.ts's applyPlanModeState (does not re-notify the shell).
  * Notifications sidecar→shell:

--- a/sidecar/src/settingsMirror.test.ts
+++ b/sidecar/src/settingsMirror.test.ts
@@ -29,16 +29,16 @@ describe('settingsMirror', () => {
   it('seedSettingsMirrorIfEmpty is a no-op once something has already landed (never regresses a fresher push)', () => {
     const first = makeSettings({ activeModel: { providerId: 'p1', modelId: 'm1' } });
     const second = makeSettings({ activeModel: { providerId: 'p2', modelId: 'm2' } });
-    applySettingsSnapshot(first);
+    applySettingsSnapshot(first, 1);
     seedSettingsMirrorIfEmpty(second);
     expect(getSettingsMirrorReader().getSnapshot()).toBe(first);
   });
 
-  it('applySettingsSnapshot always wins — latest push overwrites a prior seed or push', () => {
+  it('applySettingsSnapshot wins over a prior seed — a push is newer than a dispatch-time snapshot', () => {
     const seeded = makeSettings({ activeModel: { providerId: 'p1', modelId: 'm1' } });
     const pushed = makeSettings({ activeModel: { providerId: 'p2', modelId: 'm2' } });
     seedSettingsMirrorIfEmpty(seeded);
-    applySettingsSnapshot(pushed);
+    applySettingsSnapshot(pushed, 0);
     expect(getSettingsMirrorReader().getSnapshot()).toBe(pushed);
   });
 
@@ -46,8 +46,71 @@ describe('settingsMirror', () => {
     const readerA = getSettingsMirrorReader();
     const readerB = getSettingsMirrorReader();
     const s = makeSettings();
-    applySettingsSnapshot(s);
+    applySettingsSnapshot(s, 0);
     expect(readerA.getSnapshot()).toBe(s);
     expect(readerB.getSnapshot()).toBe(s);
+  });
+
+  /**
+   * The regression this revision exists for: `notifySidecar` is
+   * fire-and-forget, so two debounced pushes can arrive in either order.
+   * Without an ordering key the mirror keeps whichever landed LAST, which for
+   * a permission that was just tightened means silently handing it back.
+   */
+  describe('monotonic revision', () => {
+    it('drops a push that arrives out of order instead of regressing the mirror', () => {
+      const tightened = makeSettings({ allowUnattendedBrowser: false });
+      const stale = makeSettings({ allowUnattendedBrowser: true });
+
+      expect(applySettingsSnapshot(tightened, 7)).toBe(true);
+      // The pre-change snapshot, delayed in flight and arriving second.
+      expect(applySettingsSnapshot(stale, 6)).toBe(false);
+
+      expect(getSettingsMirrorReader().getSnapshot()).toBe(tightened);
+    });
+
+    it('drops a REPLAY of the revision already applied', () => {
+      const first = makeSettings({ allowUnattendedBrowser: false });
+      const replay = makeSettings({ allowUnattendedBrowser: true });
+
+      applySettingsSnapshot(first, 3);
+      expect(applySettingsSnapshot(replay, 3)).toBe(false);
+
+      expect(getSettingsMirrorReader().getSnapshot()).toBe(first);
+    });
+
+    it('applies a strictly newer push', () => {
+      const older = makeSettings({ allowUnattendedBrowser: true });
+      const newer = makeSettings({ allowUnattendedBrowser: false });
+
+      applySettingsSnapshot(older, 3);
+      expect(applySettingsSnapshot(newer, 4)).toBe(true);
+
+      expect(getSettingsMirrorReader().getSnapshot()).toBe(newer);
+    });
+
+    it('accepts revision 0 as the first push — an empty mirror has no order to violate', () => {
+      const s = makeSettings();
+      expect(applySettingsSnapshot(s, 0)).toBe(true);
+      expect(getSettingsMirrorReader().getSnapshot()).toBe(s);
+    });
+
+    it('refuses a non-finite revision rather than applying an unorderable snapshot', () => {
+      const seeded = makeSettings({ allowUnattendedBrowser: false });
+      seedSettingsMirrorIfEmpty(seeded);
+
+      expect(applySettingsSnapshot(makeSettings({ allowUnattendedBrowser: true }), Number.NaN)).toBe(false);
+      expect(applySettingsSnapshot(makeSettings({ allowUnattendedBrowser: true }), Number.POSITIVE_INFINITY)).toBe(false);
+
+      expect(getSettingsMirrorReader().getSnapshot()).toBe(seeded);
+    });
+
+    it('lets a seed fill an EMPTY mirror without claiming a revision — the next push of any revision still wins', () => {
+      const seeded = makeSettings({ activeModel: { providerId: 'p1', modelId: 'm1' } });
+      const pushed = makeSettings({ activeModel: { providerId: 'p2', modelId: 'm2' } });
+      seedSettingsMirrorIfEmpty(seeded);
+      expect(applySettingsSnapshot(pushed, 0)).toBe(true);
+      expect(getSettingsMirrorReader().getSnapshot()).toBe(pushed);
+    });
   });
 });

--- a/sidecar/src/settingsMirror.ts
+++ b/sidecar/src/settingsMirror.ts
@@ -1,33 +1,69 @@
 /**
  * Sidecar-GLOBAL (NOT per-run) settings mirror — P1-3B-3A item 2 / design doc
  * §3 "settingsReader" row: "镜像 + state.settings 推送...比 3a 的 per-run 冻结强
- * （主循环可长跑）". Unlike the 3a subagent path (a short-lived run, frozen
- * settings snapshot for its whole lifetime is an acceptable simplification —
- * see `subagentHost.ts`'s doc), a main-loop run can be long (minutes of
- * streaming + many tool turns); freezing settings for its whole duration
- * would mean a user changing e.g. `maxOutputTokens`/`computerUseEnabled`
- * mid-run never takes effect until the NEXT loop. So settings live in ONE
- * shared mirror, updated by every `state.settings` push
- * (`agentLoopRunner.ts`'s 50ms-debounced `useSettingsStore.subscribe` —
- * shell-side, P1-3b-2), and every run's injected `SettingsReader` (via
- * `AgentLoopOptions.settingsReader`) reads through to this SAME shared
- * mirror — "latest push wins; reads always return the current mirror", per
- * the design doc.
+ * （主循环可长跑）". A main-loop run can be long (minutes of streaming + many
+ * tool turns); freezing settings for its whole duration would mean a user
+ * changing e.g. `maxOutputTokens`/`allowUnattendedBrowser` mid-run never takes
+ * effect until the NEXT loop. So settings live in ONE shared mirror, updated by
+ * every `state.settings` push (`agentLoopRunner.ts`'s 50ms-debounced
+ * `useSettingsStore.subscribe` — shell-side, P1-3b-2), and every run's injected
+ * `SettingsReader` (via `AgentLoopOptions.settingsReader`) reads through to this
+ * SAME shared mirror.
  *
  * Seeded per-run from that run's OWN `settingsSnapshot` param ONLY the FIRST
  * time (i.e. if no push has landed yet) — `seedIfEmpty` is a no-op once a
  * real value exists, so a late-starting run never regresses an
  * already-fresher mirror with its own (possibly staler, dispatch-time)
  * snapshot.
+ *
+ * ## Monotonic revisions (config-batch4, 2026-09-06)
+ *
+ * "Latest push wins" used to mean "latest ARRIVAL wins", which is not the same
+ * thing. The shell debounces its pushes by 50ms and fires them through
+ * `notifySidecar` — a fire-and-forget notification with no ordering guarantee
+ * once two of them are in flight. Two rapid setting changes could therefore
+ * land out of order, and the mirror would keep the OLDER one: a user who turned
+ * the unattended browser master switch OFF could have it silently restored by a
+ * late-arriving push carrying the pre-change snapshot, and the gate would then
+ * read a permission the user had just taken away.
+ *
+ * So every push carries a shell-side monotonic `revision`, and a push whose
+ * revision is not strictly greater than the last applied one is DROPPED. The
+ * revision is required: a push without one cannot be ordered against anything,
+ * and applying an unorderable snapshot is exactly the regression this exists to
+ * prevent (`DEVELOPMENT-PLAN.md` §3: 「缺版本拒绝作为执行依据」). The shell and
+ * the sidecar ship in the same binary, so there is no older producer to be
+ * compatible with.
+ *
+ * The seed is deliberately NOT a revision: it is a run's dispatch-time snapshot,
+ * not a point on the shell's push timeline, so it fills an empty mirror without
+ * ever claiming an order relative to a push. The first real push (revision ≥ 0)
+ * then supersedes it.
  */
 import type { SettingsReader } from '@/core/agent/ports/settingsReader';
 import type { SettingsState } from '@/stores/settingsStore';
 
 let current: SettingsState | undefined;
+/**
+ * The highest revision applied so far. `undefined` means no PUSH has landed
+ * (the mirror may still hold a seeded snapshot), so the first push of any
+ * revision — including 0 — is accepted.
+ */
+let appliedRevision: number | undefined;
 
-/** `state.settings` notification handler — always wins (most recent, live). */
-export function applySettingsSnapshot(snapshot: SettingsState): void {
+/**
+ * `state.settings` notification handler.
+ *
+ * Applies the snapshot only when `revision` is strictly newer than the last
+ * applied one. Returns whether it was applied, so the caller can log a dropped
+ * push rather than silently swallowing it.
+ */
+export function applySettingsSnapshot(snapshot: SettingsState, revision: number): boolean {
+  if (!Number.isFinite(revision)) return false;
+  if (appliedRevision !== undefined && revision <= appliedRevision) return false;
   current = snapshot;
+  appliedRevision = revision;
+  return true;
 }
 
 /** Seed the mirror from a run's dispatch-time snapshot, but ONLY if nothing has landed yet (never regresses a fresher push). */
@@ -38,6 +74,7 @@ export function seedSettingsMirrorIfEmpty(snapshot: SettingsState): void {
 /** Test-only reset. */
 export function __resetSettingsMirror(): void {
   current = undefined;
+  appliedRevision = undefined;
 }
 
 const reader: SettingsReader = {

--- a/sidecar/src/subagentHost.test.ts
+++ b/sidecar/src/subagentHost.test.ts
@@ -42,6 +42,7 @@ import {
   SUBAGENT_HOST_LOOP_OPTION_WIRE_FIELDS,
   SUBAGENT_HOST_RUN_WIRE_FIELDS,
 } from './subagentHost';
+import { applySettingsSnapshot, __resetSettingsMirror } from './settingsMirror';
 
 // Unique default runId per call — `activeRuns` is real module-level state
 // that persists across tests within this file (no reset hook exists for
@@ -362,6 +363,54 @@ describe('subagentHost', () => {
           content: [{ type: 'image', attachment: { ...delegatedUserTurn.content[1].attachment, id: '/Users/tester/secret.png' } }],
         },
       }))).rejects.toMatchObject({ code: -32602 });
+    });
+
+    /**
+     * config-batch4 — the subagent's settings snapshot used to be frozen for
+     * the whole run (`getSnapshot: () => params.settingsSnapshot`). A user who
+     * turned the unattended-browser master switch off mid-run was still read as
+     * having it on by every subagent already in flight, which is exactly the
+     * case S10's 「关闭总闸阻止下一浏览器动作」 promises to cover.
+     */
+    describe('settings are LIVE, not frozen at dispatch', () => {
+      it('reads a setting the user changed after the run started', async () => {
+        __resetSettingsMirror();
+        let capturedReader: { getSnapshot: () => Record<string, unknown> } | undefined;
+        runSubagentLoopMock.mockImplementation(async (options: { settingsReader: { getSnapshot: () => Record<string, unknown> } }) => {
+          capturedReader = options.settingsReader;
+          return resultShape('ok');
+        });
+
+        await handleSubagentRun(baseParams({
+          settingsSnapshot: { agentMaxTurns: 200, allowUnattendedBrowser: true },
+        }));
+
+        expect(capturedReader?.getSnapshot().allowUnattendedBrowser).toBe(true);
+
+        // The user flips the master switch off; the shell pushes the new
+        // snapshot into the shared mirror while this subagent is still running.
+        applySettingsSnapshot(
+          { agentMaxTurns: 200, allowUnattendedBrowser: false } as never,
+          0,
+        );
+
+        expect(capturedReader?.getSnapshot().allowUnattendedBrowser).toBe(false);
+      });
+
+      it('still falls back to its own dispatch snapshot when no push has landed yet', async () => {
+        __resetSettingsMirror();
+        let capturedReader: { getSnapshot: () => Record<string, unknown> } | undefined;
+        runSubagentLoopMock.mockImplementation(async (options: { settingsReader: { getSnapshot: () => Record<string, unknown> } }) => {
+          capturedReader = options.settingsReader;
+          return resultShape('ok');
+        });
+
+        await handleSubagentRun(baseParams({
+          settingsSnapshot: { agentMaxTurns: 42, allowUnattendedBrowser: true },
+        }));
+
+        expect(capturedReader?.getSnapshot().agentMaxTurns).toBe(42);
+      });
     });
 
     it('restores only the trusted text-only delegated-media fallback', async () => {

--- a/sidecar/src/subagentHost.ts
+++ b/sidecar/src/subagentHost.ts
@@ -398,12 +398,19 @@ export async function handleSubagentRun(rawParams: unknown): Promise<unknown> {
    * This used to be `getSnapshot: () => params.settingsSnapshot` — a snapshot
    * frozen for the whole life of the subagent. The original note called that an
    * acceptable simplification because a subagent run is short; it is not. A
-   * delegated agent can browse for minutes, and every permission it consults
-   * lives in these settings — so a user who noticed something going wrong and
-   * turned the unattended-browser master switch OFF was still read as having it
-   * ON by every subagent already running. That is the one case S10/AC-S16's
-   * 「关闭总闸阻止下一浏览器动作」 promises to cover, and the frozen snapshot is
-   * where it was being lost.
+   * delegated agent can browse for minutes, and a user who changes a setting
+   * mid-run expects the change to take effect, not to wait for the run to end.
+   *
+   * WHAT THIS DOES AND DOES NOT COVER. What was frozen is what the subagent
+   * LOOP reads out of settings for itself — its turn limit, its model, the
+   * per-tool switches it consults directly. The browser gate is NOT in that
+   * set and never was: a sidecar-hosted tool call goes back to the shell over
+   * `approval.check`, and the shell answers from the renderer's LIVE store. So
+   * turning the unattended-browser master switch off did already stop the next
+   * browser action of a running subagent; do not read this comment as saying
+   * it did not. (S10/AC-S16 is satisfied by that round-trip, not by this
+   * line.) The freeze was still a real defect — a run must not read a stale
+   * turn limit or a stale model either — and SCOPE-RULING §7 named it.
    *
    * Seeding first preserves the previous behaviour for the only case the freeze
    * was actually protecting: a subagent that starts before any `state.settings`

--- a/sidecar/src/subagentHost.ts
+++ b/sidecar/src/subagentHost.ts
@@ -7,6 +7,10 @@
  * (P1-3a-pre's port #7 + the new per-run-injectable-options extension —
  * see subagentLoop.ts's `SubagentLoopOptions.settingsReader`/`toolInvoker`).
  *
+ * The `SettingsReader` is the ONE port that is deliberately NOT per-run: it is
+ * the sidecar's shared `settingsMirror`, so a setting the user changes mid-run
+ * reaches subagents already in flight. See `handleSubagentRun`'s comment.
+ *
  * Per-run isolation: each `subagent.run` gets its OWN `AbortController`,
  * `ToolInvoker` (closes over its OWN `runId` for `tool.invoke` routing),
  * and `AsyncLocalStorage` context (`subagentRunContext.ts` — carries the
@@ -42,6 +46,7 @@ import { toolResultToString } from '@/core/tools/toolResultToString';
 import { RpcError } from './protocol';
 import { sendRequest, sendNotification } from './rpcClient';
 import { findActiveRunDeltaForConversation } from './agentLoopHost';
+import { getSettingsMirrorReader, seedSettingsMirrorIfEmpty } from './settingsMirror';
 import { subagentRunContext, type SubagentRunContext } from './subagentRunContext';
 import { SUBAGENT_RUN_WIRE_FIELDS as SHARED_SUBAGENT_RUN_WIRE_FIELDS } from '@/core/agent/subagentWireContract';
 import { makeSubagentProgressToolCallId } from '@/core/agent/subagentProgressIdentity';
@@ -386,7 +391,27 @@ export async function handleSubagentRun(rawParams: unknown): Promise<unknown> {
   const controller = new AbortController();
   activeRuns.set(runId, { controller });
 
-  const settingsReader: SettingsReader = { getSnapshot: () => params.settingsSnapshot };
+  /**
+   * Read settings through the sidecar's SHARED mirror, not through this run's
+   * dispatch-time snapshot (config-batch4, 2026-09-06).
+   *
+   * This used to be `getSnapshot: () => params.settingsSnapshot` — a snapshot
+   * frozen for the whole life of the subagent. The original note called that an
+   * acceptable simplification because a subagent run is short; it is not. A
+   * delegated agent can browse for minutes, and every permission it consults
+   * lives in these settings — so a user who noticed something going wrong and
+   * turned the unattended-browser master switch OFF was still read as having it
+   * ON by every subagent already running. That is the one case S10/AC-S16's
+   * 「关闭总闸阻止下一浏览器动作」 promises to cover, and the frozen snapshot is
+   * where it was being lost.
+   *
+   * Seeding first preserves the previous behaviour for the only case the freeze
+   * was actually protecting: a subagent that starts before any `state.settings`
+   * push has landed still has its own snapshot to read. Once a push arrives,
+   * every run — main loop and subagent alike — reads the same live value.
+   */
+  seedSettingsMirrorIfEmpty(params.settingsSnapshot);
+  const settingsReader: SettingsReader = getSettingsMirrorReader();
   const toolInvoker = createReverseToolInvoker(runId, params.tools, params.parentConversationId, controller.signal);
   const workspaceReader: WorkspaceReader = { getCurrentPath: () => params.workspacePathSnapshot };
   const capsPort = createDegradedCapsPort();

--- a/src/__tests__/browserSiteGrantWriters.test.ts
+++ b/src/__tests__/browserSiteGrantWriters.test.ts
@@ -13,10 +13,21 @@
  * required to be a DECISION, taken by whoever adds it, rather than something
  * that shows up in a diff nobody reads.
  *
- * Two ways in are checked:
+ * Four ways in are checked:
  *  1. the store's setter, `setBrowserSitePermission`;
  *  2. writing the `browserSitePermissions` map straight through `setState`,
- *     which would bypass the setter entirely.
+ *     which would bypass the setter entirely;
+ *  3. casting to the branded `BrowserSiteVerdicts` type, which is how a
+ *     writer would get past the compiler now that the field is nominal
+ *     (config-batch4);
+ *  4. importing the test-only minting helper from shipped code.
+ *
+ * (3) and (4) are the escape hatches the TYPE constraint leaves open. The
+ * brand makes an accidental writer impossible — `setState({
+ * browserSitePermissions: {...} })` no longer compiles anywhere outside
+ * `settingsStore.ts` — but any nominal type in TypeScript can be forced with
+ * an `as`, so the scan still has to say that forcing it is a decision rather
+ * than a detail.
  *
  * Deliberately a source scan rather than a runtime spy: the property is about
  * code that EXISTS, and a call site nobody exercises in a test would be
@@ -37,6 +48,16 @@ const SKIP_DIRS = new Set(['node_modules', 'dist', 'dist-electron', 'coverage', 
  * walking through it.
  */
 const STORE = join('src', 'stores', 'settingsStore.ts');
+
+/**
+ * The test harness's own minting helper. It lives under `src/test/` — the
+ * directory `tsconfig.app.json` excludes and nothing shipped imports — and it
+ * is the file that HOLDS the deliberate cast, so it matches the cast scan by
+ * construction. Same relationship to the rule as `STORE`: the door, not
+ * someone walking through it. Its importers are what the scan is looking for,
+ * and that is checked separately below.
+ */
+const TEST_VERDICT_HELPER = join('src', 'test', 'browserSiteVerdicts.ts');
 
 /**
  * Every file that may write a site verdict, and the user action behind each.
@@ -79,7 +100,9 @@ function sourceFiles(): string[] {
 
 function filesMatching(predicate: (source: string) => boolean): string[] {
   return sourceFiles()
-    .filter((file) => file !== STORE && predicate(readFileSync(join(REPO_ROOT, file), 'utf-8')))
+    .filter((file) => file !== STORE
+      && file !== TEST_VERDICT_HELPER
+      && predicate(readFileSync(join(REPO_ROOT, file), 'utf-8')))
     .sort();
 }
 
@@ -88,6 +111,7 @@ describe('standing browser site verdicts have exactly two writers', () => {
     const files = sourceFiles();
     expect(files.length).toBeGreaterThan(200);
     expect(files).toContain(STORE);
+    expect(files).toContain(TEST_VERDICT_HELPER);
     for (const writer of PERMITTED_WRITERS) expect(files).toContain(writer);
     // A path typo in PERMITTED_WRITERS would otherwise make this suite pass by
     // comparing two empty-ish sets.
@@ -106,5 +130,22 @@ describe('standing browser site verdicts have exactly two writers', () => {
       (src) => /setState\s*\(/.test(src) && src.includes('browserSitePermissions'),
     );
     expect(bypass).toEqual([]);
+  });
+
+  it('lets nobody force the brand with a cast', () => {
+    // The compile-time half of the rule (config-batch4): the field's type is
+    // nominal, so only `settingsStore.ts`'s module-private
+    // `mintBrowserSiteVerdicts` can produce one. A cast is the one way past
+    // that, and it must not appear in shipped code.
+    const forced = filesMatching((src) => /\bas\s+BrowserSiteVerdicts\b/.test(src));
+    expect(forced).toEqual([]);
+  });
+
+  it('lets nobody reach for the test-only minting helper', () => {
+    // `src/test/browserSiteVerdicts.ts` casts on purpose, for component tests
+    // that arrange standing verdicts without driving the UI. A shipped file
+    // importing it would be that same cast wearing a helper's name.
+    const importers = filesMatching((src) => src.includes('test/browserSiteVerdicts'));
+    expect(importers).toEqual([]);
   });
 });

--- a/src/components/common/CommandConfirmDialog.test.tsx
+++ b/src/components/common/CommandConfirmDialog.test.tsx
@@ -7,6 +7,7 @@ import CommandConfirmDialog, { type CommandConfirmRequest } from './CommandConfi
 import { initLanguage } from '@/i18n';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { DEFAULT_BROWSER_OPERATION_POLICY } from '@/core/permissions/browserToolPolicy';
+import { testSiteVerdicts } from '@/test/browserSiteVerdicts';
 
 // Pins the browser-confirmation button set: which scopes are offered is a
 // security decision made by the requester (allowPersistentGrant), and the
@@ -17,7 +18,7 @@ describe('CommandConfirmDialog', () => {
   beforeEach(() => {
     initLanguage('zh-CN');
     useSettingsStore.setState({
-      browserSitePermissions: {},
+      browserSitePermissions: testSiteVerdicts({}),
       // Shipped default (scripting = 'ask'). Reset explicitly so a test that
       // flips the scripting row cannot rename this button for its neighbours.
       browserOperationPolicy: DEFAULT_BROWSER_OPERATION_POLICY,
@@ -198,7 +199,7 @@ describe('CommandConfirmDialog', () => {
     it('overwrites an existing allow verdict for the same origin', async () => {
       const user = userEvent.setup();
       useSettingsStore.setState({
-        browserSitePermissions: { 'https://example.com': 'allowed' },
+        browserSitePermissions: testSiteVerdicts({ 'https://example.com': 'allowed' }),
       });
       renderDialog({ browserOrigin: 'https://example.com', allowPersistentGrant: true });
 

--- a/src/components/schedule/ScheduleTaskDetail.test.tsx
+++ b/src/components/schedule/ScheduleTaskDetail.test.tsx
@@ -17,6 +17,7 @@ import { initLanguage } from '@/i18n';
 import { useScheduleStore } from '@/stores/scheduleStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import type { ScheduledTask } from '@/types/schedule';
+import { testSiteVerdicts } from '@/test/browserSiteVerdicts';
 
 vi.mock('@/core/scheduler/scheduler', () => ({
   schedulerEngine: { runNow: vi.fn() },
@@ -47,7 +48,7 @@ describe('ScheduleTaskDetail — browser authorization', () => {
     initLanguage('en-US');
     useScheduleStore.setState({ tasks: { 'task-1': TASK }, selectedTaskId: 'task-1' });
     useSettingsStore.setState({
-      browserSitePermissions: {},
+      browserSitePermissions: testSiteVerdicts({}),
       allowUnattendedBrowser: true,
       systemSettingsOpen: false,
     });
@@ -57,10 +58,10 @@ describe('ScheduleTaskDetail — browser authorization', () => {
 
   it('lists the origins an unattended run of this task may act on', () => {
     useSettingsStore.setState({
-      browserSitePermissions: {
+      browserSitePermissions: testSiteVerdicts({
         'https://reports.example.com': 'allowed',
         'https://blocked.example.com': 'denied',
-      },
+      }),
     });
     render(<ScheduleTaskDetail />);
 
@@ -71,7 +72,7 @@ describe('ScheduleTaskDetail — browser authorization', () => {
 
   it('leaves a high-risk site out of the set, even when the user allowed it', () => {
     useSettingsStore.setState({
-      browserSitePermissions: { 'https://www.paypal.com': 'allowed' },
+      browserSitePermissions: testSiteVerdicts({ 'https://www.paypal.com': 'allowed' }),
     });
     render(<ScheduleTaskDetail />);
 
@@ -81,7 +82,7 @@ describe('ScheduleTaskDetail — browser authorization', () => {
 
   it('says the task cannot use the browser at all while the master switch is off', () => {
     useSettingsStore.setState({
-      browserSitePermissions: { 'https://reports.example.com': 'allowed' },
+      browserSitePermissions: testSiteVerdicts({ 'https://reports.example.com': 'allowed' }),
       allowUnattendedBrowser: false,
     });
     render(<ScheduleTaskDetail />);
@@ -94,7 +95,7 @@ describe('ScheduleTaskDetail — browser authorization', () => {
   it('caps a long list and counts the rest', () => {
     const many: Record<string, 'allowed'> = {};
     for (let i = 0; i < 9; i += 1) many[`https://s${i}.example.com`] = 'allowed';
-    useSettingsStore.setState({ browserSitePermissions: many });
+    useSettingsStore.setState({ browserSitePermissions: testSiteVerdicts(many) });
     render(<ScheduleTaskDetail />);
 
     expect(within(card()).getByText('3 more')).toBeInTheDocument();

--- a/src/components/settings/sections/CapabilitiesSection.test.tsx
+++ b/src/components/settings/sections/CapabilitiesSection.test.tsx
@@ -15,6 +15,7 @@ import {
   hasChromeExtensionHandshaked,
   setChromeExtensionHandshaked,
 } from '@/core/capabilityPlugins/chromeHandshakeLatch';
+import { testSiteVerdicts } from '@/test/browserSiteVerdicts';
 
 const invoke = vi.fn();
 vi.mock('@tauri-apps/api/core', () => ({
@@ -337,7 +338,7 @@ describe('CapabilitiesSection', () => {
 
   it('walks into the site list and back out through the breadcrumb', async () => {
     useSettingsStore.setState({
-      browserSitePermissions: { 'https://example.com': 'allowed' },
+      browserSitePermissions: testSiteVerdicts({ 'https://example.com': 'allowed' }),
     });
     const user = userEvent.setup();
     render(<CapabilitiesSection />);
@@ -1223,10 +1224,10 @@ describe('CapabilitiesSection', () => {
   describe('browser site permissions list', () => {
     it('lists both verdicts and switches an allowed site to blocked', async () => {
       useSettingsStore.setState({
-        browserSitePermissions: {
+        browserSitePermissions: testSiteVerdicts({
           'https://allowed.example.com': 'allowed',
           'https://blocked.example.com': 'denied',
-        },
+        }),
       });
       const user = userEvent.setup();
       render(<CapabilitiesSection />);
@@ -1250,7 +1251,7 @@ describe('CapabilitiesSection', () => {
 
     it('removes a verdict entirely, restoring ask-every-time', async () => {
       useSettingsStore.setState({
-        browserSitePermissions: { 'https://example.com': 'denied' },
+        browserSitePermissions: testSiteVerdicts({ 'https://example.com': 'denied' }),
       });
       const user = userEvent.setup();
       render(<CapabilitiesSection />);
@@ -1265,7 +1266,7 @@ describe('CapabilitiesSection', () => {
     // The explanation is where the choice is, not behind a hover target.
     it('explains each verdict inside the dropdown that sets it', async () => {
       useSettingsStore.setState({
-        browserSitePermissions: { 'https://example.com': 'allowed' },
+        browserSitePermissions: testSiteVerdicts({ 'https://example.com': 'allowed' }),
       });
       const user = userEvent.setup();
       render(<CapabilitiesSection />);
@@ -1298,7 +1299,7 @@ describe('CapabilitiesSection', () => {
       // Earlier tests in this file leave verdicts behind; every assertion here
       // is about the exact contents of the map, so it starts empty.
       beforeEach(() => {
-        useSettingsStore.setState({ browserSitePermissions: {} });
+        useSettingsStore.setState({ browserSitePermissions: testSiteVerdicts({}) });
       });
 
       /** The verdict select of the ADD row — named for its job, so it never
@@ -1364,7 +1365,7 @@ describe('CapabilitiesSection', () => {
 
       it('updates an origin that is already listed instead of duplicating it', async () => {
         useSettingsStore.setState({
-          browserSitePermissions: { 'https://example.com': 'allowed' },
+          browserSitePermissions: testSiteVerdicts({ 'https://example.com': 'allowed' }),
         });
         const user = userEvent.setup();
         render(<CapabilitiesSection />);
@@ -1443,11 +1444,11 @@ describe('CapabilitiesSection', () => {
     // waiting behind it, and that both channels answer to the same list.
     it('summarizes the list on the card that leads to it', async () => {
       useSettingsStore.setState({
-        browserSitePermissions: {
+        browserSitePermissions: testSiteVerdicts({
           'https://a.example.com': 'allowed',
           'https://b.example.com': 'allowed',
           'https://c.example.com': 'denied',
-        },
+        }),
       });
       const user = userEvent.setup();
       render(<CapabilitiesSection />);
@@ -1743,7 +1744,7 @@ describe('CapabilitiesSection', () => {
       allowUnattendedBrowser: boolean,
     ) {
       useSettingsStore.setState({
-        browserSitePermissions: sitePermissions,
+        browserSitePermissions: testSiteVerdicts(sitePermissions),
         allowUnattendedBrowser,
         browserOperationPolicy: DEFAULT_BROWSER_OPERATION_POLICY,
       });

--- a/src/core/agent/agentLoopRunner.test.ts
+++ b/src/core/agent/agentLoopRunner.test.ts
@@ -1798,7 +1798,30 @@ describe('agentLoopRunner', () => {
       expect(notifySidecar).not.toHaveBeenCalled();
 
       vi.advanceTimersByTime(50);
-      expect(notifySidecar).toHaveBeenCalledWith('state.settings', { settings: { agentMaxTurns: 200 } });
+      expect(notifySidecar).toHaveBeenCalledWith('state.settings', {
+        settings: { agentMaxTurns: 200 },
+        revision: expect.any(Number),
+      });
+    });
+
+    // The mirror drops anything not strictly newer (settingsMirror.ts), so a
+    // repeated or absent revision would make the SECOND push a no-op: the user
+    // tightens a setting and the sidecar keeps reading the old one.
+    it('stamps each push with a strictly increasing revision', async () => {
+      vi.useFakeTimers();
+      const { registerRunSession } = await importFresh();
+      registerRunSession('run-1', makeSession());
+
+      capturedSettingsCb?.();
+      vi.advanceTimersByTime(50);
+      capturedSettingsCb?.();
+      vi.advanceTimersByTime(50);
+
+      const revisions = notifySidecar.mock.calls
+        .filter((c) => c[0] === 'state.settings')
+        .map((c) => (c[1] as { revision: number }).revision);
+      expect(revisions).toHaveLength(2);
+      expect(revisions[1]).toBeGreaterThan(revisions[0] as number);
     });
 
     it('coalesces rapid-fire changes into a single push', async () => {

--- a/src/core/agent/agentLoopRunner.ts
+++ b/src/core/agent/agentLoopRunner.ts
@@ -1799,12 +1799,32 @@ const SETTINGS_DEBOUNCE_MS = 50;
 
 let settingsUnsub: (() => void) | undefined;
 let settingsDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+/**
+ * Monotonic push counter — the ordering the notification channel itself does
+ * not provide.
+ *
+ * `notifySidecar` is fire-and-forget, so two pushes in flight can arrive in
+ * either order and the mirror's "latest push wins" would then mean "latest
+ * ARRIVAL wins". A snapshot taken BEFORE the user tightened a setting could
+ * therefore land after the one taken AFTER it, and the sidecar's gate would go
+ * on reading the permission the user had just removed. The revision is stamped
+ * at SEND time (not at snapshot time) because that is the order the reader has
+ * to reconstruct; `settingsMirror.ts` drops anything not strictly newer.
+ *
+ * Never reset — a restarted sidecar starts with no applied revision and accepts
+ * whatever comes next, so the counter only ever has to be increasing within one
+ * shell process.
+ */
+let settingsPushRevision = 0;
 
 function scheduleSettingsPush(): void {
   if (settingsDebounceTimer) clearTimeout(settingsDebounceTimer);
   settingsDebounceTimer = setTimeout(() => {
     settingsDebounceTimer = undefined;
-    notifySidecar('state.settings', { settings: getSettingsReader().getSnapshot() });
+    notifySidecar('state.settings', {
+      settings: getSettingsReader().getSnapshot(),
+      revision: settingsPushRevision++,
+    });
   }, SETTINGS_DEBOUNCE_MS);
 }
 

--- a/src/core/agent/agentLoopRunner.ts
+++ b/src/core/agent/agentLoopRunner.ts
@@ -1814,6 +1814,25 @@ let settingsDebounceTimer: ReturnType<typeof setTimeout> | undefined;
  * Never reset — a restarted sidecar starts with no applied revision and accepts
  * whatever comes next, so the counter only ever has to be increasing within one
  * shell process.
+ *
+ * 🔴 THE OTHER DIRECTION IS AN INVARIANT, NOT AN ACCIDENT. This is a
+ * module-level variable in the RENDERER, so it restarts at 0 whenever the
+ * renderer reloads. If a sidecar could outlive a renderer, its `appliedRevision`
+ * would stay high while this counter started over, and `settingsMirror.ts`
+ * would then discard EVERY subsequent push — the mirror frozen forever at the
+ * pre-reload snapshot, which is this change's own failure mode running
+ * backwards.
+ *
+ * It cannot happen today because a sidecar never outlives its renderer:
+ * `sidecarManager.ts` issues `mcp_kill` for the sidecar id BEFORE it spawns
+ * one, so every renderer start gets a brand-new process with no applied
+ * revision. That kill-then-spawn is the whole load-bearing structure — nothing
+ * in `electron/mcpBridge.cjs` cleans up per-webContents, and
+ * `electron/sidecarSupervisor.cjs` exists precisely to let the MAIN process own
+ * a sidecar (it did once; `mcpBridge.cjs` says so). Any refactor that moves
+ * ownership back to main must carry a producer nonce in the push — or reset
+ * `appliedRevision` when the producer changes — before it lands, or settings
+ * silently stop reaching the sidecar.
  */
 let settingsPushRevision = 0;
 

--- a/src/core/permissions/browserToolPolicy.ts
+++ b/src/core/permissions/browserToolPolicy.ts
@@ -261,6 +261,38 @@ export function browserToolTargetsPage(namespacedName: string): boolean {
 export type SiteVerdict = 'allowed' | 'denied' | 'default';
 
 /**
+ * Nominal marker on the stored per-site verdict map, so the type system —
+ * not only a source scan — enforces who may mint one.
+ *
+ * `'allowed'` is the strongest thing this app stores about a website: it is
+ * what stops the confirmation dialog appearing, AND the one signal that lets
+ * an AUTOMATIC task act on that site at all. Its safety argument is
+ * provenance: every entry is a human act, taken in a surface the user opened,
+ * with the reason next to the control. `browserSiteGrantWriters.test.ts`
+ * enumerates the writers to keep that argument checkable, and this brand is
+ * the compile-time half of the same rule: nothing outside `settingsStore.ts`
+ * can PRODUCE a value of this type, because the only function that attaches
+ * the brand (`mintBrowserSiteVerdicts`) is module-private there.
+ *
+ * READING is unaffected — the brand is an extra symbol-keyed property on top
+ * of the same string index signature, so a branded map is still assignable to
+ * the plain `Record<string, 'allowed' | 'denied'>` every consumer takes.
+ * Only construction is closed.
+ *
+ * As with any TypeScript nominal type this is not proof against a deliberate
+ * `as` cast; it is proof against an ACCIDENTAL fourth writer, which is the
+ * failure mode the rule exists for ("something that shows up in a diff nobody
+ * reads"). Test files cast freely and always could — they are not shipped
+ * behaviour, and the source scan skips them for the same reason.
+ */
+declare const BROWSER_SITE_VERDICTS_BRAND: unique symbol;
+
+/** The persisted `browserSitePermissions` map. See {@link BROWSER_SITE_VERDICTS_BRAND}. */
+export type BrowserSiteVerdicts = Record<string, 'allowed' | 'denied'> & {
+  readonly [BROWSER_SITE_VERDICTS_BRAND]: 'settingsStore';
+};
+
+/**
  * Resolve a persistent per-site verdict. Precedence is fixed:
  * denied > allowed > default — a site the user blocked stays blocked no
  * matter what else would have allowed it.

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_BROWSER_OPERATION_POLICY,
   normalizeBrowserOperationPolicy,
   type BrowserOperationPolicy,
+  type BrowserSiteVerdicts,
 } from '../core/permissions/browserToolPolicy';
 import type { CapabilitySetupTarget } from '../core/capabilityPlugins/types';
 import { hasElectronCommandHost } from '../utils/electronHost';
@@ -263,8 +264,14 @@ export interface SettingsState {
    * converge on: `denied` beats `allowed` beats absent-(ask-every-time).
    * Written from the browser confirmation dialog's "always allow this site"
    * action; revocable from Settings › Capabilities.
+   *
+   * The type is BRANDED (`BrowserSiteVerdicts`) so that `setBrowserSitePermission`
+   * / `removeBrowserSitePermission` are the only things that can produce one:
+   * `setState({ browserSitePermissions: { ... } })` from anywhere else does not
+   * typecheck. See `BROWSER_SITE_VERDICTS_BRAND` and
+   * `src/__tests__/browserSiteGrantWriters.test.ts`, its runtime counterpart.
    */
-  browserSitePermissions: Record<string, 'allowed' | 'denied'>;
+  browserSitePermissions: BrowserSiteVerdicts;
   /**
    * Operation-class three-state policy: one allow/deny/ask row per operation
    * class (read-only / interactive / scripting). Consumed by
@@ -636,6 +643,25 @@ export function getAllEnabledModels(state: SettingsState): Array<{
 
 export type SettingsStore = SettingsState & SettingsActions;
 
+/**
+ * The ONLY place a `BrowserSiteVerdicts` comes into existence.
+ *
+ * Deliberately module-private and never exported: the brand on
+ * `BrowserSiteVerdicts` makes this function the single door into the field, so
+ * exporting it would put the door back in the wall. Everything outside this
+ * file reads the map (a branded value is assignable to the plain
+ * `Record<string, 'allowed' | 'denied'>`) and writes it only through
+ * `setBrowserSitePermission` / `removeBrowserSitePermission`.
+ *
+ * Runtime is a plain identity — the brand exists only in the type system, so
+ * nothing is added to what gets persisted.
+ */
+function mintBrowserSiteVerdicts(
+  entries: Record<string, 'allowed' | 'denied'>,
+): BrowserSiteVerdicts {
+  return entries as BrowserSiteVerdicts;
+}
+
 const defaultProviders = createDefaultProviders();
 
 export const useSettingsStore = create<SettingsStore>()(
@@ -698,7 +724,7 @@ export const useSettingsStore = create<SettingsStore>()(
       behaviorSensorEnabled: false,
       telemetryOptOut: false,
       computerUseEnabled: false,
-      browserSitePermissions: {},
+      browserSitePermissions: mintBrowserSiteVerdicts({}),
       browserOperationPolicy: DEFAULT_BROWSER_OPERATION_POLICY,
       allowUnattendedBrowser: false,
       preventSleep: false,
@@ -1050,12 +1076,15 @@ export const useSettingsStore = create<SettingsStore>()(
       setBehaviorSensorEnabled: (behaviorSensorEnabled) => set({ behaviorSensorEnabled }),
       setTelemetryOptOut: (telemetryOptOut) => set({ telemetryOptOut }),
       setBrowserSitePermission: (origin, verdict) => set((state) => ({
-        browserSitePermissions: { ...state.browserSitePermissions, [origin]: verdict },
+        browserSitePermissions: mintBrowserSiteVerdicts({
+          ...state.browserSitePermissions,
+          [origin]: verdict,
+        }),
       })),
       removeBrowserSitePermission: (origin) => set((state) => {
-        const next = { ...state.browserSitePermissions };
+        const next: Record<string, 'allowed' | 'denied'> = { ...state.browserSitePermissions };
         delete next[origin];
-        return { browserSitePermissions: next };
+        return { browserSitePermissions: mintBrowserSiteVerdicts(next) };
       }),
       // Normalized on write, not just on read: the persisted policy must never
       // say something the gate will not honor — a setting that lies about what

--- a/src/test/browserSiteVerdicts.ts
+++ b/src/test/browserSiteVerdicts.ts
@@ -1,0 +1,26 @@
+import type { BrowserSiteVerdicts } from '@/core/permissions/browserToolPolicy';
+
+/**
+ * Build a `browserSitePermissions` value for a TEST.
+ *
+ * `BrowserSiteVerdicts` is branded so that only `settingsStore`'s own setters
+ * can mint one (see `BROWSER_SITE_VERDICTS_BRAND`). Tests need to arrange
+ * arbitrary standing verdicts without going through the UI that writes them,
+ * which has always been true — `browserSiteGrantWriters.test.ts` skips test
+ * files for exactly that reason: "tests may say anything about the store; they
+ * are not shipped behavior".
+ *
+ * This helper exists so that permission is spelled ONCE, in a file named after
+ * what it does, instead of as a dozen anonymous `as never` casts scattered
+ * through component tests where nobody would notice a production file picking
+ * up the same trick. `browserSiteGrantWriters.test.ts` asserts that no shipped
+ * source file imports it, and that none of them casts to the branded type by
+ * hand either.
+ *
+ * Do not import this from anything under `src/` that ships.
+ */
+export function testSiteVerdicts(
+  entries: Record<string, 'allowed' | 'denied'> = {},
+): BrowserSiteVerdicts {
+  return entries as BrowserSiteVerdicts;
+}


### PR DESCRIPTION
The three parts of the configuration-architecture proposal that fix a real
defect (`docs/browser-redesign-prd-2026-09-05/SCOPE-RULING-2026-09-05.md` §7).
The three that do not — a main-process config repository, an async tool gate,
a first-import state machine — are explicitly not done here.

Split out of the batch-4 settings work so it can be read on its own: it has no
user-visible surface, it crosses the renderer/sidecar boundary, and it should
not be held up by a copy discussion on the settings cards that depend on it.

## What a user would have hit

**A standing site verdict could be written from anywhere.** 「始终允许」 /
「禁止」 for a site is the strongest thing a user says about it, and it is
supposed to be created in exactly two places — the confirmation dialog and the
site-permissions page. Nothing enforced that: any module could assign the map
wholesale, and one careless `setState` would mint a standing grant the user
never gave. The map is now a nominal type (`BrowserSiteVerdicts`) that only a
module-private helper in `settingsStore` can produce, so writing it from
anywhere else does not compile — a class of bug moved out of review and into
`tsc`.

**A setting tightened mid-run could be overwritten by an older snapshot.**
Settings reach the sidecar as fire-and-forget pushes, and "latest push wins"
really meant "latest *arrival* wins". Two debounced pushes in flight could land
in either order, so the snapshot taken *before* the user tightened something
could arrive after the one taken *after* it — and the sidecar would go on
reading the permission the user had just removed. Pushes now carry a monotonic
counter and the mirror drops anything not strictly newer.

**A subagent read the settings it was born with, for its whole life.** A
delegated agent can run for minutes; it was reading `params.settingsSnapshot`,
frozen at dispatch — its turn limit, its model, the per-tool switches it
consults. Changing any of those while it ran did nothing until it finished. It
reads the shared mirror now, seeded from its own snapshot for the one case the
freeze was actually protecting (a run that starts before any push has landed).

The second commit corrects two comments that claimed more than the code does —
both flagged by the independent review, both in files a later reader would
quote as settled fact. In particular: the subagent freeze was **not** where
「关闭总闸阻止下一浏览器动作」 was being lost (a sidecar tool call asks the
shell over `approval.check`, and the shell answers from the live store), and
the push counter's dangerous direction is a renderer reload with a surviving
sidecar — unreachable only because `sidecarManager` kills before it spawns.

## Evidence

- `npm run verify` — exit 0 (lint + typecheck + full suite + coverage gate;
  coverage up on all four axes vs. the `dev` baseline, thresholds untouched)
- `npm run electron:test` — exit 0
- `npm run electron:dev:check` — exit 0
- `npm run test:e2e:electron` (full) — exit 0
- Mutations, each run against a committed tree and reverted with
  `git checkout HEAD --`:
  - `setState({ browserSitePermissions: … })` in a component → `tsc` **TS2322**
    (`Property '[BROWSER_SITE_VERDICTS_BRAND]' is missing`)
  - drop the mirror's `revision <= appliedRevision` check → 2 failed
  - restore `getSnapshot: () => params.settingsSnapshot` in the subagent host
    → 1 failed

Refs `docs/browser-redesign-prd-2026-09-05/SCOPE-RULING-2026-09-05.md` §7.
Follow-up filed: #392 (the push counter is only monotonic while no sidecar
outlives its renderer — unreachable today, held up by one line in
`sidecarManager`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
