### PR TITLE
test: read source text CRLF-safely in contract tests (fixes build-windows red)

### DIFF
--- a/src/core/tools/browserDialogs.contract.test.ts
+++ b/src/core/tools/browserDialogs.contract.test.ts
@@ -38,7 +38,11 @@ import {
 } from '../permissions/browserToolPolicy';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
-const HOST = fs.readFileSync(path.join(ROOT, 'electron/browserHost.cjs'), 'utf8');
+// Normalized so the anchor regexes below (`;\n`) still match when git checked
+// this file out with CRLF line endings (Windows `core.autocrlf`/`.gitattributes`
+// defaults) — otherwise every `;\n` anchor sees `;\r\n` and silently fails to
+// match, and `hostConstant`/`hostString` throw on a null match.
+const HOST = fs.readFileSync(path.join(ROOT, 'electron/browserHost.cjs'), 'utf8').replace(/\r\n/g, '\n');
 
 function hostConstant(name: string): string {
   const match = new RegExp(`const ${name} =\\s*([\\s\\S]*?);\\n`).exec(HOST);


### PR DESCRIPTION
## Symptom

`build-windows` CI has been persistently red: the `frontend` and `host-security` gate steps both run `npm test` / vitest against `src/core/tools/browserDialogs.contract.test.ts`, and on Windows the job fails with 3 `AssertionError`s:

```
AssertionError: browserHost.cjs no longer declares `const DIALOG_AUTO_DISMISS_MS`: expected null not to be null
AssertionError: browserHost.cjs no longer declares `const DIALOG_UNTRUSTED_NOTICE`: expected null not to be null
AssertionError: browserHost.cjs no longer declares `const DIALOG_BLOCKING_PREFIX`: expected null not to be null
```

Because this test has been red for a while, it stopped functioning as a real gate — any genuine regression it's meant to catch (the shared dialog-timeout / refusal-sentence contract between `abu-browser-shared/types.ts`, `electron/browserHost.cjs`, and `browserSignals.ts` drifting apart) would currently pass unnoticed inside the noise of a known-red CI job.

## Root cause

The test reads `electron/browserHost.cjs` as raw text (it's a CommonJS main-process module that vitest cannot import) and locates each `const NAME = ...;` declaration with a regex anchored on a literal `;\n`:

```ts
const HOST = fs.readFileSync(path.join(ROOT, 'electron/browserHost.cjs'), 'utf8');
...
const match = new RegExp(`const ${name} =\\s*([\\s\\S]*?);\\n`).exec(HOST);
```

On Windows, git checks this file out with CRLF line endings (no `.gitattributes` override forcing LF). So the byte sequence after each statement is `;\r\n`, not `;\n` — the regex's literal `\n` never matches the `\r` that now precedes it, `hostConstant()`'s `match` is `null`, and the `expect(match, ...).not.toBeNull()` assertion fails for every constant it tries to pull out (`DIALOG_AUTO_DISMISS_MS`, `DIALOG_UNTRUSTED_NOTICE`, `DIALOG_BLOCKING_PREFIX`). macOS/Linux CI runners check the same file out with LF, so the test is invisible there — it only reproduces on `windows-latest`.

I grepped the rest of the suite (`readFileSync(...)` combined with a regex containing a literal `\n`) and this is the only occurrence in the whole repo — no other contract test has the same latent bug.

## Fix

Normalize the file's line endings right after reading it, before any of the anchor regexes run:

```ts
const HOST = fs.readFileSync(path.join(ROOT, 'electron/browserHost.cjs'), 'utf8').replace(/\r\n/g, '\n');
```

This makes the existing `;\n`-anchored regexes correct on both LF (macOS/Linux) and CRLF (Windows) checkouts, without touching the anchor patterns themselves or the actual `browserHost.cjs` source (which stays LF in the repo — only the in-memory copy the test reads is normalized).

## CRLF verification (local repro before/after)

1. Copied `electron/browserHost.cjs`, converted the copy to CRLF (`perl -pe 's/\n/\r\n/g'`), and swapped it in.
2. **Before the fix**: `npx vitest run src/core/tools/browserDialogs.contract.test.ts` → exactly the 3 predicted `AssertionError`s (4 passed, 3 failed) — reproduces the CI red locally.
3. **After the fix**: same CRLF file, same command → all 7 tests pass.
4. Restored `electron/browserHost.cjs` to its original LF content (`git checkout HEAD -- electron/browserHost.cjs`) and re-ran the test → still 7/7 green (no regression for the normal LF case).
5. `npm run verify` → exit 0 (518 test files passed, 9364 tests passed, 1 skipped, lint + typecheck + coverage all clean).

## Files changed

- `src/core/tools/browserDialogs.contract.test.ts` — normalize CRLF before running the anchor regexes against `electron/browserHost.cjs`'s text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)