### PR TITLE
ci(electron-build): build abu-chrome-extension before the host-ui gate on both jobs

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -124,10 +124,19 @@ jobs:
 
       - name: Install dependencies
         # Root deps + abu-browser-bridge (own package: query_js worker tests
-        # resolve linkedom/ses from the bridge's local node_modules).
+        # resolve linkedom/ses from the bridge's local node_modules) +
+        # abu-chrome-extension, built: browserHost.cjs loads
+        # abu-chrome-extension/dist/content.js with no fallback (b2cc8e34), the
+        # DOM-action tests in `electron:host-ui-test` go through that loader,
+        # and dist/ is gitignored — this workflow is the only CI surface that
+        # runs that gate. `shell: bash` on purpose: the Windows default is pwsh,
+        # where `(cd X && …)` is not a subshell, so the third line would run
+        # from inside abu-browser-bridge.
+        shell: bash
         run: |
           npm ci
           (cd abu-browser-bridge && npm ci)
+          (cd abu-chrome-extension && npm ci && npm run build)
 
       - name: Require diagnostic upload target
         if: ${{ github.event_name != 'pull_request' && github.repository == 'PM-Shawn/Abu-Cowork' }}
@@ -430,10 +439,19 @@ jobs:
 
       - name: Install dependencies
         # Root deps + abu-browser-bridge (own package: query_js worker tests
-        # resolve linkedom/ses from the bridge's local node_modules).
+        # resolve linkedom/ses from the bridge's local node_modules) +
+        # abu-chrome-extension, built: browserHost.cjs loads
+        # abu-chrome-extension/dist/content.js with no fallback (b2cc8e34), the
+        # DOM-action tests in `electron:host-ui-test` go through that loader,
+        # and dist/ is gitignored — this workflow is the only CI surface that
+        # runs that gate. `shell: bash` on purpose: the Windows default is pwsh,
+        # where `(cd X && …)` is not a subshell, so the third line would run
+        # from inside abu-browser-bridge.
+        shell: bash
         run: |
           npm ci
           (cd abu-browser-bridge && npm ci)
+          (cd abu-chrome-extension && npm ci && npm run build)
 
       - name: Require diagnostic upload target
         if: ${{ github.event_name != 'pull_request' && github.repository == 'PM-Shawn/Abu-Cowork' }}

--- a/scripts/electron-release-workflow.test.mjs
+++ b/scripts/electron-release-workflow.test.mjs
@@ -550,6 +550,52 @@ test('Electron build uses native runners for all three release targets', () => {
   );
 });
 
+test('Electron build provisions the browser automation runtime before the host-ui gate', () => {
+  // browserHost.cjs loads abu-chrome-extension/dist/content.js and deliberately
+  // has no fallback to the committed src-tauri/browser-extension/ copy
+  // (b2cc8e34): a DOM action on a missing build fails loudly instead of running
+  // a bundle of unknown vintage. The DOM-action tests in electron:host-ui-test
+  // (dialogs, `find` routing, U5 origin pin) go through that loader, so the
+  // gate is only meaningful once the extension is built — and dist/ is
+  // gitignored. This workflow is the ONLY CI surface that runs the gate
+  // (ci.yml's check job never does), and its install step used to provision
+  // root + abu-browser-bridge only: 17 of 18 build-windows runs on
+  // 2026-09-05/06 went red with "browser automation runtime is missing" as
+  // soon as the batch-3 browser PRs added the first tests that reach it.
+  //
+  // Pin: both jobs build the extension in the install step, before the gate.
+  // The install step must run under bash — the Windows default is pwsh, where
+  // `(cd X && …)` is a grouping expression, not a subshell, so a second
+  // sub-package line would run from inside the first package's directory.
+  const build = workflow('electron-build.yml');
+  const gateOf = {
+    'build-mac': (step) => step.name === 'Gates',
+    'build-windows': (step) => step.id === 'windows_host_security_gates',
+  };
+  for (const [jobName, isGate] of Object.entries(gateOf)) {
+    const steps = build.jobs[jobName].steps;
+    const install = steps.find((step) => step.name === 'Install dependencies');
+    assert.ok(install, `${jobName}: install step is missing`);
+    assert.equal(install.shell, 'bash', `${jobName}: install step must run under bash`);
+    assert.match(
+      install.run,
+      /\(cd abu-browser-bridge && npm ci\)/,
+      `${jobName}: install step must still install the bridge's own deps`
+    );
+    assert.match(
+      install.run,
+      /\(cd abu-chrome-extension && npm ci && npm run build\)/,
+      `${jobName}: install step must build the browser extension`
+    );
+    const gate = steps.find(isGate);
+    assert.match(gate.run, /npm run electron:host-ui-test/);
+    assert.ok(
+      steps.indexOf(install) < steps.indexOf(gate),
+      `${jobName}: the extension build must precede the host-ui gate`
+    );
+  }
+});
+
 test('release publishes only after all Electron targets and switches root pointer transactionally', () => {
   const release = workflow('release.yml');
   const manualRelease = release.on.workflow_dispatch.inputs;


### PR DESCRIPTION
## What

`build-windows` has failed its "Windows host and security gates" step on every PR since 2026-09-05 17:38 UTC (17 of the last 18 runs, e.g. [run 34026162833](https://github.com/PM-Shawn/Abu-Cowork/actions/runs/34026162833/job/101467405752) on #396). All 11 failing tests in `electron:host-ui-test` die on the same line:

```
Error: browser automation runtime is missing (no content.js in the packaged resources or in abu-chrome-extension/dist/); build it with `npm run build:browser-extension`
```

This PR makes both `electron-build.yml` jobs install and build `abu-chrome-extension` in their install step, before the gate, and pins that with a contract test.

## Root cause

- `electron/browserHost.cjs` `automationRuntimePath()` accepts exactly two sources: `process.resourcesPath/browser-extension/content.js` (packaged) or `abu-chrome-extension/dist/content.js` (dev build). The fallback to the committed `src-tauri/browser-extension/` copy was removed on purpose in b2cc8e34 so a stale bundle can never run silently. That intent is kept: `browserHost.cjs` is untouched.
- `abu-chrome-extension/dist/` is gitignored (root `.gitignore` `dist/`).
- `electron-build.yml`'s install step ran only `npm ci` and `(cd abu-browser-bridge && npm ci)`. Nothing built the extension before `npm run electron:host-ui-test`.
- The batch-3 browser PRs (0931a019 U5 origin pin → 755843df `find` routing → 6319433b dialogs) added the first host-ui tests that complete a DOM action and therefore reach `loadAutomationRuntime()`. Every earlier host-ui test either never ran a DOM action or parked it before the loader (see `holdIsolatedWorld` in `browserHost.ownership.test.cjs`, whose comment says it works "without needing the built browser-extension runtime on disk").
- Every other consumer of this gate already provisions the artifact: `setup:electron-dev` runs `build:electron-browser-runtime` (which runs `build:browser-extension`) and the preflight requires `abu-chrome-extension/dist/manifest.json`; `electron:command-test` / `electron:browser-test` build first inside the npm script; packaging runs `build:electron-browser-runtime`. CI's `electron-build.yml` was the one consumer that did not.
- One correction to the initial read: `ci.yml`'s `check` job is green not because it builds the extension first but because it never runs `electron:host-ui-test` at all. `electron-build.yml` is the only CI surface for this gate (Windows on PRs, mac on dispatch/release), so the gap could not be caught anywhere else.

## Why build in the workflow instead of stubbing `loadAutomationRuntime` in the tests

Considered and rejected:

1. **The tests deliberately exercise the real loader.** The ownership suite already has a pattern for avoiding the artifact where it is irrelevant (`holdIsolatedWorld`), so the tests that do run through `loadAutomationRuntime()` are exercising the fail-loud resolution on the same code path the app uses. On `windows-latest` that is the only automated exercise of the win32 `path.join(__dirname, '..', 'abu-chrome-extension', 'dist', 'content.js')` resolution outside a full Electron smoke. A stub would delete that coverage to work around a CI provisioning gap.
2. **A stub needs a new `__testing` seam in `browserHost.cjs`,** which owns the origin pin (U5) and ownership gates. Adding production code to a security-sensitive module for a CI convenience is the wrong trade; a workflow-only change needs no such review surface.
3. **The provisioning gap is the mechanism-level cause,** not the file read. Fixing it where it lives (the install step) also keeps the workflow aligned with `setup:electron-dev` and `ci.yml`, both of which `npm ci` the extension as its own package.
4. **Cost is nil.** `npm ci` for the extension is three devDependencies plus esbuild; the build is a ~1 s esbuild run. `dist:electron:windows` rebuilds the extension later in the same job anyway.

## Change

`.github/workflows/electron-build.yml`, both `build-mac` and `build-windows` "Install dependencies" steps:

- `+ (cd abu-chrome-extension && npm ci && npm run build)` — same line `ci.yml` uses for the bundle-sync check; `npm ci` (not root's hoisted esbuild) so the pinned esbuild from the extension's own lockfile builds it.
- `+ shell: bash`. Verified in the failing run's log that the Windows install step ran under `pwsh` (`shell: C:\Program Files\PowerShell\7\pwsh.EXE`). In pwsh, `(cd X && …)` is a grouping expression, not a subshell, so the existing bridge line leaves the step's cwd inside `abu-browser-bridge` and the new line would fail with "no such directory". The Windows gate steps already use `shell: bash`; the install step now matches. Explicit on mac too so both steps read the same.

`scripts/electron-release-workflow.test.mjs` (runs inside the same `test:electron:release-workflow` gate): new test "Electron build provisions the browser automation runtime before the host-ui gate" pins, for both jobs, that the install step runs under bash, still installs the bridge, installs and builds the extension, and precedes the step that runs `electron:host-ui-test`. Written red first (failed on `build-mac: install step must run under bash`), green after the workflow edit.

## Verification

All in a fresh worktree off `origin/dev` 310e7882 after `npm run setup:electron-dev`:

| Check | Result |
|---|---|
| Local reproduction: `mv abu-chrome-extension/dist dist.hidden && npm run electron:host-ui-test` | 204 tests, 193 pass, **11 fail**, all with the CI error verbatim |
| Exact new install-step line `(cd abu-chrome-extension && npm ci && npm run build)`, then the gate again | **204 / 204 pass**; the rebuild took ~1 s |
| `node --test scripts/electron-release-workflow.test.mjs` before the workflow edit | new test red: `build-mac: install step must run under bash` |
| Same, after the workflow edit | 17 / 17 pass |
| `npm run verify` | exit 0 — lint, typecheck, gen:models:check, check:browser-artifacts, 518 files / 9364 tests, coverage gate green |
| `npm run electron:dev:check` | pass |
| `build-windows` on this PR | see checks below — the point of the PR |

## Notes for merging

- Not stacked: base is `dev`. Per AGENTS.md, if the base is ever changed, push a commit or close/reopen afterwards — a base change alone does not retrigger CI.
- The other two contributors to the red `build-windows` are already in `dev`: the CRLF regex (#395) and the tauriMigration timeouts (#396, pending).
- `build-mac` has the same fix but only runs on `workflow_dispatch` / `workflow_call`; it is covered by the contract test, not by this PR's CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
