### PR TITLE
test(plugins): cover signed enterprise distribution in Electron

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -51,7 +51,7 @@ under `scripts/`). E2E (`e2e/*.spec.ts`) is handled by Playwright and runs as a 
 | Quarantined (`src/__tests__/quarantine/`) | 0 |
 | Quarantined specs (`e2e/**/*.spec.ts`, `tests/e2e/**/*.spec.ts`) | 0 |
 | Web E2E (`e2e/*.spec.ts`, Playwright) | 8 |
-| Real-Electron E2E (`tests/e2e/*.spec.ts`) | 21 |
+| Real-Electron E2E (`tests/e2e/*.spec.ts`) | 22 |
 | Node `node:test` scripts (`*.test.mjs` / `*.test.cjs`) | 49 |
 <!-- test-inventory:end -->
 

--- a/tests/e2e/plugin-enterprise-install.spec.ts
+++ b/tests/e2e/plugin-enterprise-install.spec.ts
@@ -151,6 +151,11 @@ async function clientCatalog(): Promise<CatalogEntry[]> {
   });
   if (!auth.ok) throw new Error(`console client login failed: HTTP ${auth.status}`);
   const { access_token: token } = (await auth.json()) as { access_token: string };
+  const session = await fetch(`${CONSOLE_URL}/api/client/v1/session`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  expect(session.ok).toBe(true);
+  expect((await session.json()).signing.skillPublicKey).toBeNull();
   const res = await fetch(`${CONSOLE_URL}/api/skills/catalog?kinds=plugin`, {
     headers: { authorization: `Bearer ${token}` },
   });
@@ -366,6 +371,9 @@ test.describe.serial('organization plugin install loop (real shell + real consol
     await publishOwnedVersion(OWNED_V1);
 
     const catalog = await clientCatalog();
+    // Keep this suite on the supported unsigned deployment shape. Signed
+    // installs and tampering have their own opt-in regression suite.
+    expect(catalog.find(entry => entry.name === OWNED_PLUGIN)?.signature).toBeNull();
     const found = catalog.find((e) => e.name === CATALOG_PLUGIN);
     if (!found) throw new Error(`console has no published plugin named ${CATALOG_PLUGIN}`);
     catalogEntry = found;
@@ -425,6 +433,7 @@ test.describe.serial('organization plugin install loop (real shell + real consol
     // what proves the download + verify + plan actually completed — and the
     // 取消 button only replaces 关闭 there too.
     await expect(page.getByTestId('plugin-install-confirm')).toBeVisible({ timeout: INSTALL_TIMEOUT });
+    await expect(page.getByTestId('plugin-disclosure-unsigned')).toBeVisible();
     await expect(disclosure.getByText('prd-doctor', { exact: true })).toBeVisible();
     await disclosure.getByRole('button', { name: CANCEL_BUTTON }).click();
     await expect(disclosure).toBeHidden({ timeout: READY_TIMEOUT });
@@ -450,6 +459,7 @@ test.describe.serial('organization plugin install loop (real shell + real consol
     await expect(page.getByTestId('plugin-install-confirm')).toBeVisible({ timeout: INSTALL_TIMEOUT });
     // The disclosure names the skill the package will contribute, and declares
     // no connector — the same two facts the catalog row summarised as counts.
+    await expect(page.getByTestId('plugin-disclosure-unsigned')).toBeVisible();
     await expect(disclosure.getByText('prd-doctor', { exact: true })).toBeVisible();
     await expect(page.getByTestId('plugin-disclosure-server')).toHaveCount(0);
     await page.screenshot({ path: path.join(SCREENSHOT_DIR, 'e2e-enterprise-plugin-disclosure.png') });

--- a/tests/e2e/plugin-enterprise-signing.spec.ts
+++ b/tests/e2e/plugin-enterprise-signing.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Black-box signed deployment regression, separate from the seven unsigned
+ * install-loop cases. An opt-in private runner publishes real fixtures and
+ * supplies a local Console endpoint with transport-level tampering on two of
+ * them. No renderer/main network mocks or private implementation imports.
+ */
+import { expect, test } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { ElectronApplication, Page } from 'playwright';
+import { closeAbuElectron, dismissFirstRunOverlays, launchAbuElectron, removeElectronDataRoot, type ElectronDataRoot } from './electronHelpers';
+
+const url = process.env.ABU_E2E_SIGNED_CONSOLE_URL ?? '';
+const email = process.env.ABU_E2E_CONSOLE_EMAIL ?? '';
+const password = process.env.ABU_E2E_CONSOLE_PASSWORD ?? '';
+const validName = process.env.ABU_E2E_SIGNED_VALID_PLUGIN ?? '';
+const zipName = process.env.ABU_E2E_SIGNED_ZIP_PLUGIN ?? '';
+const signatureName = process.env.ABU_E2E_SIGNED_SIGNATURE_PLUGIN ?? '';
+const timeout = 60_000;
+interface CatalogItem { name: string; latestVersion: string; sha256: string; signature: string | null }
+
+function card(page: Page, name: string) {
+  return page.getByTestId('enterprise-plugin-row').filter({ has: page.getByTitle(name, { exact: true }) });
+}
+function pluginRoot(root: ElectronDataRoot) {
+  return path.join(root.appDataDir, 'Home', '.abu', 'plugin-packages');
+}
+function records(root: ElectronDataRoot): { name: string; version: string; checksum: string }[] {
+  const file = path.join(pluginRoot(root), 'installed.json');
+  return fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf8')) : [];
+}
+
+async function bind(page: Page) {
+  await page.waitForLoadState('domcontentloaded');
+  await expect(page.getByText(/交给阿布就行啦|Leave it to Abu/).or(page.getByPlaceholder(/想让阿布帮你做点什么？|What can Abu help you with\?/)).first()).toBeVisible({ timeout });
+  await dismissFirstRunOverlays(page);
+  await page.getByRole('button', { name: /^(我|Me)$/ }).first().click();
+  await page.getByRole('menuitem', { name: /^(设置|Settings)$/ }).click();
+  await page.getByRole('button', { name: /^(企业模式|Enterprise)$/ }).click();
+  await page.getByRole('button', { name: /^(切换到企业模式|Switch to enterprise mode)$/ }).click();
+  await page.getByPlaceholder('https://abu.your-company.com').fill(url);
+  await page.getByRole('button', { name: /^(继续|Continue)$/ }).click();
+  await page.getByPlaceholder('you@company.com').fill(email);
+  await page.getByPlaceholder(/^(输入密码|Enter password)$/).fill(password);
+  await page.getByRole('button', { name: /^(登录|Sign in)$/ }).click();
+  await expect(page.getByText(/已绑定到企业实例|Connected to enterprise instance/)).toBeVisible({ timeout });
+  await page.keyboard.press('Escape');
+  await page.getByLabel('Main navigation').getByRole('button', { name: /^(扩展|Extensions)$/ }).click();
+  await page.getByRole('main').getByRole('button', { name: /^(插件|Plugins)$/ }).click();
+  await page.getByTestId('extensions-source-market').click();
+}
+
+test.describe.serial('signed organization plugin distribution (real Electron)', () => {
+  test.skip(!url || !email || !password || !validName || !zipName || !signatureName,
+    'run with a signed Console and the opt-in private transport fixture runner');
+  let app: ElectronApplication;
+  let page: Page;
+  let dataRoot: ElectronDataRoot;
+  let valid: CatalogItem;
+
+  test.beforeAll(async () => {
+    const login = await fetch(`${url}/api/client/v1/auth/password`, {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ email, password }),
+    });
+    expect(login.ok).toBe(true);
+    const { access_token: token } = await login.json() as { access_token: string };
+    const headers = { authorization: `Bearer ${token}` };
+    const session = await fetch(`${url}/api/client/v1/session`, { headers });
+    expect(session.ok).toBe(true);
+    expect((await session.json()).signing.skillPublicKey).toMatch(/^[0-9a-f]{64}$/);
+    const catalog = await fetch(`${url}/api/skills/catalog?kinds=plugin`, { headers });
+    expect(catalog.ok).toBe(true);
+    const { items } = await catalog.json() as { items: CatalogItem[] };
+    const found = items.find(item => item.name === validName);
+    expect(found).toBeDefined();
+    valid = found!;
+    expect(valid.signature).toMatch(/^[A-Za-z0-9_-]{86}$/);
+    const launched = await launchAbuElectron();
+    dataRoot = launched; app = launched.app; page = await app.firstWindow();
+    await bind(page);
+  });
+  test.afterAll(async () => {
+    if (app) await closeAbuElectron(app);
+    if (dataRoot) removeElectronDataRoot(dataRoot);
+  });
+
+  test('uses the advertised key, confirms a signed artifact and installs its files and record', async () => {
+    await card(page, validName).getByRole('button', { name: '安装', exact: true }).click();
+    const dialog = page.getByTestId('plugin-install-disclosure');
+    await expect(page.getByTestId('plugin-install-confirm')).toBeVisible({ timeout });
+    // This warning is driven by the actual verifier result, not catalog metadata.
+    await expect(dialog.getByTestId('plugin-disclosure-unsigned')).toHaveCount(0);
+    await expect(dialog).not.toContainText('未签名');
+    await page.screenshot({ path: 'test-results/e2e-enterprise-signed-disclosure.png' });
+    await page.getByTestId('plugin-install-confirm').click();
+    await expect(dialog).toBeHidden({ timeout });
+    const installed = path.join(pluginRoot(dataRoot), 'enterprise', validName, valid.latestVersion);
+    await expect.poll(() => fs.existsSync(path.join(installed, '.abu-plugin', 'plugin.json')) &&
+      fs.existsSync(path.join(installed, 'skills', 'signing-fixture', 'SKILL.md')), { timeout }).toBe(true);
+    expect(records(dataRoot).find(item => item.name === validName)).toMatchObject({ version: valid.latestVersion, checksum: valid.sha256 });
+    await expect.poll(() => fs.existsSync(path.join(pluginRoot(dataRoot), 'enterprise', '.staging', validName)), { timeout }).toBe(false);
+    await expect(card(page, validName)).toContainText('已安装');
+  });
+
+  for (const [name, reason] of [[zipName, 'sha256_mismatch'], [signatureName, 'signature_invalid']]) {
+    test(`rejects ${reason} without a plugin directory, staging tree or install record`, async () => {
+      await card(page, name).getByRole('button', { name: '安装', exact: true }).click();
+      const dialog = page.getByTestId('plugin-install-disclosure');
+      await expect(page.getByRole('main').getByText(reason, { exact: false })).toBeVisible({ timeout });
+      await expect(dialog).toHaveCount(0);
+      await expect(page.getByTestId('plugin-install-confirm')).toHaveCount(0);
+      expect(fs.existsSync(path.join(pluginRoot(dataRoot), 'enterprise', name))).toBe(false);
+      expect(fs.existsSync(path.join(pluginRoot(dataRoot), 'enterprise', '.staging', name))).toBe(false);
+      expect(records(dataRoot).some(item => item.name === name)).toBe(false);
+      await page.screenshot({ path: `test-results/e2e-enterprise-${reason}.png` });
+    });
+  }
+});


### PR DESCRIPTION
## 改动类型

- [x] 安全相关回归测试

## 改了什么 · 为什么

补齐签名组织插件在真实 Electron 壳中的安装与篡改拒绝回归。保留原有 7 条 unsigned 用例，并明确断言空公钥、空签名和未签名警告；新增 3 条独立的 opt-in signed 用例，检查目录签名、无 unsigned 警告、成功安装以及两种拒绝后的磁盘清理。

此 PR 只包含黑盒 UI/协议/磁盘断言及测试清单更新。需要企业构建与外部本地 fixture runner；普通 OSS CI 不提供这些环境变量时明确跳过该 suite。没有引入企业实现或修改校验器/安装器。

## 测试层

- [x] 真 Electron E2E `tests/e2e/*.spec.ts`

## 门禁

- [x] `VITEST_MAX_WORKERS=2 npm run verify` 本地亲跑，exit 0：591 files passed；10997 tests passed / 1 existing skipped；覆盖率门禁通过（statements 80.95%、branches 72.9%、functions 81.36%、lines 82.85%）。
- [x] `npm run build`：exit 0，OSS 生产构建通过。
- 测试清单生成检查通过。

## 修复类必填

本 PR 是测试覆盖补齐，没有产品逻辑修复。服务端静默降级缺陷在独立 Console PR 修复并完成旧路由回退变红验证。

## 真机验收

- [x] 使用仓库 Playwright 启动真实 Electron（企业 renderer + main HTTP bridge），未使用 Web 预览或网络 mock。
- signed：3/3 passed（26.8s）；原 unsigned：7/7 + smoke：4/4 passed（36.7s）。
- 签名成功安装后有实际插件文件、checksum 记录且 staging 清理；ZIP 篡改报 `sha256_mismatch`，签名篡改报 `signature_invalid`，均无安装目录、staging 或记录。
- `electron:dev:check` exit 0，企业 renderer 构建 exit 0。

## 安全复审

独立代理 `gpt-6-astra + xhigh` 只读复审本批 diff；初审问题修复后复核无新增阻断项。公开仓仅保留黑盒验收，实际 fixture 发布与传输篡改 runner 保留在私有仓。
