### PR TITLE
test(browser): freeze the swapped file onto a whole second so the mtime lands exactly

### DIFF
--- a/electron/browserHost.downloads.test.cjs
+++ b/electron/browserHost.downloads.test.cjs
@@ -42,6 +42,14 @@ const electronId = require.resolve('electron');
 const tauriHostId = require.resolve('./tauriHost.cjs');
 const browserHostId = require.resolve('./browserHost.cjs');
 
+/**
+ * A modification time to freeze a file onto, in the seconds `utimesSync`
+ * takes. A WHOLE second: the syscall carries the time as float seconds, and
+ * only a value with no sub-second remainder survives that conversion exactly
+ * enough to read back as the same integer millisecond.
+ */
+const FROZEN_MTIME_SEC = 1_700_000_000;
+
 const OWNER_A = 'conversation-a';
 const OWNER_B = 'conversation-b';
 
@@ -912,19 +920,33 @@ test('refuses a same-size DIFFERENT file moved into the approved path', async ()
     const { tabId, contents } = await openTab(host, OWNER_A);
     const approvedPath = path.join(root, 'report.txt');
     fs.writeFileSync(approvedPath, 'PUBLIC!!');
-    const approved = approvedEntry(approvedPath, 'report.txt');
-    const other = path.join(root, 'other.txt');
-    fs.writeFileSync(other, 'SECRET!!');
-    fs.renameSync(other, approvedPath);
     // Round-2 review N5. Both writes are the same length, so the ONLY thing
     // that should reject this is the inode — but two `writeFileSync` calls
     // usually land in different milliseconds, and the mtime check got there
     // first. The test then passed for a reason it was not testing: a mutation
     // that deletes the `ino`/`dev` comparison went red only when the clock
-    // happened to disagree. Freeze the clock onto the approved value and the
+    // happened to disagree. Freeze both files onto one instant and the
     // identity pin is the one thing left standing.
-    const frozen = new Date(approved.mtimeMs);
-    fs.utimesSync(approvedPath, frozen, frozen);
+    //
+    // The instant is a WHOLE second on purpose, and the approved file is
+    // stamped with it BEFORE it is approved. `utimesSync` puts the time on the
+    // syscall as float seconds, so an instant carrying a millisecond fraction
+    // is not exactly representable: freezing onto `approved.mtimeMs` and
+    // reading it back landed a nanosecond BELOW the integer that was asked
+    // for about half the time, and `Math.floor` — the rule `approvedEntry`
+    // and `readApprovedUploadFile` (browserHost.cjs) both apply — then
+    // reported one millisecond less than was frozen. That is not a rounding
+    // nit to assert around: it means the freeze did not hold, and production
+    // compares with the very same expression, so the mtime branch would be
+    // what rejects this upload and the `ino`/`dev` mutation would stay green
+    // again. A whole second survives the conversion exactly, so the freeze
+    // really holds and the precondition below stays as strict as production.
+    fs.utimesSync(approvedPath, FROZEN_MTIME_SEC, FROZEN_MTIME_SEC);
+    const approved = approvedEntry(approvedPath, 'report.txt');
+    const other = path.join(root, 'other.txt');
+    fs.writeFileSync(other, 'SECRET!!');
+    fs.renameSync(other, approvedPath);
+    fs.utimesSync(approvedPath, FROZEN_MTIME_SEC, FROZEN_MTIME_SEC);
     assert.equal(Math.floor(fs.lstatSync(approvedPath).mtimeMs), approved.mtimeMs);
     assert.equal(fs.lstatSync(approvedPath).size, approved.size);
     assert.notEqual(fs.lstatSync(approvedPath).ino, approved.ino);


### PR DESCRIPTION
## What was wrong

`refuses a same-size DIFFERENT file moved into the approved path` in `electron/browserHost.downloads.test.cjs` failed on roughly 40% of runs (**5/12 measured** on `origin/dev`, pre-existing and unrelated to any browser-permission work):

```
AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+ actual   1788868251181
- expected 1788868251182
    at electron/browserHost.downloads.test.cjs:928
```

## Root cause

`fs.utimesSync` puts the time on the syscall as **float seconds**. `approved.mtimeMs` carries a millisecond fraction, so `ms / 1000` is not exactly representable in binary64 and the resulting timespec lands a nanosecond **below** the integer that was asked for.

A 3000-iteration probe on APFS: **1499 low / 1501 exact (~50%)**, the error always exactly `-0.001ms`. `Math.floor` then reports one millisecond less than was frozen.

## Why the assertion was not relaxed

`approvedEntry` stores `Math.floor(stat.mtimeMs)`, and production `readApprovedUploadFile` compares with:

```js
|| (mtimeMs > 0 && Math.floor(stat.mtimeMs) !== mtimeMs)   // browserHost.cjs:3052
```

Both ends already floor — one consistent rule — and the precondition is that production expression verbatim.

So a low read is not a rounding nit to assert around: it means **the freeze did not hold**, the mtime branch is what rejects the upload, and the `ino`/`dev` comparison goes untested. Switching the precondition to `Math.round` would have declared a broken freeze fine and re-armed exactly the mutation this test was rewritten (9c298490) to catch.

The rounding rule is therefore unchanged on both ends. Instead the freeze is made to land: the file is stamped onto a **whole second** before it is approved and again after the rename. A whole second survives the float-seconds conversion exactly — **0 mismatches over 5000 probes**.

## Verification

| Check | Result |
| --- | --- |
| Baseline, before the change | 5 / 12 runs fail |
| Fixed test, repeated runs | **0 / 45 fail** (30 tests each) |
| `npm run electron:test` | **exit 0**, all 5 stages `fail 0`, acceptance PASS |
| `electron:host-ui-test` (contains this test) | 255 / 255 pass |
| Deleting the `ino`/`dev` comparison | **8 / 8 red**, on `Missing expected rejection` |
| Same mutation against the *old* test | 8/12 killed, 4/12 red on the **precondition** instead |
| eslint | exit 0 |

That fifth and sixth row are the point: the freeze is now doing its job *deterministically* rather than 8 times in 12, and it fails on the test's real subject rather than on its setup.

`electron/browserHost.cjs` is untouched — the mutation above was reverted and the file verified byte-identical to `origin/dev`.

## Follow-ups found in passing (deliberately not bundled)

1. **`electron:host-ui-test` cannot run from a clean checkout.** It runs before `electron:browser-test`, but needs `abu-chrome-extension/dist/content.js`, which only the latter builds — ~8 tests fail with `browser automation runtime is missing`. Masked on any machine where `dist/` survives an earlier run.
2. **`spends one budget on the whole call, not one on each half` is a real-clock flake.** It asserts `spent < 420` off `Date.now()`; observed at 593ms under load average ~32, passing 15/15 once the machine was quiet. Violates the determinism rule in `TESTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
