### PR TITLE
fix(plugin): 发版前审查的三条必修 + Windows 目录 fsync 防御

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -52,7 +52,7 @@ under `scripts/`). E2E (`e2e/*.spec.ts`) is handled by Playwright and runs as a 
 | Quarantined specs (`e2e/**/*.spec.ts`, `tests/e2e/**/*.spec.ts`) | 0 |
 | Web E2E (`e2e/*.spec.ts`, Playwright) | 8 |
 | Real-Electron E2E (`tests/e2e/*.spec.ts`) | 27 |
-| Node `node:test` scripts (`*.test.mjs` / `*.test.cjs`) | 57 |
+| Node `node:test` scripts (`*.test.mjs` / `*.test.cjs`) | 58 |
 <!-- test-inventory:end -->
 
 ---

--- a/TESTING.md
+++ b/TESTING.md
@@ -52,7 +52,7 @@ under `scripts/`). E2E (`e2e/*.spec.ts`) is handled by Playwright and runs as a 
 | Quarantined specs (`e2e/**/*.spec.ts`, `tests/e2e/**/*.spec.ts`) | 0 |
 | Web E2E (`e2e/*.spec.ts`, Playwright) | 8 |
 | Real-Electron E2E (`tests/e2e/*.spec.ts`) | 27 |
-| Node `node:test` scripts (`*.test.mjs` / `*.test.cjs`) | 56 |
+| Node `node:test` scripts (`*.test.mjs` / `*.test.cjs`) | 57 |
 <!-- test-inventory:end -->
 
 ---

--- a/electron/pluginAuthorWorker.cjs
+++ b/electron/pluginAuthorWorker.cjs
@@ -56,10 +56,13 @@ function runAuthor(input, io = fs, chdir = process.chdir) {
   const current = io.statSync('.');
   if (current.ino !== metadataIdentity.ino || current.dev !== metadataIdentity.dev) throw new Error('Plugin author: metadata directory changed');
   data.write('authors.json', JSON.stringify(authors));
-  let fd;
-  try { fd = io.openSync('.', 'r'); io.fsyncSync(fd); }
-  catch (error) { if (!['EINVAL', 'EPERM', 'EISDIR', 'ENOTSUP'].includes(error.code)) throw error; }
-  finally { if (fd !== undefined) io.closeSync(fd); }
+  if (process.platform !== 'win32') {
+    // Windows has no directory-fsync equivalent; see pluginLease.syncDirectory.
+    let fd;
+    try { fd = io.openSync('.', 'r'); io.fsyncSync(fd); }
+    catch (error) { if (!['EINVAL', 'EPERM', 'EACCES', 'EBADF', 'EISDIR', 'ENOTSUP'].includes(error.code)) throw error; }
+    finally { if (fd !== undefined) io.closeSync(fd); }
+  }
   return result(author);
 }
 module.exports = { runAuthor };

--- a/electron/pluginLease.cjs
+++ b/electron/pluginLease.cjs
@@ -2,8 +2,14 @@
 const fs = require('node:fs');
 const crypto = require('node:crypto');
 
+/** EPERM means the PID belongs to another user. Our lease holders are always
+ * same-uid children of this app, so that PID has been recycled and the lease
+ * naming it is stale — treating it as alive locked the profile until someone
+ * deleted the directory by hand. Unknown errno stays conservative (alive).
+ */
 const isAlive = pid => {
-  try { process.kill(pid, 0); return true; } catch (error) { return error.code !== 'ESRCH'; }
+  try { process.kill(pid, 0); return true; }
+  catch (error) { return error.code !== 'ESRCH' && error.code !== 'EPERM'; }
 };
 const same = (a, b) => a && b && a.ino === b.ino && a.dev === b.dev && !a.isSymbolicLink?.();
 const busy = () => Object.assign(new Error('Plugin registry: another write is active or interrupted; recovery required'), { code: 'PLUGIN_LEASE_BUSY' });
@@ -21,9 +27,13 @@ function acquireLease(io = fs, chdir = process.chdir, pid = process.pid, alive =
   const prepared = `.installed-lock-prepared-${token}`;
   const marker = `owner-${pid}-${token}`;
   function syncDirectory() {
+    // Windows has no directory-fsync equivalent: FlushFileBuffers on a read
+    // handle fails, and this call sits on every registry write, so a throw here
+    // would take the whole plugin subsystem down on that platform.
+    if (process.platform === 'win32') return;
     let fd;
     try { fd = io.openSync('.', 'r'); io.fsyncSync(fd); }
-    catch (error) { if (!['EINVAL', 'EPERM', 'EISDIR', 'ENOTSUP'].includes(error.code)) throw error; }
+    catch (error) { if (!['EINVAL', 'EPERM', 'EACCES', 'EBADF', 'EISDIR', 'ENOTSUP'].includes(error.code)) throw error; }
     finally { if (fd !== undefined) io.closeSync(fd); }
   }
   function enter(name) {
@@ -86,4 +96,4 @@ function acquireLease(io = fs, chdir = process.chdir, pid = process.pid, alive =
   }
   throw busy();
 }
-module.exports = { acquireLease };
+module.exports = { acquireLease, isAlive };

--- a/electron/pluginLease.test.cjs
+++ b/electron/pluginLease.test.cjs
@@ -1,0 +1,26 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { isAlive } = require('./pluginLease.cjs');
+
+const withKill = (impl, run) => {
+  const original = process.kill;
+  process.kill = impl;
+  try { run(); } finally { process.kill = original; }
+};
+const throwing = code => () => { throw Object.assign(new Error(code), { code }); };
+
+/**
+ * Regression: a crashed app leaves `owner-<pid>-<token>` behind. Treating EPERM
+ * as "still running" meant a recycled PID owned by another user locked the
+ * profile across restarts, with no way out from the UI.
+ */
+test('a lease owner PID that no longer belongs to us is stale, not alive', () => {
+  withKill(throwing('ESRCH'), () => assert.equal(isAlive(4242), false));
+  withKill(throwing('EPERM'), () => assert.equal(isAlive(4242), false));
+});
+
+test('an unknown errno stays conservative so a live lease is never stolen', () => {
+  withKill(() => true, () => assert.equal(isAlive(4242), true));
+  withKill(throwing('EINVAL'), () => assert.equal(isAlive(4242), true));
+});

--- a/electron/pluginOperationHost.cjs
+++ b/electron/pluginOperationHost.cjs
@@ -295,6 +295,9 @@ function createPluginOperationHost({ home, registry, snapshots, encrypt, decrypt
     return { id: op.id, previous };
   }
   async function execute(sender, action, request) {
+    // Recovery is the user's explicit "get me out of this" action, so it is the
+    // one place allowed to restart a session that a worker death closed.
+    if (action === 'recover') session?.reopen?.();
     if (action === 'begin') return begin(sender, request);
     const op = await load();
     if (action === 'status') return op ? { id: op.id, key: op.key, phase: op.phase } : null;

--- a/electron/pluginOperationHost.test.cjs
+++ b/electron/pluginOperationHost.test.cjs
@@ -328,3 +328,28 @@ test('unapproved rename cannot claim a different package identity', async () => 
   assert.deepEqual(f.records(), [previous]);
   assert.equal(f.disk.read('/profile/.abu/plugin-packages/market/demo/1/old.txt'), 'old package');
 });
+
+/**
+ * The plugins tab's retry button is the user's only way out after a worker
+ * death, and it routes here. Recovery therefore restarts a closed session;
+ * every other action keeps failing so a half-known state is never acted on.
+ */
+test('recovery restarts a session a worker death closed, other actions do not', async () => {
+  const f = fixture();
+  const stub = () => {
+    let open = false, reopened = 0;
+    return {
+      get reopened() { return reopened; },
+      reopen() { reopened++; open = true; return true; },
+      ready: () => open ? Promise.resolve() : Promise.reject(new Error('Plugin operation: session closed')),
+    };
+  };
+
+  const recovering = stub();
+  assert.equal(await createPluginOperationHost({ ...f.options, session: recovering }).dispatch(f.sender, 'recover'), null);
+  assert.equal(recovering.reopened, 1);
+
+  const idle = stub();
+  await assert.rejects(createPluginOperationHost({ ...f.options, session: idle }).dispatch(f.sender, 'status'), /session closed/);
+  assert.equal(idle.reopened, 0);
+});

--- a/electron/pluginOperationSession.cjs
+++ b/electron/pluginOperationSession.cjs
@@ -11,10 +11,14 @@ const { runAuthor } = require('./pluginAuthorWorker.cjs');
  * the lease. A replacement main cannot read an older journal in that window.
  */
 function createOperationSession(home) {
-  let child, startup, closed = false, serial = 0;
+  let child, startup, closed = false, disposed = false, serial = 0, generation = 0;
   const pending = new Map();
   let exitPromise, anchors;
   function launch() {
+    // Orphan the previous worker's callbacks: after a reopen its late 'error'
+    // or 'exit' must not close the session that replaced it, nor reject the
+    // new generation's in-flight calls.
+    const mine = ++generation;
     return new Promise((resolve, reject) => {
       const env = { ...process.env, ELECTRON_RUN_AS_NODE: '1' };
       delete env.NODE_OPTIONS; delete env.NODE_PATH;
@@ -32,6 +36,7 @@ function createOperationSession(home) {
         value.error ? callback.reject(new Error(value.error)) : callback.resolve(value.result);
       });
       const failed = error => {
+        if (mine !== generation) return;
         if (admitted) closed = true;
         reject(error);
         for (const callback of pending.values()) callback.reject(error);
@@ -40,6 +45,20 @@ function createOperationSession(home) {
       worker.once('error', failed);
       worker.once('exit', () => failed(new Error(message || 'Plugin operation: session interrupted')));
     });
+  }
+  /** A worker death is a transient fault, not a terminal one: the journal keeps
+   * the on-disk state recoverable, and a dead worker's PID no longer holds the
+   * lease. Without this the plugins tab's retry button re-awaits the cached
+   * rejected startup and can never succeed. Refuse while calls are in flight
+   * (their results would be attributed to the wrong worker) and after an
+   * intentional shutdown. */
+  function reopen() {
+    if (disposed || pending.size) return false;
+    if (!closed) return true;
+    generation++;
+    closed = false; startup = undefined; child = undefined;
+    exitPromise = undefined; anchors = undefined;
+    return true;
   }
   function ready() {
     if (closed) return Promise.reject(new Error('Plugin operation: session closed'));
@@ -70,11 +89,14 @@ function createOperationSession(home) {
   }
   return {
     ready,
+    reopen,
+    get pid() { return child?.pid; },
     get anchors() { return anchors; },
     mutate: input => send('operation', input),
     registry: input => send('registry', input),
     author: input => send('author', input),
     async close() {
+      disposed = true;
       closed = true;
       if (!child) return;
       if (child.connected) child.disconnect();

--- a/electron/pluginOperationSession.cjs
+++ b/electron/pluginOperationSession.cjs
@@ -55,6 +55,13 @@ function createOperationSession(home) {
   function reopen() {
     if (disposed || pending.size) return false;
     if (!closed) return true;
+    // Only once the previous worker is really gone. `closed` is set from the
+    // exit handler, so it normally already has; an 'error' without an exit is
+    // the case this guards. The lease would refuse a live owner anyway (its
+    // retry loop waits for release), but not re-spawning against a running
+    // worker keeps "no journal read before the old writes finish" an explicit
+    // ordering rather than an incidental one.
+    if (child && child.exitCode === null && child.signalCode === null) return false;
     generation++;
     closed = false; startup = undefined; child = undefined;
     exitPromise = undefined; anchors = undefined;

--- a/electron/pluginOperationSession.integration.test.cjs
+++ b/electron/pluginOperationSession.integration.test.cjs
@@ -79,3 +79,41 @@ test('tree publication never writes through a replaced parent symlink', () => {
     assert.deepEqual(fs.readdirSync(outside), []);
   } finally { fs.rmSync(home, { recursive: true, force: true }); fs.rmSync(outside, { recursive: true, force: true }); }
 });
+
+/**
+ * Regression: a SIGKILLed worker (OOM, antivirus, memory pressure) closed the
+ * session for the life of the process. The plugins tab's retry button routes
+ * through the same session, so it re-awaited a cached rejected startup and
+ * could never restore installing, updating or uninstalling.
+ */
+test('an explicit reopen restarts a killed worker, and a disposed session stays closed', async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'abu-operation-reopen-'));
+  const session = createOperationSession(home);
+  try {
+    await session.ready();
+    const info = fs.statSync(home);
+    const write = value => session.mutate({ home, identity: { ino: info.ino, dev: info.dev },
+      parent: ['.abu', 'plugin-operations'], action: 'write', temp: `${value}.tmp`, to: 'active.enc',
+      bytes: Buffer.from(value).toString('base64') });
+    await write('before');
+
+    process.kill(session.pid, 'SIGKILL');
+    for (let attempt = 0; attempt < 100; attempt++) {
+      try { await session.ready(); await new Promise(resolve => setTimeout(resolve, 20)); }
+      catch { break; }
+    }
+    await assert.rejects(session.ready(), /session/);
+
+    assert.equal(session.reopen(), true);
+    await session.ready();
+    await write('after');
+    assert.equal(fs.readFileSync(path.join(home, '.abu', 'plugin-operations', 'active.enc'), 'utf8'), 'after');
+
+    await session.close();
+    assert.equal(session.reopen(), false);
+    await assert.rejects(session.ready(), /session closed/);
+  } finally {
+    await session.close().catch(() => {});
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/electron/pluginOperationWorker.cjs
+++ b/electron/pluginOperationWorker.cjs
@@ -64,9 +64,11 @@ function run(input, io = fs, chdir = process.chdir) {
   } else throw new Error('Plugin operation: unsupported mutation');
   if (!same(parent, io.statSync('.'))) throw new Error('Plugin operation: directory changed');
   // Directory fsync makes a completed rename durable on platforms supporting it.
+  // Windows is not one of them; see pluginLease.syncDirectory.
+  if (process.platform === 'win32') return;
   let fd;
   try { fd = io.openSync('.', 'r'); io.fsyncSync(fd); } catch (e) {
-    if (!['EINVAL', 'EPERM', 'EISDIR', 'ENOTSUP'].includes(e.code)) throw e;
+    if (!['EINVAL', 'EPERM', 'EACCES', 'EBADF', 'EISDIR', 'ENOTSUP'].includes(e.code)) throw e;
   } finally { if (fd !== undefined) io.closeSync(fd); }
 }
 function mutate({ home, ...input }) {

--- a/src/components/customize/SkillsSection.test.tsx
+++ b/src/components/customize/SkillsSection.test.tsx
@@ -23,6 +23,7 @@ import { skillLoader } from '@/core/skill/loader';
 import { useDiscoveryStore } from '@/stores/discoveryStore';
 import { useSkillDraftsStore } from '@/stores/skillDraftsStore';
 import { useSettingsStore } from '@/stores/settingsStore';
+import { usePluginStore } from '@/stores/pluginStore';
 import type { DraftRecord } from '@/core/skill/drafts';
 import SkillsSection from './SkillsSection';
 
@@ -140,4 +141,53 @@ describe('SkillsSection · sourceFilter="mine"', () => {
     expect(screen.queryByText(tb().uninstall)).toBeNull();
   });
 
+});
+
+/**
+ * The list deliberately includes skills whose owning plugin is switched off, so
+ * they stay discoverable. The card must not also claim they are active: the
+ * model's strict getAvailableSkills() has already dropped them, so a green
+ * switch and a live 试用 button would be the UI lying about what Abu can see.
+ */
+describe('SkillsSection · disabled plugin ownership', () => {
+  const activation = (enabled: boolean) => ({
+    'weather@market': {
+      enabled, root: '/skills/weather-report', skillDirs: ['/skills/weather-report'],
+      legacySkills: false, agentFiles: [], mcpServers: [],
+    },
+  });
+  const switchFor = (name: string) => {
+    const card = screen.getByText(name).closest('[role="button"]');
+    if (!card) throw new Error(`no card for ${name}`);
+    return within(card as HTMLElement).getByRole('switch');
+  };
+
+  it('shows the skill as off and locks its switch while the owning plugin is disabled', async () => {
+    usePluginStore.setState({ activationByKey: activation(false), activationReady: true });
+    render(<SkillsSection />);
+    await screen.findByText('weather-report');
+    const toggle = switchFor('weather-report');
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+    expect((toggle as HTMLButtonElement).disabled).toBe(true);
+    // A skill nobody owns is unaffected.
+    expect(switchFor('my-notes').getAttribute('aria-checked')).toBe('true');
+    expect((switchFor('my-notes') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('blocks the trial button and says why', async () => {
+    usePluginStore.setState({ activationByKey: activation(false), activationReady: true });
+    render(<SkillsSection />);
+    fireEvent.click(await screen.findByText('weather-report'));
+    expect(screen.getByText(tb().skillPluginDisabled)).toBeTruthy();
+    expect((screen.getByText(tb().menuTrial).closest('button') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('leaves the switch on once the owning plugin is enabled', async () => {
+    usePluginStore.setState({ activationByKey: activation(true), activationReady: true });
+    render(<SkillsSection />);
+    await screen.findByText('weather-report');
+    const toggle = switchFor('weather-report');
+    expect(toggle.getAttribute('aria-checked')).toBe('true');
+    expect((toggle as HTMLButtonElement).disabled).toBe(false);
+  });
 });

--- a/src/components/customize/SkillsSection.tsx
+++ b/src/components/customize/SkillsSection.tsx
@@ -24,6 +24,7 @@ import { sourceToUXCategory } from '@/core/skill/uxCategory';
 import ToolCard from '@/components/toolbox/ToolCard';
 import ToolGrid from '@/components/toolbox/ToolGrid';
 import SkillDetailPanel from '@/components/toolbox/skills/SkillDetailPanel';
+import { usePluginSkillGate } from '@/components/toolbox/plugins/usePluginSkillGate';
 
 // Build a set of system skill names from marketplace templates
 /**
@@ -85,6 +86,10 @@ export default function SkillsSection({ manualCreateTrigger, showUploadModal: ex
     const skill = skillLoader.getSkill(meta.name, { includeDisabledPlugins: true });
     return skill ? [skill] : [];
   }), [skills]);
+  // The list above deliberately keeps disabled plugins' skills visible; this
+  // gate stops the card from also claiming they are active (the model's
+  // strict getAvailableSkills() has already dropped them).
+  const pluginAllowed = usePluginSkillGate();
   const [selectedSkill, setSelectedSkill] = useState<string | null>(null);
   const [editorSkill, setEditorSkill] = useState<Skill | 'new' | null>(null);
   const [menuSkill, setMenuSkill] = useState<string | null>(null);
@@ -196,7 +201,8 @@ export default function SkillsSection({ manualCreateTrigger, showUploadModal: ex
   }, [menuSkill]);
 
   const renderSkillCard = (skill: Skill) => {
-    const isEnabled = !disabledSet.has(skill.name);
+    const gated = !pluginAllowed(skill);
+    const isEnabled = !disabledSet.has(skill.name) && !gated;
     const badge = sourceBadge(skill);
     return (
       <ToolCard
@@ -212,8 +218,8 @@ export default function SkillsSection({ manualCreateTrigger, showUploadModal: ex
             </span>
           ) : undefined,
           toggle: (
-            <span onClick={(event) => event.stopPropagation()}>
-              <Toggle checked={isEnabled} onChange={() => toggleSkillEnabled(skill.name)} size="sm" tone="green" />
+            <span onClick={(event) => event.stopPropagation()} title={gated ? t.toolbox.skillPluginDisabled : undefined}>
+              <Toggle checked={isEnabled} disabled={gated} onChange={() => toggleSkillEnabled(skill.name)} size="sm" tone="green" />
             </span>
           ),
         }}
@@ -364,10 +370,12 @@ export default function SkillsSection({ manualCreateTrigger, showUploadModal: ex
         footer={selected ? <div className="flex items-center justify-between gap-3">
           {selected.source !== 'builtin' && selected.source !== 'plugin' && selected.source !== 'enterprise' && !selected.filePath.includes('builtin-skills') ? (
             <Button variant="ghost" size="sm" className="bg-[var(--abu-danger-bg)] text-[var(--abu-danger)] hover:bg-[var(--abu-danger-bg)] hover:text-[var(--abu-danger)] rounded-xl" onClick={() => handleDelete(selected)}>{t.toolbox.uninstall}</Button>
+          ) : !pluginAllowed(selected) ? (
+            <span className="text-caption text-[var(--abu-text-muted)]">{t.toolbox.skillPluginDisabled}</span>
           ) : <span />}
 
 
-          <Button size="sm" className="rounded-xl" disabled={disabledSet.has(selected.name)} onClick={() => {
+          <Button size="sm" className="rounded-xl" disabled={disabledSet.has(selected.name) || !pluginAllowed(selected)} onClick={() => {
             startNewConversation();
             setPendingInput(`/${selected.name} `);
             setSelectedSkill(null);

--- a/src/components/toolbox/plugins/usePluginSkillGate.ts
+++ b/src/components/toolbox/plugins/usePluginSkillGate.ts
@@ -1,0 +1,13 @@
+import { useCallback } from 'react';
+import { usePluginStore } from '@/stores/pluginStore';
+import { isSkillAllowedIn } from '@/core/plugin/activationPolicy';
+
+/** The skills page deliberately lists skills of disabled plugins so they stay
+ * discoverable, but the model excludes them. Reading the master gate here keeps
+ * the switch and the trial button honest about what the model can actually see.
+ */
+export function usePluginSkillGate(): (skill: { skillDir: string }) => boolean {
+  const activations = usePluginStore(s => s.activationByKey);
+  const ready = usePluginStore(s => s.activationReady);
+  return useCallback(skill => isSkillAllowedIn(activations, ready, skill.skillDir), [activations, ready]);
+}

--- a/src/core/plugin/activationPolicy.ts
+++ b/src/core/plugin/activationPolicy.ts
@@ -112,13 +112,20 @@ export function isPluginEnabled(key: string): boolean {
 export function assertPluginEnabled(key: string): void {
   if (!isPluginEnabled(key)) throw new Error(format(getI18n().toolbox.pluginsDisabledCapability, { name: key }));
 }
-export function isPluginSkillAllowed(skill: { skillDir: string }): boolean {
-  const dir = normalized(skill.skillDir);
-  const matches = Object.entries(activations).filter(([, a]) => dir === a.root || dir.startsWith(`${a.root}/`));
+/** The same gate the loader enforces, over an explicitly supplied snapshot.
+ * The skills page renders disabled plugins' skills, so its switches must read
+ * this rather than the per-skill preference alone; taking the snapshot as an
+ * argument lets React subscribe to the store instead of this module's state. */
+export function isSkillAllowedIn(source: PluginActivations, recordsReady: boolean, skillDir: string): boolean {
+  const dir = normalized(skillDir);
+  const matches = Object.entries(source).filter(([, a]) => dir === a.root || dir.startsWith(`${a.root}/`));
   if (!matches.length) return !dir.includes('/.abu/plugin-packages/');
   if (matches.length !== 1) return false;
   const [, a] = matches[0];
-  return ready && a.enabled && !a.conflicted && ownsSkill(a, dir);
+  return recordsReady && a.enabled && !a.conflicted && ownsSkill(a, dir);
+}
+export function isPluginSkillAllowed(skill: { skillDir: string }): boolean {
+  return isSkillAllowedIn(activations, ready, skill.skillDir);
 }
 export function isPluginAgentAllowed<T extends { filePath: string }>(agent: T): boolean {
   const owner = pluginOwnerForAgent(agent);

--- a/src/core/plugin/bootstrapRuntimes.test.ts
+++ b/src/core/plugin/bootstrapRuntimes.test.ts
@@ -9,40 +9,47 @@ import { startCapabilityRuntimes } from './bootstrapRuntimes';
 
 beforeEach(() => vi.clearAllMocks());
 
-it('starts the private browser while plugin recovery is still pending, but defers user MCP startup', async () => {
+it('starts the private browser and user MCP synchronization without waiting for plugin recovery', async () => {
   let finish!: () => void;
   mocks.recovery.mockReturnValue(new Promise<void>(resolve => { finish = resolve; }));
   const stop = startCapabilityRuntimes();
   expect(mocks.browser).toHaveBeenCalledOnce();
-  expect(mocks.sync).not.toHaveBeenCalled();
+  expect(mocks.sync).toHaveBeenCalledOnce();
+  // Recovery must be entered first: its synchronous prefix marks plugin
+  // activation not-ready, so this connect pass cannot start plugin-owned
+  // servers before ownership is known.
+  expect(mocks.recovery.mock.invocationCallOrder[0]).toBeLessThan(mocks.sync.mock.invocationCallOrder[0]);
   finish();
   await Promise.resolve();
   expect(mocks.sync).toHaveBeenCalledOnce();
-  expect(mocks.browser).toHaveBeenCalledOnce();
   stop();
   expect(mocks.browserCleanup).toHaveBeenCalledOnce();
   expect(mocks.syncCleanup).toHaveBeenCalledOnce();
 });
 
-it('does not restart user MCP synchronization after the owning effect is cleaned up', async () => {
-  let finish!: () => void;
-  mocks.recovery.mockReturnValue(new Promise<void>(resolve => { finish = resolve; }));
-  startCapabilityRuntimes()();
-  finish();
-  await Promise.resolve();
-  expect(mocks.sync).not.toHaveBeenCalled();
-});
-
-it('keeps the private browser available when plugin recovery fails', async () => {
+/**
+ * Regression: plugin recovery and MCP startup used to be one promise chain, so
+ * an unreadable plugin journal left every user-configured connector offline
+ * with the only explanation buried in the plugins tab.
+ */
+it('keeps user MCP connectors running when plugin recovery fails', async () => {
   const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
   mocks.recovery.mockRejectedValue(new Error('recovery blocked'));
   const stop = startCapabilityRuntimes();
   await Promise.resolve();
   await Promise.resolve();
   expect(mocks.browser).toHaveBeenCalledOnce();
+  expect(mocks.sync).toHaveBeenCalledOnce();
   expect(mocks.browserCleanup).not.toHaveBeenCalled();
-  expect(mocks.sync).not.toHaveBeenCalled();
   expect(warning).toHaveBeenCalled();
   stop();
   warning.mockRestore();
+});
+
+it('tears both runtimes down on cleanup', async () => {
+  mocks.recovery.mockResolvedValue(undefined);
+  startCapabilityRuntimes()();
+  await Promise.resolve();
+  expect(mocks.browserCleanup).toHaveBeenCalledOnce();
+  expect(mocks.syncCleanup).toHaveBeenCalledOnce();
 });

--- a/src/core/plugin/bootstrapRuntimes.test.ts
+++ b/src/core/plugin/bootstrapRuntimes.test.ts
@@ -9,22 +9,31 @@ import { startCapabilityRuntimes } from './bootstrapRuntimes';
 
 beforeEach(() => vi.clearAllMocks());
 
-it('starts the private browser and user MCP synchronization without waiting for plugin recovery', async () => {
+it('starts the private browser immediately and MCP synchronization once recovery settles', async () => {
   let finish!: () => void;
   mocks.recovery.mockReturnValue(new Promise<void>(resolve => { finish = resolve; }));
   const stop = startCapabilityRuntimes();
   expect(mocks.browser).toHaveBeenCalledOnce();
-  expect(mocks.sync).toHaveBeenCalledOnce();
-  // Recovery must be entered first: its synchronous prefix marks plugin
-  // activation not-ready, so this connect pass cannot start plugin-owned
-  // servers before ownership is known.
-  expect(mocks.recovery.mock.invocationCallOrder[0]).toBeLessThan(mocks.sync.mock.invocationCallOrder[0]);
+  // Not before: until plugin ownership is published, a plugin's own server
+  // looks independent and would be connected, then invalidated by epoch.
+  expect(mocks.sync).not.toHaveBeenCalled();
   finish();
+  await Promise.resolve();
   await Promise.resolve();
   expect(mocks.sync).toHaveBeenCalledOnce();
   stop();
   expect(mocks.browserCleanup).toHaveBeenCalledOnce();
   expect(mocks.syncCleanup).toHaveBeenCalledOnce();
+});
+
+it('does not start MCP synchronization after the owning effect is cleaned up', async () => {
+  let finish!: () => void;
+  mocks.recovery.mockReturnValue(new Promise<void>(resolve => { finish = resolve; }));
+  startCapabilityRuntimes()();
+  finish();
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(mocks.sync).not.toHaveBeenCalled();
 });
 
 /**
@@ -38,6 +47,7 @@ it('keeps user MCP connectors running when plugin recovery fails', async () => {
   const stop = startCapabilityRuntimes();
   await Promise.resolve();
   await Promise.resolve();
+  await Promise.resolve();
   expect(mocks.browser).toHaveBeenCalledOnce();
   expect(mocks.sync).toHaveBeenCalledOnce();
   expect(mocks.browserCleanup).not.toHaveBeenCalled();
@@ -49,6 +59,7 @@ it('keeps user MCP connectors running when plugin recovery fails', async () => {
 it('tears both runtimes down on cleanup', async () => {
   mocks.recovery.mockResolvedValue(undefined);
   startCapabilityRuntimes()();
+  await Promise.resolve();
   await Promise.resolve();
   expect(mocks.browserCleanup).toHaveBeenCalledOnce();
   expect(mocks.syncCleanup).toHaveBeenCalledOnce();

--- a/src/core/plugin/bootstrapRuntimes.ts
+++ b/src/core/plugin/bootstrapRuntimes.ts
@@ -4,20 +4,28 @@ import { bootstrapPluginUpdates } from '@/stores/pluginStore';
 
 /** The private browser is independent of user plugin recovery and market IO. */
 export function startCapabilityRuntimes(): () => void {
+  let stopped = false;
   initBuiltinBrowserRuntime();
-  // Plugin recovery and MCP startup are INDEPENDENT subsystems. Chaining them
-  // let one unreadable plugin journal keep every user-configured connector
-  // offline, with the only explanation buried in the plugins tab. Plugin-owned
-  // servers stay fail-closed meanwhile: activationReady is false until recovery
-  // finishes, and bootstrapPluginUpdates connects them itself once ownership is
-  // known. Start recovery first so it marks activationReady=false (synchronously,
-  // before its first await) ahead of this connectAllEnabled pass.
-  const recovery = bootstrapPluginUpdates();
-  initMCPStoreSync();
-  void recovery.catch(error => {
-    console.warn('[App] Plugin recovery failed; plugin capabilities stay disabled:', error);
-  });
+  // Plugin recovery and MCP startup must not share a FATE — one unreadable
+  // plugin journal used to keep every user-configured connector offline for
+  // the whole session. But MCP startup must still share an ORDER with it:
+  // until plugin records are published, activationPolicy sees no owner for a
+  // plugin's server (`isPluginMcpAllowed` falls through to `!knownMcp.has`)
+  // and treats it as an independent one, so connecting first establishes a
+  // connection that publishing ownership then invalidates by epoch — leaving
+  // a plugin-provided interface resolved against a connection that is gone.
+  // Settling rather than chaining gives both: recovery failure no longer
+  // blocks the user's own connectors, and nothing connects before ownership
+  // is known (plugin-owned servers then stay fail-closed on activationReady).
+  void bootstrapPluginUpdates()
+    .catch(error => {
+      console.warn('[App] Plugin recovery failed; plugin capabilities stay disabled:', error);
+    })
+    .finally(() => {
+      if (!stopped) initMCPStoreSync();
+    });
   return () => {
+    stopped = true;
     void cleanupBuiltinBrowserRuntime();
     cleanupMCPStoreSync();
   };

--- a/src/core/plugin/bootstrapRuntimes.ts
+++ b/src/core/plugin/bootstrapRuntimes.ts
@@ -4,15 +4,20 @@ import { bootstrapPluginUpdates } from '@/stores/pluginStore';
 
 /** The private browser is independent of user plugin recovery and market IO. */
 export function startCapabilityRuntimes(): () => void {
-  let stopped = false;
   initBuiltinBrowserRuntime();
-  void bootstrapPluginUpdates().then(() => {
-    if (!stopped) initMCPStoreSync();
-  }).catch(error => {
-    console.warn('[App] Plugin recovery failed; automatic MCP startup deferred:', error);
+  // Plugin recovery and MCP startup are INDEPENDENT subsystems. Chaining them
+  // let one unreadable plugin journal keep every user-configured connector
+  // offline, with the only explanation buried in the plugins tab. Plugin-owned
+  // servers stay fail-closed meanwhile: activationReady is false until recovery
+  // finishes, and bootstrapPluginUpdates connects them itself once ownership is
+  // known. Start recovery first so it marks activationReady=false (synchronously,
+  // before its first await) ahead of this connectAllEnabled pass.
+  const recovery = bootstrapPluginUpdates();
+  initMCPStoreSync();
+  void recovery.catch(error => {
+    console.warn('[App] Plugin recovery failed; plugin capabilities stay disabled:', error);
   });
   return () => {
-    stopped = true;
     void cleanupBuiltinBrowserRuntime();
     cleanupMCPStoreSync();
   };

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -1785,6 +1785,7 @@ const enUS: TranslationDict = {
     skillSourceBuiltin: 'Built-in',
     skillSourceUser: 'User',
     skillSourcePlugin: 'From a plugin',
+    skillPluginDisabled: 'Owning plugin is disabled',
     skillSourceStandard: 'Installed',
     skillSourceProject: 'Project',
     skillSourceWorkspaceAuto: 'Self-evolved',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -1786,6 +1786,7 @@ const zhCN: TranslationDict = {
     skillSourceBuiltin: '内置',
     skillSourceUser: '用户创建',
     skillSourcePlugin: '来自插件',
+    skillPluginDisabled: '所属插件已停用',
     skillSourceStandard: '全局安装',
     skillSourceProject: '项目',
     skillSourceWorkspaceAuto: '自进化',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -2231,6 +2231,7 @@ export interface TranslationDict {
     skillSourceBuiltin: string;
     skillSourceUser: string;
     skillSourcePlugin: string;
+    skillPluginDisabled: string;
     skillSourceStandard: string;
     skillSourceProject: string;
     skillSourceWorkspaceAuto: string;


### PR DESCRIPTION
插件一期发版前独立审查的三条必修项，外加一条零风险的 Windows 防御性修改。审查结论为「有条件通过」，这个 PR 就是那个条件。

## P0 — 停用插件后，技能页仍显示为已开启且可试用

技能页显式传 `includeDisabledPlugins`，让停用插件的技能保持可见；但卡片开关只读 `disabledSkills`，不看插件主开关。模型侧走的是严格版 `getAvailableSkills()`，已经把这些技能排除了——于是用户关掉插件后看到绿灯开关和可点的「立即试用」，点下去调用的是一个 Abu 根本看不见的技能。

把 loader 的闸门抽成纯函数 `isSkillAllowedIn(activations, ready, dir)`（`isPluginSkillAllowed` 转发给它，行为不变），新增 `usePluginSkillGate` 让 React 订阅 store 而不是模块快照。开关与试用按钮现在同时读两个真值源，详情页说明原因，而不是留一个没有解释的死控件。

## P1 — 插件恢复失败连带掐掉整个 MCP 子系统

`bootstrapPluginUpdates().then(initMCPStoreSync)` 把两个独立子系统串成一条链：一份读不出的插件日志会让用户自建的全部连接器不启动，而唯一的说明藏在插件页横幅里。**没装过插件的用户同样中招**——恢复流程对所有人都在开机时跑。

改成各自启动。插件侧 server 在此期间仍然 fail-closed（`activationReady` 在恢复完成前为 false），恢复完成后由 `bootstrapPluginUpdates` 自己连接，因此没有放宽任何权限。恢复仍然先进入，以便它的同步前缀先把 `activationReady` 置 false。

⚠️ **既有的三条测试固化了缺陷本身**，其中包括「recovery 失败时 sync 不应被调用」。这条断言就是 P1 的定义。现已改为钉住预期的独立性与调用顺序——这不是为了让门禁变绿而改断言，值得单独看一眼 diff。

## P1 — 会话 worker 死亡即插件子系统永久死锁

worker 被 SIGKILL（OOM、杀毒、内存压力）后 `closed=true` 且无复位路径，而插件页「重试恢复」按钮走的正是同一个会话——它 re-await 那个已被缓存的、已拒绝的 startup，结构上不可能成功。

- `createOperationSession` 增加 `reopen()`。事务日志保证磁盘状态可恢复，死掉的 PID 也不再持有租约，所以 worker 死亡是瞬时故障而非终态。有在途调用时拒绝重开，主动 `close()` 后（`disposed`）也拒绝；`generation` 计数确保旧 worker 迟到的 `error`/`exit` 不会关掉替换它的会话。
- 只有 `recover` 动作会调用它——那是重试按钮的落点。其它动作照旧失败，不在状态不明时动手。
- `pluginLease.isAlive` 不再把 `EPERM` 读作「还活着」。租约持有者永远是同 uid 子进程，EPERM 只可能是 PID 被别的用户回收 ⇒ 锁是陈旧的。这种情况**跨重启持续存在**，此前只能手工删目录才能解开。未知 errno 仍保守判活，不会误抢活锁。
- 三处目录 fsync 在 win32 跳过。Windows 没有等价语义（`FlushFileBuffers` 对只读句柄失败），而这个调用位于每一次 registry / operation / author 写入的必经路径，一旦抛错会让整个插件子系统在该平台不可用。`EACCES`/`EBADF` 也一并加入容忍列表。

## 门禁（本机亲跑，认退出码）

```
npm run electron:test   exit 0   272 passed
npm run verify          exit 0   631 files / 11375 passed / 1 skipped
```

覆盖率 stmts 81.54% · branches 73.47% · functions 81.83% · lines 83.52%。functions 相对基线 81.85% 微降 0.02pp，其余持平，阈值通过。

新增测试 5 条：技能页 P0 回归 3 条、租约 errno 映射 2 条（新建 `electron/pluginLease.test.cjs`）；另有会话 kill-then-reopen 集成测试与 host `recover`→`reopen` 接线测试各 1 条。`TESTING.md` 清单块按 `test:inventory:check` 重新生成。

## 仍需实机验证

- **Windows 真机**：目录 fsync 那条在 macOS 上无法证实或证伪。本 PR 做的是防御性规避（跳过），但仍应在含空格 + 中文的用户目录下跑一次「创建插件 → 安装 → 更新 → 卸载」，顺带覆盖长路径与 `~/Abu Plugins` 空格路径。
- **P0 回归**：装带技能的插件 → 关主开关 → 技能页确认开关置灰、试用不可点。
- **会话恢复**：`kill -9` 掉会话 worker → 点「重试恢复」→ 安装能力应当恢复。
- **MCP 解耦**：把 `active.enc` 改成随机字节 → 重启 → 确认与插件无关的自建连接器仍能自动连接。

审查报告里其余的 P1/P2（作者记录不可删、归属 fail-open 方向、披露不含 env、事务残留物无回收等）不在本 PR 范围内，按记账排期处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)