### PR TITLE
test: make plugin operation security cases Windows-safe

### DIFF
--- a/electron/pluginOperationHost.test.cjs
+++ b/electron/pluginOperationHost.test.cjs
@@ -222,7 +222,8 @@ test('commit refuses a replaced materialized directory and missing owned agents'
 
 test('missing backup cannot silently accept a replacement as the old version', async () => {
   const f = fixture({ sameVersion: true }); const op = await f.begin(); await f.materialize();
-  for (const key of [...f.disk.entries.keys()]) if (key.includes('.abu-plugin-backup-') && key.includes('/demo/')) await f.disk.api.rm(key);
+  const isDemoBackup = key => key.includes('.abu-plugin-backup-') && key.split(path.sep).includes('demo');
+  for (const key of [...f.disk.entries.keys()]) if (isDemoBackup(key)) await f.disk.api.rm(key);
   await assert.rejects(f.host.dispatch(f.sender, 'rollback', op), /backup missing/);
   assert.equal((await f.host.dispatch(f.sender, 'status')).phase, 'prepared');
 });

--- a/electron/pluginOperationSession.integration.test.cjs
+++ b/electron/pluginOperationSession.integration.test.cjs
@@ -49,7 +49,7 @@ for (const relative of ['.abu', '.abu/plugin-operations']) {
   });
 }
 
-test('tree publication never writes through a replaced parent symlink', () => {
+test('tree publication refuses a parent replaced while entering it', () => {
   const { execFileSync } = require('node:child_process');
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'abu-tree-boundary-'));
   const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'abu-tree-outside-'));
@@ -76,6 +76,60 @@ test('tree publication never writes through a replaced parent symlink', () => {
       };
       assert.throws(() => run({ identity, parent: ['.abu', 'agents'], parentIdentity,
         action: 'tree', temp: '.incoming', to: 'helper', tree: [['AGENT.md', Buffer.from('approved').toString('base64')]] }, fs, chdir), /directory changed/);
+      assert.deepEqual(fs.readdirSync(outside), []);
+    `, path.join(__dirname, 'pluginOperationWorker.cjs'), home, outside, parent]);
+    assert.deepEqual(fs.readdirSync(outside), []);
+  } finally { fs.rmSync(home, { recursive: true, force: true }); fs.rmSync(outside, { recursive: true, force: true }); }
+});
+
+// POSIX permits replacing an active cwd; Windows prevents that replacement.
+// Exercise the publication-stage attack on both platforms, preserving each
+// platform's exact refusal and proving that no payload reaches either target.
+test(process.platform === 'win32'
+  ? 'Windows prevents replacing the active publication parent before any payload write'
+  : 'tree publication rechecks a parent replaced after entering it', () => {
+  const { execFileSync } = require('node:child_process');
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'abu-tree-publication-'));
+  const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'abu-tree-outside-'));
+  const parent = path.join(home, '.abu', 'agents');
+  fs.mkdirSync(parent, { recursive: true });
+  try {
+    execFileSync(process.execPath, ['-e', `
+      const fs = require('node:fs');
+      const path = require('node:path');
+      const assert = require('node:assert/strict');
+      const { run } = require(process.argv[1]);
+      const [home, outside, parent] = process.argv.slice(2);
+      process.chdir(home);
+      const identity = fs.statSync('.');
+      const parentIdentity = fs.statSync(parent);
+      let attempted = false;
+      const io = { ...fs, mkdirSync(name, ...args) {
+        if (name === '.incoming') {
+          attempted = true;
+          fs.renameSync(parent, parent + '-old');
+          fs.symlinkSync(outside, parent, 'dir');
+        }
+        return fs.mkdirSync(name, ...args);
+      }};
+      const publish = () => run({ identity, parent: ['.abu', 'agents'], parentIdentity,
+        action: 'tree', temp: '.incoming', to: 'helper', tree: [['AGENT.md', Buffer.from('approved').toString('base64')]] }, io);
+      if (process.platform === 'win32') {
+        assert.throws(publish, { code: 'EBUSY', syscall: 'rename' });
+        const after = fs.lstatSync(parent);
+        assert.equal(after.isSymbolicLink(), false);
+        assert.equal(after.ino, parentIdentity.ino);
+        assert.equal(after.dev, parentIdentity.dev);
+        assert.equal(fs.existsSync(parent + '-old'), false);
+        assert.deepEqual(fs.readdirSync(parent), []);
+      } else {
+        assert.throws(publish, /parent changed/);
+        assert.equal(fs.lstatSync(parent).isSymbolicLink(), true);
+        assert.equal(fs.existsSync(path.join(parent + '-old', 'helper')), false);
+        assert.deepEqual(fs.readdirSync(path.join(parent + '-old', '.incoming')), []);
+      }
+      assert.equal(attempted, true);
+      assert.equal(fs.existsSync(path.join(parent, 'helper')), false);
       assert.deepEqual(fs.readdirSync(outside), []);
     `, path.join(__dirname, 'pluginOperationWorker.cjs'), home, outside, parent]);
     assert.deepEqual(fs.readdirSync(outside), []);

--- a/electron/pluginOperationSession.integration.test.cjs
+++ b/electron/pluginOperationSession.integration.test.cjs
@@ -65,15 +65,17 @@ test('tree publication never writes through a replaced parent symlink', () => {
       process.chdir(home);
       const identity = fs.statSync('.');
       const parentIdentity = fs.statSync(parent);
-      const io = { ...fs, mkdirSync(name, ...args) {
-        if (name === '.incoming') {
+      const chdir = name => {
+        if (name === 'agents') {
+          // Replace the parent while the worker is still in .abu. Windows
+          // rejects renaming a directory that is the current working directory.
           fs.renameSync(parent, parent + '-old');
           fs.symlinkSync(outside, parent, 'dir');
         }
-        return fs.mkdirSync(name, ...args);
-      }};
+        process.chdir(name);
+      };
       assert.throws(() => run({ identity, parent: ['.abu', 'agents'], parentIdentity,
-        action: 'tree', temp: '.incoming', to: 'helper', tree: [['AGENT.md', Buffer.from('approved').toString('base64')]] }, io), /parent changed/);
+        action: 'tree', temp: '.incoming', to: 'helper', tree: [['AGENT.md', Buffer.from('approved').toString('base64')]] }, fs, chdir), /directory changed/);
       assert.deepEqual(fs.readdirSync(outside), []);
     `, path.join(__dirname, 'pluginOperationWorker.cjs'), home, outside, parent]);
     assert.deepEqual(fs.readdirSync(outside), []);


### PR DESCRIPTION
Windows host-security failed because the missing-backup fixture matched only POSIX paths and a publication test tried to rename an active working directory. This changes only the tests; production code remains unchanged.

- Remove backup fixtures using native path segments, preserving the missing-backup rejection.
- Cover parent replacement during directory entry on both platforms.
- Preserve the original publication-stage attack: POSIX must reject with `parent changed`; Windows must reject the active-cwd rename with exactly `EBUSY` / `rename`, preserve the original directory identity, and publish no payload. No silent platform skips or broadened error regexes.

Validation for HEAD `71811395`:
- `npm run verify`: exit 0; 631 files, 11,372 tests passed and 1 existing skip; line coverage 83.52%.
- `npm run build`: exit 0.
- Targeted host/session tests: 27/27 on macOS.
- Independent security review (gpt-6-astra, xhigh): passed. Removing the publication-stage identity check makes the restored POSIX test fail; the entry-stage test alone would not detect that regression.
- Updated Windows CI pending. Previous HEAD `3a0c2a61` passed Windows CI, which does not validate the added platform-specific assertions in this HEAD.

Fixes #442
