### PR TITLE
feat(agent): 记录被拒 agent.delta 批次的逐帧身份（P3 第 0 步，行为不变）

### DIFF
--- a/src/core/agent/agentLoopRunner.test.ts
+++ b/src/core/agent/agentLoopRunner.test.ts
@@ -895,6 +895,59 @@ describe('agentLoopRunner', () => {
       );
     });
 
+    it('logs a per-frame summary (never the frame args) when a batch is rejected for raw media payloads', async () => {
+      const { ensureHandlersRegistered, registerRunSession } = await importFresh();
+      ensureHandlersRegistered();
+      registerRunSession('run-1', makeSession({ conversationId: 'conv-1', loopId: 'loop-1' }));
+
+      const handler = handlerFor(onSidecarNotification, 'agent.delta');
+      handler({
+        runId: 'run-1',
+        frames: [
+          { p: 'chat', m: 'updateToolCall', a: ['conv-1', 'loop-1', { id: 'tc1', isExecuting: false }] },
+          { p: 'chat', m: 'addMessage', a: ['conv-1', { content: [{ type: 'image', source: { type: 'base64', data: 'AAAA' } }] }] },
+        ],
+      });
+
+      await Promise.resolve();
+      expect(applyDeltaFramesMock).not.toHaveBeenCalled();
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        'agent.delta rejected unsafe media payload',
+        expect.objectContaining({
+          runId: 'run-1',
+          frameCount: 2,
+          frames: [
+            { index: 0, p: 'chat', m: 'updateToolCall', toolCallId: 'tc1' },
+            { index: 1, p: 'chat', m: 'addMessage' },
+          ],
+        }),
+      );
+      expect(traceRuntimeEventMock).toHaveBeenCalledWith(
+        'renderer.agent_delta_rejected',
+        expect.objectContaining({ runId: 'run-1', frameCount: 2 }),
+      );
+      // The summary must never carry frame args (and therefore never a base64 payload).
+      expect(JSON.stringify(loggerWarnMock.mock.calls)).not.toContain('AAAA');
+      expect(JSON.stringify(traceRuntimeEventMock.mock.calls)).not.toContain('AAAA');
+    });
+
+    it('summarizeFramesForLog keeps identity only — real tool-call ids in, message/step ids out', async () => {
+      const { summarizeFramesForLog } = await importFresh();
+
+      expect(summarizeFramesForLog([
+        // Production shape: chatStore.updateToolCall(convId, messageId, toolCallId, result).
+        { p: 'chat', m: 'updateToolCall', a: ['conv-1', 'msg-1', 'tc-real', 'done'] },
+        { p: 'chat', m: 'setMessageToolCalls', a: ['conv-1', 'msg-1', [{ id: 'tc-first' }, { id: 'tc-second' }]] },
+        { p: 'chat', m: 'addMessage', a: ['conv-1', { id: 'msg-1' }] },
+        { p: 'exec', m: 'addStep', a: ['loop-1', { id: 'step-1' }] },
+      ])).toEqual([
+        { index: 0, p: 'chat', m: 'updateToolCall', toolCallId: 'tc-real' },
+        { index: 1, p: 'chat', m: 'setMessageToolCalls', toolCallId: 'tc-first' },
+        { index: 2, p: 'chat', m: 'addMessage' },
+        { index: 3, p: 'exec', m: 'addStep' },
+      ]);
+    });
+
     it('serializes separate frame batches for the same run', async () => {
       const { ensureHandlersRegistered, registerRunSession } = await importFresh();
       ensureHandlersRegistered();

--- a/src/core/agent/agentLoopRunner.ts
+++ b/src/core/agent/agentLoopRunner.ts
@@ -585,6 +585,54 @@ function trustedDeltaFramesForSession(session: RunSession, frames: PortFrame[]):
   return frames.filter((frame) => isDeltaFrameTrustedForSession(frame, session));
 }
 
+/** chat-port frames whose third arg identifies the tool call being mutated (see chatDelta.ts signatures). */
+const TOOL_CALL_FRAME_METHODS = new Set([
+  'updateToolCall',
+  'appendMessageToolCall',
+  'appendToolCallContext',
+  'setMessageToolCalls',
+]);
+const TOOL_CALL_FRAME_ARG_INDEX = 2;
+
+function toolCallIdFromObject(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const record = value as { id?: unknown; toolCallId?: unknown };
+  if (typeof record.id === 'string' && record.id) return record.id;
+  if (typeof record.toolCallId === 'string' && record.toolCallId) return record.toolCallId;
+  return undefined;
+}
+
+function toolCallIdFromFrame(frame: PortFrame): string | undefined {
+  if (frame.p !== 'chat' || !TOOL_CALL_FRAME_METHODS.has(frame.m)) return undefined;
+  const arg = frame.a[TOOL_CALL_FRAME_ARG_INDEX];
+  if (typeof arg === 'string') return arg || undefined;
+  if (Array.isArray(arg)) {
+    for (const entry of arg) {
+      const id = toolCallIdFromObject(entry);
+      if (id) return id;
+    }
+    return undefined;
+  }
+  return toolCallIdFromObject(arg);
+}
+
+/**
+ * Identity-only summary of a frame batch for logs: port, method, position and
+ * (when the method carries one) the tool call id. Frame args are NEVER
+ * serialized — a rejected batch is rejected precisely because it may carry a
+ * raw base64 media payload.
+ */
+export function summarizeFramesForLog(
+  frames: readonly PortFrame[],
+): Array<{ index: number; p: string; m: string; toolCallId?: string }> {
+  return frames.map((frame, index) => {
+    const toolCallId = toolCallIdFromFrame(frame);
+    return toolCallId === undefined
+      ? { index, p: frame.p, m: frame.m }
+      : { index, p: frame.p, m: frame.m, toolCallId };
+  });
+}
+
 /** `agent.delta` (NOTIFICATION) → {runId, frames} → applyDeltaFrames. Unknown runId → silent drop (3a discipline, matches handleSubagentAbort's unknown-runId no-op). */
 function handleAgentDelta(rawParams: unknown): void {
   const params = rawParams as { runId?: unknown; frames?: unknown } | null;
@@ -627,6 +675,12 @@ function handleAgentDelta(rawParams: unknown): void {
     logger.warn('agent.delta rejected unsafe media payload', {
       runId: params.runId,
       error: err instanceof Error ? err.message : String(err),
+      frameCount: frames.length,
+      frames: summarizeFramesForLog(frames),
+    });
+    traceRuntimeEvent('renderer.agent_delta_rejected', {
+      runId: params.runId,
+      frameCount: frames.length,
     });
     return;
   }


### PR DESCRIPTION
## P3 第 0 步 · 帧批次校验失败的观测（不改行为）

专家团验收（`docs/abu-team-acceptance-remediation-brief-2026-09-10.md` P3）里，一次派活永远停在「执行中」：sidecar → 外壳的一批 `agent.delta` 帧只要有一帧带裸 base64 媒体，`handleAgentDelta` 整批 `return`，只留一条没人看的 WARN。这一步先把丢弃坐实、可归因，下一步（3b）再改成逐帧降级。

### 改动

- `src/core/agent/agentLoopRunner.ts`：新增导出的 `summarizeFramesForLog(frames)`，每帧只记 `{index, p, m, toolCallId?}`，**绝不序列化帧参数**；被拒时 `logger.warn('agent.delta rejected unsafe media payload', { runId, error, frameCount, frames })` + `traceRuntimeEvent('renderer.agent_delta_rejected', { runId, frameCount })`。行为不变：仍然 `return`。
- `toolCallId` 只从 `updateToolCall` / `appendMessageToolCall` / `appendToolCallContext` / `setMessageToolCalls` 的第三个参数取（对照 `ports/chatDelta.ts` 签名），避免把 `addMessage` 的消息 id、`exec.addStep` 的步骤 id 误标成工具调用 id。

### 测试

- `agentLoopRunner.test.ts` 两条：① 真实走 `sidecarValueHasOpaqueMediaRefs` 抛出路径，断言 warn/trace 载荷形状，且 `JSON.stringify(warn.mock.calls)` 与 trace 调用都不含裸 base64 字符串；`applyDeltaFrames` 未被调用。② 负例：`addMessage` / `exec.addStep` 不产出 `toolCallId`。
- `npm run verify` 退出码 0（631 文件 / 11378 通过 / 1 skip，行覆盖 83.53%，2026-09-10 本机亲跑）。

### 复审

独立子代理任务复审：Approved，0 Important。遗留 minor（3b 一并处理）：`checkpointToolCallMetadata` 也是「第三参是工具调用 id」的方法，可加进集合；`toolCallId` 可加长度上限；`index` 是过信任过滤后的位置，注释说明。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
