### PR TITLE
docs(readme): 去掉「多 Harness 改造进行中」提示

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Tell Abu what you need — it reads files, runs commands, writes docs, and build
 
 </div>
 
-> 🚧 **Multi-Harness integration in progress:** Abu is evolving toward pluggable agent runtimes, with [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) among the first integration targets. Stable releases currently use Abu's native harness.
-
 ---
 
 ## Why Abu?

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,8 +18,6 @@
 
 </div>
 
-> 🚧 **多 Harness 改造进行中**：Abu 正在演进为可插拔的 Agent Runtime，并把 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 作为首批适配目标。当前稳定版仍使用 Abu 原生 Harness。
-
 ---
 
 ## 为什么选择 Abu？


### PR DESCRIPTION
## 改动

移除 README 顶部横幅下方的「Multi-Harness integration in progress / 多 Harness 改造进行中」提示条，中英两份同步。

- `README.md`：删除该 blockquote
- `README.zh-CN.md`：删除对应中文 blockquote

纯文档改动，不涉及代码逻辑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)