### PR TITLE
test(agent): compare agent paths separator-agnostically

### DIFF
--- a/src/core/agent/registryOwnership.test.ts
+++ b/src/core/agent/registryOwnership.test.ts
@@ -16,6 +16,7 @@ import { join } from 'node:path';
 import { readTextFile, readDir, exists, lstat } from '@tauri-apps/plugin-fs';
 import { homeDir, resolve } from '@tauri-apps/api/path';
 import { AgentRegistry } from './registry';
+import { normalizeSeparators } from '../../utils/pathUtils';
 
 const mockReadTextFile = vi.mocked(readTextFile);
 const mockReadDir = vi.mocked(readDir);
@@ -135,7 +136,8 @@ describe('AgentRegistry.discoverAgents over a real tree', () => {
     await registry.discoverAgents();
 
     expect(registry.hasLocal('cwd-only')).toBe(false);
-    expect(registry.getAgent('helper')?.filePath).toBe(join(userAgents, 'helper', 'AGENT.md'));
+    // The registry joins with `/`; node's `join` uses `\` on Windows.
+    expect(registry.getAgent('helper')?.filePath).toBe(normalizeSeparators(join(userAgents, 'helper', 'AGENT.md')));
     expect(mockResolve).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Follow-up to #478.

## Problem

`registryOwnership.test.ts`'s launch-cwd test compared `registry.getAgent('helper')?.filePath` against node's `join(...)`. The registry joins with `/` (`joinPath`), while `join` uses `\` on Windows, so `test-windows` and `build-windows` failed on #478 — the macOS gate could not see it. One assertion, both jobs.

## Fix

Normalise the expected path with `normalizeSeparators` before comparing.

## Verification

- `npm run verify`: exit 0 (653/653 files).
- Windows is the case that matters here, so this PR should not merge until `test-windows` and `build-windows` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)